### PR TITLE
Expose leaf callback for C code fragment output

### DIFF
--- a/examples/iprange/main.c
+++ b/examples/iprange/main.c
@@ -45,7 +45,6 @@
 #include <fsm/pred.h>
 
 #include "../../src/libfsm/out.h" /* XXX */
-#include "../../src/libfsm/internal.h" /* XXX */
 
 #include "tree.h"
 
@@ -471,16 +470,6 @@ carryopaque(const struct fsm_state **set, size_t n,
 	}
 }
 
-const char *
-nl(struct fsm_state *s)
-{
-	struct record *r;
-	struct fsm hack;
-
-	r = fsm_getopaque(&hack, s);
-	return r->rec;
-}
-
 static int
 leaf(FILE *f, const struct fsm *fsm, const struct fsm_state *state,
 	const void *opaque)
@@ -515,7 +504,6 @@ main(int argc, char **argv)
 	opt.anonymous_states  = 1;
 	opt.consolidate_edges = 1;
 	opt.case_ranges       = 1;
-	/* opt.opaque_string     = nl; */
 
 	while (c = getopt(argc, argv, "46f:l:Q"), c != -1) {
 		switch (c) {

--- a/examples/iprange/main.c
+++ b/examples/iprange/main.c
@@ -43,8 +43,7 @@
 #include <fsm/out.h>
 #include <fsm/options.h>
 #include <fsm/pred.h>
-
-#include "../../src/libfsm/out.h" /* XXX */
+#include <fsm/out.h>
 
 #include "tree.h"
 
@@ -670,9 +669,11 @@ main(int argc, char **argv)
 	}
 
 	if (oc) {
-		static const char *cp = "c";
-		/* XXX: This should be possible without private out.h. */
-		fsm_out_cfrag(fsm, stdout, cp, leaf, NULL);
+		opt.fragment    = 1;
+		opt.cp          = "c";
+		opt.leaf        = leaf;
+		opt.leaf_opaque = NULL;
+		fsm_print(fsm, stdout, FSM_OUT_C);
 	} else if (odot) {
 		fsm_print(fsm, stdout, FSM_OUT_DOT);
 	}

--- a/include/fsm/options.h
+++ b/include/fsm/options.h
@@ -46,6 +46,13 @@ struct fsm_options {
 	/* a prefix for namespacing generated identifiers. NULL if not required. */
 	const char *prefix;
 
+	/* character pointer, for C code fragment output. NULL for the default. */
+	const char *cp;
+
+	/* TODO: explain. for C code fragment output */
+	int (*leaf)(FILE *, const struct fsm *, const struct fsm_state *, const void *);
+	void *leaf_opaque;
+
 	/* TODO: explain */
 	void (*carryopaque)(const struct fsm_state **, size_t,
 		struct fsm *, struct fsm_state *);

--- a/src/libfsm/out.h
+++ b/src/libfsm/out.h
@@ -11,13 +11,6 @@
 
 #include <fsm/out.h>
 
-/* XXX: perhaps to move under fsm_options alongside .fragment */
-int
-fsm_out_cfrag(const struct fsm *fsm, FILE *f,
-	const char *cp,
-	int (*leaf)(FILE *, const struct fsm *, const struct fsm_state *, const void *),
-	const void *opaque);
-
 void
 fsm_out_stateenum(FILE *f, const struct fsm *fsm, struct fsm_state *sl);
 

--- a/src/libfsm/out/c.c
+++ b/src/libfsm/out/c.c
@@ -335,7 +335,7 @@ endstates(FILE *f, const struct fsm *fsm, struct fsm_state *sl)
 	fprintf(f, "\t}\n");
 }
 
-int
+static int
 fsm_out_cfrag(const struct fsm *fsm, FILE *f,
 	const char *cp,
 	int (*leaf)(FILE *, const struct fsm *, const struct fsm_state *, const void *),
@@ -404,14 +404,19 @@ fsm_out_c(const struct fsm *fsm, FILE *f)
 
 	/* TODO: pass in %s prefix (default to "fsm_") */
 
-	switch (fsm->opt->io) {
-	case FSM_IO_GETC: cp = "c";  break;
-	case FSM_IO_STR:  cp = "*p"; break;
-	case FSM_IO_PAIR: cp = "*p"; break;
+	if (fsm->opt->cp != NULL) {
+		cp = fsm->opt->cp;
+	} else {
+		switch (fsm->opt->io) {
+		case FSM_IO_GETC: cp = "c";  break;
+		case FSM_IO_STR:  cp = "*p"; break;
+		case FSM_IO_PAIR: cp = "*p"; break;
+		}
 	}
 
 	if (fsm->opt->fragment) {
-		(void) fsm_out_cfrag(fsm, f, cp, leaf, NULL);
+		(void) fsm_out_cfrag(fsm, f, cp,
+			fsm->opt->leaf != NULL ? fsm->opt->leaf : leaf, fsm->opt->leaf_opaque);
 		return;
 	}
 
@@ -470,7 +475,8 @@ fsm_out_c(const struct fsm *fsm, FILE *f)
 		break;
 	}
 
-	(void) fsm_out_cfrag(fsm, f, cp, leaf, NULL);
+	(void) fsm_out_cfrag(fsm, f, cp,
+		fsm->opt->leaf != NULL ? fsm->opt->leaf : leaf, fsm->opt->leaf_opaque);
 
 	fprintf(f, "\t}\n");
 	fprintf(f, "\n");

--- a/src/lx/out/c.c
+++ b/src/lx/out/c.c
@@ -23,8 +23,6 @@
 #include "lx/out.h"
 #include "lx/ast.h"
 
-static const char *cp;
-
 static int
 skip(const struct fsm *fsm, const struct fsm_state *state)
 {
@@ -819,7 +817,7 @@ out_zone(FILE *f, const struct ast *ast, const struct ast_zone *z)
 			fprintf(f, "\t\tdefault:\n");
 			if (~api_exclude & API_BUF) {
 				fprintf(f, "\t\t\tif (lx->push != NULL) {\n");
-				fprintf(f, "\t\t\t\tif (-1 == lx->push(lx, %s)) {\n", cp);
+				fprintf(f, "\t\t\t\tif (-1 == lx->push(lx, %s)) {\n", opt.cp);
 				fprintf(f, "\t\t\t\t\treturn %sERROR;\n", prefix.tok);
 				fprintf(f, "\t\t\t\t}\n");
 				fprintf(f, "\t\t\t}\n");
@@ -832,7 +830,7 @@ out_zone(FILE *f, const struct ast *ast, const struct ast_zone *z)
 		} else {
 			if (~api_exclude & API_BUF) {
 				fprintf(f, "\t\tif (lx->push != NULL) {\n");
-				fprintf(f, "\t\t\tif (-1 == lx->push(lx, %s)) {\n", cp);
+				fprintf(f, "\t\t\tif (-1 == lx->push(lx, %s)) {\n", opt.cp);
 				fprintf(f, "\t\t\t\treturn %sERROR;\n", prefix.tok);
 				fprintf(f, "\t\t\t}\n");
 				fprintf(f, "\t\t}\n");
@@ -851,10 +849,12 @@ out_zone(FILE *f, const struct ast *ast, const struct ast_zone *z)
 		opt.fragment    = 1; /* XXX */
 		opt.comments    = z->fsm->opt->comments;
 		opt.case_ranges = z->fsm->opt->case_ranges;
+		opt.leaf        = leaf;
+		opt.leaf_opaque = ast;
 
 		z->fsm->opt = &opt;
 
-		(void) fsm_out_cfrag(z->fsm, f, cp, leaf, ast);
+		(void) fsm_out_c(z->fsm, f);
 
 		z->fsm->opt = tmp;
 	}
@@ -1040,9 +1040,9 @@ lx_out_c(const struct ast *ast, FILE *f)
 	assert(f != NULL);
 
 	switch (opt.io) {
-	case FSM_IO_GETC: cp = "c"; break;
-	case FSM_IO_STR:  cp = "c"; break;
-	case FSM_IO_PAIR: cp = "c"; break;
+	case FSM_IO_GETC: opt.cp = "c"; break;
+	case FSM_IO_STR:  opt.cp = "c"; break;
+	case FSM_IO_PAIR: opt.cp = "c"; break;
 	}
 
 	for (z = ast->zl; z != NULL; z = z->next) {


### PR DESCRIPTION
We used to break abstraction to output fragments with custom code attached to each end state. That was moved under a `leaf()` callback some time ago. This PR finishes up the job, and moves that to the options struct, along with the `cp` string for the C expression representing the current a character.

As a result, the `fsm_out_cfrag()` function is no longer exposed.