### PR TITLE
libfsm: compact storage for edges

### DIFF
--- a/src/adt/bitmap.c
+++ b/src/adt/bitmap.c
@@ -152,7 +152,7 @@ bm_print(FILE *f, const struct bm *bm,
 
 		/* end of range */
 		hi = bm_next(bm, lo, mode == MODE_INVERT);
-		if (hi > UCHAR_MAX) {
+		if (hi > UCHAR_MAX && lo < UCHAR_MAX) {
 			hi = UCHAR_MAX;
 		}
 

--- a/src/adt/set.c
+++ b/src/adt/set.c
@@ -338,18 +338,16 @@ set_firstafter(const struct set *set, struct set_iter *it, void *item)
 
 	i = set_search(set, item);
 	r = set->cmp(item, set->a[i]);
-	if (i == 0) {
-		if (r < 0) {
-			it->i = 0;
-		} else {
-			it->i = 1;
-		}
-	} else {
-		if (r < 0) {
-			it->i = i;
-		} else {
-			it->i = i + 1;
-		}
+	assert(i <= set->i - 1);
+
+	if (r >= 0 && i == set->i - 1) {
+		it->set = NULL;
+		return NULL;
+	}
+
+	it->i = i;
+	if (r >= 0) {
+		it->i++;
 	}
 
 	it->set = set;

--- a/src/libfsm/complete.c
+++ b/src/libfsm/complete.c
@@ -41,14 +41,15 @@ fsm_complete(struct fsm *fsm,
 	 * to itself. That error state is implicit in most FSMs, but rarely
 	 * actually drawn. The idea here is to explicitly create it.
 	 */
-
 	new = fsm_addstate(fsm);
 	if (new == NULL) {
 		return 0;
 	}
 
 	for (i = 0; i <= UCHAR_MAX; i++) {
-		if (!set_add(&new->edges[i].sl, new)) {
+		struct fsm_edge *e;
+		e = fsm_addedge(new, new, i);
+		if (e == NULL) {
 			/* TODO: free stuff */
 			return 0;
 		}
@@ -60,11 +61,11 @@ fsm_complete(struct fsm *fsm,
 		}
 
 		for (i = 0; i <= UCHAR_MAX; i++) {
-			if (!set_empty(s->edges[i].sl)) {
+			if (!fsm_hasedge(s, i)) {
 				continue;
 			}
 
-			if (!set_add(&s->edges[i].sl, new)) {
+			if (!fsm_addedge(s, new, i)) {
 				/* TODO: free stuff */
 				return 0;
 			}

--- a/src/libfsm/exec.c
+++ b/src/libfsm/exec.c
@@ -16,16 +16,15 @@
 static struct fsm_state *
 nextstate(const struct fsm_state *state, char c)
 {
-	const struct set *s;
+	struct fsm_edge *e;
 
 	assert(state != NULL);
 
-	s = state->edges[(unsigned char) c].sl;
-	if (set_empty(s)) {
+	if (!(e = fsm_hasedge(state, c))) {
 		return NULL;
 	}
 
-	return set_only(s);
+	return set_only(e->sl);
 }
 
 struct fsm_state *

--- a/src/libfsm/fsm.c
+++ b/src/libfsm/fsm.c
@@ -12,19 +12,21 @@
 static void
 free_contents(struct fsm *fsm)
 {
-	struct fsm_state *s;
 	struct fsm_state *next;
-	int i;
+	struct fsm_state *s;
 
 	assert(fsm != NULL);
 
 	for (s = fsm->sl; s != NULL; s = next) {
+		struct set_iter it;
+		struct fsm_edge *e;
 		next = s->next;
 
-		for (i = 0; i <= FSM_EDGE_MAX; i++) {
-			set_free(s->edges[i].sl);
+		for (e = set_first(s->edges, &it); e != NULL; e = set_next(&it)) {
+			set_free(e->sl);
 		}
 
+		set_free(s->edges);
 		free(s);
 	}
 }

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -7,6 +7,7 @@
 
 #include <fsm/fsm.h>
 
+struct set;
 
 /* TODO: +2 for SOL, EOL */
 /* TODO: +lots for FSM_EDGE_* */
@@ -18,12 +19,13 @@ enum fsm_edge_type {
 
 struct fsm_edge {
 	struct set *sl;
+	enum fsm_edge_type symbol;
 };
 
 struct fsm_state {
 	unsigned int end:1;
 
-	struct fsm_edge edges[FSM_EDGE_MAX + 1];
+	struct set *edges; /* containing `struct fsm_edge *` */
 
 	void *opaque;
 
@@ -47,6 +49,11 @@ struct fsm {
 #endif
 };
 
+struct fsm_edge *
+fsm_hasedge(const struct fsm_state *s, int c);
+
+struct fsm_edge *
+fsm_addedge(struct fsm_state *from, struct fsm_state *to, enum fsm_edge_type type);
 
 #endif
 

--- a/src/libfsm/out/dot.c
+++ b/src/libfsm/out/dot.c
@@ -69,16 +69,19 @@ escputc(int c, FILE *f)
 }
 
 /* Return true if the edges after o contains state */
+/* TODO: centralise */
 static int
-contains(struct fsm_edge edges[], int o, struct fsm_state *state)
+contains(struct set *edges, int o, struct fsm_state *state)
 {
-	int i;
+	struct fsm_edge *e, search;
+	struct set_iter it;
 
 	assert(edges != NULL);
 	assert(state != NULL);
 
-	for (i = o; i <= FSM_EDGE_MAX; i++) {
-		if (set_contains(edges[i].sl, state)) {
+	search.symbol = o;
+	for (e = set_firstafter(edges, &it, &search); e != NULL; e = set_next(&it)) {
+		if (set_contains(e->sl, state)) {
 			return 1;
 		}
 	}
@@ -90,9 +93,8 @@ static void
 singlestate(const struct fsm *fsm, FILE *f, struct fsm_state *s,
 	const struct fsm_outoptions *options)
 {
+	struct fsm_edge *e, search;
 	struct set_iter it;
-	struct fsm_state *e;
-	int i;
 
 	assert(fsm != NULL);
 	assert(f != NULL);
@@ -132,17 +134,20 @@ singlestate(const struct fsm *fsm, FILE *f, struct fsm_state *s,
 	}
 
 	if (!options->consolidate_edges) {
-		for (i = 0; i <= FSM_EDGE_MAX; i++) {
-			for (e = set_first(s->edges[i].sl, &it); e != NULL; e = set_next(&it)) {
-				assert(e != NULL);
+		for (e = set_first(s->edges, &it); e != NULL; e = set_next(&it)) {
+			struct fsm_state *st;
+			struct set_iter jt;
+
+			for (st = set_first(e->sl, &jt); st != NULL; st = set_next(&jt)) {
+				assert(st != NULL);
 
 				fprintf(f, "\t%sS%-2u -> %sS%-2u [ label = <",
 					options->prefix != NULL ? options->prefix : "",
 					indexof(fsm, s),
 					options->prefix != NULL ? options->prefix : "",
-					indexof(fsm, e));
+					indexof(fsm, st));
 
-				escputc(i, f);
+				escputc(e->symbol, f);
 
 				fprintf(f, "> ];\n");
 			}
@@ -161,24 +166,36 @@ singlestate(const struct fsm *fsm, FILE *f, struct fsm_state *s,
 	 * looping through each edge.
 	 */
 	/* TODO: handle special edges upto FSM_EDGE_MAX separately */
-	for (i = 0; i <= UCHAR_MAX; i++) {
-		for (e = set_first(s->edges[i].sl, &it); e != NULL; e = set_next(&it)) {
-			struct bm bm;
-			int k;
+	for (e = set_first(s->edges, &it); e != NULL; e = set_next(&it)) {
+		struct fsm_state *st;
+		struct set_iter jt;
 
-			assert(e != NULL);
+		if (e->symbol > UCHAR_MAX) {
+			break;
+		}
+
+		for (st = set_first(e->sl, &jt); st != NULL; st = set_next(&jt)) {
+			struct fsm_edge *ne;
+			struct set_iter kt;
+			struct bm bm;
+
+			assert(st != NULL);
 
 			/* unique states only */
-			if (contains(s->edges, i + 1, e)) {
+			if (contains(s->edges, e->symbol, st)) {
 				continue;
 			}
 
 			bm_clear(&bm);
 
 			/* find all edges which go from this state to the same target state */
-			for (k = 0; k <= UCHAR_MAX; k++) {
-				if (set_contains(s->edges[k].sl, e)) {
-					bm_set(&bm, k);
+			for (ne = set_first(s->edges, &kt); ne != NULL; ne = set_next(&kt)) {
+				if (ne->symbol > UCHAR_MAX) {
+					break;
+				}
+
+				if (set_contains(ne->sl, st)) {
+					bm_set(&bm, ne->symbol);
 				}
 			}
 
@@ -186,7 +203,7 @@ singlestate(const struct fsm *fsm, FILE *f, struct fsm_state *s,
 				options->prefix != NULL ? options->prefix : "",
 				indexof(fsm, s),
 				options->prefix != NULL ? options->prefix : "",
-				indexof(fsm, e));
+				indexof(fsm, st));
 
 			(void) bm_print(f, &bm, 0, escputc);
 
@@ -197,15 +214,19 @@ singlestate(const struct fsm *fsm, FILE *f, struct fsm_state *s,
 	/*
 	 * Special edges are not consolidated above
 	 */
-	for (i = UCHAR_MAX + 1; i <= FSM_EDGE_MAX; i++) {
-		for (e = set_first(s->edges[i].sl, &it); e != NULL; e = set_next(&it)) {
+	search.symbol = UCHAR_MAX;
+	for (e = set_firstafter(s->edges, &it, &search); e != NULL; e = set_next(&it)) {
+		struct fsm_state *st;
+		struct set_iter jt;
+
+		for (st = set_first(e->sl, &jt); st != NULL; st = set_next(&jt)) {
 			fprintf(f, "\t%sS%-2u -> %sS%-2u [ label = <",
 				options->prefix != NULL ? options->prefix : "",
 				indexof(fsm, s),
 				options->prefix != NULL ? options->prefix : "",
-				indexof(fsm, e));
+				indexof(fsm, st));
 
-			escputc(i, f);
+			escputc(e->symbol, f);
 
 			fprintf(f, "> ];\n");
 		}

--- a/src/libfsm/pred/hasincoming.c
+++ b/src/libfsm/pred/hasincoming.c
@@ -13,14 +13,16 @@ int
 fsm_hasincoming(const struct fsm *fsm, const struct fsm_state *state)
 {
 	const struct fsm_state *s;
-	int i;
 
 	assert(fsm != NULL);
 	assert(state != NULL);
 
 	for (s = fsm->sl; s != NULL; s = s->next) {
-		for (i = 0; i <= FSM_EDGE_MAX; i++) {
-			if (set_contains(s->edges[i].sl, state)) {
+		struct fsm_edge *e;
+		struct set_iter it;
+
+		for (e = set_first(s->edges, &it); e != NULL; e = set_next(&it)) {
+			if (set_contains(e->sl, state)) {
 				return 1;
 			}
 		}

--- a/src/libfsm/pred/hasoutgoing.c
+++ b/src/libfsm/pred/hasoutgoing.c
@@ -12,15 +12,15 @@
 int
 fsm_hasoutgoing(const struct fsm *fsm, const struct fsm_state *state)
 {
-	int i;
+	struct fsm_edge *e;
+	struct set_iter it;
 
 	assert(fsm != NULL);
 	assert(state != NULL);
 
 	(void) fsm;
-
-	for (i = 0; i <= FSM_EDGE_MAX; i++) {
-		if (!set_empty(state->edges[i].sl)) {
+	for (e = set_first(state->edges, &it); e != NULL; e = set_next(&it)) {
+		if (!set_empty(e->sl)) {
 			return 1;
 		}
 	}

--- a/src/libfsm/pred/iscomplete.c
+++ b/src/libfsm/pred/iscomplete.c
@@ -13,19 +13,27 @@
 int
 fsm_iscomplete(const struct fsm *fsm, const struct fsm_state *state)
 {
+	struct fsm_edge *e;
+	struct set_iter it;
 	size_t i;
 
 	assert(fsm != NULL);
 	assert(state != NULL);
 
 	/* TODO: assert state is in fsm->sl */
+	i = 0;
+	for (e = set_first(state->edges, &it); e != NULL; e = set_next(&it)) {
+		if (e->symbol > UCHAR_MAX) {
+			break;
+		}
 
-	for (i = 0; i <= UCHAR_MAX; i++) {
-		if (set_empty(state->edges[i].sl)) {
+		if (set_empty(e->sl)) {
 			return 0;
 		}
+
+		i++;
 	}
 
-	return 1;
+	return i == UCHAR_MAX;
 }
 

--- a/src/libfsm/pred/isdfa.c
+++ b/src/libfsm/pred/isdfa.c
@@ -13,7 +13,8 @@
 int
 fsm_isdfa(const struct fsm *fsm, const struct fsm_state *state)
 {
-	int i;
+	struct fsm_edge *e, s;
+	struct set_iter it;
 
 	assert(fsm != NULL);
 
@@ -27,21 +28,25 @@ fsm_isdfa(const struct fsm *fsm, const struct fsm_state *state)
 	/*
 	 * DFA may not have epsilon edges.
 	 */
-	if (!set_empty(state->edges[FSM_EDGE_EPSILON].sl)) {
+	s.symbol = FSM_EDGE_EPSILON;
+	e = set_contains(state->edges, &s);
+	if (e != NULL && !set_empty(e->sl)) {
 		return 0;
 	}
 
 	/*
 	 * DFA may not have duplicate edges.
 	 */
-	for (i = 0; i <= UCHAR_MAX; i++) {
-		struct set_iter it;
+	for (e = set_first(state->edges, &it); e != NULL; e = set_next(&it)) {
+		if (e->symbol > UCHAR_MAX) {
+			break;
+		}
 
-		if (set_empty(state->edges[i].sl)) {
+		if (set_empty(e->sl)) {
 			continue;
 		}
 
-		(void) set_first(state->edges[i].sl, &it);
+		(void) set_first(e->sl, &it);
 		if (set_hasnext(&it)) {
 			return 0;
 		}

--- a/src/libfsm/reverse.c
+++ b/src/libfsm/reverse.c
@@ -106,43 +106,31 @@ fsm_reverse_opaque(struct fsm *fsm,
 
 		for (s = fsm->sl; s != NULL; s = s->next) {
 			struct fsm_state *to;
+			struct fsm_state *se;
 			struct set_iter it;
-			struct fsm_state *e;
-			int i;
+			struct fsm_edge *e;
 
 			to = equivalent(new, fsm, s);
 
 			assert(to != NULL);
 
-			for (i = 0; i <= FSM_EDGE_MAX; i++) {
-				for (e = set_first(s->edges[i].sl, &it); e != NULL; e = set_next(&it)) {
+			for (e = set_first(s->edges, &it); e != NULL; e = set_next(&it)) {
+				struct set_iter jt;
+
+				for (se = set_first(e->sl, &jt); se != NULL; se = set_next(&jt)) {
 					struct fsm_state *from;
 					struct fsm_edge *edge;
 
-					assert(e != NULL);
+					assert(se != NULL);
 
-					from = equivalent(new, fsm, e);
+					from = equivalent(new, fsm, se);
 
 					assert(from != NULL);
 
-					switch (i) {
-					case FSM_EDGE_EPSILON:
-						edge = fsm_addedge_epsilon(new, from, to);
-						if (edge == NULL) {
-							fsm_free(new);
-							return 0;
-						}
-						break;
-
-					default:
-						assert(i >= 0);
-						assert(i <= UCHAR_MAX);
-
-						edge = fsm_addedge_literal(new, from, to, i);
-						if (edge == NULL) {
-							fsm_free(new);
-							return 0;
-						}
+					edge = fsm_addedge(from, to, e->symbol);
+					if (edge == NULL) {
+						fsm_free(new);
+						return 0;
 					}
 				}
 			}

--- a/src/libfsm/shortest.c
+++ b/src/libfsm/shortest.c
@@ -64,9 +64,9 @@ fsm_shortest(const struct fsm *fsm,
 	}
 
 	while (u = priq_pop(&todo), u != NULL) {
-		const struct fsm_state *e;
+		const struct fsm_state *s;
+		struct fsm_edge *e;
 		struct set_iter it;
-		int i;
 
 		priq_move(&done, u);
 
@@ -79,28 +79,30 @@ fsm_shortest(const struct fsm *fsm,
 			goto done;
 		}
 
-		for (i = 0; i < FSM_EDGE_MAX; i++) {
-			for (e = set_first(u->state->edges[i].sl, &it); e != NULL; e = set_next(&it)) {
+		for (e = set_first(u->state->edges, &it); e != NULL; e = set_next(&it)) {
+			struct set_iter jt;
+
+			for (s = set_first(e->sl, &jt); s != NULL; s = set_next(&jt)) {
 				struct priq *v;
 				unsigned c;
 
-				v = priq_find(todo, e);
+				v = priq_find(todo, s);
 
 				/* visited already */
 				if (v == NULL) {
-					assert(priq_find(done, e));
+					assert(priq_find(done, s));
 					continue;
 				}
 
-				assert(v->state == e);
+				assert(v->state == s);
 
-				c = cost(u->state, v->state, i);
+				c = cost(u->state, v->state, e->symbol);
 
 				/* relax */
 				if (v->cost > u->cost + c) {
 					v->cost = u->cost + c;
 					v->prev = u;
-					v->type = i;
+					v->type = e->symbol;
 				}
 			}
 		}

--- a/src/libfsm/subgraph.c
+++ b/src/libfsm/subgraph.c
@@ -123,16 +123,16 @@ fsm_state_duplicatesubgraphx(struct fsm *fsm, struct fsm_state *state,
 	/* TODO: errors leave fsm in a questionable state */
 
 	while (m = getnextnotdone(mappings), m != NULL) {
-		struct set_iter it;
+		struct set_iter it, jt;
 		struct fsm_state *s;
-		int i;
+		struct fsm_edge *e;
 
 		if (x != NULL && m->old == *x) {
 			*x = m->new;
 		}
 
-		for (i = 0; i <= FSM_EDGE_MAX; i++) {
-			for (s = set_first(m->old->edges[i].sl, &it); s != NULL; s = set_next(&it)) {
+		for (e = set_first(m->old->edges, &it); e != NULL; e = set_next(&it)) {
+			for (s = set_first(e->sl, &jt); s != NULL; s = set_next(&jt)) {
 				struct mapping *to;
 
 				assert(s != NULL);
@@ -143,21 +143,8 @@ fsm_state_duplicatesubgraphx(struct fsm *fsm, struct fsm_state *state,
 					return NULL;
 				}
 
-				/* TODO: this switch occurs in a few places; centralise it */
-				switch (i) {
-				case FSM_EDGE_EPSILON:
-					if (!fsm_addedge_epsilon(fsm, m->new, to->new)) {
-						mapping_free(mappings);
-						return NULL;
-					}
-					break;
-
-				default:
-					if (!fsm_addedge_literal(fsm, m->new, to->new, i)) {
-						mapping_free(mappings);
-						return NULL;
-					}
-					break;
+				if (!fsm_addedge(m->new, to->new, e->symbol)) {
+					return NULL;
 				}
 			}
 		}

--- a/src/libfsm/walk/reachable.c
+++ b/src/libfsm/walk/reachable.c
@@ -107,23 +107,25 @@ fsm_reachable(struct fsm *fsm, struct fsm_state *state,
 	}
 
 	while (p = list_nextnotdone(list), p != NULL) {
+		struct fsm_edge *e;
 		struct set_iter it;
-		struct fsm_state *e;
-		int i;
 
 		if (!predicate(fsm, p->state)) {
 			list_free(p);
 			return 0;
 		}
 
-		for (i = 0; i <= FSM_EDGE_MAX; i++) {
-			for (e = set_first(p->state->edges[i].sl, &it); e != NULL; e = set_next(&it)) {
+		for (e = set_first(p->state->edges, &it); e != NULL; e = set_next(&it)) {
+			struct fsm_state *st;
+			struct set_iter jt;
+
+			for (st = set_first(e->sl, &jt); st != NULL; st = set_next(&jt)) {
 				/* not a list operation... */
-				if (list_contains(list, e)) {
+				if (list_contains(list, st)) {
 					continue;
 				}
 
-				if (!list_push(&list, e)) {
+				if (!list_push(&list, st)) {
 					return -1;
 				}
 			}


### PR DESCRIPTION
This stores edges using adt/set. It should result in less memory usage
in most cases, as well as faster runtime in cases like minimization,
which iterate over all edges over all states: now such cases can ignore
empty edges entirely.