### PR TITLE
Remove set API, and pass sets of states as an array for `carryopaque()`

### DIFF
--- a/examples/iprange/main.c
+++ b/examples/iprange/main.c
@@ -450,7 +450,7 @@ important(unsigned n)
 }
 
 static void
-carryopaque(void **set, size_t n, struct fsm *fsm, struct fsm_state *st)
+carryopaque(const void **set, size_t n, struct fsm *fsm, struct fsm_state *st)
 {
 	void *o = NULL;
 	size_t i;

--- a/examples/iprange/main.c
+++ b/examples/iprange/main.c
@@ -38,7 +38,6 @@
 #include <time.h>
 #include <unistd.h>
 
-#include <adt/set.h> /* XXX */
 #include <fsm/fsm.h>
 #include <fsm/bool.h>
 #include <fsm/out.h>
@@ -451,24 +450,22 @@ important(unsigned n)
 }
 
 static void
-carryopaque(struct set *set, struct fsm *fsm, struct fsm_state *st)
+carryopaque(void **set, size_t n, struct fsm *fsm, struct fsm_state *st)
 {
-	struct fsm_state *s;
-	struct set_iter it;
 	void *o = NULL;
+	size_t i;
 
-	/* XXX: This should be possible without adt/set.h */
-	for (s = set_first(set, &it); s != NULL; s = set_next(&it)) {
-		if (!fsm_isend(fsm, s)) {
+	for (i = 0; i < n; i++) {
+		if (!fsm_isend(fsm, set[i])) {
 			continue;
 		}
 
 		if (o == NULL) {
-			o = fsm_getopaque(fsm, s);
+			o = fsm_getopaque(fsm, set[i]);
 			fsm_setopaque(fsm, st, o);
 			continue;
 		} else {
-			assert(o == fsm_getopaque(fsm, s));
+			assert(o == fsm_getopaque(fsm, set[i]));
 		}
 	}
 }

--- a/examples/iprange/main.c
+++ b/examples/iprange/main.c
@@ -450,7 +450,8 @@ important(unsigned n)
 }
 
 static void
-carryopaque(const void **set, size_t n, struct fsm *fsm, struct fsm_state *st)
+carryopaque(const struct fsm_state **set, size_t n,
+	struct fsm *fsm, struct fsm_state *st)
 {
 	void *o = NULL;
 	size_t i;

--- a/include/adt/set.h
+++ b/include/adt/set.h
@@ -71,5 +71,8 @@ set_only(const struct set *set);
 int
 set_hasnext(const struct set_iter *it);
 
+void * const*
+set_array(const struct set *set);
+
 #endif
 

--- a/include/adt/set.h
+++ b/include/adt/set.h
@@ -71,7 +71,7 @@ set_only(const struct set *set);
 int
 set_hasnext(const struct set_iter *it);
 
-void * const*
+const void **
 set_array(const struct set *set);
 
 #endif

--- a/include/fsm/options.h
+++ b/include/fsm/options.h
@@ -10,8 +10,6 @@
 struct fsm;
 struct fsm_state;
 
-struct set; /* XXX */
-
 struct fsm_options {
 	/* boolean: true indicates to go to extra lengths in order to produce
 	 * neater-looking FSMs for certian operations. This usually means finding
@@ -49,7 +47,7 @@ struct fsm_options {
 	const char *prefix;
 
 	/* TODO: explain */
-	void (*carryopaque)(struct set *, struct fsm *, struct fsm_state *);
+	void (*carryopaque)(void **, size_t, struct fsm *, struct fsm_state *);
 };
 
 #endif

--- a/include/fsm/options.h
+++ b/include/fsm/options.h
@@ -47,7 +47,7 @@ struct fsm_options {
 	const char *prefix;
 
 	/* TODO: explain */
-	void (*carryopaque)(void **, size_t, struct fsm *, struct fsm_state *);
+	void (*carryopaque)(const void **, size_t, struct fsm *, struct fsm_state *);
 };
 
 #endif

--- a/include/fsm/options.h
+++ b/include/fsm/options.h
@@ -47,7 +47,8 @@ struct fsm_options {
 	const char *prefix;
 
 	/* TODO: explain */
-	void (*carryopaque)(const void **, size_t, struct fsm *, struct fsm_state *);
+	void (*carryopaque)(const struct fsm_state **, size_t,
+		struct fsm *, struct fsm_state *);
 };
 
 #endif

--- a/src/adt/set.c
+++ b/src/adt/set.c
@@ -380,3 +380,13 @@ set_hasnext(const struct set_iter *it)
 	return it->set && it->i + 1 < it->set->i;
 }
 
+void * const*
+set_array(const struct set *set)
+{
+	if (set == NULL) {
+		return 0;
+	}
+
+	return set->a;
+}
+

--- a/src/adt/set.c
+++ b/src/adt/set.c
@@ -380,7 +380,7 @@ set_hasnext(const struct set_iter *it)
 	return it->set && it->i + 1 < it->set->i;
 }
 
-void * const*
+const void **
 set_array(const struct set *set)
 {
 	if (set == NULL) {

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -528,9 +528,9 @@ determinise(struct fsm *nfa,
 		 * Carry through opaque values, if present. This isn't anything to do
 		 * with the DFA conversion; it's meaningful only to the caller.
 		 */
-		/* XXX: possibly have callback in fsm struct, instead. like the colour hooks */
 		if (dfa->opt->carryopaque != NULL) {
-			dfa->opt->carryopaque(curr->closure, dfa, curr->dfastate);
+			dfa->opt->carryopaque(set_array(curr->closure), set_count(curr->closure),
+				dfa, curr->dfastate);
 		}
 	}
 

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -528,10 +528,7 @@ determinise(struct fsm *nfa,
 		 * Carry through opaque values, if present. This isn't anything to do
 		 * with the DFA conversion; it's meaningful only to the caller.
 		 */
-		if (dfa->opt->carryopaque != NULL) {
-			dfa->opt->carryopaque(set_array(curr->closure), set_count(curr->closure),
-				dfa, curr->dfastate);
-		}
+		fsm_carryopaque(dfa, curr->closure, dfa, curr->dfastate);
 	}
 
 	free_mappings(mappings);

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -67,5 +67,9 @@ fsm_hasedge(const struct fsm_state *s, int c);
 struct fsm_edge *
 fsm_addedge(struct fsm_state *from, struct fsm_state *to, enum fsm_edge_type type);
 
+void
+fsm_carryopaque(struct fsm *fsm, const struct set *set,
+	struct fsm *new, struct fsm_state *state);
+
 #endif
 

--- a/src/libfsm/reverse.c
+++ b/src/libfsm/reverse.c
@@ -88,7 +88,7 @@ fsm_reverse(struct fsm *fsm)
 	}
 
 	if (end != NULL && fsm->opt->carryopaque != NULL) {
-		fsm->opt->carryopaque(endset, new, end);
+		fsm->opt->carryopaque(set_array(endset), set_count(endset), new, end);
 	}
 
 	/* Create reversed edges */

--- a/src/libfsm/reverse.c
+++ b/src/libfsm/reverse.c
@@ -87,9 +87,7 @@ fsm_reverse(struct fsm *fsm)
 		}
 	}
 
-	if (end != NULL && fsm->opt->carryopaque != NULL) {
-		fsm->opt->carryopaque(set_array(endset), set_count(endset), new, end);
-	}
+	fsm_carryopaque(fsm, endset, new, end);
 
 	/* Create reversed edges */
 	{

--- a/src/lx/main.c
+++ b/src/lx/main.c
@@ -13,8 +13,6 @@
 #include <string.h>
 #include <stdio.h>
 
-#include <adt/set.h>
-
 #include <fsm/fsm.h>
 #include <fsm/bool.h>
 #include <fsm/pred.h>
@@ -246,14 +244,14 @@ lang_exclude(const char *name)
 }
 
 static void
-carryopaque(struct set *set, struct fsm *fsm, struct fsm_state *state)
+carryopaque(void **set, size_t n, struct fsm *fsm, struct fsm_state *state)
 {
 	struct mapping_set *conflict;
 	struct ast_mapping *m;
-	struct set_iter it;
-	struct fsm_state *s;
+	size_t i;
 
 	assert(set != NULL); /* TODO: right? */
+	assert(n > 0); /* TODO: right? */
 	assert(fsm != NULL);
 	assert(state != NULL);
 
@@ -276,9 +274,9 @@ carryopaque(struct set *set, struct fsm *fsm, struct fsm_state *state)
 
 	m = NULL;
 
-	for (s = set_first(set, &it); s != NULL; s = set_next(&it)) {
-		if (fsm_isend(fsm, s)) {
-			m = fsm_getopaque(fsm, s);
+	for (i = 0; i < n; i++) {
+		if (fsm_isend(fsm, set[i])) {
+			m = fsm_getopaque(fsm, set[i]);
 			break;
 		}
 	}
@@ -287,16 +285,16 @@ carryopaque(struct set *set, struct fsm *fsm, struct fsm_state *state)
 
 	conflict = NULL;
 
-	for (s = set_first(set, &it); s != NULL; s = set_next(&it)) {
+	for (i = 0; i < n; i++) {
 		struct ast_mapping *p;
 
-		if (!fsm_isend(fsm, s)) {
+		if (!fsm_isend(fsm, set[i])) {
 			continue;
 		}
 
-		assert(fsm_getopaque(fsm, s) != NULL);
+		assert(fsm_getopaque(fsm, set[i]) != NULL);
 
-		p = fsm_getopaque(fsm, s);
+		p = fsm_getopaque(fsm, set[i]);
 
 		if (m->to == p->to && m->token == p->token) {
 			continue;

--- a/src/lx/main.c
+++ b/src/lx/main.c
@@ -244,7 +244,7 @@ lang_exclude(const char *name)
 }
 
 static void
-carryopaque(void **set, size_t n, struct fsm *fsm, struct fsm_state *state)
+carryopaque(const void **set, size_t n, struct fsm *fsm, struct fsm_state *state)
 {
 	struct mapping_set *conflict;
 	struct ast_mapping *m;

--- a/src/lx/main.c
+++ b/src/lx/main.c
@@ -244,7 +244,8 @@ lang_exclude(const char *name)
 }
 
 static void
-carryopaque(const void **set, size_t n, struct fsm *fsm, struct fsm_state *state)
+carryopaque(const struct fsm_state **set, size_t n,
+	struct fsm *fsm, struct fsm_state *state)
 {
 	struct mapping_set *conflict;
 	struct ast_mapping *m;

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -252,7 +252,7 @@ addmatch(struct match **head, const char *s)
 }
 
 static void
-carryopaque(void **set, size_t n, struct fsm *fsm, struct fsm_state *state)
+carryopaque(const void **set, size_t n, struct fsm *fsm, struct fsm_state *state)
 {
 	struct match *matches;
 	struct match *m;

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -252,7 +252,8 @@ addmatch(struct match **head, const char *s)
 }
 
 static void
-carryopaque(const void **set, size_t n, struct fsm *fsm, struct fsm_state *state)
+carryopaque(const struct fsm_state **set, size_t n,
+	struct fsm *fsm, struct fsm_state *state)
 {
 	struct match *matches;
 	struct match *m;

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -14,8 +14,6 @@
 #include <stdio.h>
 #include <ctype.h>
 
-#include <adt/set.h>
-
 #include <fsm/fsm.h>
 #include <fsm/bool.h>
 #include <fsm/pred.h>
@@ -254,14 +252,14 @@ addmatch(struct match **head, const char *s)
 }
 
 static void
-carryopaque(struct set *set, struct fsm *fsm, struct fsm_state *state)
+carryopaque(void **set, size_t n, struct fsm *fsm, struct fsm_state *state)
 {
-	struct set_iter it;
-	struct fsm_state *s;
-	struct match *m;
 	struct match *matches;
+	struct match *m;
+	size_t i;
 
 	assert(set != NULL); /* TODO: right? */
+	assert(n > 0); /* TODO: right? */
 	assert(fsm != NULL);
 	assert(state != NULL);
 
@@ -280,14 +278,14 @@ carryopaque(struct set *set, struct fsm *fsm, struct fsm_state *state)
 
 	matches = NULL;
 
-	for (s = set_first(set, &it); s != NULL; s = set_next(&it)) {
-		if (!fsm_isend(fsm, s)) {
+	for (i = 0; i < n; i++) {
+		if (!fsm_isend(fsm, set[i])) {
 			continue;
 		}
 
-		assert(fsm_getopaque(fsm, s) != NULL);
+		assert(fsm_getopaque(fsm, set[i]) != NULL);
 
-		for (m = fsm_getopaque(fsm, s); m != NULL; m = m->next) {
+		for (m = fsm_getopaque(fsm, set[i]); m != NULL; m = m->next) {
 			if (!addmatch(&matches, m->s)) {
 				perror("addmatch");
 				goto error;


### PR DESCRIPTION
This branch removes the internal adt/set.h API, by giving user programs a pointer into an array of `struct fsm_state *` (and a corresponding `size_t` for the number of elements). This works out, because the carryopaque callbacks treat these as read-only; more general set operations are not needed. The typical use-case is to iterate over every element.

There's a non-portable bit, and I added a compile-time assert just for that. I kept that local to the .c file where it's used, because I don't want to be in the habit of using them except for particularly questionable circumstances, and this is one of those.

If the implementation for sets changes, we could maintain this interface by constructing the equivalent array in `fsm_carryopaque()`. Typically these sets are quite small, relative to the size of an FSM.