### PR TITLE
`fsm_reverse()` in place

### DIFF
--- a/src/libfsm/reverse.c
+++ b/src/libfsm/reverse.c
@@ -63,11 +63,16 @@ fsm_reverse(struct fsm *fsm)
 				struct fsm_state *to;
 				struct set_iter jt;
 				for (to = set_first(e->sl, &jt); to != NULL; to = set_next(&jt)) {
-					/*XXX */
 					if (lq <= nq) {
+						void *tmp;
 						lq = lq > 0 ? lq * 2 : 1024;
-						q = realloc(q, lq * sizeof *q);
-						if (!q) abort();
+						tmp = realloc(q, lq * sizeof *q);
+						if (!tmp) {
+							free(q);
+							set_free(endset);
+							return 0;
+						}
+						q = tmp;
 					}
 					/* reversed because it's a description of the edge we wish to create later */
 					q[nq].from = to;

--- a/src/libfsm/reverse.c
+++ b/src/libfsm/reverse.c
@@ -46,7 +46,8 @@ fsm_reverse(struct fsm *fsm)
 
 	endcount = fsm->endcount;
 
-	/* Perform the actual reversal by listing the reversed edges we need,
+	/*
+	 * Perform the actual reversal by listing the reversed edges we need,
 	 * destroying all current edges, then adding those.
 	 */
 	{
@@ -58,9 +59,15 @@ fsm_reverse(struct fsm *fsm)
 			struct fsm_state *to;
 			enum fsm_edge_type symbol;
 		} *q = NULL;
-		size_t lq = 0, nq = 0;
+		size_t lq = 0;
+		size_t nq = 0;
+
 		size_t i;
 
+		/*
+		 * Populate our list of reversed edges. This loop will leave the FSM
+		 * without any edges at all, but otherwise consistent.
+		 */
 		for (s = fsm->sl; s != NULL; s = s->next) {
 			struct fsm_edge *e;
 			for (e = set_first(s->edges, &it); e != NULL; e = set_next(&it)) {

--- a/src/libfsm/reverse.c
+++ b/src/libfsm/reverse.c
@@ -24,6 +24,8 @@ fsm_reverse(struct fsm *fsm)
 	struct fsm_state *end;
 	struct set *endset;
 
+	unsigned long endcount;
+
 	assert(fsm != NULL);
 	assert(fsm->opt != NULL);
 
@@ -41,6 +43,8 @@ fsm_reverse(struct fsm *fsm)
 	 * only to the caller.
 	 */
 	endset = NULL;
+
+	endcount = fsm->endcount;
 
 	/* Perform the actual reversal by listing the reversed edges we need,
 	 * destroying all current edges, then adding those.
@@ -90,13 +94,12 @@ fsm_reverse(struct fsm *fsm)
 					return 0;
 				}
 
-				if (fsm->endcount == 1) {
+				if (endcount == 1) {
 					fsm->start = s;
 				}
 			}
 
-			/* deliberately don't go via the API. we'll correct the end count when we're finished with it. */
-			s->end = s == end;
+			fsm_setend(fsm, s, s == end);
 		}
 
 		/* the FSM now has no edges; add a reversed edge for each one recorded */
@@ -121,7 +124,7 @@ fsm_reverse(struct fsm *fsm)
 		struct set_iter it;
 
 
-		switch (fsm->endcount) {
+		switch (endcount) {
 		case 1:
 			/* already handled above */
 			assert(fsm->start != NULL);
@@ -210,8 +213,6 @@ fsm_reverse(struct fsm *fsm)
 	}
 
 	set_free(endset);
-
-	fsm->endcount = end != NULL ? 1 : 0;
 
 	return 1;
 }

--- a/src/libfsm/reverse.c
+++ b/src/libfsm/reverse.c
@@ -111,7 +111,11 @@ fsm_reverse(struct fsm *fsm)
 
 		/* the FSM now has no edges; add a reversed edge for each one recorded */
 		for (i = 0; i < nq; i++) {
-			fsm_addedge(q[i].to, q[i].from, q[i].symbol);
+			if (!fsm_addedge(q[i].to, q[i].from, q[i].symbol)) {
+				free(q);
+				set_free(endset);
+				return 0;
+			}
 		}
 
 		free(q);

--- a/src/libfsm/reverse.c
+++ b/src/libfsm/reverse.c
@@ -74,9 +74,8 @@ fsm_reverse(struct fsm *fsm)
 						}
 						q = tmp;
 					}
-					/* reversed because it's a description of the edge we wish to create later */
-					q[nq].from = to;
-					q[nq].to = s;
+					q[nq].from = s;
+					q[nq].to = to;
 					q[nq].symbol = e->symbol;
 					nq++;
 				}
@@ -100,9 +99,9 @@ fsm_reverse(struct fsm *fsm)
 			s->end = s == end;
 		}
 
-		/* the FSM now has no edges; add the ones we recorded */
+		/* the FSM now has no edges; add a reversed edge for each one recorded */
 		for (i = 0; i < nq; i++) {
-			fsm_addedge(q[i].from, q[i].to, q[i].symbol);
+			fsm_addedge(q[i].to, q[i].from, q[i].symbol);
 		}
 
 		free(q);


### PR DESCRIPTION
I don't think the code is nice enough to merge yet.

This slightly changes some API: if `fsm_reverse(x)` fails, `x` is no longer guaranteed to be unchanged, but still needs to be freed.