### PR TITLE
libfsm, priq: Fix shortest path calculation for fsm_example

### DIFF
--- a/include/adt/priq.h
+++ b/include/adt/priq.h
@@ -28,6 +28,12 @@ struct priq *
 priq_push(struct priq **priq,
 	struct fsm_state *state, unsigned int cost);
 
+/*
+ * Update cost of node in priq.
+ */
+void
+priq_update(struct priq **priq, struct priq *s, unsigned int cost);
+
 /* XXX: set operation */
 struct priq *
 priq_find(struct priq *priq, const struct fsm_state *state);

--- a/src/adt/priq.c
+++ b/src/adt/priq.c
@@ -27,6 +27,35 @@ priq_pop(struct priq **priq)
 	return p;
 }
 
+void
+priq_update(struct priq **priq, struct priq *s, unsigned int cost)
+{
+	struct priq **p, **pp;
+
+	pp = NULL;
+	for (p = priq; *p != NULL; p = &(*p)->next) {
+		if ((*p) == s) {
+			break;
+		}
+		pp = p;
+	}
+
+	if (!pp) {
+		return;
+	}
+
+	(*pp)->next = s->next;
+
+	for (pp = priq; *pp != NULL; pp = &(*pp)->next) {
+		if ((*pp)->cost >= cost) {
+			break;
+		}
+	}
+
+	s->next = *pp;
+	*pp = s;
+}
+
 struct priq *
 priq_push(struct priq **priq,
 	struct fsm_state *state, unsigned int cost)

--- a/src/fsm/lexer.c
+++ b/src/fsm/lexer.c
@@ -12,6 +12,9 @@ static enum lx_token z1(struct lx *lx);
 static enum lx_token z2(struct lx *lx);
 static enum lx_token z3(struct lx *lx);
 
+#if __STDC_VERSION__ >= 199901L
+inline
+#endif
 static int
 lx_getc(struct lx *lx)
 {
@@ -40,6 +43,9 @@ lx_getc(struct lx *lx)
 	return c;
 }
 
+#if __STDC_VERSION__ >= 199901L
+inline
+#endif
 static void
 lx_ungetc(struct lx *lx, int c)
 {
@@ -194,7 +200,7 @@ z0(struct lx *lx)
 		lx->clear(lx);
 	}
 
-	state = S2;
+	state = S0;
 
 	lx->start = lx->end;
 
@@ -206,25 +212,280 @@ z0(struct lx *lx)
 		}
 
 		switch (state) {
-		case S0: /* e.g. "a" */
+		case S0: /* start */
+			switch (c) {
+			case '\x00':
+			case '\x01':
+			case '\x02':
+			case '\x03':
+			case '\x04':
+			case '\x05':
+			case '\x06':
+			case '\a':
+			case '\b':
+			case '\t':
+			case '\n':
+			case '\v':
+			case '\f':
+			case '\r':
+			case '\x0e':
+			case '\x0f':
+			case '\x10':
+			case '\x11':
+			case '\x12':
+			case '\x13':
+			case '\x14':
+			case '\x15':
+			case '\x16':
+			case '\x17':
+			case '\x18':
+			case '\x19':
+			case '\x1a':
+			case '\x1b':
+			case '\x1c':
+			case '\x1d':
+			case '\x1e':
+			case '\x1f':
+			case ' ':
+			case '!':
+			case '"':
+			case '#':
+			case '$':
+			case '%':
+			case '&': state = S1; continue;
+			case '\'': state = S2; continue;
+			case '(':
+			case ')':
+			case '*':
+			case '+':
+			case ',':
+			case '-':
+			case '.':
+			case '\x2f':
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9':
+			case ':':
+			case ';':
+			case '<':
+			case '=':
+			case '>':
+			case '?':
+			case '@':
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'G':
+			case 'H':
+			case 'I':
+			case 'J':
+			case 'K':
+			case 'L':
+			case 'M':
+			case 'N':
+			case 'O':
+			case 'P':
+			case 'Q':
+			case 'R':
+			case 'S':
+			case 'T':
+			case 'U':
+			case 'V':
+			case 'W':
+			case 'X':
+			case 'Y':
+			case 'Z':
+			case '[':
+			case '\\':
+			case ']':
+			case '^':
+			case '_':
+			case '`':
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f':
+			case 'g':
+			case 'h':
+			case 'i':
+			case 'j':
+			case 'k':
+			case 'l':
+			case 'm':
+			case 'n':
+			case 'o':
+			case 'p':
+			case 'q':
+			case 'r':
+			case 's':
+			case 't':
+			case 'u':
+			case 'v':
+			case 'w':
+			case 'x':
+			case 'y':
+			case 'z':
+			case '{':
+			case '|':
+			case '}':
+			case '~':
+			case '\x7f':
+			case '\x80':
+			case '\x81':
+			case '\x82':
+			case '\x83':
+			case '\x84':
+			case '\x85':
+			case '\x86':
+			case '\x87':
+			case '\x88':
+			case '\x89':
+			case '\x8a':
+			case '\x8b':
+			case '\x8c':
+			case '\x8d':
+			case '\x8e':
+			case '\x8f':
+			case '\x90':
+			case '\x91':
+			case '\x92':
+			case '\x93':
+			case '\x94':
+			case '\x95':
+			case '\x96':
+			case '\x97':
+			case '\x98':
+			case '\x99':
+			case '\x9a':
+			case '\x9b':
+			case '\x9c':
+			case '\x9d':
+			case '\x9e':
+			case '\x9f':
+			case '\xa0':
+			case '\xa1':
+			case '\xa2':
+			case '\xa3':
+			case '\xa4':
+			case '\xa5':
+			case '\xa6':
+			case '\xa7':
+			case '\xa8':
+			case '\xa9':
+			case '\xaa':
+			case '\xab':
+			case '\xac':
+			case '\xad':
+			case '\xae':
+			case '\xaf':
+			case '\xb0':
+			case '\xb1':
+			case '\xb2':
+			case '\xb3':
+			case '\xb4':
+			case '\xb5':
+			case '\xb6':
+			case '\xb7':
+			case '\xb8':
+			case '\xb9':
+			case '\xba':
+			case '\xbb':
+			case '\xbc':
+			case '\xbd':
+			case '\xbe':
+			case '\xbf':
+			case '\xc0':
+			case '\xc1':
+			case '\xc2':
+			case '\xc3':
+			case '\xc4':
+			case '\xc5':
+			case '\xc6':
+			case '\xc7':
+			case '\xc8':
+			case '\xc9':
+			case '\xca':
+			case '\xcb':
+			case '\xcc':
+			case '\xcd':
+			case '\xce':
+			case '\xcf':
+			case '\xd0':
+			case '\xd1':
+			case '\xd2':
+			case '\xd3':
+			case '\xd4':
+			case '\xd5':
+			case '\xd6':
+			case '\xd7':
+			case '\xd8':
+			case '\xd9':
+			case '\xda':
+			case '\xdb':
+			case '\xdc':
+			case '\xdd':
+			case '\xde':
+			case '\xdf':
+			case '\xe0':
+			case '\xe1':
+			case '\xe2':
+			case '\xe3':
+			case '\xe4':
+			case '\xe5':
+			case '\xe6':
+			case '\xe7':
+			case '\xe8':
+			case '\xe9':
+			case '\xea':
+			case '\xeb':
+			case '\xec':
+			case '\xed':
+			case '\xee':
+			case '\xef':
+			case '\xf0':
+			case '\xf1':
+			case '\xf2':
+			case '\xf3':
+			case '\xf4':
+			case '\xf5':
+			case '\xf6':
+			case '\xf7':
+			case '\xf8':
+			case '\xf9':
+			case '\xfa':
+			case '\xfb':
+			case '\xfc':
+			case '\xfd':
+			case '\xfe':
+			case '\xff': state = S1; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S1: /* e.g. "a" */
 			lx_ungetc(lx, c); return TOK_CHAR;
 
-		case S1: /* e.g. "\'" */
+		case S2: /* e.g. "\'" */
 			lx_ungetc(lx, c); return lx->z = z3, TOK_LABEL;
-
-		case S2: /* start */
-			switch (c) {
-			case '\'': state = S1; continue;
-			default:  state = S0; continue;
-			}
 		}
 	}
 
 	lx->lgetc = NULL;
 
 	switch (state) {
-	case S0: return TOK_CHAR;
-	case S1: return TOK_LABEL;
+	case S1: return TOK_CHAR;
+	case S2: return TOK_LABEL;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
 }
@@ -244,7 +505,7 @@ z1(struct lx *lx)
 		lx->clear(lx);
 	}
 
-	state = S7;
+	state = S0;
 
 	lx->start = lx->end;
 
@@ -256,8 +517,56 @@ z1(struct lx *lx)
 		}
 
 		switch (state) {
-		case S0: /* e.g. "\\xa" */
+		case S0: /* start */
 			switch (c) {
+			case '\x00':
+			case '\x01':
+			case '\x02':
+			case '\x03':
+			case '\x04':
+			case '\x05':
+			case '\x06':
+			case '\a':
+			case '\b':
+			case '\t':
+			case '\n':
+			case '\v':
+			case '\f':
+			case '\r':
+			case '\x0e':
+			case '\x0f':
+			case '\x10':
+			case '\x11':
+			case '\x12':
+			case '\x13':
+			case '\x14':
+			case '\x15':
+			case '\x16':
+			case '\x17':
+			case '\x18':
+			case '\x19':
+			case '\x1a':
+			case '\x1b':
+			case '\x1c':
+			case '\x1d':
+			case '\x1e':
+			case '\x1f':
+			case ' ':
+			case '!': state = S1; continue;
+			case '"': state = S2; continue;
+			case '#':
+			case '$':
+			case '%':
+			case '&':
+			case '\'':
+			case '(':
+			case ')':
+			case '*':
+			case '+':
+			case ',':
+			case '-':
+			case '.':
+			case '\x2f':
 			case '0':
 			case '1':
 			case '2':
@@ -267,26 +576,239 @@ z1(struct lx *lx)
 			case '6':
 			case '7':
 			case '8':
-			case '9':             continue;
+			case '9':
+			case ':':
+			case ';':
+			case '<':
+			case '=':
+			case '>':
+			case '?':
+			case '@':
 			case 'A':
 			case 'B':
 			case 'C':
 			case 'D':
 			case 'E':
-			case 'F':             continue;
+			case 'F':
+			case 'G':
+			case 'H':
+			case 'I':
+			case 'J':
+			case 'K':
+			case 'L':
+			case 'M':
+			case 'N':
+			case 'O':
+			case 'P':
+			case 'Q':
+			case 'R':
+			case 'S':
+			case 'T':
+			case 'U':
+			case 'V':
+			case 'W':
+			case 'X':
+			case 'Y':
+			case 'Z':
+			case '[': state = S1; continue;
+			case '\\': state = S3; continue;
+			case ']':
+			case '^':
+			case '_':
+			case '`':
 			case 'a':
 			case 'b':
 			case 'c':
 			case 'd':
 			case 'e':
-			case 'f':             continue;
-			default:  lx_ungetc(lx, c); return TOK_HEX;
+			case 'f':
+			case 'g':
+			case 'h':
+			case 'i':
+			case 'j':
+			case 'k':
+			case 'l':
+			case 'm':
+			case 'n':
+			case 'o':
+			case 'p':
+			case 'q':
+			case 'r':
+			case 's':
+			case 't':
+			case 'u':
+			case 'v':
+			case 'w':
+			case 'x':
+			case 'y':
+			case 'z':
+			case '{':
+			case '|':
+			case '}':
+			case '~':
+			case '\x7f':
+			case '\x80':
+			case '\x81':
+			case '\x82':
+			case '\x83':
+			case '\x84':
+			case '\x85':
+			case '\x86':
+			case '\x87':
+			case '\x88':
+			case '\x89':
+			case '\x8a':
+			case '\x8b':
+			case '\x8c':
+			case '\x8d':
+			case '\x8e':
+			case '\x8f':
+			case '\x90':
+			case '\x91':
+			case '\x92':
+			case '\x93':
+			case '\x94':
+			case '\x95':
+			case '\x96':
+			case '\x97':
+			case '\x98':
+			case '\x99':
+			case '\x9a':
+			case '\x9b':
+			case '\x9c':
+			case '\x9d':
+			case '\x9e':
+			case '\x9f':
+			case '\xa0':
+			case '\xa1':
+			case '\xa2':
+			case '\xa3':
+			case '\xa4':
+			case '\xa5':
+			case '\xa6':
+			case '\xa7':
+			case '\xa8':
+			case '\xa9':
+			case '\xaa':
+			case '\xab':
+			case '\xac':
+			case '\xad':
+			case '\xae':
+			case '\xaf':
+			case '\xb0':
+			case '\xb1':
+			case '\xb2':
+			case '\xb3':
+			case '\xb4':
+			case '\xb5':
+			case '\xb6':
+			case '\xb7':
+			case '\xb8':
+			case '\xb9':
+			case '\xba':
+			case '\xbb':
+			case '\xbc':
+			case '\xbd':
+			case '\xbe':
+			case '\xbf':
+			case '\xc0':
+			case '\xc1':
+			case '\xc2':
+			case '\xc3':
+			case '\xc4':
+			case '\xc5':
+			case '\xc6':
+			case '\xc7':
+			case '\xc8':
+			case '\xc9':
+			case '\xca':
+			case '\xcb':
+			case '\xcc':
+			case '\xcd':
+			case '\xce':
+			case '\xcf':
+			case '\xd0':
+			case '\xd1':
+			case '\xd2':
+			case '\xd3':
+			case '\xd4':
+			case '\xd5':
+			case '\xd6':
+			case '\xd7':
+			case '\xd8':
+			case '\xd9':
+			case '\xda':
+			case '\xdb':
+			case '\xdc':
+			case '\xdd':
+			case '\xde':
+			case '\xdf':
+			case '\xe0':
+			case '\xe1':
+			case '\xe2':
+			case '\xe3':
+			case '\xe4':
+			case '\xe5':
+			case '\xe6':
+			case '\xe7':
+			case '\xe8':
+			case '\xe9':
+			case '\xea':
+			case '\xeb':
+			case '\xec':
+			case '\xed':
+			case '\xee':
+			case '\xef':
+			case '\xf0':
+			case '\xf1':
+			case '\xf2':
+			case '\xf3':
+			case '\xf4':
+			case '\xf5':
+			case '\xf6':
+			case '\xf7':
+			case '\xf8':
+			case '\xf9':
+			case '\xfa':
+			case '\xfb':
+			case '\xfc':
+			case '\xfd':
+			case '\xfe':
+			case '\xff': state = S1; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S1: /* e.g. "\\f" */
+		case S1: /* e.g. "a" */
+			lx_ungetc(lx, c); return TOK_CHAR;
+
+		case S2: /* e.g. """ */
+			lx_ungetc(lx, c); return lx->z = z3, TOK_LABEL;
+
+		case S3: /* e.g. "\\" */
+			switch (c) {
+			case '"': state = S4; continue;
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7': state = S5; continue;
+			case '\\': state = S4; continue;
+			case 'f': state = S4; continue;
+			case 'n': state = S4; continue;
+			case 'r': state = S4; continue;
+			case 't': state = S4; continue;
+			case 'v': state = S4; continue;
+			case 'x': state = S6; continue;
+			default:  lx_ungetc(lx, c); return TOK_CHAR;
+			}
+
+		case S4: /* e.g. "\\f" */
 			lx_ungetc(lx, c); return TOK_ESC;
 
-		case S2: /* e.g. "\\0" */
+		case S5: /* e.g. "\\0" */
 			switch (c) {
 			case '0':
 			case '1':
@@ -295,11 +817,11 @@ z1(struct lx *lx)
 			case '4':
 			case '5':
 			case '6':
-			case '7':             continue;
+			case '7': continue;
 			default:  lx_ungetc(lx, c); return TOK_OCT;
 			}
 
-		case S3: /* e.g. "\\x" */
+		case S6: /* e.g. "\\x" */
 			switch (c) {
 			case '0':
 			case '1':
@@ -310,25 +832,24 @@ z1(struct lx *lx)
 			case '6':
 			case '7':
 			case '8':
-			case '9': state = S0; continue;
+			case '9': state = S7; continue;
 			case 'A':
 			case 'B':
 			case 'C':
 			case 'D':
 			case 'E':
-			case 'F': state = S0; continue;
+			case 'F': state = S7; continue;
 			case 'a':
 			case 'b':
 			case 'c':
 			case 'd':
 			case 'e':
-			case 'f': state = S0; continue;
-			default:  lx_ungetc(lx, c); return TOK_CHAR;
+			case 'f': state = S7; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S4: /* e.g. "\\" */
+		case S7: /* e.g. "\\xa" */
 			switch (c) {
-			case '"': state = S1; continue;
 			case '0':
 			case '1':
 			case '2':
@@ -336,28 +857,22 @@ z1(struct lx *lx)
 			case '4':
 			case '5':
 			case '6':
-			case '7': state = S2; continue;
-			case '\\': state = S1; continue;
-			case 'f': state = S1; continue;
-			case 'n': state = S1; continue;
-			case 'r': state = S1; continue;
-			case 't': state = S1; continue;
-			case 'v': state = S1; continue;
-			case 'x': state = S3; continue;
-			default:  lx_ungetc(lx, c); return TOK_CHAR;
-			}
-
-		case S5: /* e.g. """ */
-			lx_ungetc(lx, c); return lx->z = z3, TOK_LABEL;
-
-		case S6: /* e.g. "a" */
-			lx_ungetc(lx, c); return TOK_CHAR;
-
-		case S7: /* start */
-			switch (c) {
-			case '"': state = S5; continue;
-			case '\\': state = S4; continue;
-			default:  state = S6; continue;
+			case '7':
+			case '8':
+			case '9': continue;
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F': continue;
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f': continue;
+			default:  lx_ungetc(lx, c); return TOK_HEX;
 			}
 		}
 	}
@@ -365,13 +880,12 @@ z1(struct lx *lx)
 	lx->lgetc = NULL;
 
 	switch (state) {
-	case S0: return TOK_HEX;
-	case S1: return TOK_ESC;
-	case S2: return TOK_OCT;
+	case S1: return TOK_CHAR;
+	case S2: return TOK_LABEL;
 	case S3: return TOK_CHAR;
-	case S4: return TOK_CHAR;
-	case S5: return TOK_LABEL;
-	case S6: return TOK_CHAR;
+	case S4: return TOK_ESC;
+	case S5: return TOK_OCT;
+	case S7: return TOK_HEX;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
 }
@@ -391,7 +905,7 @@ z2(struct lx *lx)
 		lx->clear(lx);
 	}
 
-	state = S2;
+	state = S0;
 
 	lx->start = lx->end;
 
@@ -413,25 +927,280 @@ z2(struct lx *lx)
 		}
 
 		switch (state) {
-		case S0: /* e.g. "a" */
+		case S0: /* start */
+			switch (c) {
+			case '\x00':
+			case '\x01':
+			case '\x02':
+			case '\x03':
+			case '\x04':
+			case '\x05':
+			case '\x06':
+			case '\a':
+			case '\b':
+			case '\t': state = S1; continue;
+			case '\n': state = S2; continue;
+			case '\v':
+			case '\f':
+			case '\r':
+			case '\x0e':
+			case '\x0f':
+			case '\x10':
+			case '\x11':
+			case '\x12':
+			case '\x13':
+			case '\x14':
+			case '\x15':
+			case '\x16':
+			case '\x17':
+			case '\x18':
+			case '\x19':
+			case '\x1a':
+			case '\x1b':
+			case '\x1c':
+			case '\x1d':
+			case '\x1e':
+			case '\x1f':
+			case ' ':
+			case '!':
+			case '"':
+			case '#':
+			case '$':
+			case '%':
+			case '&':
+			case '\'':
+			case '(':
+			case ')':
+			case '*':
+			case '+':
+			case ',':
+			case '-':
+			case '.':
+			case '\x2f':
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9':
+			case ':':
+			case ';':
+			case '<':
+			case '=':
+			case '>':
+			case '?':
+			case '@':
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'G':
+			case 'H':
+			case 'I':
+			case 'J':
+			case 'K':
+			case 'L':
+			case 'M':
+			case 'N':
+			case 'O':
+			case 'P':
+			case 'Q':
+			case 'R':
+			case 'S':
+			case 'T':
+			case 'U':
+			case 'V':
+			case 'W':
+			case 'X':
+			case 'Y':
+			case 'Z':
+			case '[':
+			case '\\':
+			case ']':
+			case '^':
+			case '_':
+			case '`':
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f':
+			case 'g':
+			case 'h':
+			case 'i':
+			case 'j':
+			case 'k':
+			case 'l':
+			case 'm':
+			case 'n':
+			case 'o':
+			case 'p':
+			case 'q':
+			case 'r':
+			case 's':
+			case 't':
+			case 'u':
+			case 'v':
+			case 'w':
+			case 'x':
+			case 'y':
+			case 'z':
+			case '{':
+			case '|':
+			case '}':
+			case '~':
+			case '\x7f':
+			case '\x80':
+			case '\x81':
+			case '\x82':
+			case '\x83':
+			case '\x84':
+			case '\x85':
+			case '\x86':
+			case '\x87':
+			case '\x88':
+			case '\x89':
+			case '\x8a':
+			case '\x8b':
+			case '\x8c':
+			case '\x8d':
+			case '\x8e':
+			case '\x8f':
+			case '\x90':
+			case '\x91':
+			case '\x92':
+			case '\x93':
+			case '\x94':
+			case '\x95':
+			case '\x96':
+			case '\x97':
+			case '\x98':
+			case '\x99':
+			case '\x9a':
+			case '\x9b':
+			case '\x9c':
+			case '\x9d':
+			case '\x9e':
+			case '\x9f':
+			case '\xa0':
+			case '\xa1':
+			case '\xa2':
+			case '\xa3':
+			case '\xa4':
+			case '\xa5':
+			case '\xa6':
+			case '\xa7':
+			case '\xa8':
+			case '\xa9':
+			case '\xaa':
+			case '\xab':
+			case '\xac':
+			case '\xad':
+			case '\xae':
+			case '\xaf':
+			case '\xb0':
+			case '\xb1':
+			case '\xb2':
+			case '\xb3':
+			case '\xb4':
+			case '\xb5':
+			case '\xb6':
+			case '\xb7':
+			case '\xb8':
+			case '\xb9':
+			case '\xba':
+			case '\xbb':
+			case '\xbc':
+			case '\xbd':
+			case '\xbe':
+			case '\xbf':
+			case '\xc0':
+			case '\xc1':
+			case '\xc2':
+			case '\xc3':
+			case '\xc4':
+			case '\xc5':
+			case '\xc6':
+			case '\xc7':
+			case '\xc8':
+			case '\xc9':
+			case '\xca':
+			case '\xcb':
+			case '\xcc':
+			case '\xcd':
+			case '\xce':
+			case '\xcf':
+			case '\xd0':
+			case '\xd1':
+			case '\xd2':
+			case '\xd3':
+			case '\xd4':
+			case '\xd5':
+			case '\xd6':
+			case '\xd7':
+			case '\xd8':
+			case '\xd9':
+			case '\xda':
+			case '\xdb':
+			case '\xdc':
+			case '\xdd':
+			case '\xde':
+			case '\xdf':
+			case '\xe0':
+			case '\xe1':
+			case '\xe2':
+			case '\xe3':
+			case '\xe4':
+			case '\xe5':
+			case '\xe6':
+			case '\xe7':
+			case '\xe8':
+			case '\xe9':
+			case '\xea':
+			case '\xeb':
+			case '\xec':
+			case '\xed':
+			case '\xee':
+			case '\xef':
+			case '\xf0':
+			case '\xf1':
+			case '\xf2':
+			case '\xf3':
+			case '\xf4':
+			case '\xf5':
+			case '\xf6':
+			case '\xf7':
+			case '\xf8':
+			case '\xf9':
+			case '\xfa':
+			case '\xfb':
+			case '\xfc':
+			case '\xfd':
+			case '\xfe':
+			case '\xff': state = S1; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S1: /* e.g. "a" */
 			lx_ungetc(lx, c); return lx->z(lx);
 
-		case S1: /* e.g. "\n" */
+		case S2: /* e.g. "\n" */
 			lx_ungetc(lx, c); return lx->z = z3, lx->z(lx);
-
-		case S2: /* start */
-			switch (c) {
-			case '\n': state = S1; continue;
-			default:  state = S0; continue;
-			}
 		}
 	}
 
 	lx->lgetc = NULL;
 
 	switch (state) {
-	case S0: return TOK_EOF;
 	case S1: return TOK_EOF;
+	case S2: return TOK_EOF;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
 }
@@ -453,16 +1222,16 @@ z3(struct lx *lx)
 		lx->clear(lx);
 	}
 
-	state = S20;
+	state = S0;
 
 	lx->start = lx->end;
 
 	while (c = lx_getc(lx), c != EOF) {
 		switch (state) {
-		case S9:
-		case S10:
-		case S12:
-		case S18:
+		case S1:
+		case S2:
+		case S3:
+		case S4:
 			break;
 
 		default:
@@ -476,14 +1245,17 @@ z3(struct lx *lx)
 		}
 
 		switch (state) {
-		case S0: /* e.g. "->" */
-			lx_ungetc(lx, c); return TOK_TO;
-
-		case S1: /* e.g. "end:" */
-			lx_ungetc(lx, c); return TOK_END;
-
-		case S2: /* e.g. "end" */
+		case S0: /* start */
 			switch (c) {
+			case '\t':
+			case '\n': state = S1; continue;
+			case '\r': state = S1; continue;
+			case ' ': state = S1; continue;
+			case '"': state = S2; continue;
+			case '#': state = S3; continue;
+			case '\'': state = S4; continue;
+			case ',': state = S5; continue;
+			case '-': state = S6; continue;
 			case '0':
 			case '1':
 			case '2':
@@ -493,8 +1265,9 @@ z3(struct lx *lx)
 			case '6':
 			case '7':
 			case '8':
-			case '9': state = S15; continue;
-			case ':': state = S1; continue;
+			case '9': state = S7; continue;
+			case ';': state = S8; continue;
+			case '?': state = S9; continue;
 			case 'A':
 			case 'B':
 			case 'C':
@@ -520,13 +1293,13 @@ z3(struct lx *lx)
 			case 'W':
 			case 'X':
 			case 'Y':
-			case 'Z': state = S15; continue;
-			case '_': state = S15; continue;
+			case 'Z': state = S7; continue;
+			case '_': state = S7; continue;
 			case 'a':
 			case 'b':
 			case 'c':
-			case 'd':
-			case 'e':
+			case 'd': state = S7; continue;
+			case 'e': state = S10; continue;
 			case 'f':
 			case 'g':
 			case 'h':
@@ -539,610 +1312,47 @@ z3(struct lx *lx)
 			case 'o':
 			case 'p':
 			case 'q':
-			case 'r':
-			case 's':
+			case 'r': state = S7; continue;
+			case 's': state = S11; continue;
 			case 't':
 			case 'u':
 			case 'v':
 			case 'w':
 			case 'x':
 			case 'y':
-			case 'z': state = S15; continue;
-			default:  lx_ungetc(lx, c); return TOK_IDENT;
-			}
-
-		case S3: /* e.g. "en" */
-			switch (c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9': state = S15; continue;
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F':
-			case 'G':
-			case 'H':
-			case 'I':
-			case 'J':
-			case 'K':
-			case 'L':
-			case 'M':
-			case 'N':
-			case 'O':
-			case 'P':
-			case 'Q':
-			case 'R':
-			case 'S':
-			case 'T':
-			case 'U':
-			case 'V':
-			case 'W':
-			case 'X':
-			case 'Y':
-			case 'Z': state = S15; continue;
-			case '_': state = S15; continue;
-			case 'a':
-			case 'b':
-			case 'c': state = S15; continue;
-			case 'd': state = S2; continue;
-			case 'e':
-			case 'f':
-			case 'g':
-			case 'h':
-			case 'i':
-			case 'j':
-			case 'k':
-			case 'l':
-			case 'm':
-			case 'n':
-			case 'o':
-			case 'p':
-			case 'q':
-			case 'r':
-			case 's':
-			case 't':
-			case 'u':
-			case 'v':
-			case 'w':
-			case 'x':
-			case 'y':
-			case 'z': state = S15; continue;
-			default:  lx_ungetc(lx, c); return TOK_IDENT;
-			}
-
-		case S4: /* e.g. "start:" */
-			lx_ungetc(lx, c); return TOK_START;
-
-		case S5: /* e.g. "start" */
-			switch (c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9': state = S15; continue;
-			case ':': state = S4; continue;
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F':
-			case 'G':
-			case 'H':
-			case 'I':
-			case 'J':
-			case 'K':
-			case 'L':
-			case 'M':
-			case 'N':
-			case 'O':
-			case 'P':
-			case 'Q':
-			case 'R':
-			case 'S':
-			case 'T':
-			case 'U':
-			case 'V':
-			case 'W':
-			case 'X':
-			case 'Y':
-			case 'Z': state = S15; continue;
-			case '_': state = S15; continue;
-			case 'a':
-			case 'b':
-			case 'c':
-			case 'd':
-			case 'e':
-			case 'f':
-			case 'g':
-			case 'h':
-			case 'i':
-			case 'j':
-			case 'k':
-			case 'l':
-			case 'm':
-			case 'n':
-			case 'o':
-			case 'p':
-			case 'q':
-			case 'r':
-			case 's':
-			case 't':
-			case 'u':
-			case 'v':
-			case 'w':
-			case 'x':
-			case 'y':
-			case 'z': state = S15; continue;
-			default:  lx_ungetc(lx, c); return TOK_IDENT;
-			}
-
-		case S6: /* e.g. "star" */
-			switch (c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9': state = S15; continue;
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F':
-			case 'G':
-			case 'H':
-			case 'I':
-			case 'J':
-			case 'K':
-			case 'L':
-			case 'M':
-			case 'N':
-			case 'O':
-			case 'P':
-			case 'Q':
-			case 'R':
-			case 'S':
-			case 'T':
-			case 'U':
-			case 'V':
-			case 'W':
-			case 'X':
-			case 'Y':
-			case 'Z': state = S15; continue;
-			case '_': state = S15; continue;
-			case 'a':
-			case 'b':
-			case 'c':
-			case 'd':
-			case 'e':
-			case 'f':
-			case 'g':
-			case 'h':
-			case 'i':
-			case 'j':
-			case 'k':
-			case 'l':
-			case 'm':
-			case 'n':
-			case 'o':
-			case 'p':
-			case 'q':
-			case 'r':
-			case 's': state = S15; continue;
-			case 't': state = S5; continue;
-			case 'u':
-			case 'v':
-			case 'w':
-			case 'x':
-			case 'y':
-			case 'z': state = S15; continue;
-			default:  lx_ungetc(lx, c); return TOK_IDENT;
-			}
-
-		case S7: /* e.g. "sta" */
-			switch (c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9': state = S15; continue;
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F':
-			case 'G':
-			case 'H':
-			case 'I':
-			case 'J':
-			case 'K':
-			case 'L':
-			case 'M':
-			case 'N':
-			case 'O':
-			case 'P':
-			case 'Q':
-			case 'R':
-			case 'S':
-			case 'T':
-			case 'U':
-			case 'V':
-			case 'W':
-			case 'X':
-			case 'Y':
-			case 'Z': state = S15; continue;
-			case '_': state = S15; continue;
-			case 'a':
-			case 'b':
-			case 'c':
-			case 'd':
-			case 'e':
-			case 'f':
-			case 'g':
-			case 'h':
-			case 'i':
-			case 'j':
-			case 'k':
-			case 'l':
-			case 'm':
-			case 'n':
-			case 'o':
-			case 'p':
-			case 'q': state = S15; continue;
-			case 'r': state = S6; continue;
-			case 's':
-			case 't':
-			case 'u':
-			case 'v':
-			case 'w':
-			case 'x':
-			case 'y':
-			case 'z': state = S15; continue;
-			default:  lx_ungetc(lx, c); return TOK_IDENT;
-			}
-
-		case S8: /* e.g. "st" */
-			switch (c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9': state = S15; continue;
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F':
-			case 'G':
-			case 'H':
-			case 'I':
-			case 'J':
-			case 'K':
-			case 'L':
-			case 'M':
-			case 'N':
-			case 'O':
-			case 'P':
-			case 'Q':
-			case 'R':
-			case 'S':
-			case 'T':
-			case 'U':
-			case 'V':
-			case 'W':
-			case 'X':
-			case 'Y':
-			case 'Z': state = S15; continue;
-			case '_': state = S15; continue;
-			case 'a': state = S7; continue;
-			case 'b':
-			case 'c':
-			case 'd':
-			case 'e':
-			case 'f':
-			case 'g':
-			case 'h':
-			case 'i':
-			case 'j':
-			case 'k':
-			case 'l':
-			case 'm':
-			case 'n':
-			case 'o':
-			case 'p':
-			case 'q':
-			case 'r':
-			case 's':
-			case 't':
-			case 'u':
-			case 'v':
-			case 'w':
-			case 'x':
-			case 'y':
-			case 'z': state = S15; continue;
-			default:  lx_ungetc(lx, c); return TOK_IDENT;
-			}
-
-		case S9: /* e.g. "#" */
-			lx_ungetc(lx, c); return lx->z = z2, lx->z(lx);
-
-		case S10: /* e.g. """ */
-			lx_ungetc(lx, c); return lx->z = z1, lx->z(lx);
-
-		case S11: /* e.g. "," */
-			lx_ungetc(lx, c); return TOK_COMMA;
-
-		case S12: /* e.g. "\'" */
-			lx_ungetc(lx, c); return lx->z = z0, lx->z(lx);
-
-		case S13: /* e.g. "s" */
-			switch (c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9': state = S15; continue;
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F':
-			case 'G':
-			case 'H':
-			case 'I':
-			case 'J':
-			case 'K':
-			case 'L':
-			case 'M':
-			case 'N':
-			case 'O':
-			case 'P':
-			case 'Q':
-			case 'R':
-			case 'S':
-			case 'T':
-			case 'U':
-			case 'V':
-			case 'W':
-			case 'X':
-			case 'Y':
-			case 'Z': state = S15; continue;
-			case '_': state = S15; continue;
-			case 'a':
-			case 'b':
-			case 'c':
-			case 'd':
-			case 'e':
-			case 'f':
-			case 'g':
-			case 'h':
-			case 'i':
-			case 'j':
-			case 'k':
-			case 'l':
-			case 'm':
-			case 'n':
-			case 'o':
-			case 'p':
-			case 'q':
-			case 'r':
-			case 's': state = S15; continue;
-			case 't': state = S8; continue;
-			case 'u':
-			case 'v':
-			case 'w':
-			case 'x':
-			case 'y':
-			case 'z': state = S15; continue;
-			default:  lx_ungetc(lx, c); return TOK_IDENT;
-			}
-
-		case S14: /* e.g. "e" */
-			switch (c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9': state = S15; continue;
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F':
-			case 'G':
-			case 'H':
-			case 'I':
-			case 'J':
-			case 'K':
-			case 'L':
-			case 'M':
-			case 'N':
-			case 'O':
-			case 'P':
-			case 'Q':
-			case 'R':
-			case 'S':
-			case 'T':
-			case 'U':
-			case 'V':
-			case 'W':
-			case 'X':
-			case 'Y':
-			case 'Z': state = S15; continue;
-			case '_': state = S15; continue;
-			case 'a':
-			case 'b':
-			case 'c':
-			case 'd':
-			case 'e':
-			case 'f':
-			case 'g':
-			case 'h':
-			case 'i':
-			case 'j':
-			case 'k':
-			case 'l':
-			case 'm': state = S15; continue;
-			case 'n': state = S3; continue;
-			case 'o':
-			case 'p':
-			case 'q':
-			case 'r':
-			case 's':
-			case 't':
-			case 'u':
-			case 'v':
-			case 'w':
-			case 'x':
-			case 'y':
-			case 'z': state = S15; continue;
-			default:  lx_ungetc(lx, c); return TOK_IDENT;
-			}
-
-		case S15: /* e.g. "a" */
-			switch (c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9':             continue;
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F':
-			case 'G':
-			case 'H':
-			case 'I':
-			case 'J':
-			case 'K':
-			case 'L':
-			case 'M':
-			case 'N':
-			case 'O':
-			case 'P':
-			case 'Q':
-			case 'R':
-			case 'S':
-			case 'T':
-			case 'U':
-			case 'V':
-			case 'W':
-			case 'X':
-			case 'Y':
-			case 'Z':             continue;
-			case '_':             continue;
-			case 'a':
-			case 'b':
-			case 'c':
-			case 'd':
-			case 'e':
-			case 'f':
-			case 'g':
-			case 'h':
-			case 'i':
-			case 'j':
-			case 'k':
-			case 'l':
-			case 'm':
-			case 'n':
-			case 'o':
-			case 'p':
-			case 'q':
-			case 'r':
-			case 's':
-			case 't':
-			case 'u':
-			case 'v':
-			case 'w':
-			case 'x':
-			case 'y':
-			case 'z':             continue;
-			default:  lx_ungetc(lx, c); return TOK_IDENT;
-			}
-
-		case S16: /* e.g. "-" */
-			switch (c) {
-			case '>': state = S0; continue;
+			case 'z': state = S7; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S17: /* e.g. "?" */
-			lx_ungetc(lx, c); return TOK_ANY;
-
-		case S18: /* e.g. "\t" */
+		case S1: /* e.g. "\t" */
 			switch (c) {
 			case '\t':
-			case '\n':             continue;
-			case '\r':             continue;
-			case ' ':             continue;
+			case '\n': continue;
+			case '\r': continue;
+			case ' ': continue;
 			default:  lx_ungetc(lx, c); return lx->z(lx);
 			}
 
-		case S19: /* e.g. ";" */
-			lx_ungetc(lx, c); return TOK_SEP;
+		case S2: /* e.g. """ */
+			lx_ungetc(lx, c); return lx->z = z1, lx->z(lx);
 
-		case S20: /* start */
+		case S3: /* e.g. "#" */
+			lx_ungetc(lx, c); return lx->z = z2, lx->z(lx);
+
+		case S4: /* e.g. "\'" */
+			lx_ungetc(lx, c); return lx->z = z0, lx->z(lx);
+
+		case S5: /* e.g. "," */
+			lx_ungetc(lx, c); return TOK_COMMA;
+
+		case S6: /* e.g. "-" */
 			switch (c) {
-			case '\t':
-			case '\n': state = S18; continue;
-			case '\r': state = S18; continue;
-			case ' ': state = S18; continue;
-			case '"': state = S10; continue;
-			case '#': state = S9; continue;
-			case '\'': state = S12; continue;
-			case ',': state = S11; continue;
-			case '-': state = S16; continue;
+			case '>': state = S12; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S7: /* e.g. "a" */
+			switch (c) {
 			case '0':
 			case '1':
 			case '2':
@@ -1152,9 +1362,7 @@ z3(struct lx *lx)
 			case '6':
 			case '7':
 			case '8':
-			case '9': state = S15; continue;
-			case ';': state = S19; continue;
-			case '?': state = S17; continue;
+			case '9': continue;
 			case 'A':
 			case 'B':
 			case 'C':
@@ -1180,13 +1388,13 @@ z3(struct lx *lx)
 			case 'W':
 			case 'X':
 			case 'Y':
-			case 'Z': state = S15; continue;
-			case '_': state = S15; continue;
+			case 'Z': continue;
+			case '_': continue;
 			case 'a':
 			case 'b':
 			case 'c':
-			case 'd': state = S15; continue;
-			case 'e': state = S14; continue;
+			case 'd':
+			case 'e':
 			case 'f':
 			case 'g':
 			case 'h':
@@ -1199,42 +1407,603 @@ z3(struct lx *lx)
 			case 'o':
 			case 'p':
 			case 'q':
-			case 'r': state = S15; continue;
-			case 's': state = S13; continue;
+			case 'r':
+			case 's':
 			case 't':
 			case 'u':
 			case 'v':
 			case 'w':
 			case 'x':
 			case 'y':
-			case 'z': state = S15; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			case 'z': continue;
+			default:  lx_ungetc(lx, c); return TOK_IDENT;
 			}
+
+		case S8: /* e.g. ";" */
+			lx_ungetc(lx, c); return TOK_SEP;
+
+		case S9: /* e.g. "?" */
+			lx_ungetc(lx, c); return TOK_ANY;
+
+		case S10: /* e.g. "e" */
+			switch (c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9': state = S7; continue;
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'G':
+			case 'H':
+			case 'I':
+			case 'J':
+			case 'K':
+			case 'L':
+			case 'M':
+			case 'N':
+			case 'O':
+			case 'P':
+			case 'Q':
+			case 'R':
+			case 'S':
+			case 'T':
+			case 'U':
+			case 'V':
+			case 'W':
+			case 'X':
+			case 'Y':
+			case 'Z': state = S7; continue;
+			case '_': state = S7; continue;
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f':
+			case 'g':
+			case 'h':
+			case 'i':
+			case 'j':
+			case 'k':
+			case 'l':
+			case 'm': state = S7; continue;
+			case 'n': state = S15; continue;
+			case 'o':
+			case 'p':
+			case 'q':
+			case 'r':
+			case 's':
+			case 't':
+			case 'u':
+			case 'v':
+			case 'w':
+			case 'x':
+			case 'y':
+			case 'z': state = S7; continue;
+			default:  lx_ungetc(lx, c); return TOK_IDENT;
+			}
+
+		case S11: /* e.g. "s" */
+			switch (c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9': state = S7; continue;
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'G':
+			case 'H':
+			case 'I':
+			case 'J':
+			case 'K':
+			case 'L':
+			case 'M':
+			case 'N':
+			case 'O':
+			case 'P':
+			case 'Q':
+			case 'R':
+			case 'S':
+			case 'T':
+			case 'U':
+			case 'V':
+			case 'W':
+			case 'X':
+			case 'Y':
+			case 'Z': state = S7; continue;
+			case '_': state = S7; continue;
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f':
+			case 'g':
+			case 'h':
+			case 'i':
+			case 'j':
+			case 'k':
+			case 'l':
+			case 'm':
+			case 'n':
+			case 'o':
+			case 'p':
+			case 'q':
+			case 'r':
+			case 's': state = S7; continue;
+			case 't': state = S13; continue;
+			case 'u':
+			case 'v':
+			case 'w':
+			case 'x':
+			case 'y':
+			case 'z': state = S7; continue;
+			default:  lx_ungetc(lx, c); return TOK_IDENT;
+			}
+
+		case S12: /* e.g. "->" */
+			lx_ungetc(lx, c); return TOK_TO;
+
+		case S13: /* e.g. "st" */
+			switch (c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9': state = S7; continue;
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'G':
+			case 'H':
+			case 'I':
+			case 'J':
+			case 'K':
+			case 'L':
+			case 'M':
+			case 'N':
+			case 'O':
+			case 'P':
+			case 'Q':
+			case 'R':
+			case 'S':
+			case 'T':
+			case 'U':
+			case 'V':
+			case 'W':
+			case 'X':
+			case 'Y':
+			case 'Z': state = S7; continue;
+			case '_': state = S7; continue;
+			case 'a': state = S14; continue;
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f':
+			case 'g':
+			case 'h':
+			case 'i':
+			case 'j':
+			case 'k':
+			case 'l':
+			case 'm':
+			case 'n':
+			case 'o':
+			case 'p':
+			case 'q':
+			case 'r':
+			case 's':
+			case 't':
+			case 'u':
+			case 'v':
+			case 'w':
+			case 'x':
+			case 'y':
+			case 'z': state = S7; continue;
+			default:  lx_ungetc(lx, c); return TOK_IDENT;
+			}
+
+		case S14: /* e.g. "sta" */
+			switch (c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9': state = S7; continue;
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'G':
+			case 'H':
+			case 'I':
+			case 'J':
+			case 'K':
+			case 'L':
+			case 'M':
+			case 'N':
+			case 'O':
+			case 'P':
+			case 'Q':
+			case 'R':
+			case 'S':
+			case 'T':
+			case 'U':
+			case 'V':
+			case 'W':
+			case 'X':
+			case 'Y':
+			case 'Z': state = S7; continue;
+			case '_': state = S7; continue;
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f':
+			case 'g':
+			case 'h':
+			case 'i':
+			case 'j':
+			case 'k':
+			case 'l':
+			case 'm':
+			case 'n':
+			case 'o':
+			case 'p':
+			case 'q': state = S7; continue;
+			case 'r': state = S17; continue;
+			case 's':
+			case 't':
+			case 'u':
+			case 'v':
+			case 'w':
+			case 'x':
+			case 'y':
+			case 'z': state = S7; continue;
+			default:  lx_ungetc(lx, c); return TOK_IDENT;
+			}
+
+		case S15: /* e.g. "en" */
+			switch (c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9': state = S7; continue;
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'G':
+			case 'H':
+			case 'I':
+			case 'J':
+			case 'K':
+			case 'L':
+			case 'M':
+			case 'N':
+			case 'O':
+			case 'P':
+			case 'Q':
+			case 'R':
+			case 'S':
+			case 'T':
+			case 'U':
+			case 'V':
+			case 'W':
+			case 'X':
+			case 'Y':
+			case 'Z': state = S7; continue;
+			case '_': state = S7; continue;
+			case 'a':
+			case 'b':
+			case 'c': state = S7; continue;
+			case 'd': state = S16; continue;
+			case 'e':
+			case 'f':
+			case 'g':
+			case 'h':
+			case 'i':
+			case 'j':
+			case 'k':
+			case 'l':
+			case 'm':
+			case 'n':
+			case 'o':
+			case 'p':
+			case 'q':
+			case 'r':
+			case 's':
+			case 't':
+			case 'u':
+			case 'v':
+			case 'w':
+			case 'x':
+			case 'y':
+			case 'z': state = S7; continue;
+			default:  lx_ungetc(lx, c); return TOK_IDENT;
+			}
+
+		case S16: /* e.g. "end" */
+			switch (c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9': state = S7; continue;
+			case ':': state = S18; continue;
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'G':
+			case 'H':
+			case 'I':
+			case 'J':
+			case 'K':
+			case 'L':
+			case 'M':
+			case 'N':
+			case 'O':
+			case 'P':
+			case 'Q':
+			case 'R':
+			case 'S':
+			case 'T':
+			case 'U':
+			case 'V':
+			case 'W':
+			case 'X':
+			case 'Y':
+			case 'Z': state = S7; continue;
+			case '_': state = S7; continue;
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f':
+			case 'g':
+			case 'h':
+			case 'i':
+			case 'j':
+			case 'k':
+			case 'l':
+			case 'm':
+			case 'n':
+			case 'o':
+			case 'p':
+			case 'q':
+			case 'r':
+			case 's':
+			case 't':
+			case 'u':
+			case 'v':
+			case 'w':
+			case 'x':
+			case 'y':
+			case 'z': state = S7; continue;
+			default:  lx_ungetc(lx, c); return TOK_IDENT;
+			}
+
+		case S17: /* e.g. "star" */
+			switch (c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9': state = S7; continue;
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'G':
+			case 'H':
+			case 'I':
+			case 'J':
+			case 'K':
+			case 'L':
+			case 'M':
+			case 'N':
+			case 'O':
+			case 'P':
+			case 'Q':
+			case 'R':
+			case 'S':
+			case 'T':
+			case 'U':
+			case 'V':
+			case 'W':
+			case 'X':
+			case 'Y':
+			case 'Z': state = S7; continue;
+			case '_': state = S7; continue;
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f':
+			case 'g':
+			case 'h':
+			case 'i':
+			case 'j':
+			case 'k':
+			case 'l':
+			case 'm':
+			case 'n':
+			case 'o':
+			case 'p':
+			case 'q':
+			case 'r':
+			case 's': state = S7; continue;
+			case 't': state = S19; continue;
+			case 'u':
+			case 'v':
+			case 'w':
+			case 'x':
+			case 'y':
+			case 'z': state = S7; continue;
+			default:  lx_ungetc(lx, c); return TOK_IDENT;
+			}
+
+		case S18: /* e.g. "end:" */
+			lx_ungetc(lx, c); return TOK_END;
+
+		case S19: /* e.g. "start" */
+			switch (c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9': state = S7; continue;
+			case ':': state = S20; continue;
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'G':
+			case 'H':
+			case 'I':
+			case 'J':
+			case 'K':
+			case 'L':
+			case 'M':
+			case 'N':
+			case 'O':
+			case 'P':
+			case 'Q':
+			case 'R':
+			case 'S':
+			case 'T':
+			case 'U':
+			case 'V':
+			case 'W':
+			case 'X':
+			case 'Y':
+			case 'Z': state = S7; continue;
+			case '_': state = S7; continue;
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f':
+			case 'g':
+			case 'h':
+			case 'i':
+			case 'j':
+			case 'k':
+			case 'l':
+			case 'm':
+			case 'n':
+			case 'o':
+			case 'p':
+			case 'q':
+			case 'r':
+			case 's':
+			case 't':
+			case 'u':
+			case 'v':
+			case 'w':
+			case 'x':
+			case 'y':
+			case 'z': state = S7; continue;
+			default:  lx_ungetc(lx, c); return TOK_IDENT;
+			}
+
+		case S20: /* e.g. "start:" */
+			lx_ungetc(lx, c); return TOK_START;
 		}
 	}
 
 	lx->lgetc = NULL;
 
 	switch (state) {
-	case S0: return TOK_TO;
-	case S1: return TOK_END;
-	case S2: return TOK_IDENT;
-	case S3: return TOK_IDENT;
-	case S4: return TOK_START;
-	case S5: return TOK_IDENT;
-	case S6: return TOK_IDENT;
+	case S1: return TOK_EOF;
+	case S2: return TOK_EOF;
+	case S3: return TOK_EOF;
+	case S4: return TOK_EOF;
+	case S5: return TOK_COMMA;
 	case S7: return TOK_IDENT;
-	case S8: return TOK_IDENT;
-	case S9: return TOK_EOF;
-	case S10: return TOK_EOF;
-	case S11: return TOK_COMMA;
-	case S12: return TOK_EOF;
+	case S8: return TOK_SEP;
+	case S9: return TOK_ANY;
+	case S10: return TOK_IDENT;
+	case S11: return TOK_IDENT;
+	case S12: return TOK_TO;
 	case S13: return TOK_IDENT;
 	case S14: return TOK_IDENT;
 	case S15: return TOK_IDENT;
-	case S17: return TOK_ANY;
-	case S18: return TOK_EOF;
-	case S19: return TOK_SEP;
+	case S16: return TOK_IDENT;
+	case S17: return TOK_IDENT;
+	case S18: return TOK_END;
+	case S19: return TOK_IDENT;
+	case S20: return TOK_START;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
 }
@@ -1276,7 +2045,7 @@ lx_example(enum lx_token (*z)(struct lx *), enum lx_token t)
 	} else
 	if (z == z1) {
 		switch (t) {
-		case TOK_CHAR: return "\\";
+		case TOK_CHAR: return "a";
 		case TOK_HEX: return "\\xa";
 		case TOK_OCT: return "\\0";
 		case TOK_ESC: return "\\f";
@@ -1295,7 +2064,7 @@ lx_example(enum lx_token (*z)(struct lx *), enum lx_token t)
 		case TOK_SEP: return ";";
 		case TOK_ANY: return "?";
 		case TOK_TO: return "->";
-		case TOK_IDENT: return "s";
+		case TOK_IDENT: return "a";
 		case TOK_END: return "end:";
 		case TOK_START: return "start:";
 		default: goto error;
@@ -1318,7 +2087,7 @@ lx_init(struct lx *lx)
 	*lx = lx_default;
 
 	lx->c = EOF;
-	lx->z = NULL;
+	lx->z = z3;
 
 	lx->end.byte = 0;
 	lx->end.line = 1;
@@ -1331,13 +2100,10 @@ lx_next(struct lx *lx)
 	enum lx_token t;
 
 	assert(lx != NULL);
+	assert(lx->z != NULL);
 
 	if (lx->lgetc == NULL) {
 		return TOK_EOF;
-	}
-
-	if (lx->z == NULL) {
-		lx->z = z3;
 	}
 
 	t = lx->z(lx);

--- a/src/libfsm/shortest.c
+++ b/src/libfsm/shortest.c
@@ -103,6 +103,8 @@ fsm_shortest(const struct fsm *fsm,
 					v->cost = u->cost + c;
 					v->prev = u;
 					v->type = e->symbol;
+
+					priq_update(&todo, v, v->cost);
 				}
 			}
 		}

--- a/src/libre/dialect/glob/lexer.c
+++ b/src/libre/dialect/glob/lexer.c
@@ -9,6 +9,9 @@
 
 static enum lx_glob_token z0(struct lx_glob_lx *lx);
 
+#if __STDC_VERSION__ >= 199901L
+inline
+#endif
 static int
 lx_getc(struct lx_glob_lx *lx)
 {
@@ -37,6 +40,9 @@ lx_getc(struct lx_glob_lx *lx)
 	return c;
 }
 
+#if __STDC_VERSION__ >= 199901L
+inline
+#endif
 static void
 lx_glob_ungetc(struct lx_glob_lx *lx, int c)
 {
@@ -56,15 +62,6 @@ lx_glob_ungetc(struct lx_glob_lx *lx, int c)
 		lx->end.line--;
 		lx->end.col = 0; /* XXX: lost information */
 	}
-}
-
-int
-lx_glob_fgetc(struct lx_glob_lx *lx)
-{
-	assert(lx != NULL);
-	assert(lx->opaque != NULL);
-
-	return fgetc(lx->opaque);
 }
 
 int
@@ -191,7 +188,7 @@ z0(struct lx_glob_lx *lx)
 		lx->clear(lx);
 	}
 
-	state = S3;
+	state = S0;
 
 	lx->start = lx->end;
 
@@ -203,30 +200,284 @@ z0(struct lx_glob_lx *lx)
 		}
 
 		switch (state) {
-		case S0: /* e.g. "?" */
-			lx_glob_ungetc(lx, c); return TOK_ANY;
+		case S0: /* start */
+			switch (c) {
+			case '\x00':
+			case '\x01':
+			case '\x02':
+			case '\x03':
+			case '\x04':
+			case '\x05':
+			case '\x06':
+			case '\a':
+			case '\b':
+			case '\t':
+			case '\n':
+			case '\v':
+			case '\f':
+			case '\r':
+			case '\x0e':
+			case '\x0f':
+			case '\x10':
+			case '\x11':
+			case '\x12':
+			case '\x13':
+			case '\x14':
+			case '\x15':
+			case '\x16':
+			case '\x17':
+			case '\x18':
+			case '\x19':
+			case '\x1a':
+			case '\x1b':
+			case '\x1c':
+			case '\x1d':
+			case '\x1e':
+			case '\x1f':
+			case ' ':
+			case '!':
+			case '"':
+			case '#':
+			case '$':
+			case '%':
+			case '&':
+			case '\'':
+			case '(':
+			case ')': state = S1; continue;
+			case '*': state = S2; continue;
+			case '+':
+			case ',':
+			case '-':
+			case '.':
+			case '\x2f':
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9':
+			case ':':
+			case ';':
+			case '<':
+			case '=':
+			case '>': state = S1; continue;
+			case '?': state = S3; continue;
+			case '@':
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'G':
+			case 'H':
+			case 'I':
+			case 'J':
+			case 'K':
+			case 'L':
+			case 'M':
+			case 'N':
+			case 'O':
+			case 'P':
+			case 'Q':
+			case 'R':
+			case 'S':
+			case 'T':
+			case 'U':
+			case 'V':
+			case 'W':
+			case 'X':
+			case 'Y':
+			case 'Z':
+			case '[':
+			case '\\':
+			case ']':
+			case '^':
+			case '_':
+			case '`':
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f':
+			case 'g':
+			case 'h':
+			case 'i':
+			case 'j':
+			case 'k':
+			case 'l':
+			case 'm':
+			case 'n':
+			case 'o':
+			case 'p':
+			case 'q':
+			case 'r':
+			case 's':
+			case 't':
+			case 'u':
+			case 'v':
+			case 'w':
+			case 'x':
+			case 'y':
+			case 'z':
+			case '{':
+			case '|':
+			case '}':
+			case '~':
+			case '\x7f':
+			case '\x80':
+			case '\x81':
+			case '\x82':
+			case '\x83':
+			case '\x84':
+			case '\x85':
+			case '\x86':
+			case '\x87':
+			case '\x88':
+			case '\x89':
+			case '\x8a':
+			case '\x8b':
+			case '\x8c':
+			case '\x8d':
+			case '\x8e':
+			case '\x8f':
+			case '\x90':
+			case '\x91':
+			case '\x92':
+			case '\x93':
+			case '\x94':
+			case '\x95':
+			case '\x96':
+			case '\x97':
+			case '\x98':
+			case '\x99':
+			case '\x9a':
+			case '\x9b':
+			case '\x9c':
+			case '\x9d':
+			case '\x9e':
+			case '\x9f':
+			case '\xa0':
+			case '\xa1':
+			case '\xa2':
+			case '\xa3':
+			case '\xa4':
+			case '\xa5':
+			case '\xa6':
+			case '\xa7':
+			case '\xa8':
+			case '\xa9':
+			case '\xaa':
+			case '\xab':
+			case '\xac':
+			case '\xad':
+			case '\xae':
+			case '\xaf':
+			case '\xb0':
+			case '\xb1':
+			case '\xb2':
+			case '\xb3':
+			case '\xb4':
+			case '\xb5':
+			case '\xb6':
+			case '\xb7':
+			case '\xb8':
+			case '\xb9':
+			case '\xba':
+			case '\xbb':
+			case '\xbc':
+			case '\xbd':
+			case '\xbe':
+			case '\xbf':
+			case '\xc0':
+			case '\xc1':
+			case '\xc2':
+			case '\xc3':
+			case '\xc4':
+			case '\xc5':
+			case '\xc6':
+			case '\xc7':
+			case '\xc8':
+			case '\xc9':
+			case '\xca':
+			case '\xcb':
+			case '\xcc':
+			case '\xcd':
+			case '\xce':
+			case '\xcf':
+			case '\xd0':
+			case '\xd1':
+			case '\xd2':
+			case '\xd3':
+			case '\xd4':
+			case '\xd5':
+			case '\xd6':
+			case '\xd7':
+			case '\xd8':
+			case '\xd9':
+			case '\xda':
+			case '\xdb':
+			case '\xdc':
+			case '\xdd':
+			case '\xde':
+			case '\xdf':
+			case '\xe0':
+			case '\xe1':
+			case '\xe2':
+			case '\xe3':
+			case '\xe4':
+			case '\xe5':
+			case '\xe6':
+			case '\xe7':
+			case '\xe8':
+			case '\xe9':
+			case '\xea':
+			case '\xeb':
+			case '\xec':
+			case '\xed':
+			case '\xee':
+			case '\xef':
+			case '\xf0':
+			case '\xf1':
+			case '\xf2':
+			case '\xf3':
+			case '\xf4':
+			case '\xf5':
+			case '\xf6':
+			case '\xf7':
+			case '\xf8':
+			case '\xf9':
+			case '\xfa':
+			case '\xfb':
+			case '\xfc':
+			case '\xfd':
+			case '\xfe':
+			case '\xff': state = S1; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
 
-		case S1: /* e.g. "*" */
-			lx_glob_ungetc(lx, c); return TOK_MANY;
-
-		case S2: /* e.g. "a" */
+		case S1: /* e.g. "a" */
 			lx_glob_ungetc(lx, c); return TOK_CHAR;
 
-		case S3: /* start */
-			switch (c) {
-			case '*': state = S1; continue;
-			case '?': state = S0; continue;
-			default:  state = S2; continue;
-			}
+		case S2: /* e.g. "*" */
+			lx_glob_ungetc(lx, c); return TOK_MANY;
+
+		case S3: /* e.g. "?" */
+			lx_glob_ungetc(lx, c); return TOK_ANY;
 		}
 	}
 
 	lx->lgetc = NULL;
 
 	switch (state) {
-	case S0: return TOK_ANY;
-	case S1: return TOK_MANY;
-	case S2: return TOK_CHAR;
+	case S1: return TOK_CHAR;
+	case S2: return TOK_MANY;
+	case S3: return TOK_ANY;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
 }
@@ -275,7 +526,7 @@ lx_glob_init(struct lx_glob_lx *lx)
 	*lx = lx_default;
 
 	lx->c = EOF;
-	lx->z = NULL;
+	lx->z = z0;
 
 	lx->end.byte = 0;
 	lx->end.line = 1;
@@ -288,13 +539,10 @@ lx_glob_next(struct lx_glob_lx *lx)
 	enum lx_glob_token t;
 
 	assert(lx != NULL);
+	assert(lx->z != NULL);
 
 	if (lx->lgetc == NULL) {
 		return TOK_EOF;
-	}
-
-	if (lx->z == NULL) {
-		lx->z = z0;
 	}
 
 	t = lx->z(lx);

--- a/src/libre/dialect/glob/lexer.h
+++ b/src/libre/dialect/glob/lexer.h
@@ -82,8 +82,6 @@ const char *lx_glob_example(enum lx_glob_token (*z)(struct lx_glob_lx *), enum l
 void lx_glob_init(struct lx_glob_lx *lx);
 enum lx_glob_token lx_glob_next(struct lx_glob_lx *lx);
 
-int lx_glob_fgetc(struct lx_glob_lx *lx);
-
 int  lx_glob_dynpush(struct lx_glob_lx *lx, char c);
 void lx_glob_dynpop(struct lx_glob_lx *lx);
 int  lx_glob_dynclear(struct lx_glob_lx *lx);

--- a/src/libre/dialect/like/lexer.c
+++ b/src/libre/dialect/like/lexer.c
@@ -9,6 +9,9 @@
 
 static enum lx_like_token z0(struct lx_like_lx *lx);
 
+#if __STDC_VERSION__ >= 199901L
+inline
+#endif
 static int
 lx_getc(struct lx_like_lx *lx)
 {
@@ -37,6 +40,9 @@ lx_getc(struct lx_like_lx *lx)
 	return c;
 }
 
+#if __STDC_VERSION__ >= 199901L
+inline
+#endif
 static void
 lx_like_ungetc(struct lx_like_lx *lx, int c)
 {
@@ -56,15 +62,6 @@ lx_like_ungetc(struct lx_like_lx *lx, int c)
 		lx->end.line--;
 		lx->end.col = 0; /* XXX: lost information */
 	}
-}
-
-int
-lx_like_fgetc(struct lx_like_lx *lx)
-{
-	assert(lx != NULL);
-	assert(lx->opaque != NULL);
-
-	return fgetc(lx->opaque);
 }
 
 int
@@ -191,7 +188,7 @@ z0(struct lx_like_lx *lx)
 		lx->clear(lx);
 	}
 
-	state = S3;
+	state = S0;
 
 	lx->start = lx->end;
 
@@ -203,30 +200,284 @@ z0(struct lx_like_lx *lx)
 		}
 
 		switch (state) {
-		case S0: /* e.g. "_" */
-			lx_like_ungetc(lx, c); return TOK_ANY;
+		case S0: /* start */
+			switch (c) {
+			case '\x00':
+			case '\x01':
+			case '\x02':
+			case '\x03':
+			case '\x04':
+			case '\x05':
+			case '\x06':
+			case '\a':
+			case '\b':
+			case '\t':
+			case '\n':
+			case '\v':
+			case '\f':
+			case '\r':
+			case '\x0e':
+			case '\x0f':
+			case '\x10':
+			case '\x11':
+			case '\x12':
+			case '\x13':
+			case '\x14':
+			case '\x15':
+			case '\x16':
+			case '\x17':
+			case '\x18':
+			case '\x19':
+			case '\x1a':
+			case '\x1b':
+			case '\x1c':
+			case '\x1d':
+			case '\x1e':
+			case '\x1f':
+			case ' ':
+			case '!':
+			case '"':
+			case '#':
+			case '$': state = S1; continue;
+			case '%': state = S2; continue;
+			case '&':
+			case '\'':
+			case '(':
+			case ')':
+			case '*':
+			case '+':
+			case ',':
+			case '-':
+			case '.':
+			case '\x2f':
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9':
+			case ':':
+			case ';':
+			case '<':
+			case '=':
+			case '>':
+			case '?':
+			case '@':
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'G':
+			case 'H':
+			case 'I':
+			case 'J':
+			case 'K':
+			case 'L':
+			case 'M':
+			case 'N':
+			case 'O':
+			case 'P':
+			case 'Q':
+			case 'R':
+			case 'S':
+			case 'T':
+			case 'U':
+			case 'V':
+			case 'W':
+			case 'X':
+			case 'Y':
+			case 'Z':
+			case '[':
+			case '\\':
+			case ']':
+			case '^': state = S1; continue;
+			case '_': state = S3; continue;
+			case '`':
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f':
+			case 'g':
+			case 'h':
+			case 'i':
+			case 'j':
+			case 'k':
+			case 'l':
+			case 'm':
+			case 'n':
+			case 'o':
+			case 'p':
+			case 'q':
+			case 'r':
+			case 's':
+			case 't':
+			case 'u':
+			case 'v':
+			case 'w':
+			case 'x':
+			case 'y':
+			case 'z':
+			case '{':
+			case '|':
+			case '}':
+			case '~':
+			case '\x7f':
+			case '\x80':
+			case '\x81':
+			case '\x82':
+			case '\x83':
+			case '\x84':
+			case '\x85':
+			case '\x86':
+			case '\x87':
+			case '\x88':
+			case '\x89':
+			case '\x8a':
+			case '\x8b':
+			case '\x8c':
+			case '\x8d':
+			case '\x8e':
+			case '\x8f':
+			case '\x90':
+			case '\x91':
+			case '\x92':
+			case '\x93':
+			case '\x94':
+			case '\x95':
+			case '\x96':
+			case '\x97':
+			case '\x98':
+			case '\x99':
+			case '\x9a':
+			case '\x9b':
+			case '\x9c':
+			case '\x9d':
+			case '\x9e':
+			case '\x9f':
+			case '\xa0':
+			case '\xa1':
+			case '\xa2':
+			case '\xa3':
+			case '\xa4':
+			case '\xa5':
+			case '\xa6':
+			case '\xa7':
+			case '\xa8':
+			case '\xa9':
+			case '\xaa':
+			case '\xab':
+			case '\xac':
+			case '\xad':
+			case '\xae':
+			case '\xaf':
+			case '\xb0':
+			case '\xb1':
+			case '\xb2':
+			case '\xb3':
+			case '\xb4':
+			case '\xb5':
+			case '\xb6':
+			case '\xb7':
+			case '\xb8':
+			case '\xb9':
+			case '\xba':
+			case '\xbb':
+			case '\xbc':
+			case '\xbd':
+			case '\xbe':
+			case '\xbf':
+			case '\xc0':
+			case '\xc1':
+			case '\xc2':
+			case '\xc3':
+			case '\xc4':
+			case '\xc5':
+			case '\xc6':
+			case '\xc7':
+			case '\xc8':
+			case '\xc9':
+			case '\xca':
+			case '\xcb':
+			case '\xcc':
+			case '\xcd':
+			case '\xce':
+			case '\xcf':
+			case '\xd0':
+			case '\xd1':
+			case '\xd2':
+			case '\xd3':
+			case '\xd4':
+			case '\xd5':
+			case '\xd6':
+			case '\xd7':
+			case '\xd8':
+			case '\xd9':
+			case '\xda':
+			case '\xdb':
+			case '\xdc':
+			case '\xdd':
+			case '\xde':
+			case '\xdf':
+			case '\xe0':
+			case '\xe1':
+			case '\xe2':
+			case '\xe3':
+			case '\xe4':
+			case '\xe5':
+			case '\xe6':
+			case '\xe7':
+			case '\xe8':
+			case '\xe9':
+			case '\xea':
+			case '\xeb':
+			case '\xec':
+			case '\xed':
+			case '\xee':
+			case '\xef':
+			case '\xf0':
+			case '\xf1':
+			case '\xf2':
+			case '\xf3':
+			case '\xf4':
+			case '\xf5':
+			case '\xf6':
+			case '\xf7':
+			case '\xf8':
+			case '\xf9':
+			case '\xfa':
+			case '\xfb':
+			case '\xfc':
+			case '\xfd':
+			case '\xfe':
+			case '\xff': state = S1; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
 
-		case S1: /* e.g. "%" */
-			lx_like_ungetc(lx, c); return TOK_MANY;
-
-		case S2: /* e.g. "a" */
+		case S1: /* e.g. "a" */
 			lx_like_ungetc(lx, c); return TOK_CHAR;
 
-		case S3: /* start */
-			switch (c) {
-			case '%': state = S1; continue;
-			case '_': state = S0; continue;
-			default:  state = S2; continue;
-			}
+		case S2: /* e.g. "%" */
+			lx_like_ungetc(lx, c); return TOK_MANY;
+
+		case S3: /* e.g. "_" */
+			lx_like_ungetc(lx, c); return TOK_ANY;
 		}
 	}
 
 	lx->lgetc = NULL;
 
 	switch (state) {
-	case S0: return TOK_ANY;
-	case S1: return TOK_MANY;
-	case S2: return TOK_CHAR;
+	case S1: return TOK_CHAR;
+	case S2: return TOK_MANY;
+	case S3: return TOK_ANY;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
 }
@@ -275,7 +526,7 @@ lx_like_init(struct lx_like_lx *lx)
 	*lx = lx_default;
 
 	lx->c = EOF;
-	lx->z = NULL;
+	lx->z = z0;
 
 	lx->end.byte = 0;
 	lx->end.line = 1;
@@ -288,13 +539,10 @@ lx_like_next(struct lx_like_lx *lx)
 	enum lx_like_token t;
 
 	assert(lx != NULL);
+	assert(lx->z != NULL);
 
 	if (lx->lgetc == NULL) {
 		return TOK_EOF;
-	}
-
-	if (lx->z == NULL) {
-		lx->z = z0;
 	}
 
 	t = lx->z(lx);

--- a/src/libre/dialect/like/lexer.h
+++ b/src/libre/dialect/like/lexer.h
@@ -82,8 +82,6 @@ const char *lx_like_example(enum lx_like_token (*z)(struct lx_like_lx *), enum l
 void lx_like_init(struct lx_like_lx *lx);
 enum lx_like_token lx_like_next(struct lx_like_lx *lx);
 
-int lx_like_fgetc(struct lx_like_lx *lx);
-
 int  lx_like_dynpush(struct lx_like_lx *lx, char c);
 void lx_like_dynpop(struct lx_like_lx *lx);
 int  lx_like_dynclear(struct lx_like_lx *lx);

--- a/src/libre/dialect/literal/lexer.c
+++ b/src/libre/dialect/literal/lexer.c
@@ -9,6 +9,9 @@
 
 static enum lx_literal_token z0(struct lx_literal_lx *lx);
 
+#if __STDC_VERSION__ >= 199901L
+inline
+#endif
 static int
 lx_getc(struct lx_literal_lx *lx)
 {
@@ -37,6 +40,9 @@ lx_getc(struct lx_literal_lx *lx)
 	return c;
 }
 
+#if __STDC_VERSION__ >= 199901L
+inline
+#endif
 static void
 lx_literal_ungetc(struct lx_literal_lx *lx, int c)
 {
@@ -56,15 +62,6 @@ lx_literal_ungetc(struct lx_literal_lx *lx, int c)
 		lx->end.line--;
 		lx->end.col = 0; /* XXX: lost information */
 	}
-}
-
-int
-lx_literal_fgetc(struct lx_literal_lx *lx)
-{
-	assert(lx != NULL);
-	assert(lx->opaque != NULL);
-
-	return fgetc(lx->opaque);
 }
 
 int
@@ -191,7 +188,7 @@ z0(struct lx_literal_lx *lx)
 		lx->clear(lx);
 	}
 
-	state = S1;
+	state = S0;
 
 	lx->start = lx->end;
 
@@ -203,20 +200,276 @@ z0(struct lx_literal_lx *lx)
 		}
 
 		switch (state) {
-		case S0: /* e.g. "a" */
-			lx_literal_ungetc(lx, c); return TOK_CHAR;
-
-		case S1: /* start */
+		case S0: /* start */
 			switch (c) {
-			default:  state = S0; continue;
+			case '\x00':
+			case '\x01':
+			case '\x02':
+			case '\x03':
+			case '\x04':
+			case '\x05':
+			case '\x06':
+			case '\a':
+			case '\b':
+			case '\t':
+			case '\n':
+			case '\v':
+			case '\f':
+			case '\r':
+			case '\x0e':
+			case '\x0f':
+			case '\x10':
+			case '\x11':
+			case '\x12':
+			case '\x13':
+			case '\x14':
+			case '\x15':
+			case '\x16':
+			case '\x17':
+			case '\x18':
+			case '\x19':
+			case '\x1a':
+			case '\x1b':
+			case '\x1c':
+			case '\x1d':
+			case '\x1e':
+			case '\x1f':
+			case ' ':
+			case '!':
+			case '"':
+			case '#':
+			case '$':
+			case '%':
+			case '&':
+			case '\'':
+			case '(':
+			case ')':
+			case '*':
+			case '+':
+			case ',':
+			case '-':
+			case '.':
+			case '\x2f':
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9':
+			case ':':
+			case ';':
+			case '<':
+			case '=':
+			case '>':
+			case '?':
+			case '@':
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'G':
+			case 'H':
+			case 'I':
+			case 'J':
+			case 'K':
+			case 'L':
+			case 'M':
+			case 'N':
+			case 'O':
+			case 'P':
+			case 'Q':
+			case 'R':
+			case 'S':
+			case 'T':
+			case 'U':
+			case 'V':
+			case 'W':
+			case 'X':
+			case 'Y':
+			case 'Z':
+			case '[':
+			case '\\':
+			case ']':
+			case '^':
+			case '_':
+			case '`':
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f':
+			case 'g':
+			case 'h':
+			case 'i':
+			case 'j':
+			case 'k':
+			case 'l':
+			case 'm':
+			case 'n':
+			case 'o':
+			case 'p':
+			case 'q':
+			case 'r':
+			case 's':
+			case 't':
+			case 'u':
+			case 'v':
+			case 'w':
+			case 'x':
+			case 'y':
+			case 'z':
+			case '{':
+			case '|':
+			case '}':
+			case '~':
+			case '\x7f':
+			case '\x80':
+			case '\x81':
+			case '\x82':
+			case '\x83':
+			case '\x84':
+			case '\x85':
+			case '\x86':
+			case '\x87':
+			case '\x88':
+			case '\x89':
+			case '\x8a':
+			case '\x8b':
+			case '\x8c':
+			case '\x8d':
+			case '\x8e':
+			case '\x8f':
+			case '\x90':
+			case '\x91':
+			case '\x92':
+			case '\x93':
+			case '\x94':
+			case '\x95':
+			case '\x96':
+			case '\x97':
+			case '\x98':
+			case '\x99':
+			case '\x9a':
+			case '\x9b':
+			case '\x9c':
+			case '\x9d':
+			case '\x9e':
+			case '\x9f':
+			case '\xa0':
+			case '\xa1':
+			case '\xa2':
+			case '\xa3':
+			case '\xa4':
+			case '\xa5':
+			case '\xa6':
+			case '\xa7':
+			case '\xa8':
+			case '\xa9':
+			case '\xaa':
+			case '\xab':
+			case '\xac':
+			case '\xad':
+			case '\xae':
+			case '\xaf':
+			case '\xb0':
+			case '\xb1':
+			case '\xb2':
+			case '\xb3':
+			case '\xb4':
+			case '\xb5':
+			case '\xb6':
+			case '\xb7':
+			case '\xb8':
+			case '\xb9':
+			case '\xba':
+			case '\xbb':
+			case '\xbc':
+			case '\xbd':
+			case '\xbe':
+			case '\xbf':
+			case '\xc0':
+			case '\xc1':
+			case '\xc2':
+			case '\xc3':
+			case '\xc4':
+			case '\xc5':
+			case '\xc6':
+			case '\xc7':
+			case '\xc8':
+			case '\xc9':
+			case '\xca':
+			case '\xcb':
+			case '\xcc':
+			case '\xcd':
+			case '\xce':
+			case '\xcf':
+			case '\xd0':
+			case '\xd1':
+			case '\xd2':
+			case '\xd3':
+			case '\xd4':
+			case '\xd5':
+			case '\xd6':
+			case '\xd7':
+			case '\xd8':
+			case '\xd9':
+			case '\xda':
+			case '\xdb':
+			case '\xdc':
+			case '\xdd':
+			case '\xde':
+			case '\xdf':
+			case '\xe0':
+			case '\xe1':
+			case '\xe2':
+			case '\xe3':
+			case '\xe4':
+			case '\xe5':
+			case '\xe6':
+			case '\xe7':
+			case '\xe8':
+			case '\xe9':
+			case '\xea':
+			case '\xeb':
+			case '\xec':
+			case '\xed':
+			case '\xee':
+			case '\xef':
+			case '\xf0':
+			case '\xf1':
+			case '\xf2':
+			case '\xf3':
+			case '\xf4':
+			case '\xf5':
+			case '\xf6':
+			case '\xf7':
+			case '\xf8':
+			case '\xf9':
+			case '\xfa':
+			case '\xfb':
+			case '\xfc':
+			case '\xfd':
+			case '\xfe':
+			case '\xff': state = S1; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
+
+		case S1: /* e.g. "a" */
+			lx_literal_ungetc(lx, c); return TOK_CHAR;
 		}
 	}
 
 	lx->lgetc = NULL;
 
 	switch (state) {
-	case S0: return TOK_CHAR;
+	case S1: return TOK_CHAR;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
 }
@@ -261,7 +514,7 @@ lx_literal_init(struct lx_literal_lx *lx)
 	*lx = lx_default;
 
 	lx->c = EOF;
-	lx->z = NULL;
+	lx->z = z0;
 
 	lx->end.byte = 0;
 	lx->end.line = 1;
@@ -274,13 +527,10 @@ lx_literal_next(struct lx_literal_lx *lx)
 	enum lx_literal_token t;
 
 	assert(lx != NULL);
+	assert(lx->z != NULL);
 
 	if (lx->lgetc == NULL) {
 		return TOK_EOF;
-	}
-
-	if (lx->z == NULL) {
-		lx->z = z0;
 	}
 
 	t = lx->z(lx);

--- a/src/libre/dialect/literal/lexer.h
+++ b/src/libre/dialect/literal/lexer.h
@@ -80,8 +80,6 @@ const char *lx_literal_example(enum lx_literal_token (*z)(struct lx_literal_lx *
 void lx_literal_init(struct lx_literal_lx *lx);
 enum lx_literal_token lx_literal_next(struct lx_literal_lx *lx);
 
-int lx_literal_fgetc(struct lx_literal_lx *lx);
-
 int  lx_literal_dynpush(struct lx_literal_lx *lx, char c);
 void lx_literal_dynpop(struct lx_literal_lx *lx);
 int  lx_literal_dynclear(struct lx_literal_lx *lx);

--- a/src/libre/dialect/native/lexer.c
+++ b/src/libre/dialect/native/lexer.c
@@ -11,6 +11,9 @@ static enum lx_native_token z0(struct lx_native_lx *lx);
 static enum lx_native_token z1(struct lx_native_lx *lx);
 static enum lx_native_token z2(struct lx_native_lx *lx);
 
+#if __STDC_VERSION__ >= 199901L
+inline
+#endif
 static int
 lx_getc(struct lx_native_lx *lx)
 {
@@ -39,6 +42,9 @@ lx_getc(struct lx_native_lx *lx)
 	return c;
 }
 
+#if __STDC_VERSION__ >= 199901L
+inline
+#endif
 static void
 lx_native_ungetc(struct lx_native_lx *lx, int c)
 {
@@ -58,15 +64,6 @@ lx_native_ungetc(struct lx_native_lx *lx, int c)
 		lx->end.line--;
 		lx->end.col = 0; /* XXX: lost information */
 	}
-}
-
-int
-lx_native_fgetc(struct lx_native_lx *lx)
-{
-	assert(lx != NULL);
-	assert(lx->opaque != NULL);
-
-	return fgetc(lx->opaque);
 }
 
 int
@@ -193,7 +190,7 @@ z0(struct lx_native_lx *lx)
 		lx->clear(lx);
 	}
 
-	state = S3;
+	state = S0;
 
 	lx->start = lx->end;
 
@@ -205,11 +202,25 @@ z0(struct lx_native_lx *lx)
 		}
 
 		switch (state) {
-		case S0: /* e.g. "," */
-			lx_native_ungetc(lx, c); return TOK_SEP;
+		case S0: /* start */
+			switch (c) {
+			case ',': state = S1; continue;
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9': state = S2; continue;
+			case '}': state = S3; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
 
-		case S1: /* e.g. "}" */
-			lx_native_ungetc(lx, c); return lx->z = z2, TOK_CLOSECOUNT;
+		case S1: /* e.g. "," */
+			lx_native_ungetc(lx, c); return TOK_SEP;
 
 		case S2: /* e.g. "0" */
 			switch (c) {
@@ -222,35 +233,21 @@ z0(struct lx_native_lx *lx)
 			case '6':
 			case '7':
 			case '8':
-			case '9':             continue;
+			case '9': continue;
 			default:  lx_native_ungetc(lx, c); return TOK_COUNT;
 			}
 
-		case S3: /* start */
-			switch (c) {
-			case ',': state = S0; continue;
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9': state = S2; continue;
-			case '}': state = S1; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
+		case S3: /* e.g. "}" */
+			lx_native_ungetc(lx, c); return lx->z = z2, TOK_CLOSECOUNT;
 		}
 	}
 
 	lx->lgetc = NULL;
 
 	switch (state) {
-	case S0: return TOK_SEP;
-	case S1: return TOK_CLOSECOUNT;
+	case S1: return TOK_SEP;
 	case S2: return TOK_COUNT;
+	case S3: return TOK_CLOSECOUNT;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
 }
@@ -271,7 +268,7 @@ z1(struct lx_native_lx *lx)
 		lx->clear(lx);
 	}
 
-	state = S9;
+	state = S0;
 
 	lx->start = lx->end;
 
@@ -283,8 +280,56 @@ z1(struct lx_native_lx *lx)
 		}
 
 		switch (state) {
-		case S0: /* e.g. "\\xa" */
+		case S0: /* start */
 			switch (c) {
+			case '\x00':
+			case '\x01':
+			case '\x02':
+			case '\x03':
+			case '\x04':
+			case '\x05':
+			case '\x06':
+			case '\a':
+			case '\b':
+			case '\t':
+			case '\n':
+			case '\v':
+			case '\f':
+			case '\r':
+			case '\x0e':
+			case '\x0f':
+			case '\x10':
+			case '\x11':
+			case '\x12':
+			case '\x13':
+			case '\x14':
+			case '\x15':
+			case '\x16':
+			case '\x17':
+			case '\x18':
+			case '\x19':
+			case '\x1a':
+			case '\x1b':
+			case '\x1c':
+			case '\x1d':
+			case '\x1e':
+			case '\x1f':
+			case ' ':
+			case '!':
+			case '"':
+			case '#':
+			case '$':
+			case '%':
+			case '&':
+			case '\'':
+			case '(':
+			case ')':
+			case '*':
+			case '+':
+			case ',': state = S1; continue;
+			case '-': state = S2; continue;
+			case '.':
+			case '\x2f':
 			case '0':
 			case '1':
 			case '2':
@@ -294,53 +339,246 @@ z1(struct lx_native_lx *lx)
 			case '6':
 			case '7':
 			case '8':
-			case '9':             continue;
+			case '9':
+			case ':':
+			case ';':
+			case '<':
+			case '=':
+			case '>':
+			case '?':
+			case '@':
 			case 'A':
 			case 'B':
 			case 'C':
 			case 'D':
 			case 'E':
-			case 'F':             continue;
+			case 'F':
+			case 'G':
+			case 'H':
+			case 'I':
+			case 'J':
+			case 'K':
+			case 'L':
+			case 'M':
+			case 'N':
+			case 'O':
+			case 'P':
+			case 'Q':
+			case 'R':
+			case 'S':
+			case 'T':
+			case 'U':
+			case 'V':
+			case 'W':
+			case 'X':
+			case 'Y':
+			case 'Z':
+			case '[': state = S1; continue;
+			case '\\': state = S3; continue;
+			case ']': state = S4; continue;
+			case '^': state = S5; continue;
+			case '_':
+			case '`':
 			case 'a':
 			case 'b':
 			case 'c':
 			case 'd':
 			case 'e':
-			case 'f':             continue;
-			default:  lx_native_ungetc(lx, c); return TOK_HEX;
-			}
-
-		case S1: /* e.g. "\\f" */
-			lx_native_ungetc(lx, c); return TOK_ESC;
-
-		case S2: /* e.g. "\\x" */
-			switch (c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9': state = S0; continue;
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F': state = S0; continue;
-			case 'a':
-			case 'b':
-			case 'c':
-			case 'd':
-			case 'e':
-			case 'f': state = S0; continue;
+			case 'f':
+			case 'g':
+			case 'h':
+			case 'i':
+			case 'j':
+			case 'k':
+			case 'l':
+			case 'm':
+			case 'n':
+			case 'o':
+			case 'p':
+			case 'q':
+			case 'r':
+			case 's':
+			case 't':
+			case 'u':
+			case 'v':
+			case 'w':
+			case 'x':
+			case 'y':
+			case 'z':
+			case '{':
+			case '|':
+			case '}':
+			case '~':
+			case '\x7f':
+			case '\x80':
+			case '\x81':
+			case '\x82':
+			case '\x83':
+			case '\x84':
+			case '\x85':
+			case '\x86':
+			case '\x87':
+			case '\x88':
+			case '\x89':
+			case '\x8a':
+			case '\x8b':
+			case '\x8c':
+			case '\x8d':
+			case '\x8e':
+			case '\x8f':
+			case '\x90':
+			case '\x91':
+			case '\x92':
+			case '\x93':
+			case '\x94':
+			case '\x95':
+			case '\x96':
+			case '\x97':
+			case '\x98':
+			case '\x99':
+			case '\x9a':
+			case '\x9b':
+			case '\x9c':
+			case '\x9d':
+			case '\x9e':
+			case '\x9f':
+			case '\xa0':
+			case '\xa1':
+			case '\xa2':
+			case '\xa3':
+			case '\xa4':
+			case '\xa5':
+			case '\xa6':
+			case '\xa7':
+			case '\xa8':
+			case '\xa9':
+			case '\xaa':
+			case '\xab':
+			case '\xac':
+			case '\xad':
+			case '\xae':
+			case '\xaf':
+			case '\xb0':
+			case '\xb1':
+			case '\xb2':
+			case '\xb3':
+			case '\xb4':
+			case '\xb5':
+			case '\xb6':
+			case '\xb7':
+			case '\xb8':
+			case '\xb9':
+			case '\xba':
+			case '\xbb':
+			case '\xbc':
+			case '\xbd':
+			case '\xbe':
+			case '\xbf':
+			case '\xc0':
+			case '\xc1':
+			case '\xc2':
+			case '\xc3':
+			case '\xc4':
+			case '\xc5':
+			case '\xc6':
+			case '\xc7':
+			case '\xc8':
+			case '\xc9':
+			case '\xca':
+			case '\xcb':
+			case '\xcc':
+			case '\xcd':
+			case '\xce':
+			case '\xcf':
+			case '\xd0':
+			case '\xd1':
+			case '\xd2':
+			case '\xd3':
+			case '\xd4':
+			case '\xd5':
+			case '\xd6':
+			case '\xd7':
+			case '\xd8':
+			case '\xd9':
+			case '\xda':
+			case '\xdb':
+			case '\xdc':
+			case '\xdd':
+			case '\xde':
+			case '\xdf':
+			case '\xe0':
+			case '\xe1':
+			case '\xe2':
+			case '\xe3':
+			case '\xe4':
+			case '\xe5':
+			case '\xe6':
+			case '\xe7':
+			case '\xe8':
+			case '\xe9':
+			case '\xea':
+			case '\xeb':
+			case '\xec':
+			case '\xed':
+			case '\xee':
+			case '\xef':
+			case '\xf0':
+			case '\xf1':
+			case '\xf2':
+			case '\xf3':
+			case '\xf4':
+			case '\xf5':
+			case '\xf6':
+			case '\xf7':
+			case '\xf8':
+			case '\xf9':
+			case '\xfa':
+			case '\xfb':
+			case '\xfc':
+			case '\xfd':
+			case '\xfe':
+			case '\xff': state = S1; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S3: /* e.g. "\\0" */
+		case S1: /* e.g. "a" */
+			lx_native_ungetc(lx, c); return TOK_CHAR;
+
+		case S2: /* e.g. "-" */
+			lx_native_ungetc(lx, c); return TOK_RANGE;
+
+		case S3: /* e.g. "\\" */
+			switch (c) {
+			case '-': state = S6; continue;
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7': state = S7; continue;
+			case '\\': state = S6; continue;
+			case '^': state = S6; continue;
+			case 'f': state = S6; continue;
+			case 'n': state = S6; continue;
+			case 'r': state = S6; continue;
+			case 't': state = S6; continue;
+			case 'v': state = S6; continue;
+			case 'x': state = S8; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S4: /* e.g. "]" */
+			lx_native_ungetc(lx, c); return lx->z = z2, TOK_CLOSEGROUP;
+
+		case S5: /* e.g. "^" */
+			lx_native_ungetc(lx, c); return TOK_INVERT;
+
+		case S6: /* e.g. "\\f" */
+			lx_native_ungetc(lx, c); return TOK_ESC;
+
+		case S7: /* e.g. "\\0" */
 			switch (c) {
 			case '0':
 			case '1':
@@ -349,19 +587,12 @@ z1(struct lx_native_lx *lx)
 			case '4':
 			case '5':
 			case '6':
-			case '7':             continue;
+			case '7': continue;
 			default:  lx_native_ungetc(lx, c); return TOK_OCT;
 			}
 
-		case S4: /* e.g. "^" */
-			lx_native_ungetc(lx, c); return TOK_INVERT;
-
-		case S5: /* e.g. "]" */
-			lx_native_ungetc(lx, c); return lx->z = z2, TOK_CLOSEGROUP;
-
-		case S6: /* e.g. "\\" */
+		case S8: /* e.g. "\\x" */
 			switch (c) {
-			case '-': state = S1; continue;
 			case '0':
 			case '1':
 			case '2':
@@ -369,31 +600,49 @@ z1(struct lx_native_lx *lx)
 			case '4':
 			case '5':
 			case '6':
-			case '7': state = S3; continue;
-			case '\\': state = S1; continue;
-			case '^': state = S1; continue;
-			case 'f': state = S1; continue;
-			case 'n': state = S1; continue;
-			case 'r': state = S1; continue;
-			case 't': state = S1; continue;
-			case 'v': state = S1; continue;
-			case 'x': state = S2; continue;
+			case '7':
+			case '8':
+			case '9': state = S9; continue;
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F': state = S9; continue;
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f': state = S9; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S7: /* e.g. "-" */
-			lx_native_ungetc(lx, c); return TOK_RANGE;
-
-		case S8: /* e.g. "a" */
-			lx_native_ungetc(lx, c); return TOK_CHAR;
-
-		case S9: /* start */
+		case S9: /* e.g. "\\xa" */
 			switch (c) {
-			case '-': state = S7; continue;
-			case '\\': state = S6; continue;
-			case ']': state = S5; continue;
-			case '^': state = S4; continue;
-			default:  state = S8; continue;
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9': continue;
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F': continue;
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f': continue;
+			default:  lx_native_ungetc(lx, c); return TOK_HEX;
 			}
 		}
 	}
@@ -401,13 +650,13 @@ z1(struct lx_native_lx *lx)
 	lx->lgetc = NULL;
 
 	switch (state) {
-	case S0: return TOK_HEX;
-	case S1: return TOK_ESC;
-	case S3: return TOK_OCT;
-	case S4: return TOK_INVERT;
-	case S5: return TOK_CLOSEGROUP;
-	case S7: return TOK_RANGE;
-	case S8: return TOK_CHAR;
+	case S1: return TOK_CHAR;
+	case S2: return TOK_RANGE;
+	case S4: return TOK_CLOSEGROUP;
+	case S5: return TOK_INVERT;
+	case S6: return TOK_ESC;
+	case S7: return TOK_OCT;
+	case S9: return TOK_HEX;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
 }
@@ -428,7 +677,7 @@ z2(struct lx_native_lx *lx)
 		lx->clear(lx);
 	}
 
-	state = S17;
+	state = S0;
 
 	lx->start = lx->end;
 
@@ -440,8 +689,56 @@ z2(struct lx_native_lx *lx)
 		}
 
 		switch (state) {
-		case S0: /* e.g. "\\xa" */
+		case S0: /* start */
 			switch (c) {
+			case '\x00':
+			case '\x01':
+			case '\x02':
+			case '\x03':
+			case '\x04':
+			case '\x05':
+			case '\x06':
+			case '\a':
+			case '\b':
+			case '\t':
+			case '\n':
+			case '\v':
+			case '\f':
+			case '\r':
+			case '\x0e':
+			case '\x0f':
+			case '\x10':
+			case '\x11':
+			case '\x12':
+			case '\x13':
+			case '\x14':
+			case '\x15':
+			case '\x16':
+			case '\x17':
+			case '\x18':
+			case '\x19':
+			case '\x1a':
+			case '\x1b':
+			case '\x1c':
+			case '\x1d':
+			case '\x1e':
+			case '\x1f':
+			case ' ':
+			case '!':
+			case '"':
+			case '#': state = S1; continue;
+			case '$': state = S2; continue;
+			case '%':
+			case '&':
+			case '\'': state = S1; continue;
+			case '(': state = S3; continue;
+			case ')': state = S4; continue;
+			case '*': state = S5; continue;
+			case '+': state = S6; continue;
+			case ',':
+			case '-': state = S1; continue;
+			case '.': state = S7; continue;
+			case '\x2f':
 			case '0':
 			case '1':
 			case '2':
@@ -451,97 +748,243 @@ z2(struct lx_native_lx *lx)
 			case '6':
 			case '7':
 			case '8':
-			case '9':             continue;
+			case '9':
+			case ':':
+			case ';':
+			case '<':
+			case '=':
+			case '>': state = S1; continue;
+			case '?': state = S8; continue;
+			case '@':
 			case 'A':
 			case 'B':
 			case 'C':
 			case 'D':
 			case 'E':
-			case 'F':             continue;
+			case 'F':
+			case 'G':
+			case 'H':
+			case 'I':
+			case 'J':
+			case 'K':
+			case 'L':
+			case 'M':
+			case 'N':
+			case 'O':
+			case 'P':
+			case 'Q':
+			case 'R':
+			case 'S':
+			case 'T':
+			case 'U':
+			case 'V':
+			case 'W':
+			case 'X':
+			case 'Y':
+			case 'Z': state = S1; continue;
+			case '[': state = S9; continue;
+			case '\\': state = S10; continue;
+			case ']': state = S1; continue;
+			case '^': state = S11; continue;
+			case '_':
+			case '`':
 			case 'a':
 			case 'b':
 			case 'c':
 			case 'd':
 			case 'e':
-			case 'f':             continue;
-			default:  lx_native_ungetc(lx, c); return TOK_HEX;
+			case 'f':
+			case 'g':
+			case 'h':
+			case 'i':
+			case 'j':
+			case 'k':
+			case 'l':
+			case 'm':
+			case 'n':
+			case 'o':
+			case 'p':
+			case 'q':
+			case 'r':
+			case 's':
+			case 't':
+			case 'u':
+			case 'v':
+			case 'w':
+			case 'x':
+			case 'y':
+			case 'z': state = S1; continue;
+			case '{': state = S12; continue;
+			case '|': state = S13; continue;
+			case '}':
+			case '~':
+			case '\x7f':
+			case '\x80':
+			case '\x81':
+			case '\x82':
+			case '\x83':
+			case '\x84':
+			case '\x85':
+			case '\x86':
+			case '\x87':
+			case '\x88':
+			case '\x89':
+			case '\x8a':
+			case '\x8b':
+			case '\x8c':
+			case '\x8d':
+			case '\x8e':
+			case '\x8f':
+			case '\x90':
+			case '\x91':
+			case '\x92':
+			case '\x93':
+			case '\x94':
+			case '\x95':
+			case '\x96':
+			case '\x97':
+			case '\x98':
+			case '\x99':
+			case '\x9a':
+			case '\x9b':
+			case '\x9c':
+			case '\x9d':
+			case '\x9e':
+			case '\x9f':
+			case '\xa0':
+			case '\xa1':
+			case '\xa2':
+			case '\xa3':
+			case '\xa4':
+			case '\xa5':
+			case '\xa6':
+			case '\xa7':
+			case '\xa8':
+			case '\xa9':
+			case '\xaa':
+			case '\xab':
+			case '\xac':
+			case '\xad':
+			case '\xae':
+			case '\xaf':
+			case '\xb0':
+			case '\xb1':
+			case '\xb2':
+			case '\xb3':
+			case '\xb4':
+			case '\xb5':
+			case '\xb6':
+			case '\xb7':
+			case '\xb8':
+			case '\xb9':
+			case '\xba':
+			case '\xbb':
+			case '\xbc':
+			case '\xbd':
+			case '\xbe':
+			case '\xbf':
+			case '\xc0':
+			case '\xc1':
+			case '\xc2':
+			case '\xc3':
+			case '\xc4':
+			case '\xc5':
+			case '\xc6':
+			case '\xc7':
+			case '\xc8':
+			case '\xc9':
+			case '\xca':
+			case '\xcb':
+			case '\xcc':
+			case '\xcd':
+			case '\xce':
+			case '\xcf':
+			case '\xd0':
+			case '\xd1':
+			case '\xd2':
+			case '\xd3':
+			case '\xd4':
+			case '\xd5':
+			case '\xd6':
+			case '\xd7':
+			case '\xd8':
+			case '\xd9':
+			case '\xda':
+			case '\xdb':
+			case '\xdc':
+			case '\xdd':
+			case '\xde':
+			case '\xdf':
+			case '\xe0':
+			case '\xe1':
+			case '\xe2':
+			case '\xe3':
+			case '\xe4':
+			case '\xe5':
+			case '\xe6':
+			case '\xe7':
+			case '\xe8':
+			case '\xe9':
+			case '\xea':
+			case '\xeb':
+			case '\xec':
+			case '\xed':
+			case '\xee':
+			case '\xef':
+			case '\xf0':
+			case '\xf1':
+			case '\xf2':
+			case '\xf3':
+			case '\xf4':
+			case '\xf5':
+			case '\xf6':
+			case '\xf7':
+			case '\xf8':
+			case '\xf9':
+			case '\xfa':
+			case '\xfb':
+			case '\xfc':
+			case '\xfd':
+			case '\xfe':
+			case '\xff': state = S1; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S1: /* e.g. "\\f" */
-			lx_native_ungetc(lx, c); return TOK_ESC;
+		case S1: /* e.g. "a" */
+			lx_native_ungetc(lx, c); return TOK_CHAR;
 
-		case S2: /* e.g. "\\0" */
-			switch (c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':             continue;
-			default:  lx_native_ungetc(lx, c); return TOK_OCT;
-			}
+		case S2: /* e.g. "$" */
+			lx_native_ungetc(lx, c); return TOK_END;
 
-		case S3: /* e.g. "\\x" */
-			switch (c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9': state = S0; continue;
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F': state = S0; continue;
-			case 'a':
-			case 'b':
-			case 'c':
-			case 'd':
-			case 'e':
-			case 'f': state = S0; continue;
-			default:  lx_native_ungetc(lx, c); return TOK_CHAR;
-			}
-
-		case S4: /* e.g. "(" */
+		case S3: /* e.g. "(" */
 			lx_native_ungetc(lx, c); return TOK_OPENSUB;
 
-		case S5: /* e.g. ")" */
+		case S4: /* e.g. ")" */
 			lx_native_ungetc(lx, c); return TOK_CLOSESUB;
 
-		case S6: /* e.g. "^" */
-			lx_native_ungetc(lx, c); return TOK_START;
+		case S5: /* e.g. "*" */
+			lx_native_ungetc(lx, c); return TOK_STAR;
 
-		case S7: /* e.g. "$" */
-			lx_native_ungetc(lx, c); return TOK_END;
+		case S6: /* e.g. "+" */
+			lx_native_ungetc(lx, c); return TOK_PLUS;
+
+		case S7: /* e.g. "." */
+			lx_native_ungetc(lx, c); return TOK_ANY;
 
 		case S8: /* e.g. "?" */
 			lx_native_ungetc(lx, c); return TOK_OPT;
 
-		case S9: /* e.g. "*" */
-			lx_native_ungetc(lx, c); return TOK_STAR;
+		case S9: /* e.g. "[" */
+			lx_native_ungetc(lx, c); return lx->z = z1, TOK_OPENGROUP;
 
-		case S10: /* e.g. "+" */
-			lx_native_ungetc(lx, c); return TOK_PLUS;
-
-		case S11: /* e.g. "." */
-			lx_native_ungetc(lx, c); return TOK_ANY;
-
-		case S12: /* e.g. "\\" */
+		case S10: /* e.g. "\\" */
 			switch (c) {
-			case '$': state = S1; continue;
+			case '$': state = S14; continue;
 			case '(':
 			case ')':
 			case '*':
-			case '+': state = S1; continue;
-			case '.': state = S1; continue;
+			case '+': state = S14; continue;
+			case '.': state = S14; continue;
 			case '0':
 			case '1':
 			case '2':
@@ -549,49 +992,99 @@ z2(struct lx_native_lx *lx)
 			case '4':
 			case '5':
 			case '6':
-			case '7': state = S2; continue;
-			case '?': state = S1; continue;
+			case '7': state = S15; continue;
+			case '?': state = S14; continue;
 			case '[':
-			case '\\': state = S1; continue;
-			case '^': state = S1; continue;
-			case 'f': state = S1; continue;
-			case 'n': state = S1; continue;
-			case 'r': state = S1; continue;
-			case 't': state = S1; continue;
-			case 'v': state = S1; continue;
-			case 'x': state = S3; continue;
+			case '\\': state = S14; continue;
+			case '^': state = S14; continue;
+			case 'f': state = S14; continue;
+			case 'n': state = S14; continue;
+			case 'r': state = S14; continue;
+			case 't': state = S14; continue;
+			case 'v': state = S14; continue;
+			case 'x': state = S16; continue;
 			case '{':
-			case '|': state = S1; continue;
+			case '|': state = S14; continue;
 			default:  lx_native_ungetc(lx, c); return TOK_CHAR;
 			}
 
-		case S13: /* e.g. "{" */
+		case S11: /* e.g. "^" */
+			lx_native_ungetc(lx, c); return TOK_START;
+
+		case S12: /* e.g. "{" */
 			lx_native_ungetc(lx, c); return lx->z = z0, TOK_OPENCOUNT;
 
-		case S14: /* e.g. "|" */
+		case S13: /* e.g. "|" */
 			lx_native_ungetc(lx, c); return TOK_ALT;
 
-		case S15: /* e.g. "[" */
-			lx_native_ungetc(lx, c); return lx->z = z1, TOK_OPENGROUP;
+		case S14: /* e.g. "\\f" */
+			lx_native_ungetc(lx, c); return TOK_ESC;
 
-		case S16: /* e.g. "a" */
-			lx_native_ungetc(lx, c); return TOK_CHAR;
-
-		case S17: /* start */
+		case S15: /* e.g. "\\0" */
 			switch (c) {
-			case '$': state = S7; continue;
-			case '(': state = S4; continue;
-			case ')': state = S5; continue;
-			case '*': state = S9; continue;
-			case '+': state = S10; continue;
-			case '.': state = S11; continue;
-			case '?': state = S8; continue;
-			case '[': state = S15; continue;
-			case '\\': state = S12; continue;
-			case '^': state = S6; continue;
-			case '{': state = S13; continue;
-			case '|': state = S14; continue;
-			default:  state = S16; continue;
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7': continue;
+			default:  lx_native_ungetc(lx, c); return TOK_OCT;
+			}
+
+		case S16: /* e.g. "\\x" */
+			switch (c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9': state = S17; continue;
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F': state = S17; continue;
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f': state = S17; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S17: /* e.g. "\\xa" */
+			switch (c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9': continue;
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F': continue;
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f': continue;
+			default:  lx_native_ungetc(lx, c); return TOK_HEX;
 			}
 		}
 	}
@@ -599,23 +1092,22 @@ z2(struct lx_native_lx *lx)
 	lx->lgetc = NULL;
 
 	switch (state) {
-	case S0: return TOK_HEX;
-	case S1: return TOK_ESC;
-	case S2: return TOK_OCT;
-	case S3: return TOK_CHAR;
-	case S4: return TOK_OPENSUB;
-	case S5: return TOK_CLOSESUB;
-	case S6: return TOK_START;
-	case S7: return TOK_END;
+	case S1: return TOK_CHAR;
+	case S2: return TOK_END;
+	case S3: return TOK_OPENSUB;
+	case S4: return TOK_CLOSESUB;
+	case S5: return TOK_STAR;
+	case S6: return TOK_PLUS;
+	case S7: return TOK_ANY;
 	case S8: return TOK_OPT;
-	case S9: return TOK_STAR;
-	case S10: return TOK_PLUS;
-	case S11: return TOK_ANY;
-	case S12: return TOK_CHAR;
-	case S13: return TOK_OPENCOUNT;
-	case S14: return TOK_ALT;
-	case S15: return TOK_OPENGROUP;
-	case S16: return TOK_CHAR;
+	case S9: return TOK_OPENGROUP;
+	case S10: return TOK_CHAR;
+	case S11: return TOK_START;
+	case S12: return TOK_OPENCOUNT;
+	case S13: return TOK_ALT;
+	case S14: return TOK_ESC;
+	case S15: return TOK_OCT;
+	case S17: return TOK_HEX;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
 }
@@ -680,7 +1172,7 @@ lx_native_example(enum lx_native_token (*z)(struct lx_native_lx *), enum lx_nati
 	if (z == z2) {
 		switch (t) {
 		case TOK_OPENCOUNT: return "{";
-		case TOK_CHAR: return "\\";
+		case TOK_CHAR: return "a";
 		case TOK_OPENGROUP: return "[";
 		case TOK_HEX: return "\\xa";
 		case TOK_OCT: return "\\0";
@@ -714,7 +1206,7 @@ lx_native_init(struct lx_native_lx *lx)
 	*lx = lx_default;
 
 	lx->c = EOF;
-	lx->z = NULL;
+	lx->z = z2;
 
 	lx->end.byte = 0;
 	lx->end.line = 1;
@@ -727,13 +1219,10 @@ lx_native_next(struct lx_native_lx *lx)
 	enum lx_native_token t;
 
 	assert(lx != NULL);
+	assert(lx->z != NULL);
 
 	if (lx->lgetc == NULL) {
 		return TOK_EOF;
-	}
-
-	if (lx->z == NULL) {
-		lx->z = z2;
 	}
 
 	t = lx->z(lx);

--- a/src/libre/dialect/native/lexer.h
+++ b/src/libre/dialect/native/lexer.h
@@ -100,8 +100,6 @@ const char *lx_native_example(enum lx_native_token (*z)(struct lx_native_lx *), 
 void lx_native_init(struct lx_native_lx *lx);
 enum lx_native_token lx_native_next(struct lx_native_lx *lx);
 
-int lx_native_fgetc(struct lx_native_lx *lx);
-
 int  lx_native_dynpush(struct lx_native_lx *lx, char c);
 void lx_native_dynpop(struct lx_native_lx *lx);
 int  lx_native_dynclear(struct lx_native_lx *lx);

--- a/src/lx/lexer.c
+++ b/src/lx/lexer.c
@@ -13,6 +13,9 @@ static enum lx_token z2(struct lx *lx);
 static enum lx_token z3(struct lx *lx);
 static enum lx_token z4(struct lx *lx);
 
+#if __STDC_VERSION__ >= 199901L
+inline
+#endif
 static int
 lx_getc(struct lx *lx)
 {
@@ -41,6 +44,9 @@ lx_getc(struct lx *lx)
 	return c;
 }
 
+#if __STDC_VERSION__ >= 199901L
+inline
+#endif
 static void
 lx_ungetc(struct lx *lx, int c)
 {
@@ -195,7 +201,7 @@ z0(struct lx *lx)
 		lx->clear(lx);
 	}
 
-	state = S2;
+	state = S0;
 
 	lx->start = lx->end;
 
@@ -207,10 +213,271 @@ z0(struct lx *lx)
 		}
 
 		switch (state) {
-		case S0: /* e.g. "a" */
+		case S0: /* start */
+			switch (c) {
+			case '\x00':
+			case '\x01':
+			case '\x02':
+			case '\x03':
+			case '\x04':
+			case '\x05':
+			case '\x06':
+			case '\a':
+			case '\b':
+			case '\t':
+			case '\n':
+			case '\v':
+			case '\f':
+			case '\r':
+			case '\x0e':
+			case '\x0f':
+			case '\x10':
+			case '\x11':
+			case '\x12':
+			case '\x13':
+			case '\x14':
+			case '\x15':
+			case '\x16':
+			case '\x17':
+			case '\x18':
+			case '\x19':
+			case '\x1a':
+			case '\x1b':
+			case '\x1c':
+			case '\x1d':
+			case '\x1e':
+			case '\x1f':
+			case ' ':
+			case '!':
+			case '"':
+			case '#':
+			case '$':
+			case '%':
+			case '&':
+			case '\'':
+			case '(':
+			case ')':
+			case '*':
+			case '+':
+			case ',':
+			case '-':
+			case '.': state = S1; continue;
+			case '\x2f': state = S2; continue;
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9':
+			case ':':
+			case ';':
+			case '<':
+			case '=':
+			case '>':
+			case '?':
+			case '@':
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'G':
+			case 'H':
+			case 'I':
+			case 'J':
+			case 'K':
+			case 'L':
+			case 'M':
+			case 'N':
+			case 'O':
+			case 'P':
+			case 'Q':
+			case 'R':
+			case 'S':
+			case 'T':
+			case 'U':
+			case 'V':
+			case 'W':
+			case 'X':
+			case 'Y':
+			case 'Z':
+			case '[':
+			case '\\':
+			case ']':
+			case '^':
+			case '_':
+			case '`':
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f':
+			case 'g':
+			case 'h':
+			case 'i':
+			case 'j':
+			case 'k':
+			case 'l':
+			case 'm':
+			case 'n':
+			case 'o':
+			case 'p':
+			case 'q':
+			case 'r':
+			case 's':
+			case 't':
+			case 'u':
+			case 'v':
+			case 'w':
+			case 'x':
+			case 'y':
+			case 'z':
+			case '{':
+			case '|':
+			case '}':
+			case '~':
+			case '\x7f':
+			case '\x80':
+			case '\x81':
+			case '\x82':
+			case '\x83':
+			case '\x84':
+			case '\x85':
+			case '\x86':
+			case '\x87':
+			case '\x88':
+			case '\x89':
+			case '\x8a':
+			case '\x8b':
+			case '\x8c':
+			case '\x8d':
+			case '\x8e':
+			case '\x8f':
+			case '\x90':
+			case '\x91':
+			case '\x92':
+			case '\x93':
+			case '\x94':
+			case '\x95':
+			case '\x96':
+			case '\x97':
+			case '\x98':
+			case '\x99':
+			case '\x9a':
+			case '\x9b':
+			case '\x9c':
+			case '\x9d':
+			case '\x9e':
+			case '\x9f':
+			case '\xa0':
+			case '\xa1':
+			case '\xa2':
+			case '\xa3':
+			case '\xa4':
+			case '\xa5':
+			case '\xa6':
+			case '\xa7':
+			case '\xa8':
+			case '\xa9':
+			case '\xaa':
+			case '\xab':
+			case '\xac':
+			case '\xad':
+			case '\xae':
+			case '\xaf':
+			case '\xb0':
+			case '\xb1':
+			case '\xb2':
+			case '\xb3':
+			case '\xb4':
+			case '\xb5':
+			case '\xb6':
+			case '\xb7':
+			case '\xb8':
+			case '\xb9':
+			case '\xba':
+			case '\xbb':
+			case '\xbc':
+			case '\xbd':
+			case '\xbe':
+			case '\xbf':
+			case '\xc0':
+			case '\xc1':
+			case '\xc2':
+			case '\xc3':
+			case '\xc4':
+			case '\xc5':
+			case '\xc6':
+			case '\xc7':
+			case '\xc8':
+			case '\xc9':
+			case '\xca':
+			case '\xcb':
+			case '\xcc':
+			case '\xcd':
+			case '\xce':
+			case '\xcf':
+			case '\xd0':
+			case '\xd1':
+			case '\xd2':
+			case '\xd3':
+			case '\xd4':
+			case '\xd5':
+			case '\xd6':
+			case '\xd7':
+			case '\xd8':
+			case '\xd9':
+			case '\xda':
+			case '\xdb':
+			case '\xdc':
+			case '\xdd':
+			case '\xde':
+			case '\xdf':
+			case '\xe0':
+			case '\xe1':
+			case '\xe2':
+			case '\xe3':
+			case '\xe4':
+			case '\xe5':
+			case '\xe6':
+			case '\xe7':
+			case '\xe8':
+			case '\xe9':
+			case '\xea':
+			case '\xeb':
+			case '\xec':
+			case '\xed':
+			case '\xee':
+			case '\xef':
+			case '\xf0':
+			case '\xf1':
+			case '\xf2':
+			case '\xf3':
+			case '\xf4':
+			case '\xf5':
+			case '\xf6':
+			case '\xf7':
+			case '\xf8':
+			case '\xf9':
+			case '\xfa':
+			case '\xfb':
+			case '\xfc':
+			case '\xfd':
+			case '\xfe':
+			case '\xff': state = S1; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S1: /* e.g. "a" */
 			lx_ungetc(lx, c); return TOK_CHAR;
 
-		case S1: /* e.g. "\057" */
+		case S2: /* e.g. "\x2f" */
 			switch (c) {
 			case 'A':
 			case 'B':
@@ -237,7 +504,7 @@ z0(struct lx *lx)
 			case 'W':
 			case 'X':
 			case 'Y':
-			case 'Z':             continue;
+			case 'Z': continue;
 			case 'a':
 			case 'b':
 			case 'c':
@@ -263,14 +530,8 @@ z0(struct lx *lx)
 			case 'w':
 			case 'x':
 			case 'y':
-			case 'z':             continue;
+			case 'z': continue;
 			default:  lx_ungetc(lx, c); return lx->z = z4, TOK_RE;
-			}
-
-		case S2: /* start */
-			switch (c) {
-			case '\057': state = S1; continue;
-			default:  state = S0; continue;
 			}
 		}
 	}
@@ -278,8 +539,8 @@ z0(struct lx *lx)
 	lx->lgetc = NULL;
 
 	switch (state) {
-	case S0: return TOK_CHAR;
-	case S1: return TOK_RE;
+	case S1: return TOK_CHAR;
+	case S2: return TOK_RE;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
 }
@@ -299,7 +560,7 @@ z1(struct lx *lx)
 		lx->clear(lx);
 	}
 
-	state = S7;
+	state = S0;
 
 	lx->start = lx->end;
 
@@ -311,8 +572,56 @@ z1(struct lx *lx)
 		}
 
 		switch (state) {
-		case S0: /* e.g. "\\xa" */
+		case S0: /* start */
 			switch (c) {
+			case '\x00':
+			case '\x01':
+			case '\x02':
+			case '\x03':
+			case '\x04':
+			case '\x05':
+			case '\x06':
+			case '\a':
+			case '\b':
+			case '\t':
+			case '\n':
+			case '\v':
+			case '\f':
+			case '\r':
+			case '\x0e':
+			case '\x0f':
+			case '\x10':
+			case '\x11':
+			case '\x12':
+			case '\x13':
+			case '\x14':
+			case '\x15':
+			case '\x16':
+			case '\x17':
+			case '\x18':
+			case '\x19':
+			case '\x1a':
+			case '\x1b':
+			case '\x1c':
+			case '\x1d':
+			case '\x1e':
+			case '\x1f':
+			case ' ':
+			case '!': state = S1; continue;
+			case '"': state = S2; continue;
+			case '#':
+			case '$':
+			case '%':
+			case '&':
+			case '\'':
+			case '(':
+			case ')':
+			case '*':
+			case '+':
+			case ',':
+			case '-':
+			case '.':
+			case '\x2f':
 			case '0':
 			case '1':
 			case '2':
@@ -322,26 +631,239 @@ z1(struct lx *lx)
 			case '6':
 			case '7':
 			case '8':
-			case '9':             continue;
+			case '9':
+			case ':':
+			case ';':
+			case '<':
+			case '=':
+			case '>':
+			case '?':
+			case '@':
 			case 'A':
 			case 'B':
 			case 'C':
 			case 'D':
 			case 'E':
-			case 'F':             continue;
+			case 'F':
+			case 'G':
+			case 'H':
+			case 'I':
+			case 'J':
+			case 'K':
+			case 'L':
+			case 'M':
+			case 'N':
+			case 'O':
+			case 'P':
+			case 'Q':
+			case 'R':
+			case 'S':
+			case 'T':
+			case 'U':
+			case 'V':
+			case 'W':
+			case 'X':
+			case 'Y':
+			case 'Z':
+			case '[': state = S1; continue;
+			case '\\': state = S3; continue;
+			case ']':
+			case '^':
+			case '_':
+			case '`':
 			case 'a':
 			case 'b':
 			case 'c':
 			case 'd':
 			case 'e':
-			case 'f':             continue;
-			default:  lx_ungetc(lx, c); return TOK_HEX;
+			case 'f':
+			case 'g':
+			case 'h':
+			case 'i':
+			case 'j':
+			case 'k':
+			case 'l':
+			case 'm':
+			case 'n':
+			case 'o':
+			case 'p':
+			case 'q':
+			case 'r':
+			case 's':
+			case 't':
+			case 'u':
+			case 'v':
+			case 'w':
+			case 'x':
+			case 'y':
+			case 'z':
+			case '{':
+			case '|':
+			case '}':
+			case '~':
+			case '\x7f':
+			case '\x80':
+			case '\x81':
+			case '\x82':
+			case '\x83':
+			case '\x84':
+			case '\x85':
+			case '\x86':
+			case '\x87':
+			case '\x88':
+			case '\x89':
+			case '\x8a':
+			case '\x8b':
+			case '\x8c':
+			case '\x8d':
+			case '\x8e':
+			case '\x8f':
+			case '\x90':
+			case '\x91':
+			case '\x92':
+			case '\x93':
+			case '\x94':
+			case '\x95':
+			case '\x96':
+			case '\x97':
+			case '\x98':
+			case '\x99':
+			case '\x9a':
+			case '\x9b':
+			case '\x9c':
+			case '\x9d':
+			case '\x9e':
+			case '\x9f':
+			case '\xa0':
+			case '\xa1':
+			case '\xa2':
+			case '\xa3':
+			case '\xa4':
+			case '\xa5':
+			case '\xa6':
+			case '\xa7':
+			case '\xa8':
+			case '\xa9':
+			case '\xaa':
+			case '\xab':
+			case '\xac':
+			case '\xad':
+			case '\xae':
+			case '\xaf':
+			case '\xb0':
+			case '\xb1':
+			case '\xb2':
+			case '\xb3':
+			case '\xb4':
+			case '\xb5':
+			case '\xb6':
+			case '\xb7':
+			case '\xb8':
+			case '\xb9':
+			case '\xba':
+			case '\xbb':
+			case '\xbc':
+			case '\xbd':
+			case '\xbe':
+			case '\xbf':
+			case '\xc0':
+			case '\xc1':
+			case '\xc2':
+			case '\xc3':
+			case '\xc4':
+			case '\xc5':
+			case '\xc6':
+			case '\xc7':
+			case '\xc8':
+			case '\xc9':
+			case '\xca':
+			case '\xcb':
+			case '\xcc':
+			case '\xcd':
+			case '\xce':
+			case '\xcf':
+			case '\xd0':
+			case '\xd1':
+			case '\xd2':
+			case '\xd3':
+			case '\xd4':
+			case '\xd5':
+			case '\xd6':
+			case '\xd7':
+			case '\xd8':
+			case '\xd9':
+			case '\xda':
+			case '\xdb':
+			case '\xdc':
+			case '\xdd':
+			case '\xde':
+			case '\xdf':
+			case '\xe0':
+			case '\xe1':
+			case '\xe2':
+			case '\xe3':
+			case '\xe4':
+			case '\xe5':
+			case '\xe6':
+			case '\xe7':
+			case '\xe8':
+			case '\xe9':
+			case '\xea':
+			case '\xeb':
+			case '\xec':
+			case '\xed':
+			case '\xee':
+			case '\xef':
+			case '\xf0':
+			case '\xf1':
+			case '\xf2':
+			case '\xf3':
+			case '\xf4':
+			case '\xf5':
+			case '\xf6':
+			case '\xf7':
+			case '\xf8':
+			case '\xf9':
+			case '\xfa':
+			case '\xfb':
+			case '\xfc':
+			case '\xfd':
+			case '\xfe':
+			case '\xff': state = S1; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S1: /* e.g. "\\f" */
+		case S1: /* e.g. "a" */
+			lx_ungetc(lx, c); return TOK_CHAR;
+
+		case S2: /* e.g. """ */
+			lx_ungetc(lx, c); return lx->z = z4, TOK_STR;
+
+		case S3: /* e.g. "\\" */
+			switch (c) {
+			case '"': state = S4; continue;
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7': state = S5; continue;
+			case '\\': state = S4; continue;
+			case 'f': state = S4; continue;
+			case 'n': state = S4; continue;
+			case 'r': state = S4; continue;
+			case 't': state = S4; continue;
+			case 'v': state = S4; continue;
+			case 'x': state = S6; continue;
+			default:  lx_ungetc(lx, c); return TOK_CHAR;
+			}
+
+		case S4: /* e.g. "\\f" */
 			lx_ungetc(lx, c); return TOK_ESC;
 
-		case S2: /* e.g. "\\0" */
+		case S5: /* e.g. "\\0" */
 			switch (c) {
 			case '0':
 			case '1':
@@ -350,11 +872,11 @@ z1(struct lx *lx)
 			case '4':
 			case '5':
 			case '6':
-			case '7':             continue;
+			case '7': continue;
 			default:  lx_ungetc(lx, c); return TOK_OCT;
 			}
 
-		case S3: /* e.g. "\\x" */
+		case S6: /* e.g. "\\x" */
 			switch (c) {
 			case '0':
 			case '1':
@@ -365,25 +887,24 @@ z1(struct lx *lx)
 			case '6':
 			case '7':
 			case '8':
-			case '9': state = S0; continue;
+			case '9': state = S7; continue;
 			case 'A':
 			case 'B':
 			case 'C':
 			case 'D':
 			case 'E':
-			case 'F': state = S0; continue;
+			case 'F': state = S7; continue;
 			case 'a':
 			case 'b':
 			case 'c':
 			case 'd':
 			case 'e':
-			case 'f': state = S0; continue;
-			default:  lx_ungetc(lx, c); return TOK_CHAR;
+			case 'f': state = S7; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S4: /* e.g. "\\" */
+		case S7: /* e.g. "\\xa" */
 			switch (c) {
-			case '"': state = S1; continue;
 			case '0':
 			case '1':
 			case '2':
@@ -391,28 +912,22 @@ z1(struct lx *lx)
 			case '4':
 			case '5':
 			case '6':
-			case '7': state = S2; continue;
-			case '\\': state = S1; continue;
-			case 'f': state = S1; continue;
-			case 'n': state = S1; continue;
-			case 'r': state = S1; continue;
-			case 't': state = S1; continue;
-			case 'v': state = S1; continue;
-			case 'x': state = S3; continue;
-			default:  lx_ungetc(lx, c); return TOK_CHAR;
-			}
-
-		case S5: /* e.g. """ */
-			lx_ungetc(lx, c); return lx->z = z4, TOK_STR;
-
-		case S6: /* e.g. "a" */
-			lx_ungetc(lx, c); return TOK_CHAR;
-
-		case S7: /* start */
-			switch (c) {
-			case '"': state = S5; continue;
-			case '\\': state = S4; continue;
-			default:  state = S6; continue;
+			case '7':
+			case '8':
+			case '9': continue;
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F': continue;
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f': continue;
+			default:  lx_ungetc(lx, c); return TOK_HEX;
 			}
 		}
 	}
@@ -420,13 +935,12 @@ z1(struct lx *lx)
 	lx->lgetc = NULL;
 
 	switch (state) {
-	case S0: return TOK_HEX;
-	case S1: return TOK_ESC;
-	case S2: return TOK_OCT;
+	case S1: return TOK_CHAR;
+	case S2: return TOK_STR;
 	case S3: return TOK_CHAR;
-	case S4: return TOK_CHAR;
-	case S5: return TOK_STR;
-	case S6: return TOK_CHAR;
+	case S4: return TOK_ESC;
+	case S5: return TOK_OCT;
+	case S7: return TOK_HEX;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
 }
@@ -446,7 +960,7 @@ z2(struct lx *lx)
 		lx->clear(lx);
 	}
 
-	state = S2;
+	state = S0;
 
 	lx->start = lx->end;
 
@@ -458,25 +972,280 @@ z2(struct lx *lx)
 		}
 
 		switch (state) {
-		case S0: /* e.g. "a" */
+		case S0: /* start */
+			switch (c) {
+			case '\x00':
+			case '\x01':
+			case '\x02':
+			case '\x03':
+			case '\x04':
+			case '\x05':
+			case '\x06':
+			case '\a':
+			case '\b':
+			case '\t':
+			case '\n':
+			case '\v':
+			case '\f':
+			case '\r':
+			case '\x0e':
+			case '\x0f':
+			case '\x10':
+			case '\x11':
+			case '\x12':
+			case '\x13':
+			case '\x14':
+			case '\x15':
+			case '\x16':
+			case '\x17':
+			case '\x18':
+			case '\x19':
+			case '\x1a':
+			case '\x1b':
+			case '\x1c':
+			case '\x1d':
+			case '\x1e':
+			case '\x1f':
+			case ' ':
+			case '!':
+			case '"':
+			case '#':
+			case '$':
+			case '%':
+			case '&': state = S1; continue;
+			case '\'': state = S2; continue;
+			case '(':
+			case ')':
+			case '*':
+			case '+':
+			case ',':
+			case '-':
+			case '.':
+			case '\x2f':
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9':
+			case ':':
+			case ';':
+			case '<':
+			case '=':
+			case '>':
+			case '?':
+			case '@':
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'G':
+			case 'H':
+			case 'I':
+			case 'J':
+			case 'K':
+			case 'L':
+			case 'M':
+			case 'N':
+			case 'O':
+			case 'P':
+			case 'Q':
+			case 'R':
+			case 'S':
+			case 'T':
+			case 'U':
+			case 'V':
+			case 'W':
+			case 'X':
+			case 'Y':
+			case 'Z':
+			case '[':
+			case '\\':
+			case ']':
+			case '^':
+			case '_':
+			case '`':
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f':
+			case 'g':
+			case 'h':
+			case 'i':
+			case 'j':
+			case 'k':
+			case 'l':
+			case 'm':
+			case 'n':
+			case 'o':
+			case 'p':
+			case 'q':
+			case 'r':
+			case 's':
+			case 't':
+			case 'u':
+			case 'v':
+			case 'w':
+			case 'x':
+			case 'y':
+			case 'z':
+			case '{':
+			case '|':
+			case '}':
+			case '~':
+			case '\x7f':
+			case '\x80':
+			case '\x81':
+			case '\x82':
+			case '\x83':
+			case '\x84':
+			case '\x85':
+			case '\x86':
+			case '\x87':
+			case '\x88':
+			case '\x89':
+			case '\x8a':
+			case '\x8b':
+			case '\x8c':
+			case '\x8d':
+			case '\x8e':
+			case '\x8f':
+			case '\x90':
+			case '\x91':
+			case '\x92':
+			case '\x93':
+			case '\x94':
+			case '\x95':
+			case '\x96':
+			case '\x97':
+			case '\x98':
+			case '\x99':
+			case '\x9a':
+			case '\x9b':
+			case '\x9c':
+			case '\x9d':
+			case '\x9e':
+			case '\x9f':
+			case '\xa0':
+			case '\xa1':
+			case '\xa2':
+			case '\xa3':
+			case '\xa4':
+			case '\xa5':
+			case '\xa6':
+			case '\xa7':
+			case '\xa8':
+			case '\xa9':
+			case '\xaa':
+			case '\xab':
+			case '\xac':
+			case '\xad':
+			case '\xae':
+			case '\xaf':
+			case '\xb0':
+			case '\xb1':
+			case '\xb2':
+			case '\xb3':
+			case '\xb4':
+			case '\xb5':
+			case '\xb6':
+			case '\xb7':
+			case '\xb8':
+			case '\xb9':
+			case '\xba':
+			case '\xbb':
+			case '\xbc':
+			case '\xbd':
+			case '\xbe':
+			case '\xbf':
+			case '\xc0':
+			case '\xc1':
+			case '\xc2':
+			case '\xc3':
+			case '\xc4':
+			case '\xc5':
+			case '\xc6':
+			case '\xc7':
+			case '\xc8':
+			case '\xc9':
+			case '\xca':
+			case '\xcb':
+			case '\xcc':
+			case '\xcd':
+			case '\xce':
+			case '\xcf':
+			case '\xd0':
+			case '\xd1':
+			case '\xd2':
+			case '\xd3':
+			case '\xd4':
+			case '\xd5':
+			case '\xd6':
+			case '\xd7':
+			case '\xd8':
+			case '\xd9':
+			case '\xda':
+			case '\xdb':
+			case '\xdc':
+			case '\xdd':
+			case '\xde':
+			case '\xdf':
+			case '\xe0':
+			case '\xe1':
+			case '\xe2':
+			case '\xe3':
+			case '\xe4':
+			case '\xe5':
+			case '\xe6':
+			case '\xe7':
+			case '\xe8':
+			case '\xe9':
+			case '\xea':
+			case '\xeb':
+			case '\xec':
+			case '\xed':
+			case '\xee':
+			case '\xef':
+			case '\xf0':
+			case '\xf1':
+			case '\xf2':
+			case '\xf3':
+			case '\xf4':
+			case '\xf5':
+			case '\xf6':
+			case '\xf7':
+			case '\xf8':
+			case '\xf9':
+			case '\xfa':
+			case '\xfb':
+			case '\xfc':
+			case '\xfd':
+			case '\xfe':
+			case '\xff': state = S1; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S1: /* e.g. "a" */
 			lx_ungetc(lx, c); return TOK_CHAR;
 
-		case S1: /* e.g. "\'" */
+		case S2: /* e.g. "\'" */
 			lx_ungetc(lx, c); return lx->z = z4, TOK_STR;
-
-		case S2: /* start */
-			switch (c) {
-			case '\'': state = S1; continue;
-			default:  state = S0; continue;
-			}
 		}
 	}
 
 	lx->lgetc = NULL;
 
 	switch (state) {
-	case S0: return TOK_CHAR;
-	case S1: return TOK_STR;
+	case S1: return TOK_CHAR;
+	case S2: return TOK_STR;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
 }
@@ -496,7 +1265,7 @@ z3(struct lx *lx)
 		lx->clear(lx);
 	}
 
-	state = S2;
+	state = S0;
 
 	lx->start = lx->end;
 
@@ -518,25 +1287,280 @@ z3(struct lx *lx)
 		}
 
 		switch (state) {
-		case S0: /* e.g. "a" */
+		case S0: /* start */
+			switch (c) {
+			case '\x00':
+			case '\x01':
+			case '\x02':
+			case '\x03':
+			case '\x04':
+			case '\x05':
+			case '\x06':
+			case '\a':
+			case '\b':
+			case '\t': state = S1; continue;
+			case '\n': state = S2; continue;
+			case '\v':
+			case '\f':
+			case '\r':
+			case '\x0e':
+			case '\x0f':
+			case '\x10':
+			case '\x11':
+			case '\x12':
+			case '\x13':
+			case '\x14':
+			case '\x15':
+			case '\x16':
+			case '\x17':
+			case '\x18':
+			case '\x19':
+			case '\x1a':
+			case '\x1b':
+			case '\x1c':
+			case '\x1d':
+			case '\x1e':
+			case '\x1f':
+			case ' ':
+			case '!':
+			case '"':
+			case '#':
+			case '$':
+			case '%':
+			case '&':
+			case '\'':
+			case '(':
+			case ')':
+			case '*':
+			case '+':
+			case ',':
+			case '-':
+			case '.':
+			case '\x2f':
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9':
+			case ':':
+			case ';':
+			case '<':
+			case '=':
+			case '>':
+			case '?':
+			case '@':
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'G':
+			case 'H':
+			case 'I':
+			case 'J':
+			case 'K':
+			case 'L':
+			case 'M':
+			case 'N':
+			case 'O':
+			case 'P':
+			case 'Q':
+			case 'R':
+			case 'S':
+			case 'T':
+			case 'U':
+			case 'V':
+			case 'W':
+			case 'X':
+			case 'Y':
+			case 'Z':
+			case '[':
+			case '\\':
+			case ']':
+			case '^':
+			case '_':
+			case '`':
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f':
+			case 'g':
+			case 'h':
+			case 'i':
+			case 'j':
+			case 'k':
+			case 'l':
+			case 'm':
+			case 'n':
+			case 'o':
+			case 'p':
+			case 'q':
+			case 'r':
+			case 's':
+			case 't':
+			case 'u':
+			case 'v':
+			case 'w':
+			case 'x':
+			case 'y':
+			case 'z':
+			case '{':
+			case '|':
+			case '}':
+			case '~':
+			case '\x7f':
+			case '\x80':
+			case '\x81':
+			case '\x82':
+			case '\x83':
+			case '\x84':
+			case '\x85':
+			case '\x86':
+			case '\x87':
+			case '\x88':
+			case '\x89':
+			case '\x8a':
+			case '\x8b':
+			case '\x8c':
+			case '\x8d':
+			case '\x8e':
+			case '\x8f':
+			case '\x90':
+			case '\x91':
+			case '\x92':
+			case '\x93':
+			case '\x94':
+			case '\x95':
+			case '\x96':
+			case '\x97':
+			case '\x98':
+			case '\x99':
+			case '\x9a':
+			case '\x9b':
+			case '\x9c':
+			case '\x9d':
+			case '\x9e':
+			case '\x9f':
+			case '\xa0':
+			case '\xa1':
+			case '\xa2':
+			case '\xa3':
+			case '\xa4':
+			case '\xa5':
+			case '\xa6':
+			case '\xa7':
+			case '\xa8':
+			case '\xa9':
+			case '\xaa':
+			case '\xab':
+			case '\xac':
+			case '\xad':
+			case '\xae':
+			case '\xaf':
+			case '\xb0':
+			case '\xb1':
+			case '\xb2':
+			case '\xb3':
+			case '\xb4':
+			case '\xb5':
+			case '\xb6':
+			case '\xb7':
+			case '\xb8':
+			case '\xb9':
+			case '\xba':
+			case '\xbb':
+			case '\xbc':
+			case '\xbd':
+			case '\xbe':
+			case '\xbf':
+			case '\xc0':
+			case '\xc1':
+			case '\xc2':
+			case '\xc3':
+			case '\xc4':
+			case '\xc5':
+			case '\xc6':
+			case '\xc7':
+			case '\xc8':
+			case '\xc9':
+			case '\xca':
+			case '\xcb':
+			case '\xcc':
+			case '\xcd':
+			case '\xce':
+			case '\xcf':
+			case '\xd0':
+			case '\xd1':
+			case '\xd2':
+			case '\xd3':
+			case '\xd4':
+			case '\xd5':
+			case '\xd6':
+			case '\xd7':
+			case '\xd8':
+			case '\xd9':
+			case '\xda':
+			case '\xdb':
+			case '\xdc':
+			case '\xdd':
+			case '\xde':
+			case '\xdf':
+			case '\xe0':
+			case '\xe1':
+			case '\xe2':
+			case '\xe3':
+			case '\xe4':
+			case '\xe5':
+			case '\xe6':
+			case '\xe7':
+			case '\xe8':
+			case '\xe9':
+			case '\xea':
+			case '\xeb':
+			case '\xec':
+			case '\xed':
+			case '\xee':
+			case '\xef':
+			case '\xf0':
+			case '\xf1':
+			case '\xf2':
+			case '\xf3':
+			case '\xf4':
+			case '\xf5':
+			case '\xf6':
+			case '\xf7':
+			case '\xf8':
+			case '\xf9':
+			case '\xfa':
+			case '\xfb':
+			case '\xfc':
+			case '\xfd':
+			case '\xfe':
+			case '\xff': state = S1; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S1: /* e.g. "a" */
 			lx_ungetc(lx, c); return lx->z(lx);
 
-		case S1: /* e.g. "\n" */
+		case S2: /* e.g. "\n" */
 			lx_ungetc(lx, c); return lx->z = z4, lx->z(lx);
-
-		case S2: /* start */
-			switch (c) {
-			case '\n': state = S1; continue;
-			default:  state = S0; continue;
-			}
 		}
 	}
 
 	lx->lgetc = NULL;
 
 	switch (state) {
-	case S0: return TOK_EOF;
 	case S1: return TOK_EOF;
+	case S2: return TOK_EOF;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
 }
@@ -558,17 +1582,17 @@ z4(struct lx *lx)
 		lx->clear(lx);
 	}
 
-	state = S27;
+	state = S0;
 
 	lx->start = lx->end;
 
 	while (c = lx_getc(lx), c != EOF) {
 		switch (state) {
+		case S1:
 		case S3:
-		case S5:
-		case S6:
+		case S4:
 		case S7:
-		case S8:
+		case S14:
 			break;
 
 		default:
@@ -582,228 +1606,306 @@ z4(struct lx *lx)
 		}
 
 		switch (state) {
-		case S0: /* e.g. "$a" */
-			switch (c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9':             continue;
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F':
-			case 'G':
-			case 'H':
-			case 'I':
-			case 'J':
-			case 'K':
-			case 'L':
-			case 'M':
-			case 'N':
-			case 'O':
-			case 'P':
-			case 'Q':
-			case 'R':
-			case 'S':
-			case 'T':
-			case 'U':
-			case 'V':
-			case 'W':
-			case 'X':
-			case 'Y':
-			case 'Z':             continue;
-			case '_':             continue;
-			case 'a':
-			case 'b':
-			case 'c':
-			case 'd':
-			case 'e':
-			case 'f':
-			case 'g':
-			case 'h':
-			case 'i':
-			case 'j':
-			case 'k':
-			case 'l':
-			case 'm':
-			case 'n':
-			case 'o':
-			case 'p':
-			case 'q':
-			case 'r':
-			case 's':
-			case 't':
-			case 'u':
-			case 'v':
-			case 'w':
-			case 'x':
-			case 'y':
-			case 'z':             continue;
-			default:  lx_ungetc(lx, c); return TOK_TOKEN;
-			}
-
-		case S1: /* e.g. ".." */
-			lx_ungetc(lx, c); return TOK_TO;
-
-		case S2: /* e.g. "->" */
-			lx_ungetc(lx, c); return TOK_MAP;
-
-		case S3: /* e.g. "#" */
-			lx_ungetc(lx, c); return lx->z = z3, lx->z(lx);
-
-		case S4: /* e.g. "a" */
-			switch (c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9':             continue;
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F':
-			case 'G':
-			case 'H':
-			case 'I':
-			case 'J':
-			case 'K':
-			case 'L':
-			case 'M':
-			case 'N':
-			case 'O':
-			case 'P':
-			case 'Q':
-			case 'R':
-			case 'S':
-			case 'T':
-			case 'U':
-			case 'V':
-			case 'W':
-			case 'X':
-			case 'Y':
-			case 'Z':             continue;
-			case '_':             continue;
-			case 'a':
-			case 'b':
-			case 'c':
-			case 'd':
-			case 'e':
-			case 'f':
-			case 'g':
-			case 'h':
-			case 'i':
-			case 'j':
-			case 'k':
-			case 'l':
-			case 'm':
-			case 'n':
-			case 'o':
-			case 'p':
-			case 'q':
-			case 'r':
-			case 's':
-			case 't':
-			case 'u':
-			case 'v':
-			case 'w':
-			case 'x':
-			case 'y':
-			case 'z':             continue;
-			default:  lx_ungetc(lx, c); return TOK_IDENT;
-			}
-
-		case S5: /* e.g. "\t" */
+		case S0: /* start */
 			switch (c) {
 			case '\t':
-			case '\n':             continue;
-			case '\r':             continue;
-			case ' ':             continue;
+			case '\n': state = S1; continue;
+			case '\r': state = S1; continue;
+			case ' ': state = S1; continue;
+			case '!': state = S2; continue;
+			case '"': state = S3; continue;
+			case '#': state = S4; continue;
+			case '$': state = S5; continue;
+			case '&': state = S6; continue;
+			case '\'': state = S7; continue;
+			case '(': state = S8; continue;
+			case ')': state = S9; continue;
+			case '*': state = S10; continue;
+			case '+': state = S11; continue;
+			case '-': state = S12; continue;
+			case '.': state = S13; continue;
+			case '\x2f': state = S14; continue;
+			case ';': state = S15; continue;
+			case '=': state = S16; continue;
+			case '?': state = S17; continue;
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'G':
+			case 'H':
+			case 'I':
+			case 'J':
+			case 'K':
+			case 'L':
+			case 'M':
+			case 'N':
+			case 'O':
+			case 'P':
+			case 'Q':
+			case 'R':
+			case 'S':
+			case 'T':
+			case 'U':
+			case 'V':
+			case 'W':
+			case 'X':
+			case 'Y':
+			case 'Z': state = S18; continue;
+			case '\\': state = S19; continue;
+			case '^': state = S20; continue;
+			case '_': state = S18; continue;
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f':
+			case 'g':
+			case 'h':
+			case 'i':
+			case 'j':
+			case 'k':
+			case 'l':
+			case 'm':
+			case 'n':
+			case 'o':
+			case 'p':
+			case 'q':
+			case 'r':
+			case 's':
+			case 't':
+			case 'u':
+			case 'v':
+			case 'w':
+			case 'x':
+			case 'y':
+			case 'z': state = S18; continue;
+			case '{': state = S21; continue;
+			case '|': state = S22; continue;
+			case '}': state = S23; continue;
+			case '~': state = S24; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S1: /* e.g. "\t" */
+			switch (c) {
+			case '\t':
+			case '\n': continue;
+			case '\r': continue;
+			case ' ': continue;
 			default:  lx_ungetc(lx, c); return lx->z(lx);
 			}
 
-		case S6: /* e.g. "\'" */
-			lx_ungetc(lx, c); return lx->z = z2, lx->z(lx);
-
-		case S7: /* e.g. """ */
-			lx_ungetc(lx, c); return lx->z = z1, lx->z(lx);
-
-		case S8: /* e.g. "\057" */
-			lx_ungetc(lx, c); return lx->z = z0, lx->z(lx);
-
-		case S9: /* e.g. "=" */
-			lx_ungetc(lx, c); return TOK_BIND;
-
-		case S10: /* e.g. "{" */
-			lx_ungetc(lx, c); return TOK_OPEN;
-
-		case S11: /* e.g. "}" */
-			lx_ungetc(lx, c); return TOK_CLOSE;
-
-		case S12: /* e.g. ")" */
-			lx_ungetc(lx, c); return TOK_RPAREN;
-
-		case S13: /* e.g. "*" */
-			lx_ungetc(lx, c); return TOK_STAR;
-
-		case S14: /* e.g. "+" */
-			lx_ungetc(lx, c); return TOK_CROSS;
-
-		case S15: /* e.g. "?" */
-			lx_ungetc(lx, c); return TOK_QMARK;
-
-		case S16: /* e.g. ";" */
-			lx_ungetc(lx, c); return TOK_SEMI;
-
-		case S17: /* e.g. "~" */
-			lx_ungetc(lx, c); return TOK_TILDE;
-
-		case S18: /* e.g. "!" */
+		case S2: /* e.g. "!" */
 			lx_ungetc(lx, c); return TOK_BANG;
 
-		case S19: /* e.g. "^" */
-			lx_ungetc(lx, c); return TOK_HAT;
+		case S3: /* e.g. """ */
+			lx_ungetc(lx, c); return lx->z = z1, lx->z(lx);
 
-		case S20: /* e.g. "-" */
+		case S4: /* e.g. "#" */
+			lx_ungetc(lx, c); return lx->z = z3, lx->z(lx);
+
+		case S5: /* e.g. "$" */
 			switch (c) {
-			case '>': state = S2; continue;
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'G':
+			case 'H':
+			case 'I':
+			case 'J':
+			case 'K':
+			case 'L':
+			case 'M':
+			case 'N':
+			case 'O':
+			case 'P':
+			case 'Q':
+			case 'R':
+			case 'S':
+			case 'T':
+			case 'U':
+			case 'V':
+			case 'W':
+			case 'X':
+			case 'Y':
+			case 'Z': state = S25; continue;
+			case '_': state = S25; continue;
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f':
+			case 'g':
+			case 'h':
+			case 'i':
+			case 'j':
+			case 'k':
+			case 'l':
+			case 'm':
+			case 'n':
+			case 'o':
+			case 'p':
+			case 'q':
+			case 'r':
+			case 's':
+			case 't':
+			case 'u':
+			case 'v':
+			case 'w':
+			case 'x':
+			case 'y':
+			case 'z': state = S25; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S6: /* e.g. "&" */
+			lx_ungetc(lx, c); return TOK_AND;
+
+		case S7: /* e.g. "\'" */
+			lx_ungetc(lx, c); return lx->z = z2, lx->z(lx);
+
+		case S8: /* e.g. "(" */
+			lx_ungetc(lx, c); return TOK_LPAREN;
+
+		case S9: /* e.g. ")" */
+			lx_ungetc(lx, c); return TOK_RPAREN;
+
+		case S10: /* e.g. "*" */
+			lx_ungetc(lx, c); return TOK_STAR;
+
+		case S11: /* e.g. "+" */
+			lx_ungetc(lx, c); return TOK_CROSS;
+
+		case S12: /* e.g. "-" */
+			switch (c) {
+			case '>': state = S27; continue;
 			default:  lx_ungetc(lx, c); return TOK_DASH;
 			}
 
-		case S21: /* e.g. "\\" */
-			lx_ungetc(lx, c); return TOK_DASH;
-
-		case S22: /* e.g. "(" */
-			lx_ungetc(lx, c); return TOK_LPAREN;
-
-		case S23: /* e.g. "." */
+		case S13: /* e.g. "." */
 			switch (c) {
-			case '.': state = S1; continue;
+			case '.': state = S26; continue;
 			default:  lx_ungetc(lx, c); return TOK_DOT;
 			}
 
-		case S24: /* e.g. "|" */
+		case S14: /* e.g. "\x2f" */
+			lx_ungetc(lx, c); return lx->z = z0, lx->z(lx);
+
+		case S15: /* e.g. ";" */
+			lx_ungetc(lx, c); return TOK_SEMI;
+
+		case S16: /* e.g. "=" */
+			lx_ungetc(lx, c); return TOK_BIND;
+
+		case S17: /* e.g. "?" */
+			lx_ungetc(lx, c); return TOK_QMARK;
+
+		case S18: /* e.g. "a" */
+			switch (c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9': continue;
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'G':
+			case 'H':
+			case 'I':
+			case 'J':
+			case 'K':
+			case 'L':
+			case 'M':
+			case 'N':
+			case 'O':
+			case 'P':
+			case 'Q':
+			case 'R':
+			case 'S':
+			case 'T':
+			case 'U':
+			case 'V':
+			case 'W':
+			case 'X':
+			case 'Y':
+			case 'Z': continue;
+			case '_': continue;
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f':
+			case 'g':
+			case 'h':
+			case 'i':
+			case 'j':
+			case 'k':
+			case 'l':
+			case 'm':
+			case 'n':
+			case 'o':
+			case 'p':
+			case 'q':
+			case 'r':
+			case 's':
+			case 't':
+			case 'u':
+			case 'v':
+			case 'w':
+			case 'x':
+			case 'y':
+			case 'z': continue;
+			default:  lx_ungetc(lx, c); return TOK_IDENT;
+			}
+
+		case S19: /* e.g. "\\" */
+			lx_ungetc(lx, c); return TOK_DASH;
+
+		case S20: /* e.g. "^" */
+			lx_ungetc(lx, c); return TOK_HAT;
+
+		case S21: /* e.g. "{" */
+			lx_ungetc(lx, c); return TOK_OPEN;
+
+		case S22: /* e.g. "|" */
 			lx_ungetc(lx, c); return TOK_PIPE;
 
-		case S25: /* e.g. "&" */
-			lx_ungetc(lx, c); return TOK_AND;
+		case S23: /* e.g. "}" */
+			lx_ungetc(lx, c); return TOK_CLOSE;
 
-		case S26: /* e.g. "$" */
+		case S24: /* e.g. "~" */
+			lx_ungetc(lx, c); return TOK_TILDE;
+
+		case S25: /* e.g. "$a" */
 			switch (c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9': continue;
 			case 'A':
 			case 'B':
 			case 'C':
@@ -829,8 +1931,8 @@ z4(struct lx *lx)
 			case 'W':
 			case 'X':
 			case 'Y':
-			case 'Z': state = S0; continue;
-			case '_': state = S0; continue;
+			case 'Z': continue;
+			case '_': continue;
 			case 'a':
 			case 'b':
 			case 'c':
@@ -856,125 +1958,47 @@ z4(struct lx *lx)
 			case 'w':
 			case 'x':
 			case 'y':
-			case 'z': state = S0; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			case 'z': continue;
+			default:  lx_ungetc(lx, c); return TOK_TOKEN;
 			}
 
-		case S27: /* start */
-			switch (c) {
-			case '\t':
-			case '\n': state = S5; continue;
-			case '\r': state = S5; continue;
-			case ' ': state = S5; continue;
-			case '!': state = S18; continue;
-			case '"': state = S7; continue;
-			case '#': state = S3; continue;
-			case '$': state = S26; continue;
-			case '&': state = S25; continue;
-			case '\'': state = S6; continue;
-			case '(': state = S22; continue;
-			case ')': state = S12; continue;
-			case '*': state = S13; continue;
-			case '+': state = S14; continue;
-			case '-': state = S20; continue;
-			case '.': state = S23; continue;
-			case '\057': state = S8; continue;
-			case ';': state = S16; continue;
-			case '=': state = S9; continue;
-			case '?': state = S15; continue;
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F':
-			case 'G':
-			case 'H':
-			case 'I':
-			case 'J':
-			case 'K':
-			case 'L':
-			case 'M':
-			case 'N':
-			case 'O':
-			case 'P':
-			case 'Q':
-			case 'R':
-			case 'S':
-			case 'T':
-			case 'U':
-			case 'V':
-			case 'W':
-			case 'X':
-			case 'Y':
-			case 'Z': state = S4; continue;
-			case '\\': state = S21; continue;
-			case '^': state = S19; continue;
-			case '_': state = S4; continue;
-			case 'a':
-			case 'b':
-			case 'c':
-			case 'd':
-			case 'e':
-			case 'f':
-			case 'g':
-			case 'h':
-			case 'i':
-			case 'j':
-			case 'k':
-			case 'l':
-			case 'm':
-			case 'n':
-			case 'o':
-			case 'p':
-			case 'q':
-			case 'r':
-			case 's':
-			case 't':
-			case 'u':
-			case 'v':
-			case 'w':
-			case 'x':
-			case 'y':
-			case 'z': state = S4; continue;
-			case '{': state = S10; continue;
-			case '|': state = S24; continue;
-			case '}': state = S11; continue;
-			case '~': state = S17; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
+		case S26: /* e.g. ".." */
+			lx_ungetc(lx, c); return TOK_TO;
+
+		case S27: /* e.g. "->" */
+			lx_ungetc(lx, c); return TOK_MAP;
 		}
 	}
 
 	lx->lgetc = NULL;
 
 	switch (state) {
-	case S0: return TOK_TOKEN;
-	case S1: return TOK_TO;
-	case S2: return TOK_MAP;
+	case S1: return TOK_EOF;
+	case S2: return TOK_BANG;
 	case S3: return TOK_EOF;
-	case S4: return TOK_IDENT;
-	case S5: return TOK_EOF;
-	case S6: return TOK_EOF;
+	case S4: return TOK_EOF;
+	case S6: return TOK_AND;
 	case S7: return TOK_EOF;
-	case S8: return TOK_EOF;
-	case S9: return TOK_BIND;
-	case S10: return TOK_OPEN;
-	case S11: return TOK_CLOSE;
-	case S12: return TOK_RPAREN;
-	case S13: return TOK_STAR;
-	case S14: return TOK_CROSS;
-	case S15: return TOK_QMARK;
-	case S16: return TOK_SEMI;
-	case S17: return TOK_TILDE;
-	case S18: return TOK_BANG;
-	case S19: return TOK_HAT;
-	case S20: return TOK_DASH;
-	case S21: return TOK_DASH;
-	case S22: return TOK_LPAREN;
-	case S23: return TOK_DOT;
-	case S24: return TOK_PIPE;
-	case S25: return TOK_AND;
+	case S8: return TOK_LPAREN;
+	case S9: return TOK_RPAREN;
+	case S10: return TOK_STAR;
+	case S11: return TOK_CROSS;
+	case S12: return TOK_DASH;
+	case S13: return TOK_DOT;
+	case S14: return TOK_EOF;
+	case S15: return TOK_SEMI;
+	case S16: return TOK_BIND;
+	case S17: return TOK_QMARK;
+	case S18: return TOK_IDENT;
+	case S19: return TOK_DASH;
+	case S20: return TOK_HAT;
+	case S21: return TOK_OPEN;
+	case S22: return TOK_PIPE;
+	case S23: return TOK_CLOSE;
+	case S24: return TOK_TILDE;
+	case S25: return TOK_TOKEN;
+	case S26: return TOK_TO;
+	case S27: return TOK_MAP;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
 }
@@ -1023,7 +2047,7 @@ lx_example(enum lx_token (*z)(struct lx *), enum lx_token t)
 
 	if (z == z0) {
 		switch (t) {
-		case TOK_RE: return "\057";
+		case TOK_RE: return "\x2f";
 		case TOK_CHAR: return "a";
 		default: goto error;
 		}
@@ -1033,7 +2057,7 @@ lx_example(enum lx_token (*z)(struct lx *), enum lx_token t)
 		case TOK_HEX: return "\\xa";
 		case TOK_OCT: return "\\0";
 		case TOK_ESC: return "\\f";
-		case TOK_CHAR: return "\\";
+		case TOK_CHAR: return "a";
 		case TOK_STR: return "\"";
 		default: goto error;
 		}
@@ -1092,7 +2116,7 @@ lx_init(struct lx *lx)
 	*lx = lx_default;
 
 	lx->c = EOF;
-	lx->z = NULL;
+	lx->z = z4;
 
 	lx->end.byte = 0;
 	lx->end.line = 1;
@@ -1105,13 +2129,10 @@ lx_next(struct lx *lx)
 	enum lx_token t;
 
 	assert(lx != NULL);
+	assert(lx->z != NULL);
 
 	if (lx->lgetc == NULL) {
 		return TOK_EOF;
-	}
-
-	if (lx->z == NULL) {
-		lx->z = z4;
 	}
 
 	t = lx->z(lx);


### PR DESCRIPTION
This broke after the state list from an edge was no longer maintained in
insertion order, commit 69779c0. The
breakage only happened on FSMs with more than two states, and only if
the ordering of the edges was not insertion order.

The reason for the breakage was that fsm_shortest updated the priq in
Dijkstra without reordering the elements in the priq. This wasn't
problematic before the change, because destination states from an edge
being in insertion order gave some guarantees about how the path could
be reached.

A new function, `priq_update` is introduced to update the cost of a node
in a priq, maintaining the semantics of the structure. `fsm_shortest`
now calls this function when it finds a shorter path over some edge. And
we now have working examples again.