### PR TITLE
libfsm: add an output option for case ranges

### DIFF
--- a/include/fsm/out.h
+++ b/include/fsm/out.h
@@ -40,6 +40,11 @@ struct fsm_outoptions {
 	 * where possible. */
 	unsigned int comments:1;
 
+	/* boolean: true indicates to use compiler-specific case ranges in generated
+	 * code, when possible.
+	 */
+	unsigned int case_ranges:1;
+
 	/* for generated code, what kind of I/O API to generate */
 	enum fsm_io io;
 

--- a/src/libfsm/out/c.c
+++ b/src/libfsm/out/c.c
@@ -195,10 +195,32 @@ singlecase(FILE *f, const struct fsm *fsm,
 
 			fprintf(f, "\t\t\tcase '");
 			escputc(e->symbol, f);
+
+			if (options->case_ranges) {
+				const struct fsm_edge *ne;
+				enum fsm_edge_type p, q;
+				struct set_iter ic, ir;
+				
+				ir = ic = it;
+				p = q = e->symbol;
+				ne = set_next(&ic);
+				while (ne && ne->symbol - q == 1) {
+					q = ne->symbol;
+					ir = ic;
+					ne = set_next(&ic);
+				}
+
+				if (q - p) {
+					fprintf(f, "' ... '");
+					escputc(q, f);
+					it = ir;
+				}
+			}
+
 			fprintf(f, "':");
 
 			/* non-unique states fall through */
-			if (e->symbol <= UCHAR_MAX - 1) {
+			if (!options->case_ranges && e->symbol <= UCHAR_MAX - 1) {
 				const struct fsm_edge *ne;
 				struct set_iter jt;
 


### PR DESCRIPTION
At least gcc and clang support "case range" syntax for switch statements,
e.g. `case 'A' ... 'Z':`. This can help reduce file size output on large
FSMs, when this option is enabled.