### PR TITLE
lx, libre: Add support for inputs with embedded 0 bytes

### DIFF
--- a/include/re/re.h
+++ b/include/re/re.h
@@ -97,6 +97,12 @@ struct re_err {
 	char dup[128];
 };
 
+struct re_buf {
+	char *ptr;
+	size_t pos;
+	size_t len;
+};
+
 /*
  * Parse flags. Returns -1 on error.
  */
@@ -149,6 +155,7 @@ re_perror(enum re_dialect dialect, const struct re_err *err,
  */
 int re_sgetc(void *opaque); /* expects opaque to be char ** */
 int re_fgetc(void *oapque); /* expects opaque to be FILE *  */
+int re_bgetc(void *opaque); /* expects opaque to be struct re_buf * */
 
 #endif
 

--- a/src/libre/getc.c
+++ b/src/libre/getc.c
@@ -39,3 +39,18 @@ re_fgetc(void *opaque)
 	return fgetc(f);
 }
 
+int
+re_bgetc(void *opaque)
+{
+	struct re_buf *b = opaque;
+
+	assert(b != NULL);
+	assert(b->ptr != NULL);
+	assert(b->pos <= b->len);
+
+	if (b->pos == b->len) {
+		return EOF;
+	}
+
+	return (unsigned char) b->ptr[b->pos++];
+}

--- a/src/lx/parser.act
+++ b/src/lx/parser.act
@@ -45,7 +45,12 @@
 	#include "out.h"
 	#include "var.h"
 
-	typedef char *               string;
+	struct string {
+		char *p;
+		size_t l;
+	};
+
+	typedef struct string *      string;
 	typedef enum re_flags        flags;
 	typedef struct fsm *         fsm;
 	typedef struct ast_zone *    zone;
@@ -61,8 +66,6 @@
 		struct lx lx;
 		struct lx_dynbuf buf;
 
-		/* TODO: use lx's generated conveniences for the pattern buffer */
-		struct lx_pos pstart;
 		char a[512];
 		char *p;
 	};
@@ -128,11 +131,6 @@
 
 		default:   @c = '\0'; break; /* TODO: handle error */
 		}
-
-		/* position of first character */
-		if (lex_state->p == lex_state->a) {
-			lex_state->pstart = lex_state->lx.start;
-		}
 	@};
 
 	OCT: () -> (c :char) = @{
@@ -194,28 +192,37 @@
 		assert(lex_state->buf.a[1] == '\0');
 
 		@c = lex_state->buf.a[0];
-
-		/* position of first character */
-		if (lex_state->p == lex_state->a) {
-			lex_state->pstart = lex_state->lx.start;
-		}
 	@};
 
 	TOKEN: () -> (s :string) = @{
 		/* TODO: submatch addressing */
-		@s = xstrdup(lex_state->buf.a + 1); /* +1 for '$' prefix */
+		@s = malloc(sizeof *@s);
 		if (@s == NULL) {
+			perror("malloc");
+			exit(EXIT_FAILURE);
+		}
+		@s->p = xstrdup(lex_state->buf.a + 1); /* +1 for '$' prefix */
+		if (@s->p == NULL) {
 			perror("xstrdup");
 			exit(EXIT_FAILURE);
 		}
+		@s->l = strlen(@s->p);
 	@};
 
 	IDENT: () -> (s :string) = @{
-		@s = xstrdup(lex_state->buf.a);
+		@s = malloc(sizeof *@s);
 		if (@s == NULL) {
+			perror("malloc");
+			exit(EXIT_FAILURE);
+		}
+
+		@s->p = xstrdup(lex_state->buf.a);
+		if (@s->p == NULL) {
 			perror("xstrdup");
 			exit(EXIT_FAILURE);
 		}
+
+		@s->l = strlen(@s->p);
 	@};
 
 	RE: () -> (f :flags) = @{
@@ -241,16 +248,24 @@
 		*lex_state->p++ = '\0';
 
 		/*
-		 * Note we strdup() here because the grammar permits adjacent patterns,
-		 * and so the pattern buffer will be overwritten by the LL(1) one-token
+		 * Note we copy the string here because the grammar permits adjacent
+		 * patterns; the pattern buffer will be overwritten by the LL(1) one-token
 		 * lookahead.
 		 */
-		@s = xstrdup(lex_state->a);
+		@s = malloc(sizeof *@s);
 		if (@s == NULL) {
-			perror("xstrdup");
+			perror("malloc");
 			exit(EXIT_FAILURE);
 		}
 
+		@s->l = lex_state->p - lex_state->a;
+		@s->p = malloc(@s->l);
+		if (@s->p == NULL) {
+			perror("malloc");
+			exit(EXIT_FAILURE);
+		}
+
+		memcpy(@s->p, lex_state->a, @s->l);
 		lex_state->p = lex_state->a;
 	@};
 
@@ -259,16 +274,17 @@
 
 		assert(@z != NULL);
 		assert(@s != NULL);
+		assert(@s->p != NULL);
 
 		for (z = @z; z != NULL; z = z->parent) {
-			@r = var_find(z->vl, @s);
+			@r = var_find(z->vl, @s->p);
 			if (@r != NULL) {
 				break;
 			}
 
 			if (@z->parent == NULL) {
 				/* TODO: use *err */
-				err(lex_state, "No such variable: %s", @s);
+				err(lex_state, "No such variable: %s", @s->p);
 				@!;
 			}
 		}
@@ -285,6 +301,7 @@
 		const struct ast_mapping *m;
 
 		assert(@t != NULL);
+		assert(@t->b != NULL);
 
 		@r = fsm_new();
 		if (@r == NULL) {
@@ -302,7 +319,7 @@
 				continue;
 			}
 
-			if (0 != strcmp(m->token->s, @t)) {
+			if (0 != strcmp(m->token->s, @t->p)) {
 				continue;
 			}
 
@@ -331,17 +348,20 @@
 
 	<compile-literal>: (s :string) -> (r :fsm) = @{
 		struct re_err err;
-		const char *s;
+		struct re_buf buf;
 
 		assert(@s != NULL);
+		assert(@s->p != NULL);
 
-		s = @s;
+		buf.ptr = @s->p;
+		buf.len = @s->l;
+		buf.pos = 0;
 
-		@r = re_comp(RE_LITERAL, re_sgetc, &s, 0, &err);
+		@r = re_comp(RE_LITERAL, re_bgetc, &buf, 0, &err);
 		if (@r == NULL) {
 			assert(err.e != RE_EBADDIALECT);
 			/* TODO: pass filename for .lx source */
-			re_perror(RE_LITERAL, &err, NULL, @s);
+			re_perror(RE_LITERAL, &err, NULL, @s->p);
 			exit(EXIT_FAILURE);
 		}
 
@@ -350,17 +370,20 @@
 
 	<compile-regex>: (s :string, f :flags) -> (r :fsm) = @{
 		struct re_err err;
-		const char *s;
+		struct re_buf buf;
 
 		assert(@s != NULL);
+		assert(@s->p != NULL);
 
-		s = @s;
+		buf.ptr = @s->p;
+		buf.len = @s->l;
+		buf.pos = 0;
 
-		@r = re_comp(RE_NATIVE, re_sgetc, &s, @f, &err);
+		@r = re_comp(RE_NATIVE, re_bgetc, &buf, @f, &err);
 		if (@r == NULL) {
 			assert(err.e != RE_EBADDIALECT);
 			/* TODO: pass filename for .lx source */
-			re_perror(RE_NATIVE, &err, NULL, @s);
+			re_perror(RE_NATIVE, &err, NULL, @s->p);
 			exit(EXIT_FAILURE);
 		}
 
@@ -432,7 +455,7 @@
 		assert(@r != NULL);
 
 		if (@t != NULL) {
-			t = ast_addtoken(@a, @t);
+			t = ast_addtoken(@a, @t->p);
 			if (t == NULL) {
 				perror("ast_addtoken");
 				@!;
@@ -453,12 +476,13 @@
 
 		assert(@a != NULL);
 		assert(@z != NULL);
-		assert(@n != NULL);
 		assert(@r != NULL);
+		assert(@n != NULL);
+		assert(@n->p != NULL);
 
 		(void) @a;
 
-		v = var_bind(&@z->vl, @n, @r);
+		v = var_bind(&@z->vl, @n->p, @r);
 		if (v == NULL) {
 			perror("var_bind");
 			@!;
@@ -739,6 +763,7 @@
 	@};
 
 	<free>: (s :string) -> () = @{
+		free(@s->p);
 		free(@s);
 	@};
 

--- a/src/lx/parser.h
+++ b/src/lx/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 111 "src/lx/parser.act"
+#line 114 "src/lx/parser.act"
 
 
 	#include <stdio.h>
@@ -29,7 +29,7 @@
 extern void p_lx(lex_state, act_state, ast *);
 /* BEGINNING OF TRAILER */
 
-#line 839 "src/lx/parser.act"
+#line 870 "src/lx/parser.act"
 
 
 #line 36 "src/lx/parser.h"


### PR DESCRIPTION
Previously, lx would generate incorrect output when literals or regexps contained `0` bytes as it used `xstrdup`, which would truncate at the byte. This caused other failures when the first byte was a `\0`.

After this, libre would also fail to handle such regular expressions during compile due to lx consuming its getc interface that expects C strings.