### PR TITLE
bitmap: fix off-by-one in bm_print at end of range

### DIFF
--- a/src/adt/bitmap.c
+++ b/src/adt/bitmap.c
@@ -152,7 +152,7 @@ bm_print(FILE *f, const struct bm *bm,
 
 		/* end of range */
 		hi = bm_next(bm, lo, mode == MODE_INVERT);
-		if (hi > UCHAR_MAX) {
+		if (hi > UCHAR_MAX && lo < UCHAR_MAX) {
 			hi = UCHAR_MAX;
 		}
 


### PR DESCRIPTION
When calling bm_print on a short range that includes UCHAR_MAX, the
current implementation has an off-by-one, causing a crash when
assertions are enabled.

Consider a system where UCHAR_MAX is 255, and a bitmap includes the
range 252-255, 253-255, or 254-255, or 255-255. The current
implementation to output such small ranges as a sequence of individual
bytes in a regexp accept group (e.g. [\xfd\xfe\xff]), rather than as a
range in that group (e.g. [\xfd-\xff]).

When this strategy is chosen, we iterate the bitmap between two
variables, lo and hi. In our example of \xfd-\xff, hi is initially set
to -1, and lo is populated as the first bit set after that -- which will
be \xfd in our example. After we've completed output of lo, we set hi to
lo, and continue our iteration with hi set to \xfd.

This continues until lo is set to \xff. We then find that hi would be
\x100, which is larger than UCHAR_MAX. Therefore, we clamp hi to
UCHAR_MAX. We then assert hi > lo, which is not true.

The fix is to only clamp hi to UCHAR_MAX when lo is < UCHAR_MAX. If lo
is equal to UCHAR_MAX, this fix works correctly. When lo is > UCHAR_MAX
(as it is after this final iteration), we exit our loop.