### PR TITLE
Bugfix to mark the end state for empty regexps.

### DIFF
--- a/src/libre/dialect/glob/parser.c
+++ b/src/libre/dialect/glob/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 138 "src/libre/parser.act"
+#line 137 "src/libre/parser.act"
 
 
 	#include <assert.h>
@@ -87,7 +87,6 @@
 
 	typedef struct lx_pos t_pos;
 	typedef struct fsm * t_fsm;
-	typedef struct fsm_state * t_fsm__state;
 	typedef enum re_flags t_re__flags;
 	typedef struct grp t_grp;
 
@@ -404,7 +403,7 @@
 		return NULL;
 	}
 
-#line 408 "src/libre/dialect/glob/parser.c"
+#line 407 "src/libre/dialect/glob/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -418,7 +417,7 @@ static void p_list_Hof_Hatoms(fsm, flags, lex_state, act_state, err, t_fsm__stat
 static void p_list_Hof_Hatoms_C_Catom(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state *);
 static void p_list_Hof_Hatoms_C_Cmany(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 static void p_list_Hof_Hatoms_C_Cany(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
-extern void p_re__glob(fsm, flags, lex_state, act_state, err);
+extern void p_re__glob(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 
 /* BEGINNING OF STATIC VARIABLES */
 
@@ -450,7 +449,7 @@ p_list_Hof_Hatoms_C_Cliteral(fsm fsm, flags flags, lex_state lex_state, act_stat
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 454 "src/libre/dialect/glob/parser.c"
+#line 453 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			break;
@@ -460,7 +459,7 @@ p_list_Hof_Hatoms_C_Cliteral(fsm fsm, flags flags, lex_state lex_state, act_stat
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: add-literal */
 		{
-#line 847 "src/libre/parser.act"
+#line 831 "src/libre/parser.act"
 
 		assert((ZIx) != NULL);
 		assert((ZIy) != NULL);
@@ -471,7 +470,7 @@ p_list_Hof_Hatoms_C_Cliteral(fsm fsm, flags flags, lex_state lex_state, act_stat
 			goto ZL1;
 		}
 	
-#line 475 "src/libre/dialect/glob/parser.c"
+#line 474 "src/libre/dialect/glob/parser.c"
 		}
 		/* END OF ACTION: add-literal */
 	}
@@ -493,14 +492,14 @@ ZL2_list_Hof_Hatoms:;
 
 		/* BEGINNING OF ACTION: add-concat */
 		{
-#line 823 "src/libre/parser.act"
+#line 807 "src/libre/parser.act"
 
 		(ZIz) = fsm_addstate(fsm);
 		if ((ZIz) == NULL) {
 			goto ZL1;
 		}
 	
-#line 504 "src/libre/dialect/glob/parser.c"
+#line 503 "src/libre/dialect/glob/parser.c"
 		}
 		/* END OF ACTION: add-concat */
 		p_list_Hof_Hatoms_C_Catom (fsm, flags, lex_state, act_state, err, ZIx, &ZIz);
@@ -519,13 +518,13 @@ ZL2_list_Hof_Hatoms:;
 				{
 					/* BEGINNING OF ACTION: add-epsilon */
 					{
-#line 830 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIz), (ZIy))) {
 			goto ZL1;
 		}
 	
-#line 529 "src/libre/dialect/glob/parser.c"
+#line 528 "src/libre/dialect/glob/parser.c"
 					}
 					/* END OF ACTION: add-epsilon */
 				}
@@ -556,12 +555,12 @@ p_list_Hof_Hatoms_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state a
 			}
 			/* BEGINNING OF ACTION: count-1 */
 			{
-#line 996 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 		(void) (ZIx);
 		(void) (*ZIy);
 	
-#line 565 "src/libre/dialect/glob/parser.c"
+#line 564 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: count-1 */
 		}
@@ -575,12 +574,12 @@ p_list_Hof_Hatoms_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state a
 			}
 			/* BEGINNING OF ACTION: count-1 */
 			{
-#line 996 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 		(void) (ZIx);
 		(void) (*ZIy);
 	
-#line 584 "src/libre/dialect/glob/parser.c"
+#line 583 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: count-1 */
 		}
@@ -594,7 +593,7 @@ p_list_Hof_Hatoms_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state a
 			}
 			/* BEGINNING OF ACTION: count-0-or-many */
 			{
-#line 946 "src/libre/parser.act"
+#line 930 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (*ZIy))) {
 			goto ZL1;
@@ -621,7 +620,7 @@ p_list_Hof_Hatoms_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state a
 			(*ZIy) = z;
 		}
 	
-#line 625 "src/libre/dialect/glob/parser.c"
+#line 624 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: count-0-or-many */
 		}
@@ -653,7 +652,7 @@ p_list_Hof_Hatoms_C_Cmany(fsm fsm, flags flags, lex_state lex_state, act_state a
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: add-any */
 		{
-#line 860 "src/libre/parser.act"
+#line 844 "src/libre/parser.act"
 
 		struct fsm *any;
 
@@ -671,7 +670,7 @@ p_list_Hof_Hatoms_C_Cmany(fsm fsm, flags flags, lex_state lex_state, act_state a
 			goto ZL1;
 		}
 	
-#line 675 "src/libre/dialect/glob/parser.c"
+#line 674 "src/libre/dialect/glob/parser.c"
 		}
 		/* END OF ACTION: add-any */
 	}
@@ -697,7 +696,7 @@ p_list_Hof_Hatoms_C_Cany(fsm fsm, flags flags, lex_state lex_state, act_state ac
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: add-any */
 		{
-#line 860 "src/libre/parser.act"
+#line 844 "src/libre/parser.act"
 
 		struct fsm *any;
 
@@ -715,7 +714,7 @@ p_list_Hof_Hatoms_C_Cany(fsm fsm, flags flags, lex_state lex_state, act_state ac
 			goto ZL1;
 		}
 	
-#line 719 "src/libre/dialect/glob/parser.c"
+#line 718 "src/libre/dialect/glob/parser.c"
 		}
 		/* END OF ACTION: add-any */
 	}
@@ -726,35 +725,12 @@ ZL1:;
 }
 
 void
-p_re__glob(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err)
+p_re__glob(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_fsm__state ZIx, t_fsm__state ZIy)
 {
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 		return;
 	}
 	{
-		t_fsm__state ZIx;
-		t_fsm__state ZIy;
-
-		/* BEGINNING OF ACTION: make-states */
-		{
-#line 625 "src/libre/parser.act"
-
-		assert(fsm != NULL);
-		/* TODO: assert fsm is empty */
-
-		(ZIx) = fsm_getstart(fsm);
-		assert((ZIx) != NULL);
-
-		(ZIy) = fsm_addstate(fsm);
-		if ((ZIy) == NULL) {
-			goto ZL1;
-		}
-
-		fsm_setend(fsm, (ZIy), 1);
-	
-#line 756 "src/libre/dialect/glob/parser.c"
-		}
-		/* END OF ACTION: make-states */
 		/* BEGINNING OF INLINE: 105 */
 		{
 			switch (CURRENT_TERMINAL) {
@@ -771,13 +747,13 @@ p_re__glob(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err e
 				{
 					/* BEGINNING OF ACTION: add-epsilon */
 					{
-#line 830 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (ZIy))) {
 			goto ZL3;
 		}
 	
-#line 781 "src/libre/dialect/glob/parser.c"
+#line 757 "src/libre/dialect/glob/parser.c"
 					}
 					/* END OF ACTION: add-epsilon */
 				}
@@ -788,13 +764,13 @@ p_re__glob(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err e
 			{
 				/* BEGINNING OF ACTION: err-expected-atoms */
 				{
-#line 1043 "src/libre/parser.act"
+#line 1027 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXATOMS;
 		}
 	
-#line 798 "src/libre/dialect/glob/parser.c"
+#line 774 "src/libre/dialect/glob/parser.c"
 				}
 				/* END OF ACTION: err-expected-atoms */
 			}
@@ -817,13 +793,13 @@ p_re__glob(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err e
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 1085 "src/libre/parser.act"
+#line 1069 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
 		}
 	
-#line 827 "src/libre/dialect/glob/parser.c"
+#line 803 "src/libre/dialect/glob/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
@@ -831,15 +807,11 @@ p_re__glob(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err e
 		}
 		/* END OF INLINE: 106 */
 	}
-	return;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
 }
 
 /* BEGINNING OF TRAILER */
 
-#line 1257 "src/libre/parser.act"
+#line 1259 "src/libre/parser.act"
 
 
 	static int
@@ -859,9 +831,11 @@ ZL1:;
 
 	static int
 	parse(int (*f)(void *opaque), void *opaque,
-		void (*entry)(struct fsm *, flags, lex_state, act_state, err),
+		void (*entry)(struct fsm *, flags, lex_state, act_state, err,
+			struct fsm_state *, struct fsm_state *),
 		struct flags *flags, int overlap,
-		struct fsm *new, struct re_err *err)
+		struct fsm *new, struct re_err *err,
+		struct fsm_state *x, struct fsm_state *y)
 	{
 		struct act_state  act_state_s;
 		struct act_state *act_state;
@@ -910,7 +884,7 @@ ZL1:;
 		err->e = RE_ESUCCESS;
 
 		ADVANCE_LEXER;
-		entry(new, flags, lex_state, act_state, err);
+		entry(new, flags, lex_state, act_state, err, x, y);
 
 		lx->free(lx);
 
@@ -976,6 +950,7 @@ ZL1:;
 		struct re_err *err)
 	{
 		struct fsm *new;
+		struct fsm_state *x, *y;
 		struct flags top, *fl = &top;
 
 		top.flags = flags;
@@ -987,14 +962,29 @@ ZL1:;
 			return NULL;
 		}
 
-		if (-1 == parse(f, opaque, DIALECT_ENTRY, fl, overlap, new, err)) {
-			fsm_free(new);
-			return NULL;
+		x = fsm_getstart(new);
+		assert(x != NULL);
+
+		y = fsm_addstate(new);
+		if (y == NULL) {
+			goto error;
+		}
+
+		fsm_setend(new, y, 1);
+
+		if (-1 == parse(f, opaque, DIALECT_ENTRY, fl, overlap, new, err, x, y)) {
+			goto error;
 		}
 
 		return new;
+
+	error:
+
+		fsm_free(new);
+
+		return NULL;
 	}
 
-#line 999 "src/libre/dialect/glob/parser.c"
+#line 989 "src/libre/dialect/glob/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/glob/parser.h
+++ b/src/libre/dialect/glob/parser.h
@@ -17,20 +17,21 @@
 	typedef struct lex_state * lex_state;
 	typedef struct act_state * act_state;
 
-	typedef struct fsm *  fsm;
+	typedef struct fsm * fsm;
+	typedef struct fsm_state * t_fsm__state;
 	typedef struct flags *flags;
 	typedef struct re_err * err;
 
-#line 25 "src/libre/dialect/glob/parser.h"
+#line 26 "src/libre/dialect/glob/parser.h"
 
 /* BEGINNING OF FUNCTION DECLARATIONS */
 
-extern void p_re__glob(fsm, flags, lex_state, act_state, err);
+extern void p_re__glob(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 /* BEGINNING OF TRAILER */
 
-#line 1259 "src/libre/parser.act"
+#line 1261 "src/libre/parser.act"
 
 
-#line 35 "src/libre/dialect/glob/parser.h"
+#line 36 "src/libre/dialect/glob/parser.h"
 
 /* END OF FILE */

--- a/src/libre/dialect/glob/parser.sid
+++ b/src/libre/dialect/glob/parser.sid
@@ -69,8 +69,6 @@
 
 %productions%
 
-	<make-states>: () -> (:fsm_state, :fsm_state);
-
 	!<make-group>: () -> (:grp);
 	!<invert-group>:    (:grp &) -> ();
 	!<group-add-char>:  (:grp &, :char) -> ();
@@ -151,9 +149,7 @@
 		};
 	};
 
-	re_glob: () -> () = {
-		(x, y) = <make-states>;
-
+	re_glob: (x :fsm_state, y:fsm_state) -> () = {
 		{
 			list-of-atoms(x, y);
 		||

--- a/src/libre/dialect/like/parser.c
+++ b/src/libre/dialect/like/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 138 "src/libre/parser.act"
+#line 137 "src/libre/parser.act"
 
 
 	#include <assert.h>
@@ -87,7 +87,6 @@
 
 	typedef struct lx_pos t_pos;
 	typedef struct fsm * t_fsm;
-	typedef struct fsm_state * t_fsm__state;
 	typedef enum re_flags t_re__flags;
 	typedef struct grp t_grp;
 
@@ -404,7 +403,7 @@
 		return NULL;
 	}
 
-#line 408 "src/libre/dialect/like/parser.c"
+#line 407 "src/libre/dialect/like/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -418,7 +417,7 @@ static void p_list_Hof_Hatoms(fsm, flags, lex_state, act_state, err, t_fsm__stat
 static void p_list_Hof_Hatoms_C_Catom(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state *);
 static void p_list_Hof_Hatoms_C_Cmany(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 static void p_list_Hof_Hatoms_C_Cany(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
-extern void p_re__like(fsm, flags, lex_state, act_state, err);
+extern void p_re__like(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 
 /* BEGINNING OF STATIC VARIABLES */
 
@@ -433,8 +432,8 @@ p_list_Hof_Hatoms_C_Cliteral(fsm fsm, flags flags, lex_state lex_state, act_stat
 	}
 	{
 		t_char ZIc;
+		t_pos ZI94;
 		t_pos ZI95;
-		t_pos ZI96;
 
 		switch (CURRENT_TERMINAL) {
 		case (TOK_CHAR):
@@ -445,12 +444,12 @@ p_list_Hof_Hatoms_C_Cliteral(fsm fsm, flags flags, lex_state lex_state, act_stat
 		assert(lex_state->buf.a[0] != '\0');
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI95 = lex_state->lx.start;
-		ZI96   = lex_state->lx.end;
+		ZI94 = lex_state->lx.start;
+		ZI95   = lex_state->lx.end;
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 454 "src/libre/dialect/like/parser.c"
+#line 453 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			break;
@@ -460,7 +459,7 @@ p_list_Hof_Hatoms_C_Cliteral(fsm fsm, flags flags, lex_state lex_state, act_stat
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: add-literal */
 		{
-#line 847 "src/libre/parser.act"
+#line 831 "src/libre/parser.act"
 
 		assert((ZIx) != NULL);
 		assert((ZIy) != NULL);
@@ -471,7 +470,7 @@ p_list_Hof_Hatoms_C_Cliteral(fsm fsm, flags flags, lex_state lex_state, act_stat
 			goto ZL1;
 		}
 	
-#line 475 "src/libre/dialect/like/parser.c"
+#line 474 "src/libre/dialect/like/parser.c"
 		}
 		/* END OF ACTION: add-literal */
 	}
@@ -493,18 +492,18 @@ ZL2_list_Hof_Hatoms:;
 
 		/* BEGINNING OF ACTION: add-concat */
 		{
-#line 823 "src/libre/parser.act"
+#line 807 "src/libre/parser.act"
 
 		(ZIz) = fsm_addstate(fsm);
 		if ((ZIz) == NULL) {
 			goto ZL1;
 		}
 	
-#line 504 "src/libre/dialect/like/parser.c"
+#line 503 "src/libre/dialect/like/parser.c"
 		}
 		/* END OF ACTION: add-concat */
 		p_list_Hof_Hatoms_C_Catom (fsm, flags, lex_state, act_state, err, ZIx, &ZIz);
-		/* BEGINNING OF INLINE: 104 */
+		/* BEGINNING OF INLINE: 103 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_MANY): case (TOK_CHAR):
@@ -519,13 +518,13 @@ ZL2_list_Hof_Hatoms:;
 				{
 					/* BEGINNING OF ACTION: add-epsilon */
 					{
-#line 830 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIz), (ZIy))) {
 			goto ZL1;
 		}
 	
-#line 529 "src/libre/dialect/like/parser.c"
+#line 528 "src/libre/dialect/like/parser.c"
 					}
 					/* END OF ACTION: add-epsilon */
 				}
@@ -535,7 +534,7 @@ ZL2_list_Hof_Hatoms:;
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 104 */
+		/* END OF INLINE: 103 */
 	}
 	return;
 ZL1:;
@@ -556,12 +555,12 @@ p_list_Hof_Hatoms_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state a
 			}
 			/* BEGINNING OF ACTION: count-1 */
 			{
-#line 996 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 		(void) (ZIx);
 		(void) (*ZIy);
 	
-#line 565 "src/libre/dialect/like/parser.c"
+#line 564 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: count-1 */
 		}
@@ -575,12 +574,12 @@ p_list_Hof_Hatoms_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state a
 			}
 			/* BEGINNING OF ACTION: count-1 */
 			{
-#line 996 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 		(void) (ZIx);
 		(void) (*ZIy);
 	
-#line 584 "src/libre/dialect/like/parser.c"
+#line 583 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: count-1 */
 		}
@@ -594,7 +593,7 @@ p_list_Hof_Hatoms_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state a
 			}
 			/* BEGINNING OF ACTION: count-0-or-many */
 			{
-#line 946 "src/libre/parser.act"
+#line 930 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (*ZIy))) {
 			goto ZL1;
@@ -621,7 +620,7 @@ p_list_Hof_Hatoms_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state a
 			(*ZIy) = z;
 		}
 	
-#line 625 "src/libre/dialect/like/parser.c"
+#line 624 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: count-0-or-many */
 		}
@@ -653,7 +652,7 @@ p_list_Hof_Hatoms_C_Cmany(fsm fsm, flags flags, lex_state lex_state, act_state a
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: add-any */
 		{
-#line 860 "src/libre/parser.act"
+#line 844 "src/libre/parser.act"
 
 		struct fsm *any;
 
@@ -671,7 +670,7 @@ p_list_Hof_Hatoms_C_Cmany(fsm fsm, flags flags, lex_state lex_state, act_state a
 			goto ZL1;
 		}
 	
-#line 675 "src/libre/dialect/like/parser.c"
+#line 674 "src/libre/dialect/like/parser.c"
 		}
 		/* END OF ACTION: add-any */
 	}
@@ -697,7 +696,7 @@ p_list_Hof_Hatoms_C_Cany(fsm fsm, flags flags, lex_state lex_state, act_state ac
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: add-any */
 		{
-#line 860 "src/libre/parser.act"
+#line 844 "src/libre/parser.act"
 
 		struct fsm *any;
 
@@ -715,7 +714,7 @@ p_list_Hof_Hatoms_C_Cany(fsm fsm, flags flags, lex_state lex_state, act_state ac
 			goto ZL1;
 		}
 	
-#line 719 "src/libre/dialect/like/parser.c"
+#line 718 "src/libre/dialect/like/parser.c"
 		}
 		/* END OF ACTION: add-any */
 	}
@@ -726,36 +725,13 @@ ZL1:;
 }
 
 void
-p_re__like(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err)
+p_re__like(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_fsm__state ZIx, t_fsm__state ZIy)
 {
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 		return;
 	}
 	{
-		t_fsm__state ZIx;
-		t_fsm__state ZIy;
-
-		/* BEGINNING OF ACTION: make-states */
-		{
-#line 625 "src/libre/parser.act"
-
-		assert(fsm != NULL);
-		/* TODO: assert fsm is empty */
-
-		(ZIx) = fsm_getstart(fsm);
-		assert((ZIx) != NULL);
-
-		(ZIy) = fsm_addstate(fsm);
-		if ((ZIy) == NULL) {
-			goto ZL1;
-		}
-
-		fsm_setend(fsm, (ZIy), 1);
-	
-#line 756 "src/libre/dialect/like/parser.c"
-		}
-		/* END OF ACTION: make-states */
-		/* BEGINNING OF INLINE: 106 */
+		/* BEGINNING OF INLINE: 105 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_MANY): case (TOK_CHAR):
@@ -771,13 +747,13 @@ p_re__like(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err e
 				{
 					/* BEGINNING OF ACTION: add-epsilon */
 					{
-#line 830 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (ZIy))) {
 			goto ZL3;
 		}
 	
-#line 781 "src/libre/dialect/like/parser.c"
+#line 757 "src/libre/dialect/like/parser.c"
 					}
 					/* END OF ACTION: add-epsilon */
 				}
@@ -788,20 +764,20 @@ p_re__like(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err e
 			{
 				/* BEGINNING OF ACTION: err-expected-atoms */
 				{
-#line 1043 "src/libre/parser.act"
+#line 1027 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXATOMS;
 		}
 	
-#line 798 "src/libre/dialect/like/parser.c"
+#line 774 "src/libre/dialect/like/parser.c"
 				}
 				/* END OF ACTION: err-expected-atoms */
 			}
 		ZL2:;
 		}
-		/* END OF INLINE: 106 */
-		/* BEGINNING OF INLINE: 107 */
+		/* END OF INLINE: 105 */
+		/* BEGINNING OF INLINE: 106 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -817,29 +793,25 @@ p_re__like(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err e
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 1085 "src/libre/parser.act"
+#line 1069 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
 		}
 	
-#line 827 "src/libre/dialect/like/parser.c"
+#line 803 "src/libre/dialect/like/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
 		ZL4:;
 		}
-		/* END OF INLINE: 107 */
+		/* END OF INLINE: 106 */
 	}
-	return;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
 }
 
 /* BEGINNING OF TRAILER */
 
-#line 1257 "src/libre/parser.act"
+#line 1259 "src/libre/parser.act"
 
 
 	static int
@@ -859,9 +831,11 @@ ZL1:;
 
 	static int
 	parse(int (*f)(void *opaque), void *opaque,
-		void (*entry)(struct fsm *, flags, lex_state, act_state, err),
+		void (*entry)(struct fsm *, flags, lex_state, act_state, err,
+			struct fsm_state *, struct fsm_state *),
 		struct flags *flags, int overlap,
-		struct fsm *new, struct re_err *err)
+		struct fsm *new, struct re_err *err,
+		struct fsm_state *x, struct fsm_state *y)
 	{
 		struct act_state  act_state_s;
 		struct act_state *act_state;
@@ -910,7 +884,7 @@ ZL1:;
 		err->e = RE_ESUCCESS;
 
 		ADVANCE_LEXER;
-		entry(new, flags, lex_state, act_state, err);
+		entry(new, flags, lex_state, act_state, err, x, y);
 
 		lx->free(lx);
 
@@ -976,6 +950,7 @@ ZL1:;
 		struct re_err *err)
 	{
 		struct fsm *new;
+		struct fsm_state *x, *y;
 		struct flags top, *fl = &top;
 
 		top.flags = flags;
@@ -987,14 +962,29 @@ ZL1:;
 			return NULL;
 		}
 
-		if (-1 == parse(f, opaque, DIALECT_ENTRY, fl, overlap, new, err)) {
-			fsm_free(new);
-			return NULL;
+		x = fsm_getstart(new);
+		assert(x != NULL);
+
+		y = fsm_addstate(new);
+		if (y == NULL) {
+			goto error;
+		}
+
+		fsm_setend(new, y, 1);
+
+		if (-1 == parse(f, opaque, DIALECT_ENTRY, fl, overlap, new, err, x, y)) {
+			goto error;
 		}
 
 		return new;
+
+	error:
+
+		fsm_free(new);
+
+		return NULL;
 	}
 
-#line 999 "src/libre/dialect/like/parser.c"
+#line 989 "src/libre/dialect/like/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/like/parser.h
+++ b/src/libre/dialect/like/parser.h
@@ -17,20 +17,21 @@
 	typedef struct lex_state * lex_state;
 	typedef struct act_state * act_state;
 
-	typedef struct fsm *  fsm;
+	typedef struct fsm * fsm;
+	typedef struct fsm_state * t_fsm__state;
 	typedef struct flags *flags;
 	typedef struct re_err * err;
 
-#line 25 "src/libre/dialect/like/parser.h"
+#line 26 "src/libre/dialect/like/parser.h"
 
 /* BEGINNING OF FUNCTION DECLARATIONS */
 
-extern void p_re__like(fsm, flags, lex_state, act_state, err);
+extern void p_re__like(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 /* BEGINNING OF TRAILER */
 
-#line 1259 "src/libre/parser.act"
+#line 1261 "src/libre/parser.act"
 
 
-#line 35 "src/libre/dialect/like/parser.h"
+#line 36 "src/libre/dialect/like/parser.h"
 
 /* END OF FILE */

--- a/src/libre/dialect/like/parser.sid
+++ b/src/libre/dialect/like/parser.sid
@@ -69,8 +69,6 @@
 
 %productions%
 
-	<make-states>: () -> (:fsm_state, :fsm_state);
-
 	!<make-group>: () -> (:grp);
 	!<invert-group>:    (:grp &) -> ();
 	!<group-add-char>:  (:grp &, :char) -> ();
@@ -151,9 +149,7 @@
 		};
 	};
 
-	re_like: () -> () = {
-		(x, y) = <make-states>;
-
+	re_like: (x :fsm_state, y :fsm_state) -> () = {
 		{
 			list-of-atoms(x, y);
 		||

--- a/src/libre/dialect/literal/parser.c
+++ b/src/libre/dialect/literal/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 138 "src/libre/parser.act"
+#line 137 "src/libre/parser.act"
 
 
 	#include <assert.h>
@@ -87,7 +87,6 @@
 
 	typedef struct lx_pos t_pos;
 	typedef struct fsm * t_fsm;
-	typedef struct fsm_state * t_fsm__state;
 	typedef enum re_flags t_re__flags;
 	typedef struct grp t_grp;
 
@@ -404,7 +403,7 @@
 		return NULL;
 	}
 
-#line 408 "src/libre/dialect/literal/parser.c"
+#line 407 "src/libre/dialect/literal/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -413,7 +412,7 @@
 
 /* BEGINNING OF FUNCTION DECLARATIONS */
 
-extern void p_re__literal(fsm, flags, lex_state, act_state, err);
+extern void p_re__literal(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 static void p_list_Hof_Hliterals_C_Cliteral(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 static void p_list_Hof_Hliterals(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 
@@ -423,35 +422,12 @@ static void p_list_Hof_Hliterals(fsm, flags, lex_state, act_state, err, t_fsm__s
 /* BEGINNING OF FUNCTION DEFINITIONS */
 
 void
-p_re__literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err)
+p_re__literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_fsm__state ZIx, t_fsm__state ZIy)
 {
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 		return;
 	}
 	{
-		t_fsm__state ZIx;
-		t_fsm__state ZIy;
-
-		/* BEGINNING OF ACTION: make-states */
-		{
-#line 625 "src/libre/parser.act"
-
-		assert(fsm != NULL);
-		/* TODO: assert fsm is empty */
-
-		(ZIx) = fsm_getstart(fsm);
-		assert((ZIx) != NULL);
-
-		(ZIy) = fsm_addstate(fsm);
-		if ((ZIy) == NULL) {
-			goto ZL1;
-		}
-
-		fsm_setend(fsm, (ZIy), 1);
-	
-#line 453 "src/libre/dialect/literal/parser.c"
-		}
-		/* END OF ACTION: make-states */
 		/* BEGINNING OF INLINE: 99 */
 		{
 			switch (CURRENT_TERMINAL) {
@@ -468,13 +444,13 @@ p_re__literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, er
 				{
 					/* BEGINNING OF ACTION: add-epsilon */
 					{
-#line 830 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (ZIy))) {
 			goto ZL3;
 		}
 	
-#line 478 "src/libre/dialect/literal/parser.c"
+#line 454 "src/libre/dialect/literal/parser.c"
 					}
 					/* END OF ACTION: add-epsilon */
 				}
@@ -485,13 +461,13 @@ p_re__literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, er
 			{
 				/* BEGINNING OF ACTION: err-expected-atoms */
 				{
-#line 1043 "src/libre/parser.act"
+#line 1027 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXATOMS;
 		}
 	
-#line 495 "src/libre/dialect/literal/parser.c"
+#line 471 "src/libre/dialect/literal/parser.c"
 				}
 				/* END OF ACTION: err-expected-atoms */
 			}
@@ -514,13 +490,13 @@ p_re__literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, er
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 1085 "src/libre/parser.act"
+#line 1069 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
 		}
 	
-#line 524 "src/libre/dialect/literal/parser.c"
+#line 500 "src/libre/dialect/literal/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
@@ -528,10 +504,6 @@ p_re__literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, er
 		}
 		/* END OF INLINE: 100 */
 	}
-	return;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
 }
 
 static void
@@ -559,7 +531,7 @@ p_list_Hof_Hliterals_C_Cliteral(fsm fsm, flags flags, lex_state lex_state, act_s
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 563 "src/libre/dialect/literal/parser.c"
+#line 535 "src/libre/dialect/literal/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			break;
@@ -569,7 +541,7 @@ p_list_Hof_Hliterals_C_Cliteral(fsm fsm, flags flags, lex_state lex_state, act_s
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: add-literal */
 		{
-#line 847 "src/libre/parser.act"
+#line 831 "src/libre/parser.act"
 
 		assert((ZIx) != NULL);
 		assert((ZIy) != NULL);
@@ -580,17 +552,17 @@ p_list_Hof_Hliterals_C_Cliteral(fsm fsm, flags flags, lex_state lex_state, act_s
 			goto ZL1;
 		}
 	
-#line 584 "src/libre/dialect/literal/parser.c"
+#line 556 "src/libre/dialect/literal/parser.c"
 		}
 		/* END OF ACTION: add-literal */
 		/* BEGINNING OF ACTION: count-1 */
 		{
-#line 996 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 		(void) (ZIx);
 		(void) (ZIy);
 	
-#line 594 "src/libre/dialect/literal/parser.c"
+#line 566 "src/libre/dialect/literal/parser.c"
 		}
 		/* END OF ACTION: count-1 */
 	}
@@ -612,14 +584,14 @@ ZL2_list_Hof_Hliterals:;
 
 		/* BEGINNING OF ACTION: add-concat */
 		{
-#line 823 "src/libre/parser.act"
+#line 807 "src/libre/parser.act"
 
 		(ZIz) = fsm_addstate(fsm);
 		if ((ZIz) == NULL) {
 			goto ZL1;
 		}
 	
-#line 623 "src/libre/dialect/literal/parser.c"
+#line 595 "src/libre/dialect/literal/parser.c"
 		}
 		/* END OF ACTION: add-concat */
 		p_list_Hof_Hliterals_C_Cliteral (fsm, flags, lex_state, act_state, err, ZIx, ZIz);
@@ -638,13 +610,13 @@ ZL2_list_Hof_Hliterals:;
 				{
 					/* BEGINNING OF ACTION: add-epsilon */
 					{
-#line 830 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIz), (ZIy))) {
 			goto ZL1;
 		}
 	
-#line 648 "src/libre/dialect/literal/parser.c"
+#line 620 "src/libre/dialect/literal/parser.c"
 					}
 					/* END OF ACTION: add-epsilon */
 				}
@@ -664,7 +636,7 @@ ZL1:;
 
 /* BEGINNING OF TRAILER */
 
-#line 1257 "src/libre/parser.act"
+#line 1259 "src/libre/parser.act"
 
 
 	static int
@@ -684,9 +656,11 @@ ZL1:;
 
 	static int
 	parse(int (*f)(void *opaque), void *opaque,
-		void (*entry)(struct fsm *, flags, lex_state, act_state, err),
+		void (*entry)(struct fsm *, flags, lex_state, act_state, err,
+			struct fsm_state *, struct fsm_state *),
 		struct flags *flags, int overlap,
-		struct fsm *new, struct re_err *err)
+		struct fsm *new, struct re_err *err,
+		struct fsm_state *x, struct fsm_state *y)
 	{
 		struct act_state  act_state_s;
 		struct act_state *act_state;
@@ -735,7 +709,7 @@ ZL1:;
 		err->e = RE_ESUCCESS;
 
 		ADVANCE_LEXER;
-		entry(new, flags, lex_state, act_state, err);
+		entry(new, flags, lex_state, act_state, err, x, y);
 
 		lx->free(lx);
 
@@ -801,6 +775,7 @@ ZL1:;
 		struct re_err *err)
 	{
 		struct fsm *new;
+		struct fsm_state *x, *y;
 		struct flags top, *fl = &top;
 
 		top.flags = flags;
@@ -812,14 +787,29 @@ ZL1:;
 			return NULL;
 		}
 
-		if (-1 == parse(f, opaque, DIALECT_ENTRY, fl, overlap, new, err)) {
-			fsm_free(new);
-			return NULL;
+		x = fsm_getstart(new);
+		assert(x != NULL);
+
+		y = fsm_addstate(new);
+		if (y == NULL) {
+			goto error;
+		}
+
+		fsm_setend(new, y, 1);
+
+		if (-1 == parse(f, opaque, DIALECT_ENTRY, fl, overlap, new, err, x, y)) {
+			goto error;
 		}
 
 		return new;
+
+	error:
+
+		fsm_free(new);
+
+		return NULL;
 	}
 
-#line 824 "src/libre/dialect/literal/parser.c"
+#line 814 "src/libre/dialect/literal/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/literal/parser.h
+++ b/src/libre/dialect/literal/parser.h
@@ -17,20 +17,21 @@
 	typedef struct lex_state * lex_state;
 	typedef struct act_state * act_state;
 
-	typedef struct fsm *  fsm;
+	typedef struct fsm * fsm;
+	typedef struct fsm_state * t_fsm__state;
 	typedef struct flags *flags;
 	typedef struct re_err * err;
 
-#line 25 "src/libre/dialect/literal/parser.h"
+#line 26 "src/libre/dialect/literal/parser.h"
 
 /* BEGINNING OF FUNCTION DECLARATIONS */
 
-extern void p_re__literal(fsm, flags, lex_state, act_state, err);
+extern void p_re__literal(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 /* BEGINNING OF TRAILER */
 
-#line 1259 "src/libre/parser.act"
+#line 1261 "src/libre/parser.act"
 
 
-#line 35 "src/libre/dialect/literal/parser.h"
+#line 36 "src/libre/dialect/literal/parser.h"
 
 /* END OF FILE */

--- a/src/libre/dialect/literal/parser.sid
+++ b/src/libre/dialect/literal/parser.sid
@@ -69,8 +69,6 @@
 
 %productions%
 
-	<make-states>: () -> (:fsm_state, :fsm_state);
-
 	!<make-group>: () -> (:grp);
 	!<invert-group>:    (:grp &) -> ();
 	!<group-add-char>:  (:grp &, :char) -> ();
@@ -130,9 +128,7 @@
 		};
 	};
 
-	re_literal: () -> () = {
-		(x, y) = <make-states>;
-
+	re_literal: (x :fsm_state, y :fsm_state) -> () = {
 		{
 			list-of-literals(x, y);
 		||

--- a/src/libre/dialect/native/parser.c
+++ b/src/libre/dialect/native/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 138 "src/libre/parser.act"
+#line 137 "src/libre/parser.act"
 
 
 	#include <assert.h>
@@ -87,7 +87,6 @@
 
 	typedef struct lx_pos t_pos;
 	typedef struct fsm * t_fsm;
-	typedef struct fsm_state * t_fsm__state;
 	typedef enum re_flags t_re__flags;
 	typedef struct grp t_grp;
 
@@ -404,7 +403,7 @@
 		return NULL;
 	}
 
-#line 408 "src/libre/dialect/native/parser.c"
+#line 407 "src/libre/dialect/native/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -417,14 +416,14 @@ static void p_anchor(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm_
 static void p_expr_C_Clist_Hof_Halts_C_Calt(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 static void p_group(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 static void p_group_C_Cgroup_Hbody(fsm, flags, lex_state, act_state, err, t_grp *);
-static void p_188(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state, t_fsm__state *, t_fsm__state *);
-static void p_193(fsm, flags, lex_state, act_state, err, t_grp *);
+static void p_187(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state, t_fsm__state *, t_fsm__state *);
+static void p_192(fsm, flags, lex_state, act_state, err, t_grp *);
 static void p_expr(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
-extern void p_re__native(fsm, flags, lex_state, act_state, err);
+extern void p_re__native(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 static void p_group_C_Clist_Hof_Hterms(fsm, flags, lex_state, act_state, err, t_grp *);
-static void p_205(fsm, flags, lex_state, act_state, err, t_grp *, t_char *, t_pos *);
+static void p_204(fsm, flags, lex_state, act_state, err, t_grp *, t_char *, t_pos *);
 static void p_expr_C_Clist_Hof_Hatoms(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
-static void p_209(fsm, flags, lex_state, act_state, err, t_fsm__state *, t_fsm__state *, t_pos *, t_unsigned *);
+static void p_208(fsm, flags, lex_state, act_state, err, t_fsm__state *, t_fsm__state *, t_pos *, t_unsigned *);
 static void p_group_C_Cgroup_Hbm(fsm, flags, lex_state, act_state, err, t_grp *);
 static void p_expr_C_Clist_Hof_Halts(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 static void p_expr_C_Catom(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state *);
@@ -444,7 +443,7 @@ p_anchor(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err
 	{
 		t_pred ZIp;
 
-		/* BEGINNING OF INLINE: 156 */
+		/* BEGINNING OF INLINE: 155 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_END):
@@ -463,7 +462,7 @@ p_anchor(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err
 			ZIp = 0U;
 		}
 	
-#line 467 "src/libre/dialect/native/parser.c"
+#line 466 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: END */
 					ADVANCE_LEXER;
@@ -485,7 +484,7 @@ p_anchor(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err
 			ZIp = 0U;
 		}
 	
-#line 489 "src/libre/dialect/native/parser.c"
+#line 488 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: START */
 					ADVANCE_LEXER;
@@ -495,10 +494,10 @@ p_anchor(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 156 */
+		/* END OF INLINE: 155 */
 		/* BEGINNING OF ACTION: add-pred */
 		{
-#line 836 "src/libre/parser.act"
+#line 820 "src/libre/parser.act"
 
 		assert((ZIx) != NULL);
 		assert((ZIy) != NULL);
@@ -509,7 +508,7 @@ p_anchor(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err
 		}
 */
 	
-#line 513 "src/libre/dialect/native/parser.c"
+#line 512 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: add-pred */
 	}
@@ -530,25 +529,25 @@ p_expr_C_Clist_Hof_Halts_C_Calt(fsm fsm, flags flags, lex_state lex_state, act_s
 
 		/* BEGINNING OF ACTION: add-concat */
 		{
-#line 823 "src/libre/parser.act"
+#line 807 "src/libre/parser.act"
 
 		(ZIz) = fsm_addstate(fsm);
 		if ((ZIz) == NULL) {
 			goto ZL1;
 		}
 	
-#line 541 "src/libre/dialect/native/parser.c"
+#line 540 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: add-concat */
 		/* BEGINNING OF ACTION: add-epsilon */
 		{
-#line 830 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (ZIz))) {
 			goto ZL1;
 		}
 	
-#line 552 "src/libre/dialect/native/parser.c"
+#line 551 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: add-epsilon */
 		p_expr_C_Clist_Hof_Hatoms (fsm, flags, lex_state, act_state, err, ZIz, ZIy);
@@ -574,7 +573,7 @@ p_group(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err,
 
 		/* BEGINNING OF ACTION: make-group */
 		{
-#line 638 "src/libre/parser.act"
+#line 622 "src/libre/parser.act"
 
 		(ZIg).set = fsm_new_blank(fsm->opt);
 		if ((ZIg).set == NULL) {
@@ -587,7 +586,7 @@ p_group(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err,
 			goto ZL1;
 		}
 	
-#line 591 "src/libre/dialect/native/parser.c"
+#line 590 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: make-group */
 		p_group_C_Cgroup_Hbm (fsm, flags, lex_state, act_state, err, &ZIg);
@@ -597,7 +596,7 @@ p_group(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err,
 		}
 		/* BEGINNING OF ACTION: group-to-states */
 		{
-#line 763 "src/libre/parser.act"
+#line 747 "src/libre/parser.act"
 
 		int r;
 
@@ -640,7 +639,7 @@ p_group(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err,
 
 		fsm_free((&ZIg)->dup);
 	
-#line 644 "src/libre/dialect/native/parser.c"
+#line 643 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: group-to-states */
 	}
@@ -657,40 +656,40 @@ p_group_C_Cgroup_Hbody(fsm fsm, flags flags, lex_state lex_state, act_state act_
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 129 */
+		/* BEGINNING OF INLINE: 128 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CLOSEGROUP):
 				{
-					t_char ZI190;
+					t_char ZI189;
+					t_pos ZI190;
 					t_pos ZI191;
-					t_pos ZI192;
 
 					/* BEGINNING OF EXTRACT: CLOSEGROUP */
 					{
 #line 448 "src/libre/parser.act"
 
-		ZI190 = ']';
-		ZI191 = lex_state->lx.start;
-		ZI192   = lex_state->lx.end;
+		ZI189 = ']';
+		ZI190 = lex_state->lx.start;
+		ZI191   = lex_state->lx.end;
 	
-#line 678 "src/libre/dialect/native/parser.c"
+#line 677 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: CLOSEGROUP */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: group-add-char */
 					{
-#line 672 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
-		if (-1 == group_add((ZIg), flags->flags, (ZI190))) {
+		if (-1 == group_add((ZIg), flags->flags, (ZI189))) {
 			err->e = RE_EERRNO;
 			goto ZL1;
 		}
 	
-#line 691 "src/libre/dialect/native/parser.c"
+#line 690 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: group-add-char */
-					p_193 (fsm, flags, lex_state, act_state, err, ZIg);
+					p_192 (fsm, flags, lex_state, act_state, err, ZIg);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL1;
@@ -700,31 +699,31 @@ p_group_C_Cgroup_Hbody(fsm fsm, flags flags, lex_state lex_state, act_state act_
 			case (TOK_RANGE):
 				{
 					t_char ZIc;
+					t_pos ZI131;
 					t_pos ZI132;
-					t_pos ZI133;
 
 					/* BEGINNING OF EXTRACT: RANGE */
 					{
 #line 437 "src/libre/parser.act"
 
 		ZIc = '-';
-		ZI132 = lex_state->lx.start;
-		ZI133   = lex_state->lx.end;
+		ZI131 = lex_state->lx.start;
+		ZI132   = lex_state->lx.end;
 	
-#line 715 "src/libre/dialect/native/parser.c"
+#line 714 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: RANGE */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: group-add-char */
 					{
-#line 672 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
 		if (-1 == group_add((ZIg), flags->flags, (ZIc))) {
 			err->e = RE_EERRNO;
 			goto ZL1;
 		}
 	
-#line 728 "src/libre/dialect/native/parser.c"
+#line 727 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: group-add-char */
 				}
@@ -733,16 +732,16 @@ p_group_C_Cgroup_Hbody(fsm fsm, flags flags, lex_state lex_state, act_state act_
 				break;
 			}
 		}
-		/* END OF INLINE: 129 */
+		/* END OF INLINE: 128 */
 		p_group_C_Clist_Hof_Hterms (fsm, flags, lex_state, act_state, err, ZIg);
-		/* BEGINNING OF INLINE: 138 */
+		/* BEGINNING OF INLINE: 137 */
 		{
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 138 */
+		/* END OF INLINE: 137 */
 	}
 	return;
 ZL1:;
@@ -751,31 +750,31 @@ ZL1:;
 }
 
 static void
-p_188(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_fsm__state ZI184, t_fsm__state ZI185, t_fsm__state *ZO186, t_fsm__state *ZO187)
+p_187(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_fsm__state ZI183, t_fsm__state ZI184, t_fsm__state *ZO185, t_fsm__state *ZO186)
 {
+	t_fsm__state ZI185;
 	t_fsm__state ZI186;
-	t_fsm__state ZI187;
 
-ZL2_188:;
+ZL2_187:;
 	switch (CURRENT_TERMINAL) {
 	case (TOK_ALT):
 		{
 			ADVANCE_LEXER;
-			p_expr_C_Clist_Hof_Halts_C_Calt (fsm, flags, lex_state, act_state, err, ZI184, ZI185);
-			/* BEGINNING OF INLINE: 188 */
+			p_expr_C_Clist_Hof_Halts_C_Calt (fsm, flags, lex_state, act_state, err, ZI183, ZI184);
+			/* BEGINNING OF INLINE: 187 */
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
 			} else {
-				goto ZL2_188;
+				goto ZL2_187;
 			}
-			/* END OF INLINE: 188 */
+			/* END OF INLINE: 187 */
 		}
 		/* UNREACHED */
 	default:
 		{
+			ZI185 = ZI183;
 			ZI186 = ZI184;
-			ZI187 = ZI185;
 		}
 		break;
 	case (ERROR_TERMINAL):
@@ -786,42 +785,42 @@ ZL1:;
 	SAVE_LEXER ((ERROR_TERMINAL));
 	return;
 ZL0:;
+	*ZO185 = ZI185;
 	*ZO186 = ZI186;
-	*ZO187 = ZI187;
 }
 
 static void
-p_193(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_grp *ZIg)
+p_192(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_grp *ZIg)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_RANGE):
 		{
 			t_char ZIb;
+			t_pos ZI135;
 			t_pos ZI136;
-			t_pos ZI137;
 
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
 #line 437 "src/libre/parser.act"
 
 		ZIb = '-';
-		ZI136 = lex_state->lx.start;
-		ZI137   = lex_state->lx.end;
+		ZI135 = lex_state->lx.start;
+		ZI136   = lex_state->lx.end;
 	
-#line 812 "src/libre/dialect/native/parser.c"
+#line 811 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: group-add-char */
 			{
-#line 672 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
 		if (-1 == group_add((ZIg), flags->flags, (ZIb))) {
 			err->e = RE_EERRNO;
 			goto ZL1;
 		}
 	
-#line 825 "src/libre/dialect/native/parser.c"
+#line 824 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: group-add-char */
 		}
@@ -857,36 +856,13 @@ ZL1:;
 }
 
 void
-p_re__native(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err)
+p_re__native(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_fsm__state ZIx, t_fsm__state ZIy)
 {
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 		return;
 	}
 	{
-		t_fsm__state ZIx;
-		t_fsm__state ZIy;
-
-		/* BEGINNING OF ACTION: make-states */
-		{
-#line 625 "src/libre/parser.act"
-
-		assert(fsm != NULL);
-		/* TODO: assert fsm is empty */
-
-		(ZIx) = fsm_getstart(fsm);
-		assert((ZIx) != NULL);
-
-		(ZIy) = fsm_addstate(fsm);
-		if ((ZIy) == NULL) {
-			goto ZL1;
-		}
-
-		fsm_setend(fsm, (ZIy), 1);
-	
-#line 887 "src/libre/dialect/native/parser.c"
-		}
-		/* END OF ACTION: make-states */
-		/* BEGINNING OF INLINE: 179 */
+		/* BEGINNING OF INLINE: 178 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_OPENSUB): case (TOK_OPENGROUP): case (TOK_ESC):
@@ -904,13 +880,13 @@ p_re__native(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err
 				{
 					/* BEGINNING OF ACTION: add-epsilon */
 					{
-#line 830 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (ZIy))) {
 			goto ZL3;
 		}
 	
-#line 914 "src/libre/dialect/native/parser.c"
+#line 890 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: add-epsilon */
 				}
@@ -921,20 +897,20 @@ p_re__native(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err
 			{
 				/* BEGINNING OF ACTION: err-expected-alts */
 				{
-#line 1049 "src/libre/parser.act"
+#line 1033 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXALTS;
 		}
 	
-#line 931 "src/libre/dialect/native/parser.c"
+#line 907 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF ACTION: err-expected-alts */
 			}
 		ZL2:;
 		}
-		/* END OF INLINE: 179 */
-		/* BEGINNING OF INLINE: 180 */
+		/* END OF INLINE: 178 */
+		/* BEGINNING OF INLINE: 179 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -950,24 +926,20 @@ p_re__native(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 1085 "src/libre/parser.act"
+#line 1069 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
 		}
 	
-#line 960 "src/libre/dialect/native/parser.c"
+#line 936 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
 		ZL4:;
 		}
-		/* END OF INLINE: 180 */
+		/* END OF INLINE: 179 */
 	}
-	return;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
 }
 
 static void
@@ -978,14 +950,14 @@ p_group_C_Clist_Hof_Hterms(fsm fsm, flags flags, lex_state lex_state, act_state 
 	}
 ZL2_group_C_Clist_Hof_Hterms:;
 	{
-		/* BEGINNING OF INLINE: 125 */
+		/* BEGINNING OF INLINE: 124 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CHAR):
 				{
-					t_char ZI202;
+					t_char ZI201;
+					t_pos ZI202;
 					t_pos ZI203;
-					t_pos ZI204;
 
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
@@ -994,16 +966,16 @@ ZL2_group_C_Clist_Hof_Hterms:;
 		assert(lex_state->buf.a[0] != '\0');
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI203 = lex_state->lx.start;
-		ZI204   = lex_state->lx.end;
+		ZI202 = lex_state->lx.start;
+		ZI203   = lex_state->lx.end;
 
-		ZI202 = lex_state->buf.a[0];
+		ZI201 = lex_state->buf.a[0];
 	
-#line 1003 "src/libre/dialect/native/parser.c"
+#line 975 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: CHAR */
 					ADVANCE_LEXER;
-					p_205 (fsm, flags, lex_state, act_state, err, ZIg, &ZI202, &ZI203);
+					p_204 (fsm, flags, lex_state, act_state, err, ZIg, &ZI201, &ZI202);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL4;
@@ -1033,29 +1005,29 @@ ZL2_group_C_Clist_Hof_Hterms:;
 		default:             break;
 		}
 	
-#line 1037 "src/libre/dialect/native/parser.c"
+#line 1009 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: ESC */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: group-add-char */
 					{
-#line 672 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
 		if (-1 == group_add((ZIg), flags->flags, (ZIc))) {
 			err->e = RE_EERRNO;
 			goto ZL4;
 		}
 	
-#line 1050 "src/libre/dialect/native/parser.c"
+#line 1022 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: group-add-char */
 				}
 				break;
 			case (TOK_HEX):
 				{
-					t_char ZI198;
+					t_char ZI197;
+					t_pos ZI198;
 					t_pos ZI199;
-					t_pos ZI200;
 
 					/* BEGINNING OF EXTRACT: HEX */
 					{
@@ -1067,8 +1039,8 @@ ZL2_group_C_Clist_Hof_Hterms:;
 		assert(0 == strncmp(lex_state->buf.a, "\\x", 2));
 		assert(strlen(lex_state->buf.a) >= 3);
 
-		ZI199 = lex_state->lx.start;
-		ZI200   = lex_state->lx.end;
+		ZI198 = lex_state->lx.start;
+		ZI199   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -1085,13 +1057,13 @@ ZL2_group_C_Clist_Hof_Hterms:;
 			goto ZL4;
 		}
 
-		ZI198 = (char) (unsigned char) u;
+		ZI197 = (char) (unsigned char) u;
 	
-#line 1091 "src/libre/dialect/native/parser.c"
+#line 1063 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: HEX */
 					ADVANCE_LEXER;
-					p_205 (fsm, flags, lex_state, act_state, err, ZIg, &ZI198, &ZI199);
+					p_204 (fsm, flags, lex_state, act_state, err, ZIg, &ZI197, &ZI198);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL4;
@@ -1100,9 +1072,9 @@ ZL2_group_C_Clist_Hof_Hterms:;
 				break;
 			case (TOK_OCT):
 				{
-					t_char ZI194;
+					t_char ZI193;
+					t_pos ZI194;
 					t_pos ZI195;
-					t_pos ZI196;
 
 					/* BEGINNING OF EXTRACT: OCT */
 					{
@@ -1114,8 +1086,8 @@ ZL2_group_C_Clist_Hof_Hterms:;
 		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
 		assert(strlen(lex_state->buf.a) >= 2);
 
-		ZI195 = lex_state->lx.start;
-		ZI196   = lex_state->lx.end;
+		ZI194 = lex_state->lx.start;
+		ZI195   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -1132,13 +1104,13 @@ ZL2_group_C_Clist_Hof_Hterms:;
 			goto ZL4;
 		}
 
-		ZI194 = (char) (unsigned char) u;
+		ZI193 = (char) (unsigned char) u;
 	
-#line 1138 "src/libre/dialect/native/parser.c"
+#line 1110 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: OCT */
 					ADVANCE_LEXER;
-					p_205 (fsm, flags, lex_state, act_state, err, ZIg, &ZI194, &ZI195);
+					p_204 (fsm, flags, lex_state, act_state, err, ZIg, &ZI193, &ZI194);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL4;
@@ -1161,7 +1133,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 								{
 #line 463 "src/libre/parser.act"
  ZIk = class_alnum_fsm(fsm->opt);  if (ZIk == NULL) { err->e = RE_EERRNO; goto ZL4; } 
-#line 1165 "src/libre/dialect/native/parser.c"
+#line 1137 "src/libre/dialect/native/parser.c"
 								}
 								/* END OF EXTRACT: CLASS_alnum */
 								ADVANCE_LEXER;
@@ -1173,7 +1145,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 								{
 #line 464 "src/libre/parser.act"
  ZIk = class_alpha_fsm(fsm->opt);  if (ZIk == NULL) { err->e = RE_EERRNO; goto ZL4; } 
-#line 1177 "src/libre/dialect/native/parser.c"
+#line 1149 "src/libre/dialect/native/parser.c"
 								}
 								/* END OF EXTRACT: CLASS_alpha */
 								ADVANCE_LEXER;
@@ -1185,7 +1157,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 								{
 #line 466 "src/libre/parser.act"
  ZIk = class_ascii_fsm(fsm->opt);  if (ZIk == NULL) { err->e = RE_EERRNO; goto ZL4; } 
-#line 1189 "src/libre/dialect/native/parser.c"
+#line 1161 "src/libre/dialect/native/parser.c"
 								}
 								/* END OF EXTRACT: CLASS_ascii */
 								ADVANCE_LEXER;
@@ -1197,7 +1169,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 								{
 #line 467 "src/libre/parser.act"
  ZIk = class_blank_fsm(fsm->opt);  if (ZIk == NULL) { err->e = RE_EERRNO; goto ZL4; } 
-#line 1201 "src/libre/dialect/native/parser.c"
+#line 1173 "src/libre/dialect/native/parser.c"
 								}
 								/* END OF EXTRACT: CLASS_blank */
 								ADVANCE_LEXER;
@@ -1209,7 +1181,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 								{
 #line 468 "src/libre/parser.act"
  ZIk = class_cntrl_fsm(fsm->opt);  if (ZIk == NULL) { err->e = RE_EERRNO; goto ZL4; } 
-#line 1213 "src/libre/dialect/native/parser.c"
+#line 1185 "src/libre/dialect/native/parser.c"
 								}
 								/* END OF EXTRACT: CLASS_cntrl */
 								ADVANCE_LEXER;
@@ -1221,7 +1193,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 								{
 #line 469 "src/libre/parser.act"
  ZIk = class_digit_fsm(fsm->opt);  if (ZIk == NULL) { err->e = RE_EERRNO; goto ZL4; } 
-#line 1225 "src/libre/dialect/native/parser.c"
+#line 1197 "src/libre/dialect/native/parser.c"
 								}
 								/* END OF EXTRACT: CLASS_digit */
 								ADVANCE_LEXER;
@@ -1233,7 +1205,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 								{
 #line 470 "src/libre/parser.act"
  ZIk = class_graph_fsm(fsm->opt);  if (ZIk == NULL) { err->e = RE_EERRNO; goto ZL4; } 
-#line 1237 "src/libre/dialect/native/parser.c"
+#line 1209 "src/libre/dialect/native/parser.c"
 								}
 								/* END OF EXTRACT: CLASS_graph */
 								ADVANCE_LEXER;
@@ -1245,7 +1217,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 								{
 #line 471 "src/libre/parser.act"
  ZIk = class_lower_fsm(fsm->opt);  if (ZIk == NULL) { err->e = RE_EERRNO; goto ZL4; } 
-#line 1249 "src/libre/dialect/native/parser.c"
+#line 1221 "src/libre/dialect/native/parser.c"
 								}
 								/* END OF EXTRACT: CLASS_lower */
 								ADVANCE_LEXER;
@@ -1257,7 +1229,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 								{
 #line 472 "src/libre/parser.act"
  ZIk = class_print_fsm(fsm->opt);  if (ZIk == NULL) { err->e = RE_EERRNO; goto ZL4; } 
-#line 1261 "src/libre/dialect/native/parser.c"
+#line 1233 "src/libre/dialect/native/parser.c"
 								}
 								/* END OF EXTRACT: CLASS_print */
 								ADVANCE_LEXER;
@@ -1269,7 +1241,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 								{
 #line 473 "src/libre/parser.act"
  ZIk = class_punct_fsm(fsm->opt);  if (ZIk == NULL) { err->e = RE_EERRNO; goto ZL4; } 
-#line 1273 "src/libre/dialect/native/parser.c"
+#line 1245 "src/libre/dialect/native/parser.c"
 								}
 								/* END OF EXTRACT: CLASS_punct */
 								ADVANCE_LEXER;
@@ -1281,7 +1253,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 								{
 #line 474 "src/libre/parser.act"
  ZIk = class_space_fsm(fsm->opt);  if (ZIk == NULL) { err->e = RE_EERRNO; goto ZL4; } 
-#line 1285 "src/libre/dialect/native/parser.c"
+#line 1257 "src/libre/dialect/native/parser.c"
 								}
 								/* END OF EXTRACT: CLASS_space */
 								ADVANCE_LEXER;
@@ -1293,7 +1265,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 								{
 #line 476 "src/libre/parser.act"
  ZIk = class_upper_fsm(fsm->opt);  if (ZIk == NULL) { err->e = RE_EERRNO; goto ZL4; } 
-#line 1297 "src/libre/dialect/native/parser.c"
+#line 1269 "src/libre/dialect/native/parser.c"
 								}
 								/* END OF EXTRACT: CLASS_upper */
 								ADVANCE_LEXER;
@@ -1305,7 +1277,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 								{
 #line 477 "src/libre/parser.act"
  ZIk = class_word_fsm(fsm->opt);   if (ZIk == NULL) { err->e = RE_EERRNO; goto ZL4; } 
-#line 1309 "src/libre/dialect/native/parser.c"
+#line 1281 "src/libre/dialect/native/parser.c"
 								}
 								/* END OF EXTRACT: CLASS_word */
 								ADVANCE_LEXER;
@@ -1317,7 +1289,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 								{
 #line 478 "src/libre/parser.act"
  ZIk = class_xdigit_fsm(fsm->opt); if (ZIk == NULL) { err->e = RE_EERRNO; goto ZL4; } 
-#line 1321 "src/libre/dialect/native/parser.c"
+#line 1293 "src/libre/dialect/native/parser.c"
 								}
 								/* END OF EXTRACT: CLASS_xdigit */
 								ADVANCE_LEXER;
@@ -1330,7 +1302,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 					/* END OF INLINE: group::class */
 					/* BEGINNING OF ACTION: group-add-class */
 					{
-#line 686 "src/libre/parser.act"
+#line 670 "src/libre/parser.act"
 
 		struct fsm *q;
 		int r;
@@ -1390,7 +1362,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 			}
 		}
 	
-#line 1394 "src/libre/dialect/native/parser.c"
+#line 1366 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: group-add-class */
 				}
@@ -1403,20 +1375,20 @@ ZL2_group_C_Clist_Hof_Hterms:;
 			{
 				/* BEGINNING OF ACTION: err-expected-term */
 				{
-#line 1031 "src/libre/parser.act"
+#line 1015 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXTERM;
 		}
 	
-#line 1413 "src/libre/dialect/native/parser.c"
+#line 1385 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF ACTION: err-expected-term */
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 125 */
-		/* BEGINNING OF INLINE: 126 */
+		/* END OF INLINE: 124 */
+		/* BEGINNING OF INLINE: 125 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CLASS__alnum): case (TOK_CLASS__alpha): case (TOK_CLASS__ascii): case (TOK_CLASS__blank):
@@ -1434,12 +1406,12 @@ ZL2_group_C_Clist_Hof_Hterms:;
 				break;
 			}
 		}
-		/* END OF INLINE: 126 */
+		/* END OF INLINE: 125 */
 	}
 }
 
 static void
-p_205(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_grp *ZIg, t_char *ZI202, t_pos *ZI203)
+p_204(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_grp *ZIg, t_char *ZI201, t_pos *ZI202)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_RANGE):
@@ -1447,12 +1419,12 @@ p_205(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			t_char ZIb;
 			t_pos ZIend;
 
-			/* BEGINNING OF INLINE: 112 */
+			/* BEGINNING OF INLINE: 111 */
 			{
 				{
-					t_char ZI113;
+					t_char ZI112;
+					t_pos ZI113;
 					t_pos ZI114;
-					t_pos ZI115;
 
 					switch (CURRENT_TERMINAL) {
 					case (TOK_RANGE):
@@ -1460,11 +1432,11 @@ p_205(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 						{
 #line 437 "src/libre/parser.act"
 
-		ZI113 = '-';
-		ZI114 = lex_state->lx.start;
-		ZI115   = lex_state->lx.end;
+		ZI112 = '-';
+		ZI113 = lex_state->lx.start;
+		ZI114   = lex_state->lx.end;
 	
-#line 1468 "src/libre/dialect/native/parser.c"
+#line 1440 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF EXTRACT: RANGE */
 						break;
@@ -1478,25 +1450,25 @@ p_205(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 				{
 					/* BEGINNING OF ACTION: err-expected-range */
 					{
-#line 1055 "src/libre/parser.act"
+#line 1039 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXRANGE;
 		}
 	
-#line 1488 "src/libre/dialect/native/parser.c"
+#line 1460 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: err-expected-range */
 				}
 			ZL2:;
 			}
-			/* END OF INLINE: 112 */
-			/* BEGINNING OF INLINE: 116 */
+			/* END OF INLINE: 111 */
+			/* BEGINNING OF INLINE: 115 */
 			{
 				switch (CURRENT_TERMINAL) {
 				case (TOK_CHAR):
 					{
-						t_pos ZI120;
+						t_pos ZI119;
 
 						/* BEGINNING OF EXTRACT: CHAR */
 						{
@@ -1505,12 +1477,12 @@ p_205(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 		assert(lex_state->buf.a[0] != '\0');
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI120 = lex_state->lx.start;
+		ZI119 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 
 		ZIb = lex_state->buf.a[0];
 	
-#line 1514 "src/libre/dialect/native/parser.c"
+#line 1486 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF EXTRACT: CHAR */
 						ADVANCE_LEXER;
@@ -1518,7 +1490,7 @@ p_205(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 					break;
 				case (TOK_HEX):
 					{
-						t_pos ZI119;
+						t_pos ZI118;
 
 						/* BEGINNING OF EXTRACT: HEX */
 						{
@@ -1530,7 +1502,7 @@ p_205(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 		assert(0 == strncmp(lex_state->buf.a, "\\x", 2));
 		assert(strlen(lex_state->buf.a) >= 3);
 
-		ZI119 = lex_state->lx.start;
+		ZI118 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 
 		errno = 0;
@@ -1550,7 +1522,7 @@ p_205(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 
 		ZIb = (char) (unsigned char) u;
 	
-#line 1554 "src/libre/dialect/native/parser.c"
+#line 1526 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF EXTRACT: HEX */
 						ADVANCE_LEXER;
@@ -1558,7 +1530,7 @@ p_205(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 					break;
 				case (TOK_OCT):
 					{
-						t_pos ZI117;
+						t_pos ZI116;
 
 						/* BEGINNING OF EXTRACT: OCT */
 						{
@@ -1570,7 +1542,7 @@ p_205(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
 		assert(strlen(lex_state->buf.a) >= 2);
 
-		ZI117 = lex_state->lx.start;
+		ZI116 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 
 		errno = 0;
@@ -1590,7 +1562,7 @@ p_205(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 
 		ZIb = (char) (unsigned char) u;
 	
-#line 1594 "src/libre/dialect/native/parser.c"
+#line 1566 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF EXTRACT: OCT */
 						ADVANCE_LEXER;
@@ -1598,17 +1570,17 @@ p_205(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 					break;
 				case (TOK_RANGE):
 					{
-						t_pos ZI121;
+						t_pos ZI120;
 
 						/* BEGINNING OF EXTRACT: RANGE */
 						{
 #line 437 "src/libre/parser.act"
 
 		ZIb = '-';
-		ZI121 = lex_state->lx.start;
+		ZI120 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1612 "src/libre/dialect/native/parser.c"
+#line 1584 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF EXTRACT: RANGE */
 						ADVANCE_LEXER;
@@ -1618,42 +1590,42 @@ p_205(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 					goto ZL1;
 				}
 			}
-			/* END OF INLINE: 116 */
+			/* END OF INLINE: 115 */
 			/* BEGINNING OF ACTION: mark-range */
 			{
-#line 1093 "src/libre/parser.act"
+#line 1077 "src/libre/parser.act"
 
-		mark(&act_state->rangestart, &(*ZI203));
+		mark(&act_state->rangestart, &(*ZI202));
 		mark(&act_state->rangeend,   &(ZIend));
 	
-#line 1630 "src/libre/dialect/native/parser.c"
+#line 1602 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: group-add-range */
 			{
-#line 741 "src/libre/parser.act"
+#line 725 "src/libre/parser.act"
 
 		int i;
 
-		if ((unsigned char) (ZIb) < (unsigned char) (*ZI202)) {
+		if ((unsigned char) (ZIb) < (unsigned char) (*ZI201)) {
 			char a[5], b[5];
 
 			assert(sizeof err->set >= 1 + sizeof a + 1 + sizeof b + 1 + 1);
 
 			sprintf(err->set, "%s-%s",
-				escchar(a, sizeof a, (*ZI202)), escchar(b, sizeof b, (ZIb)));
+				escchar(a, sizeof a, (*ZI201)), escchar(b, sizeof b, (ZIb)));
 			err->e = RE_ENEGRANGE;
 			goto ZL1;
 		}
 
-		for (i = (unsigned char) (*ZI202); i <= (unsigned char) (ZIb); i++) {
+		for (i = (unsigned char) (*ZI201); i <= (unsigned char) (ZIb); i++) {
 			if (-1 == group_add((ZIg), flags->flags, (char) i)) {
 				err->e = RE_EERRNO;
 				goto ZL1;
 			}
 		}
 	
-#line 1657 "src/libre/dialect/native/parser.c"
+#line 1629 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: group-add-range */
 		}
@@ -1662,14 +1634,14 @@ p_205(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 		{
 			/* BEGINNING OF ACTION: group-add-char */
 			{
-#line 672 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
-		if (-1 == group_add((ZIg), flags->flags, (*ZI202))) {
+		if (-1 == group_add((ZIg), flags->flags, (*ZI201))) {
 			err->e = RE_EERRNO;
 			goto ZL1;
 		}
 	
-#line 1673 "src/libre/dialect/native/parser.c"
+#line 1645 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: group-add-char */
 		}
@@ -1695,17 +1667,17 @@ ZL2_expr_C_Clist_Hof_Hatoms:;
 
 		/* BEGINNING OF ACTION: add-concat */
 		{
-#line 823 "src/libre/parser.act"
+#line 807 "src/libre/parser.act"
 
 		(ZIz) = fsm_addstate(fsm);
 		if ((ZIz) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1706 "src/libre/dialect/native/parser.c"
+#line 1678 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: add-concat */
-		/* BEGINNING OF INLINE: 172 */
+		/* BEGINNING OF INLINE: 171 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_START): case (TOK_END):
@@ -1731,8 +1703,8 @@ ZL2_expr_C_Clist_Hof_Hatoms:;
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 172 */
-		/* BEGINNING OF INLINE: 173 */
+		/* END OF INLINE: 171 */
+		/* BEGINNING OF INLINE: 172 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_OPENSUB): case (TOK_OPENGROUP): case (TOK_ESC):
@@ -1749,20 +1721,20 @@ ZL2_expr_C_Clist_Hof_Hatoms:;
 				{
 					/* BEGINNING OF ACTION: add-epsilon */
 					{
-#line 830 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIz), (ZIy))) {
 			goto ZL1;
 		}
 	
-#line 1759 "src/libre/dialect/native/parser.c"
+#line 1731 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: add-epsilon */
 				}
 				break;
 			}
 		}
-		/* END OF INLINE: 173 */
+		/* END OF INLINE: 172 */
 	}
 	return;
 ZL1:;
@@ -1771,51 +1743,51 @@ ZL1:;
 }
 
 static void
-p_209(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_fsm__state *ZIx, t_fsm__state *ZIy, t_pos *ZI206, t_unsigned *ZI208)
+p_208(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_fsm__state *ZIx, t_fsm__state *ZIy, t_pos *ZI205, t_unsigned *ZI207)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CLOSECOUNT):
 		{
-			t_pos ZI165;
+			t_pos ZI164;
 			t_pos ZIend;
 
 			/* BEGINNING OF EXTRACT: CLOSECOUNT */
 			{
 #line 459 "src/libre/parser.act"
 
-		ZI165 = lex_state->lx.start;
+		ZI164 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1790 "src/libre/dialect/native/parser.c"
+#line 1762 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: CLOSECOUNT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 1098 "src/libre/parser.act"
+#line 1082 "src/libre/parser.act"
 
-		mark(&act_state->countstart, &(*ZI206));
+		mark(&act_state->countstart, &(*ZI205));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 1801 "src/libre/dialect/native/parser.c"
+#line 1773 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-m-to-n */
 			{
-#line 901 "src/libre/parser.act"
+#line 885 "src/libre/parser.act"
 
 		unsigned i;
 		struct fsm_state *a;
 		struct fsm_state *b;
 
-		if ((*ZI208) < (*ZI208)) {
+		if ((*ZI207) < (*ZI207)) {
 			err->e = RE_ENEGCOUNT;
-			err->m = (*ZI208);
-			err->n = (*ZI208);
+			err->m = (*ZI207);
+			err->n = (*ZI207);
 			goto ZL1;
 		}
 
-		if ((*ZI208) == 0) {
+		if ((*ZI207) == 0) {
 			if (!fsm_addedge_epsilon(fsm, (*ZIx), (*ZIy))) {
 				goto ZL1;
 			}
@@ -1823,7 +1795,7 @@ p_209(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 
 		b = (*ZIy);
 
-		for (i = 1; i < (*ZI208); i++) {
+		for (i = 1; i < (*ZI207); i++) {
 			a = fsm_state_duplicatesubgraphx(fsm, (*ZIx), &b);
 			if (a == NULL) {
 				goto ZL1;
@@ -1835,7 +1807,7 @@ p_209(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 				goto ZL1;
 			}
 
-			if (i >= (*ZI208)) {
+			if (i >= (*ZI207)) {
 				if (!fsm_addedge_epsilon(fsm, (*ZIy), b)) {
 					goto ZL1;
 				}
@@ -1845,7 +1817,7 @@ p_209(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			(*ZIx) = a;
 		}
 	
-#line 1849 "src/libre/dialect/native/parser.c"
+#line 1821 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: count-m-to-n */
 		}
@@ -1854,7 +1826,7 @@ p_209(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 		{
 			t_unsigned ZIn;
 			t_pos ZIend;
-			t_pos ZI168;
+			t_pos ZI167;
 
 			ADVANCE_LEXER;
 			switch (CURRENT_TERMINAL) {
@@ -1881,7 +1853,7 @@ p_209(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 
 		ZIn = (unsigned int) u;
 	
-#line 1885 "src/libre/dialect/native/parser.c"
+#line 1857 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -1896,9 +1868,9 @@ p_209(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 #line 459 "src/libre/parser.act"
 
 		ZIend = lex_state->lx.start;
-		ZI168   = lex_state->lx.end;
+		ZI167   = lex_state->lx.end;
 	
-#line 1902 "src/libre/dialect/native/parser.c"
+#line 1874 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF EXTRACT: CLOSECOUNT */
 				break;
@@ -1908,30 +1880,30 @@ p_209(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 1098 "src/libre/parser.act"
+#line 1082 "src/libre/parser.act"
 
-		mark(&act_state->countstart, &(*ZI206));
+		mark(&act_state->countstart, &(*ZI205));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 1917 "src/libre/dialect/native/parser.c"
+#line 1889 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-m-to-n */
 			{
-#line 901 "src/libre/parser.act"
+#line 885 "src/libre/parser.act"
 
 		unsigned i;
 		struct fsm_state *a;
 		struct fsm_state *b;
 
-		if ((ZIn) < (*ZI208)) {
+		if ((ZIn) < (*ZI207)) {
 			err->e = RE_ENEGCOUNT;
-			err->m = (*ZI208);
+			err->m = (*ZI207);
 			err->n = (ZIn);
 			goto ZL1;
 		}
 
-		if ((*ZI208) == 0) {
+		if ((*ZI207) == 0) {
 			if (!fsm_addedge_epsilon(fsm, (*ZIx), (*ZIy))) {
 				goto ZL1;
 			}
@@ -1951,7 +1923,7 @@ p_209(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 				goto ZL1;
 			}
 
-			if (i >= (*ZI208)) {
+			if (i >= (*ZI207)) {
 				if (!fsm_addedge_epsilon(fsm, (*ZIy), b)) {
 					goto ZL1;
 				}
@@ -1961,7 +1933,7 @@ p_209(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			(*ZIx) = a;
 		}
 	
-#line 1965 "src/libre/dialect/native/parser.c"
+#line 1937 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: count-m-to-n */
 		}
@@ -1985,7 +1957,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 	}
 	{
 		t_pos ZIstart;
-		t_pos ZI141;
+		t_pos ZI140;
 
 		switch (CURRENT_TERMINAL) {
 		case (TOK_OPENGROUP):
@@ -1994,9 +1966,9 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 #line 443 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
-		ZI141   = lex_state->lx.end;
+		ZI140   = lex_state->lx.end;
 	
-#line 2000 "src/libre/dialect/native/parser.c"
+#line 1972 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: OPENGROUP */
 			break;
@@ -2004,20 +1976,20 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 			goto ZL1;
 		}
 		ADVANCE_LEXER;
-		/* BEGINNING OF INLINE: 142 */
+		/* BEGINNING OF INLINE: 141 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_INVERT):
 				{
-					t_char ZI143;
+					t_char ZI142;
 
 					/* BEGINNING OF EXTRACT: INVERT */
 					{
 #line 433 "src/libre/parser.act"
 
-		ZI143 = '^';
+		ZI142 = '^';
 	
-#line 2021 "src/libre/dialect/native/parser.c"
+#line 1993 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: INVERT */
 					ADVANCE_LEXER;
@@ -2028,7 +2000,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 					}
 					/* BEGINNING OF ACTION: invert-group */
 					{
-#line 656 "src/libre/parser.act"
+#line 640 "src/libre/parser.act"
 
 		struct fsm *any;
 
@@ -2049,7 +2021,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 		 * kept in the positive.
 		 */
 	
-#line 2053 "src/libre/dialect/native/parser.c"
+#line 2025 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: invert-group */
 				}
@@ -2071,12 +2043,12 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 142 */
-		/* BEGINNING OF INLINE: 144 */
+		/* END OF INLINE: 141 */
+		/* BEGINNING OF INLINE: 143 */
 		{
 			{
-				t_char ZI145;
-				t_pos ZI146;
+				t_char ZI144;
+				t_pos ZI145;
 				t_pos ZIend;
 
 				switch (CURRENT_TERMINAL) {
@@ -2085,11 +2057,11 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 					{
 #line 448 "src/libre/parser.act"
 
-		ZI145 = ']';
-		ZI146 = lex_state->lx.start;
+		ZI144 = ']';
+		ZI145 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 2093 "src/libre/dialect/native/parser.c"
+#line 2065 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: CLOSEGROUP */
 					break;
@@ -2099,12 +2071,12 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 				ADVANCE_LEXER;
 				/* BEGINNING OF ACTION: mark-group */
 				{
-#line 1088 "src/libre/parser.act"
+#line 1072 "src/libre/parser.act"
 
 		mark(&act_state->groupstart, &(ZIstart));
 		mark(&act_state->groupend,   &(ZIend));
 	
-#line 2108 "src/libre/dialect/native/parser.c"
+#line 2080 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF ACTION: mark-group */
 			}
@@ -2113,49 +2085,49 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 			{
 				/* BEGINNING OF ACTION: err-expected-closegroup */
 				{
-#line 1061 "src/libre/parser.act"
+#line 1045 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCLOSEGROUP;
 		}
 	
-#line 2123 "src/libre/dialect/native/parser.c"
+#line 2095 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF ACTION: err-expected-closegroup */
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 144 */
+		/* END OF INLINE: 143 */
 	}
 	return;
 ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-groupbody */
 		{
-#line 1067 "src/libre/parser.act"
+#line 1051 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXGROUPBODY;
 		}
 	
-#line 2142 "src/libre/dialect/native/parser.c"
+#line 2114 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: err-expected-groupbody */
 	}
 }
 
 static void
-p_expr_C_Clist_Hof_Halts(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_fsm__state ZI184, t_fsm__state ZI185)
+p_expr_C_Clist_Hof_Halts(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_fsm__state ZI183, t_fsm__state ZI184)
 {
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 		return;
 	}
 	{
+		t_fsm__state ZI185;
 		t_fsm__state ZI186;
-		t_fsm__state ZI187;
 
-		p_expr_C_Clist_Hof_Halts_C_Calt (fsm, flags, lex_state, act_state, err, ZI184, ZI185);
-		p_188 (fsm, flags, lex_state, act_state, err, ZI184, ZI185, &ZI186, &ZI187);
+		p_expr_C_Clist_Hof_Halts_C_Calt (fsm, flags, lex_state, act_state, err, ZI183, ZI184);
+		p_187 (fsm, flags, lex_state, act_state, err, ZI183, ZI184, &ZI185, &ZI186);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -2174,7 +2146,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 161 */
+		/* BEGINNING OF INLINE: 160 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY):
@@ -2182,7 +2154,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: add-any */
 					{
-#line 860 "src/libre/parser.act"
+#line 844 "src/libre/parser.act"
 
 		struct fsm *any;
 
@@ -2200,7 +2172,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 2204 "src/libre/dialect/native/parser.c"
+#line 2176 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: add-any */
 				}
@@ -2243,24 +2215,24 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 161 */
-		/* BEGINNING OF INLINE: 162 */
+		/* END OF INLINE: 160 */
+		/* BEGINNING OF INLINE: 161 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_OPENCOUNT):
 				{
+					t_pos ZI205;
 					t_pos ZI206;
-					t_pos ZI207;
-					t_unsigned ZI208;
+					t_unsigned ZI207;
 
 					/* BEGINNING OF EXTRACT: OPENCOUNT */
 					{
 #line 454 "src/libre/parser.act"
 
-		ZI206 = lex_state->lx.start;
-		ZI207   = lex_state->lx.end;
+		ZI205 = lex_state->lx.start;
+		ZI206   = lex_state->lx.end;
 	
-#line 2264 "src/libre/dialect/native/parser.c"
+#line 2236 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: OPENCOUNT */
 					ADVANCE_LEXER;
@@ -2286,9 +2258,9 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL4;
 		}
 
-		ZI208 = (unsigned int) u;
+		ZI207 = (unsigned int) u;
 	
-#line 2292 "src/libre/dialect/native/parser.c"
+#line 2264 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF EXTRACT: COUNT */
 						break;
@@ -2296,7 +2268,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 						goto ZL4;
 					}
 					ADVANCE_LEXER;
-					p_209 (fsm, flags, lex_state, act_state, err, &ZIx, ZIy, &ZI206, &ZI208);
+					p_208 (fsm, flags, lex_state, act_state, err, &ZIx, ZIy, &ZI205, &ZI207);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL4;
@@ -2308,13 +2280,13 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: count-0-or-1 */
 					{
-#line 940 "src/libre/parser.act"
+#line 924 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (*ZIy))) {
 			goto ZL4;
 		}
 	
-#line 2318 "src/libre/dialect/native/parser.c"
+#line 2290 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: count-0-or-1 */
 				}
@@ -2324,7 +2296,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: count-1-or-many */
 					{
-#line 973 "src/libre/parser.act"
+#line 957 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (*ZIy), (ZIx))) {
 			goto ZL4;
@@ -2347,7 +2319,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 			(*ZIy) = z;
 		}
 	
-#line 2351 "src/libre/dialect/native/parser.c"
+#line 2323 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: count-1-or-many */
 				}
@@ -2357,7 +2329,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: count-0-or-many */
 					{
-#line 946 "src/libre/parser.act"
+#line 930 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (*ZIy))) {
 			goto ZL4;
@@ -2384,7 +2356,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 			(*ZIy) = z;
 		}
 	
-#line 2388 "src/libre/dialect/native/parser.c"
+#line 2360 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: count-0-or-many */
 				}
@@ -2393,12 +2365,12 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 				{
 					/* BEGINNING OF ACTION: count-1 */
 					{
-#line 996 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 		(void) (ZIx);
 		(void) (*ZIy);
 	
-#line 2402 "src/libre/dialect/native/parser.c"
+#line 2374 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: count-1 */
 				}
@@ -2409,19 +2381,19 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 			{
 				/* BEGINNING OF ACTION: err-expected-count */
 				{
-#line 1037 "src/libre/parser.act"
+#line 1021 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCOUNT;
 		}
 	
-#line 2419 "src/libre/dialect/native/parser.c"
+#line 2391 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF ACTION: err-expected-count */
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 162 */
+		/* END OF INLINE: 161 */
 	}
 	return;
 ZL1:;
@@ -2438,13 +2410,13 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 	{
 		t_char ZIc;
 
-		/* BEGINNING OF INLINE: 148 */
+		/* BEGINNING OF INLINE: 147 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CHAR):
 				{
+					t_pos ZI152;
 					t_pos ZI153;
-					t_pos ZI154;
 
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
@@ -2453,12 +2425,12 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 		assert(lex_state->buf.a[0] != '\0');
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI153 = lex_state->lx.start;
-		ZI154   = lex_state->lx.end;
+		ZI152 = lex_state->lx.start;
+		ZI153   = lex_state->lx.end;
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 2462 "src/libre/dialect/native/parser.c"
+#line 2434 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: CHAR */
 					ADVANCE_LEXER;
@@ -2485,7 +2457,7 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 		default:             break;
 		}
 	
-#line 2489 "src/libre/dialect/native/parser.c"
+#line 2461 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: ESC */
 					ADVANCE_LEXER;
@@ -2493,8 +2465,8 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 				break;
 			case (TOK_HEX):
 				{
+					t_pos ZI150;
 					t_pos ZI151;
-					t_pos ZI152;
 
 					/* BEGINNING OF EXTRACT: HEX */
 					{
@@ -2506,8 +2478,8 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 		assert(0 == strncmp(lex_state->buf.a, "\\x", 2));
 		assert(strlen(lex_state->buf.a) >= 3);
 
-		ZI151 = lex_state->lx.start;
-		ZI152   = lex_state->lx.end;
+		ZI150 = lex_state->lx.start;
+		ZI151   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -2526,7 +2498,7 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 2530 "src/libre/dialect/native/parser.c"
+#line 2502 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: HEX */
 					ADVANCE_LEXER;
@@ -2534,8 +2506,8 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 				break;
 			case (TOK_OCT):
 				{
+					t_pos ZI148;
 					t_pos ZI149;
-					t_pos ZI150;
 
 					/* BEGINNING OF EXTRACT: OCT */
 					{
@@ -2547,8 +2519,8 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
 		assert(strlen(lex_state->buf.a) >= 2);
 
-		ZI149 = lex_state->lx.start;
-		ZI150   = lex_state->lx.end;
+		ZI148 = lex_state->lx.start;
+		ZI149   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -2567,7 +2539,7 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 2571 "src/libre/dialect/native/parser.c"
+#line 2543 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: OCT */
 					ADVANCE_LEXER;
@@ -2577,10 +2549,10 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 148 */
+		/* END OF INLINE: 147 */
 		/* BEGINNING OF ACTION: add-literal */
 		{
-#line 847 "src/libre/parser.act"
+#line 831 "src/libre/parser.act"
 
 		assert((ZIx) != NULL);
 		assert((ZIy) != NULL);
@@ -2591,7 +2563,7 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 			goto ZL1;
 		}
 	
-#line 2595 "src/libre/dialect/native/parser.c"
+#line 2567 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: add-literal */
 	}
@@ -2603,7 +2575,7 @@ ZL1:;
 
 /* BEGINNING OF TRAILER */
 
-#line 1257 "src/libre/parser.act"
+#line 1259 "src/libre/parser.act"
 
 
 	static int
@@ -2623,9 +2595,11 @@ ZL1:;
 
 	static int
 	parse(int (*f)(void *opaque), void *opaque,
-		void (*entry)(struct fsm *, flags, lex_state, act_state, err),
+		void (*entry)(struct fsm *, flags, lex_state, act_state, err,
+			struct fsm_state *, struct fsm_state *),
 		struct flags *flags, int overlap,
-		struct fsm *new, struct re_err *err)
+		struct fsm *new, struct re_err *err,
+		struct fsm_state *x, struct fsm_state *y)
 	{
 		struct act_state  act_state_s;
 		struct act_state *act_state;
@@ -2674,7 +2648,7 @@ ZL1:;
 		err->e = RE_ESUCCESS;
 
 		ADVANCE_LEXER;
-		entry(new, flags, lex_state, act_state, err);
+		entry(new, flags, lex_state, act_state, err, x, y);
 
 		lx->free(lx);
 
@@ -2740,6 +2714,7 @@ ZL1:;
 		struct re_err *err)
 	{
 		struct fsm *new;
+		struct fsm_state *x, *y;
 		struct flags top, *fl = &top;
 
 		top.flags = flags;
@@ -2751,14 +2726,29 @@ ZL1:;
 			return NULL;
 		}
 
-		if (-1 == parse(f, opaque, DIALECT_ENTRY, fl, overlap, new, err)) {
-			fsm_free(new);
-			return NULL;
+		x = fsm_getstart(new);
+		assert(x != NULL);
+
+		y = fsm_addstate(new);
+		if (y == NULL) {
+			goto error;
+		}
+
+		fsm_setend(new, y, 1);
+
+		if (-1 == parse(f, opaque, DIALECT_ENTRY, fl, overlap, new, err, x, y)) {
+			goto error;
 		}
 
 		return new;
+
+	error:
+
+		fsm_free(new);
+
+		return NULL;
 	}
 
-#line 2763 "src/libre/dialect/native/parser.c"
+#line 2753 "src/libre/dialect/native/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/native/parser.h
+++ b/src/libre/dialect/native/parser.h
@@ -17,20 +17,21 @@
 	typedef struct lex_state * lex_state;
 	typedef struct act_state * act_state;
 
-	typedef struct fsm *  fsm;
+	typedef struct fsm * fsm;
+	typedef struct fsm_state * t_fsm__state;
 	typedef struct flags *flags;
 	typedef struct re_err * err;
 
-#line 25 "src/libre/dialect/native/parser.h"
+#line 26 "src/libre/dialect/native/parser.h"
 
 /* BEGINNING OF FUNCTION DECLARATIONS */
 
-extern void p_re__native(fsm, flags, lex_state, act_state, err);
+extern void p_re__native(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 /* BEGINNING OF TRAILER */
 
-#line 1259 "src/libre/parser.act"
+#line 1261 "src/libre/parser.act"
 
 
-#line 35 "src/libre/dialect/native/parser.h"
+#line 36 "src/libre/dialect/native/parser.h"
 
 /* END OF FILE */

--- a/src/libre/dialect/native/parser.sid
+++ b/src/libre/dialect/native/parser.sid
@@ -74,8 +74,6 @@
 
 %productions%
 
-	<make-states>: () -> (:fsm_state, :fsm_state);
-
 	<make-group>:  () -> (:grp);
 	<invert-group>:    (:grp &) -> ();
 	<group-add-char>:  (:grp &, :char) -> ();
@@ -377,9 +375,7 @@
 		list-of-alts(x, y);
 	};
 
-	re_native: () -> () = {
-		(x, y) = <make-states>;
-
+	re_native: (x :fsm_state, y :fsm_state) -> () = {
 		{
 			expr(x, y);
 		||

--- a/src/libre/dialect/pcre/parser.c
+++ b/src/libre/dialect/pcre/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 138 "src/libre/parser.act"
+#line 137 "src/libre/parser.act"
 
 
 	#include <assert.h>
@@ -87,7 +87,6 @@
 
 	typedef struct lx_pos t_pos;
 	typedef struct fsm * t_fsm;
-	typedef struct fsm_state * t_fsm__state;
 	typedef enum re_flags t_re__flags;
 	typedef struct grp t_grp;
 
@@ -404,7 +403,7 @@
 		return NULL;
 	}
 
-#line 408 "src/libre/dialect/pcre/parser.c"
+#line 407 "src/libre/dialect/pcre/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -420,15 +419,15 @@ static void p_group(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__
 static void p_group_C_Cgroup_Hbody(fsm, flags, lex_state, act_state, err, t_grp *);
 static void p_inline_Hflags(fsm, flags, lex_state, act_state, err);
 static void p_expr(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
+static void p_197(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state, t_fsm__state *, t_fsm__state *);
 static void p_group_C_Clist_Hof_Hterms(fsm, flags, lex_state, act_state, err, t_grp *);
-static void p_198(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state, t_fsm__state *, t_fsm__state *);
-static void p_203(fsm, flags, lex_state, act_state, err, t_grp *);
+static void p_202(fsm, flags, lex_state, act_state, err, t_grp *);
 static void p_expr_C_Clist_Hof_Hatoms(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 static void p_group_C_Cgroup_Hbm(fsm, flags, lex_state, act_state, err, t_grp *);
-static void p_215(fsm, flags, lex_state, act_state, err, t_grp *, t_char *, t_pos *);
-static void p_219(fsm, flags, lex_state, act_state, err, t_fsm__state *, t_fsm__state *, t_pos *, t_unsigned *);
+static void p_214(fsm, flags, lex_state, act_state, err, t_grp *, t_char *, t_pos *);
+static void p_218(fsm, flags, lex_state, act_state, err, t_fsm__state *, t_fsm__state *, t_pos *, t_unsigned *);
 static void p_expr_C_Clist_Hof_Halts(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
-extern void p_re__pcre(fsm, flags, lex_state, act_state, err);
+extern void p_re__pcre(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 static void p_expr_C_Catom(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state *);
 static void p_literal(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 
@@ -446,7 +445,7 @@ p_anchor(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err
 	{
 		t_pred ZIp;
 
-		/* BEGINNING OF INLINE: 154 */
+		/* BEGINNING OF INLINE: 153 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_END):
@@ -465,7 +464,7 @@ p_anchor(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err
 			ZIp = 0U;
 		}
 	
-#line 469 "src/libre/dialect/pcre/parser.c"
+#line 468 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: END */
 					ADVANCE_LEXER;
@@ -487,7 +486,7 @@ p_anchor(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err
 			ZIp = 0U;
 		}
 	
-#line 491 "src/libre/dialect/pcre/parser.c"
+#line 490 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: START */
 					ADVANCE_LEXER;
@@ -497,10 +496,10 @@ p_anchor(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 154 */
+		/* END OF INLINE: 153 */
 		/* BEGINNING OF ACTION: add-pred */
 		{
-#line 836 "src/libre/parser.act"
+#line 820 "src/libre/parser.act"
 
 		assert((ZIx) != NULL);
 		assert((ZIy) != NULL);
@@ -511,7 +510,7 @@ p_anchor(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err
 		}
 */
 	
-#line 515 "src/libre/dialect/pcre/parser.c"
+#line 514 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: add-pred */
 	}
@@ -529,7 +528,7 @@ p_inline_Hflags_C_Cnegative(fsm fsm, flags flags, lex_state lex_state, act_state
 	}
 ZL2_inline_Hflags_C_Cnegative:;
 	{
-		/* BEGINNING OF INLINE: 163 */
+		/* BEGINNING OF INLINE: 162 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_FLAG__INSENSITIVE):
@@ -542,17 +541,17 @@ ZL2_inline_Hflags_C_Cnegative:;
 
 		ZIc = RE_ICASE;
 	
-#line 546 "src/libre/dialect/pcre/parser.c"
+#line 545 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: FLAG_INSENSITIVE */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: clear-flag */
 					{
-#line 1023 "src/libre/parser.act"
+#line 1007 "src/libre/parser.act"
 
 		flags->flags &= ~(ZIc);
 	
-#line 556 "src/libre/dialect/pcre/parser.c"
+#line 555 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: clear-flag */
 				}
@@ -562,13 +561,13 @@ ZL2_inline_Hflags_C_Cnegative:;
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: err-unknown-flag */
 					{
-#line 1073 "src/libre/parser.act"
+#line 1057 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EFLAG;
 		}
 	
-#line 572 "src/libre/dialect/pcre/parser.c"
+#line 571 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: err-unknown-flag */
 				}
@@ -577,8 +576,8 @@ ZL2_inline_Hflags_C_Cnegative:;
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 163 */
-		/* BEGINNING OF INLINE: 164 */
+		/* END OF INLINE: 162 */
+		/* BEGINNING OF INLINE: 163 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_FLAG__UNKNOWN): case (TOK_FLAG__INSENSITIVE):
@@ -592,7 +591,7 @@ ZL2_inline_Hflags_C_Cnegative:;
 				break;
 			}
 		}
-		/* END OF INLINE: 164 */
+		/* END OF INLINE: 163 */
 	}
 	return;
 ZL1:;
@@ -612,25 +611,25 @@ p_expr_C_Clist_Hof_Halts_C_Calt(fsm fsm, flags flags, lex_state lex_state, act_s
 
 			/* BEGINNING OF ACTION: add-concat */
 			{
-#line 823 "src/libre/parser.act"
+#line 807 "src/libre/parser.act"
 
 		(ZIz) = fsm_addstate(fsm);
 		if ((ZIz) == NULL) {
 			goto ZL1;
 		}
 	
-#line 623 "src/libre/dialect/pcre/parser.c"
+#line 622 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: add-concat */
 			/* BEGINNING OF ACTION: add-epsilon */
 			{
-#line 830 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (ZIz))) {
 			goto ZL1;
 		}
 	
-#line 634 "src/libre/dialect/pcre/parser.c"
+#line 633 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: add-epsilon */
 			p_expr_C_Clist_Hof_Hatoms (fsm, flags, lex_state, act_state, err, ZIz, ZIy);
@@ -644,13 +643,13 @@ p_expr_C_Clist_Hof_Halts_C_Calt(fsm fsm, flags flags, lex_state lex_state, act_s
 		{
 			/* BEGINNING OF ACTION: add-epsilon */
 			{
-#line 830 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (ZIy))) {
 			goto ZL1;
 		}
 	
-#line 654 "src/libre/dialect/pcre/parser.c"
+#line 653 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: add-epsilon */
 		}
@@ -675,7 +674,7 @@ p_group(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err,
 
 		/* BEGINNING OF ACTION: make-group */
 		{
-#line 638 "src/libre/parser.act"
+#line 622 "src/libre/parser.act"
 
 		(ZIg).set = fsm_new_blank(fsm->opt);
 		if ((ZIg).set == NULL) {
@@ -688,7 +687,7 @@ p_group(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err,
 			goto ZL1;
 		}
 	
-#line 692 "src/libre/dialect/pcre/parser.c"
+#line 691 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: make-group */
 		p_group_C_Cgroup_Hbm (fsm, flags, lex_state, act_state, err, &ZIg);
@@ -698,7 +697,7 @@ p_group(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err,
 		}
 		/* BEGINNING OF ACTION: group-to-states */
 		{
-#line 763 "src/libre/parser.act"
+#line 747 "src/libre/parser.act"
 
 		int r;
 
@@ -741,7 +740,7 @@ p_group(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err,
 
 		fsm_free((&ZIg)->dup);
 	
-#line 745 "src/libre/dialect/pcre/parser.c"
+#line 744 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: group-to-states */
 	}
@@ -758,40 +757,40 @@ p_group_C_Cgroup_Hbody(fsm fsm, flags flags, lex_state lex_state, act_state act_
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 127 */
+		/* BEGINNING OF INLINE: 126 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CLOSEGROUP):
 				{
-					t_char ZI200;
+					t_char ZI199;
+					t_pos ZI200;
 					t_pos ZI201;
-					t_pos ZI202;
 
 					/* BEGINNING OF EXTRACT: CLOSEGROUP */
 					{
 #line 448 "src/libre/parser.act"
 
-		ZI200 = ']';
-		ZI201 = lex_state->lx.start;
-		ZI202   = lex_state->lx.end;
+		ZI199 = ']';
+		ZI200 = lex_state->lx.start;
+		ZI201   = lex_state->lx.end;
 	
-#line 779 "src/libre/dialect/pcre/parser.c"
+#line 778 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CLOSEGROUP */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: group-add-char */
 					{
-#line 672 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
-		if (-1 == group_add((ZIg), flags->flags, (ZI200))) {
+		if (-1 == group_add((ZIg), flags->flags, (ZI199))) {
 			err->e = RE_EERRNO;
 			goto ZL1;
 		}
 	
-#line 792 "src/libre/dialect/pcre/parser.c"
+#line 791 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: group-add-char */
-					p_203 (fsm, flags, lex_state, act_state, err, ZIg);
+					p_202 (fsm, flags, lex_state, act_state, err, ZIg);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL1;
@@ -801,31 +800,31 @@ p_group_C_Cgroup_Hbody(fsm fsm, flags flags, lex_state lex_state, act_state act_
 			case (TOK_RANGE):
 				{
 					t_char ZIc;
+					t_pos ZI129;
 					t_pos ZI130;
-					t_pos ZI131;
 
 					/* BEGINNING OF EXTRACT: RANGE */
 					{
 #line 437 "src/libre/parser.act"
 
 		ZIc = '-';
-		ZI130 = lex_state->lx.start;
-		ZI131   = lex_state->lx.end;
+		ZI129 = lex_state->lx.start;
+		ZI130   = lex_state->lx.end;
 	
-#line 816 "src/libre/dialect/pcre/parser.c"
+#line 815 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: RANGE */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: group-add-char */
 					{
-#line 672 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
 		if (-1 == group_add((ZIg), flags->flags, (ZIc))) {
 			err->e = RE_EERRNO;
 			goto ZL1;
 		}
 	
-#line 829 "src/libre/dialect/pcre/parser.c"
+#line 828 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: group-add-char */
 				}
@@ -834,16 +833,16 @@ p_group_C_Cgroup_Hbody(fsm fsm, flags flags, lex_state lex_state, act_state act_
 				break;
 			}
 		}
-		/* END OF INLINE: 127 */
+		/* END OF INLINE: 126 */
 		p_group_C_Clist_Hof_Hterms (fsm, flags, lex_state, act_state, err, ZIg);
-		/* BEGINNING OF INLINE: 136 */
+		/* BEGINNING OF INLINE: 135 */
 		{
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 136 */
+		/* END OF INLINE: 135 */
 	}
 	return;
 ZL1:;
@@ -865,16 +864,16 @@ p_inline_Hflags(fsm fsm, flags flags, lex_state lex_state, act_state act_state, 
 			goto ZL1;
 		}
 		ADVANCE_LEXER;
-		/* BEGINNING OF INLINE: 165 */
+		/* BEGINNING OF INLINE: 164 */
 		{
-		ZL3_165:;
+		ZL3_164:;
 			switch (CURRENT_TERMINAL) {
 			case (TOK_FLAG__UNKNOWN): case (TOK_FLAG__INSENSITIVE):
 				{
 					/* BEGINNING OF INLINE: inline-flags::positive */
 					{
 						{
-							/* BEGINNING OF INLINE: 159 */
+							/* BEGINNING OF INLINE: 158 */
 							{
 								switch (CURRENT_TERMINAL) {
 								case (TOK_FLAG__INSENSITIVE):
@@ -887,17 +886,17 @@ p_inline_Hflags(fsm fsm, flags flags, lex_state lex_state, act_state act_state, 
 
 		ZIc = RE_ICASE;
 	
-#line 891 "src/libre/dialect/pcre/parser.c"
+#line 890 "src/libre/dialect/pcre/parser.c"
 										}
 										/* END OF EXTRACT: FLAG_INSENSITIVE */
 										ADVANCE_LEXER;
 										/* BEGINNING OF ACTION: set-flag */
 										{
-#line 1019 "src/libre/parser.act"
+#line 1003 "src/libre/parser.act"
 
 		flags->flags |= (ZIc);
 	
-#line 901 "src/libre/dialect/pcre/parser.c"
+#line 900 "src/libre/dialect/pcre/parser.c"
 										}
 										/* END OF ACTION: set-flag */
 									}
@@ -907,13 +906,13 @@ p_inline_Hflags(fsm fsm, flags flags, lex_state lex_state, act_state act_state, 
 										ADVANCE_LEXER;
 										/* BEGINNING OF ACTION: err-unknown-flag */
 										{
-#line 1073 "src/libre/parser.act"
+#line 1057 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EFLAG;
 		}
 	
-#line 917 "src/libre/dialect/pcre/parser.c"
+#line 916 "src/libre/dialect/pcre/parser.c"
 										}
 										/* END OF ACTION: err-unknown-flag */
 									}
@@ -922,10 +921,10 @@ p_inline_Hflags(fsm fsm, flags flags, lex_state lex_state, act_state act_state, 
 									goto ZL1;
 								}
 							}
-							/* END OF INLINE: 159 */
-							/* BEGINNING OF INLINE: 165 */
-							goto ZL3_165;
-							/* END OF INLINE: 165 */
+							/* END OF INLINE: 158 */
+							/* BEGINNING OF INLINE: 164 */
+							goto ZL3_164;
+							/* END OF INLINE: 164 */
 						}
 						/* UNREACHED */
 					}
@@ -936,8 +935,8 @@ p_inline_Hflags(fsm fsm, flags flags, lex_state lex_state, act_state act_state, 
 				break;
 			}
 		}
-		/* END OF INLINE: 165 */
-		/* BEGINNING OF INLINE: 166 */
+		/* END OF INLINE: 164 */
+		/* BEGINNING OF INLINE: 165 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_NEGATE):
@@ -954,7 +953,7 @@ p_inline_Hflags(fsm fsm, flags flags, lex_state lex_state, act_state act_state, 
 				break;
 			}
 		}
-		/* END OF INLINE: 166 */
+		/* END OF INLINE: 165 */
 		switch (CURRENT_TERMINAL) {
 		case (TOK_CLOSEFLAGS):
 			break;
@@ -968,13 +967,13 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-closeflags */
 		{
-#line 1079 "src/libre/parser.act"
+#line 1063 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCLOSEFLAGS;
 		}
 	
-#line 978 "src/libre/dialect/pcre/parser.c"
+#line 977 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-expected-closeflags */
 	}
@@ -1000,6 +999,46 @@ ZL1:;
 }
 
 static void
+p_197(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_fsm__state ZI193, t_fsm__state ZI194, t_fsm__state *ZO195, t_fsm__state *ZO196)
+{
+	t_fsm__state ZI195;
+	t_fsm__state ZI196;
+
+ZL2_197:;
+	switch (CURRENT_TERMINAL) {
+	case (TOK_ALT):
+		{
+			ADVANCE_LEXER;
+			p_expr_C_Clist_Hof_Halts_C_Calt (fsm, flags, lex_state, act_state, err, ZI193, ZI194);
+			/* BEGINNING OF INLINE: 197 */
+			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+				RESTORE_LEXER;
+				goto ZL1;
+			} else {
+				goto ZL2_197;
+			}
+			/* END OF INLINE: 197 */
+		}
+		/* UNREACHED */
+	default:
+		{
+			ZI195 = ZI193;
+			ZI196 = ZI194;
+		}
+		break;
+	case (ERROR_TERMINAL):
+		return;
+	}
+	goto ZL0;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+ZL0:;
+	*ZO195 = ZI195;
+	*ZO196 = ZI196;
+}
+
+static void
 p_group_C_Clist_Hof_Hterms(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_grp *ZIg)
 {
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
@@ -1007,14 +1046,14 @@ p_group_C_Clist_Hof_Hterms(fsm fsm, flags flags, lex_state lex_state, act_state 
 	}
 ZL2_group_C_Clist_Hof_Hterms:;
 	{
-		/* BEGINNING OF INLINE: 123 */
+		/* BEGINNING OF INLINE: 122 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CHAR):
 				{
-					t_char ZI212;
+					t_char ZI211;
+					t_pos ZI212;
 					t_pos ZI213;
-					t_pos ZI214;
 
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
@@ -1023,16 +1062,16 @@ ZL2_group_C_Clist_Hof_Hterms:;
 		assert(lex_state->buf.a[0] != '\0');
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI213 = lex_state->lx.start;
-		ZI214   = lex_state->lx.end;
+		ZI212 = lex_state->lx.start;
+		ZI213   = lex_state->lx.end;
 
-		ZI212 = lex_state->buf.a[0];
+		ZI211 = lex_state->buf.a[0];
 	
-#line 1032 "src/libre/dialect/pcre/parser.c"
+#line 1071 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CHAR */
 					ADVANCE_LEXER;
-					p_215 (fsm, flags, lex_state, act_state, err, ZIg, &ZI212, &ZI213);
+					p_214 (fsm, flags, lex_state, act_state, err, ZIg, &ZI211, &ZI212);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL4;
@@ -1062,29 +1101,29 @@ ZL2_group_C_Clist_Hof_Hterms:;
 		default:             break;
 		}
 	
-#line 1066 "src/libre/dialect/pcre/parser.c"
+#line 1105 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: ESC */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: group-add-char */
 					{
-#line 672 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
 		if (-1 == group_add((ZIg), flags->flags, (ZIc))) {
 			err->e = RE_EERRNO;
 			goto ZL4;
 		}
 	
-#line 1079 "src/libre/dialect/pcre/parser.c"
+#line 1118 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: group-add-char */
 				}
 				break;
 			case (TOK_HEX):
 				{
-					t_char ZI208;
+					t_char ZI207;
+					t_pos ZI208;
 					t_pos ZI209;
-					t_pos ZI210;
 
 					/* BEGINNING OF EXTRACT: HEX */
 					{
@@ -1096,8 +1135,8 @@ ZL2_group_C_Clist_Hof_Hterms:;
 		assert(0 == strncmp(lex_state->buf.a, "\\x", 2));
 		assert(strlen(lex_state->buf.a) >= 3);
 
-		ZI209 = lex_state->lx.start;
-		ZI210   = lex_state->lx.end;
+		ZI208 = lex_state->lx.start;
+		ZI209   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -1114,13 +1153,13 @@ ZL2_group_C_Clist_Hof_Hterms:;
 			goto ZL4;
 		}
 
-		ZI208 = (char) (unsigned char) u;
+		ZI207 = (char) (unsigned char) u;
 	
-#line 1120 "src/libre/dialect/pcre/parser.c"
+#line 1159 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: HEX */
 					ADVANCE_LEXER;
-					p_215 (fsm, flags, lex_state, act_state, err, ZIg, &ZI208, &ZI209);
+					p_214 (fsm, flags, lex_state, act_state, err, ZIg, &ZI207, &ZI208);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL4;
@@ -1129,9 +1168,9 @@ ZL2_group_C_Clist_Hof_Hterms:;
 				break;
 			case (TOK_OCT):
 				{
-					t_char ZI204;
+					t_char ZI203;
+					t_pos ZI204;
 					t_pos ZI205;
-					t_pos ZI206;
 
 					/* BEGINNING OF EXTRACT: OCT */
 					{
@@ -1143,8 +1182,8 @@ ZL2_group_C_Clist_Hof_Hterms:;
 		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
 		assert(strlen(lex_state->buf.a) >= 2);
 
-		ZI205 = lex_state->lx.start;
-		ZI206   = lex_state->lx.end;
+		ZI204 = lex_state->lx.start;
+		ZI205   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -1161,13 +1200,13 @@ ZL2_group_C_Clist_Hof_Hterms:;
 			goto ZL4;
 		}
 
-		ZI204 = (char) (unsigned char) u;
+		ZI203 = (char) (unsigned char) u;
 	
-#line 1167 "src/libre/dialect/pcre/parser.c"
+#line 1206 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OCT */
 					ADVANCE_LEXER;
-					p_215 (fsm, flags, lex_state, act_state, err, ZIg, &ZI204, &ZI205);
+					p_214 (fsm, flags, lex_state, act_state, err, ZIg, &ZI203, &ZI204);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL4;
@@ -1182,20 +1221,20 @@ ZL2_group_C_Clist_Hof_Hterms:;
 			{
 				/* BEGINNING OF ACTION: err-expected-term */
 				{
-#line 1031 "src/libre/parser.act"
+#line 1015 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXTERM;
 		}
 	
-#line 1192 "src/libre/dialect/pcre/parser.c"
+#line 1231 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: err-expected-term */
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 123 */
-		/* BEGINNING OF INLINE: 124 */
+		/* END OF INLINE: 122 */
+		/* BEGINNING OF INLINE: 123 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ESC): case (TOK_OCT): case (TOK_HEX): case (TOK_CHAR):
@@ -1209,82 +1248,42 @@ ZL2_group_C_Clist_Hof_Hterms:;
 				break;
 			}
 		}
-		/* END OF INLINE: 124 */
+		/* END OF INLINE: 123 */
 	}
 }
 
 static void
-p_198(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_fsm__state ZI194, t_fsm__state ZI195, t_fsm__state *ZO196, t_fsm__state *ZO197)
-{
-	t_fsm__state ZI196;
-	t_fsm__state ZI197;
-
-ZL2_198:;
-	switch (CURRENT_TERMINAL) {
-	case (TOK_ALT):
-		{
-			ADVANCE_LEXER;
-			p_expr_C_Clist_Hof_Halts_C_Calt (fsm, flags, lex_state, act_state, err, ZI194, ZI195);
-			/* BEGINNING OF INLINE: 198 */
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			} else {
-				goto ZL2_198;
-			}
-			/* END OF INLINE: 198 */
-		}
-		/* UNREACHED */
-	default:
-		{
-			ZI196 = ZI194;
-			ZI197 = ZI195;
-		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZO196 = ZI196;
-	*ZO197 = ZI197;
-}
-
-static void
-p_203(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_grp *ZIg)
+p_202(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_grp *ZIg)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_RANGE):
 		{
 			t_char ZIb;
+			t_pos ZI133;
 			t_pos ZI134;
-			t_pos ZI135;
 
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
 #line 437 "src/libre/parser.act"
 
 		ZIb = '-';
-		ZI134 = lex_state->lx.start;
-		ZI135   = lex_state->lx.end;
+		ZI133 = lex_state->lx.start;
+		ZI134   = lex_state->lx.end;
 	
-#line 1275 "src/libre/dialect/pcre/parser.c"
+#line 1274 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: group-add-char */
 			{
-#line 672 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
 		if (-1 == group_add((ZIg), flags->flags, (ZIb))) {
 			err->e = RE_EERRNO;
 			goto ZL1;
 		}
 	
-#line 1288 "src/libre/dialect/pcre/parser.c"
+#line 1287 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: group-add-char */
 		}
@@ -1312,17 +1311,17 @@ ZL2_expr_C_Clist_Hof_Hatoms:;
 
 		/* BEGINNING OF ACTION: add-concat */
 		{
-#line 823 "src/libre/parser.act"
+#line 807 "src/libre/parser.act"
 
 		(ZIz) = fsm_addstate(fsm);
 		if ((ZIz) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1323 "src/libre/dialect/pcre/parser.c"
+#line 1322 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: add-concat */
-		/* BEGINNING OF INLINE: 182 */
+		/* BEGINNING OF INLINE: 181 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_START): case (TOK_END):
@@ -1349,8 +1348,8 @@ ZL2_expr_C_Clist_Hof_Hatoms:;
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 182 */
-		/* BEGINNING OF INLINE: 183 */
+		/* END OF INLINE: 181 */
+		/* BEGINNING OF INLINE: 182 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_OPENSUB): case (TOK_OPENCAPTURE): case (TOK_OPENGROUP):
@@ -1367,20 +1366,20 @@ ZL2_expr_C_Clist_Hof_Hatoms:;
 				{
 					/* BEGINNING OF ACTION: add-epsilon */
 					{
-#line 830 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIz), (ZIy))) {
 			goto ZL1;
 		}
 	
-#line 1377 "src/libre/dialect/pcre/parser.c"
+#line 1376 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: add-epsilon */
 				}
 				break;
 			}
 		}
-		/* END OF INLINE: 183 */
+		/* END OF INLINE: 182 */
 	}
 	return;
 ZL1:;
@@ -1396,7 +1395,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 	}
 	{
 		t_pos ZIstart;
-		t_pos ZI139;
+		t_pos ZI138;
 
 		switch (CURRENT_TERMINAL) {
 		case (TOK_OPENGROUP):
@@ -1405,9 +1404,9 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 #line 443 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
-		ZI139   = lex_state->lx.end;
+		ZI138   = lex_state->lx.end;
 	
-#line 1411 "src/libre/dialect/pcre/parser.c"
+#line 1410 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: OPENGROUP */
 			break;
@@ -1415,20 +1414,20 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 			goto ZL1;
 		}
 		ADVANCE_LEXER;
-		/* BEGINNING OF INLINE: 140 */
+		/* BEGINNING OF INLINE: 139 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_INVERT):
 				{
-					t_char ZI141;
+					t_char ZI140;
 
 					/* BEGINNING OF EXTRACT: INVERT */
 					{
 #line 433 "src/libre/parser.act"
 
-		ZI141 = '^';
+		ZI140 = '^';
 	
-#line 1432 "src/libre/dialect/pcre/parser.c"
+#line 1431 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: INVERT */
 					ADVANCE_LEXER;
@@ -1439,7 +1438,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 					}
 					/* BEGINNING OF ACTION: invert-group */
 					{
-#line 656 "src/libre/parser.act"
+#line 640 "src/libre/parser.act"
 
 		struct fsm *any;
 
@@ -1460,7 +1459,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 		 * kept in the positive.
 		 */
 	
-#line 1464 "src/libre/dialect/pcre/parser.c"
+#line 1463 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: invert-group */
 				}
@@ -1479,12 +1478,12 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 140 */
-		/* BEGINNING OF INLINE: 142 */
+		/* END OF INLINE: 139 */
+		/* BEGINNING OF INLINE: 141 */
 		{
 			{
-				t_char ZI143;
-				t_pos ZI144;
+				t_char ZI142;
+				t_pos ZI143;
 				t_pos ZIend;
 
 				switch (CURRENT_TERMINAL) {
@@ -1493,11 +1492,11 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 					{
 #line 448 "src/libre/parser.act"
 
-		ZI143 = ']';
-		ZI144 = lex_state->lx.start;
+		ZI142 = ']';
+		ZI143 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1501 "src/libre/dialect/pcre/parser.c"
+#line 1500 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CLOSEGROUP */
 					break;
@@ -1507,12 +1506,12 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 				ADVANCE_LEXER;
 				/* BEGINNING OF ACTION: mark-group */
 				{
-#line 1088 "src/libre/parser.act"
+#line 1072 "src/libre/parser.act"
 
 		mark(&act_state->groupstart, &(ZIstart));
 		mark(&act_state->groupend,   &(ZIend));
 	
-#line 1516 "src/libre/dialect/pcre/parser.c"
+#line 1515 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: mark-group */
 			}
@@ -1521,39 +1520,39 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 			{
 				/* BEGINNING OF ACTION: err-expected-closegroup */
 				{
-#line 1061 "src/libre/parser.act"
+#line 1045 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCLOSEGROUP;
 		}
 	
-#line 1531 "src/libre/dialect/pcre/parser.c"
+#line 1530 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: err-expected-closegroup */
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 142 */
+		/* END OF INLINE: 141 */
 	}
 	return;
 ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-groupbody */
 		{
-#line 1067 "src/libre/parser.act"
+#line 1051 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXGROUPBODY;
 		}
 	
-#line 1550 "src/libre/dialect/pcre/parser.c"
+#line 1549 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-expected-groupbody */
 	}
 }
 
 static void
-p_215(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_grp *ZIg, t_char *ZI212, t_pos *ZI213)
+p_214(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_grp *ZIg, t_char *ZI211, t_pos *ZI212)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_RANGE):
@@ -1561,12 +1560,12 @@ p_215(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			t_char ZIb;
 			t_pos ZIend;
 
-			/* BEGINNING OF INLINE: 110 */
+			/* BEGINNING OF INLINE: 109 */
 			{
 				{
-					t_char ZI111;
+					t_char ZI110;
+					t_pos ZI111;
 					t_pos ZI112;
-					t_pos ZI113;
 
 					switch (CURRENT_TERMINAL) {
 					case (TOK_RANGE):
@@ -1574,11 +1573,11 @@ p_215(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 						{
 #line 437 "src/libre/parser.act"
 
-		ZI111 = '-';
-		ZI112 = lex_state->lx.start;
-		ZI113   = lex_state->lx.end;
+		ZI110 = '-';
+		ZI111 = lex_state->lx.start;
+		ZI112   = lex_state->lx.end;
 	
-#line 1582 "src/libre/dialect/pcre/parser.c"
+#line 1581 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF EXTRACT: RANGE */
 						break;
@@ -1592,25 +1591,25 @@ p_215(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 				{
 					/* BEGINNING OF ACTION: err-expected-range */
 					{
-#line 1055 "src/libre/parser.act"
+#line 1039 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXRANGE;
 		}
 	
-#line 1602 "src/libre/dialect/pcre/parser.c"
+#line 1601 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: err-expected-range */
 				}
 			ZL2:;
 			}
-			/* END OF INLINE: 110 */
-			/* BEGINNING OF INLINE: 114 */
+			/* END OF INLINE: 109 */
+			/* BEGINNING OF INLINE: 113 */
 			{
 				switch (CURRENT_TERMINAL) {
 				case (TOK_CHAR):
 					{
-						t_pos ZI118;
+						t_pos ZI117;
 
 						/* BEGINNING OF EXTRACT: CHAR */
 						{
@@ -1619,12 +1618,12 @@ p_215(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 		assert(lex_state->buf.a[0] != '\0');
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI118 = lex_state->lx.start;
+		ZI117 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 
 		ZIb = lex_state->buf.a[0];
 	
-#line 1628 "src/libre/dialect/pcre/parser.c"
+#line 1627 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF EXTRACT: CHAR */
 						ADVANCE_LEXER;
@@ -1632,7 +1631,7 @@ p_215(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 					break;
 				case (TOK_HEX):
 					{
-						t_pos ZI117;
+						t_pos ZI116;
 
 						/* BEGINNING OF EXTRACT: HEX */
 						{
@@ -1644,7 +1643,7 @@ p_215(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 		assert(0 == strncmp(lex_state->buf.a, "\\x", 2));
 		assert(strlen(lex_state->buf.a) >= 3);
 
-		ZI117 = lex_state->lx.start;
+		ZI116 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 
 		errno = 0;
@@ -1664,7 +1663,7 @@ p_215(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 
 		ZIb = (char) (unsigned char) u;
 	
-#line 1668 "src/libre/dialect/pcre/parser.c"
+#line 1667 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF EXTRACT: HEX */
 						ADVANCE_LEXER;
@@ -1672,7 +1671,7 @@ p_215(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 					break;
 				case (TOK_OCT):
 					{
-						t_pos ZI115;
+						t_pos ZI114;
 
 						/* BEGINNING OF EXTRACT: OCT */
 						{
@@ -1684,7 +1683,7 @@ p_215(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
 		assert(strlen(lex_state->buf.a) >= 2);
 
-		ZI115 = lex_state->lx.start;
+		ZI114 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 
 		errno = 0;
@@ -1704,7 +1703,7 @@ p_215(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 
 		ZIb = (char) (unsigned char) u;
 	
-#line 1708 "src/libre/dialect/pcre/parser.c"
+#line 1707 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF EXTRACT: OCT */
 						ADVANCE_LEXER;
@@ -1712,17 +1711,17 @@ p_215(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 					break;
 				case (TOK_RANGE):
 					{
-						t_pos ZI119;
+						t_pos ZI118;
 
 						/* BEGINNING OF EXTRACT: RANGE */
 						{
 #line 437 "src/libre/parser.act"
 
 		ZIb = '-';
-		ZI119 = lex_state->lx.start;
+		ZI118 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1726 "src/libre/dialect/pcre/parser.c"
+#line 1725 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF EXTRACT: RANGE */
 						ADVANCE_LEXER;
@@ -1732,42 +1731,42 @@ p_215(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 					goto ZL1;
 				}
 			}
-			/* END OF INLINE: 114 */
+			/* END OF INLINE: 113 */
 			/* BEGINNING OF ACTION: mark-range */
 			{
-#line 1093 "src/libre/parser.act"
+#line 1077 "src/libre/parser.act"
 
-		mark(&act_state->rangestart, &(*ZI213));
+		mark(&act_state->rangestart, &(*ZI212));
 		mark(&act_state->rangeend,   &(ZIend));
 	
-#line 1744 "src/libre/dialect/pcre/parser.c"
+#line 1743 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: group-add-range */
 			{
-#line 741 "src/libre/parser.act"
+#line 725 "src/libre/parser.act"
 
 		int i;
 
-		if ((unsigned char) (ZIb) < (unsigned char) (*ZI212)) {
+		if ((unsigned char) (ZIb) < (unsigned char) (*ZI211)) {
 			char a[5], b[5];
 
 			assert(sizeof err->set >= 1 + sizeof a + 1 + sizeof b + 1 + 1);
 
 			sprintf(err->set, "%s-%s",
-				escchar(a, sizeof a, (*ZI212)), escchar(b, sizeof b, (ZIb)));
+				escchar(a, sizeof a, (*ZI211)), escchar(b, sizeof b, (ZIb)));
 			err->e = RE_ENEGRANGE;
 			goto ZL1;
 		}
 
-		for (i = (unsigned char) (*ZI212); i <= (unsigned char) (ZIb); i++) {
+		for (i = (unsigned char) (*ZI211); i <= (unsigned char) (ZIb); i++) {
 			if (-1 == group_add((ZIg), flags->flags, (char) i)) {
 				err->e = RE_EERRNO;
 				goto ZL1;
 			}
 		}
 	
-#line 1771 "src/libre/dialect/pcre/parser.c"
+#line 1770 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: group-add-range */
 		}
@@ -1776,14 +1775,14 @@ p_215(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 		{
 			/* BEGINNING OF ACTION: group-add-char */
 			{
-#line 672 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
-		if (-1 == group_add((ZIg), flags->flags, (*ZI212))) {
+		if (-1 == group_add((ZIg), flags->flags, (*ZI211))) {
 			err->e = RE_EERRNO;
 			goto ZL1;
 		}
 	
-#line 1787 "src/libre/dialect/pcre/parser.c"
+#line 1786 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: group-add-char */
 		}
@@ -1798,51 +1797,51 @@ ZL1:;
 }
 
 static void
-p_219(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_fsm__state *ZIx, t_fsm__state *ZIy, t_pos *ZI216, t_unsigned *ZI218)
+p_218(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_fsm__state *ZIx, t_fsm__state *ZIy, t_pos *ZI215, t_unsigned *ZI217)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CLOSECOUNT):
 		{
-			t_pos ZI175;
+			t_pos ZI174;
 			t_pos ZIend;
 
 			/* BEGINNING OF EXTRACT: CLOSECOUNT */
 			{
 #line 459 "src/libre/parser.act"
 
-		ZI175 = lex_state->lx.start;
+		ZI174 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1817 "src/libre/dialect/pcre/parser.c"
+#line 1816 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: CLOSECOUNT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 1098 "src/libre/parser.act"
+#line 1082 "src/libre/parser.act"
 
-		mark(&act_state->countstart, &(*ZI216));
+		mark(&act_state->countstart, &(*ZI215));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 1828 "src/libre/dialect/pcre/parser.c"
+#line 1827 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-m-to-n */
 			{
-#line 901 "src/libre/parser.act"
+#line 885 "src/libre/parser.act"
 
 		unsigned i;
 		struct fsm_state *a;
 		struct fsm_state *b;
 
-		if ((*ZI218) < (*ZI218)) {
+		if ((*ZI217) < (*ZI217)) {
 			err->e = RE_ENEGCOUNT;
-			err->m = (*ZI218);
-			err->n = (*ZI218);
+			err->m = (*ZI217);
+			err->n = (*ZI217);
 			goto ZL1;
 		}
 
-		if ((*ZI218) == 0) {
+		if ((*ZI217) == 0) {
 			if (!fsm_addedge_epsilon(fsm, (*ZIx), (*ZIy))) {
 				goto ZL1;
 			}
@@ -1850,7 +1849,7 @@ p_219(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 
 		b = (*ZIy);
 
-		for (i = 1; i < (*ZI218); i++) {
+		for (i = 1; i < (*ZI217); i++) {
 			a = fsm_state_duplicatesubgraphx(fsm, (*ZIx), &b);
 			if (a == NULL) {
 				goto ZL1;
@@ -1862,7 +1861,7 @@ p_219(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 				goto ZL1;
 			}
 
-			if (i >= (*ZI218)) {
+			if (i >= (*ZI217)) {
 				if (!fsm_addedge_epsilon(fsm, (*ZIy), b)) {
 					goto ZL1;
 				}
@@ -1872,7 +1871,7 @@ p_219(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			(*ZIx) = a;
 		}
 	
-#line 1876 "src/libre/dialect/pcre/parser.c"
+#line 1875 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-m-to-n */
 		}
@@ -1881,7 +1880,7 @@ p_219(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 		{
 			t_unsigned ZIn;
 			t_pos ZIend;
-			t_pos ZI178;
+			t_pos ZI177;
 
 			ADVANCE_LEXER;
 			switch (CURRENT_TERMINAL) {
@@ -1908,7 +1907,7 @@ p_219(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 
 		ZIn = (unsigned int) u;
 	
-#line 1912 "src/libre/dialect/pcre/parser.c"
+#line 1911 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -1923,9 +1922,9 @@ p_219(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 #line 459 "src/libre/parser.act"
 
 		ZIend = lex_state->lx.start;
-		ZI178   = lex_state->lx.end;
+		ZI177   = lex_state->lx.end;
 	
-#line 1929 "src/libre/dialect/pcre/parser.c"
+#line 1928 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF EXTRACT: CLOSECOUNT */
 				break;
@@ -1935,30 +1934,30 @@ p_219(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 1098 "src/libre/parser.act"
+#line 1082 "src/libre/parser.act"
 
-		mark(&act_state->countstart, &(*ZI216));
+		mark(&act_state->countstart, &(*ZI215));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 1944 "src/libre/dialect/pcre/parser.c"
+#line 1943 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-m-to-n */
 			{
-#line 901 "src/libre/parser.act"
+#line 885 "src/libre/parser.act"
 
 		unsigned i;
 		struct fsm_state *a;
 		struct fsm_state *b;
 
-		if ((ZIn) < (*ZI218)) {
+		if ((ZIn) < (*ZI217)) {
 			err->e = RE_ENEGCOUNT;
-			err->m = (*ZI218);
+			err->m = (*ZI217);
 			err->n = (ZIn);
 			goto ZL1;
 		}
 
-		if ((*ZI218) == 0) {
+		if ((*ZI217) == 0) {
 			if (!fsm_addedge_epsilon(fsm, (*ZIx), (*ZIy))) {
 				goto ZL1;
 			}
@@ -1978,7 +1977,7 @@ p_219(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 				goto ZL1;
 			}
 
-			if (i >= (*ZI218)) {
+			if (i >= (*ZI217)) {
 				if (!fsm_addedge_epsilon(fsm, (*ZIy), b)) {
 					goto ZL1;
 				}
@@ -1988,7 +1987,7 @@ p_219(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			(*ZIx) = a;
 		}
 	
-#line 1992 "src/libre/dialect/pcre/parser.c"
+#line 1991 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-m-to-n */
 		}
@@ -2005,17 +2004,17 @@ ZL1:;
 }
 
 static void
-p_expr_C_Clist_Hof_Halts(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_fsm__state ZI194, t_fsm__state ZI195)
+p_expr_C_Clist_Hof_Halts(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_fsm__state ZI193, t_fsm__state ZI194)
 {
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 		return;
 	}
 	{
+		t_fsm__state ZI195;
 		t_fsm__state ZI196;
-		t_fsm__state ZI197;
 
-		p_expr_C_Clist_Hof_Halts_C_Calt (fsm, flags, lex_state, act_state, err, ZI194, ZI195);
-		p_198 (fsm, flags, lex_state, act_state, err, ZI194, ZI195, &ZI196, &ZI197);
+		p_expr_C_Clist_Hof_Halts_C_Calt (fsm, flags, lex_state, act_state, err, ZI193, ZI194);
+		p_197 (fsm, flags, lex_state, act_state, err, ZI193, ZI194, &ZI195, &ZI196);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -2028,36 +2027,13 @@ ZL1:;
 }
 
 void
-p_re__pcre(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err)
+p_re__pcre(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_fsm__state ZIx, t_fsm__state ZIy)
 {
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 		return;
 	}
 	{
-		t_fsm__state ZIx;
-		t_fsm__state ZIy;
-
-		/* BEGINNING OF ACTION: make-states */
-		{
-#line 625 "src/libre/parser.act"
-
-		assert(fsm != NULL);
-		/* TODO: assert fsm is empty */
-
-		(ZIx) = fsm_getstart(fsm);
-		assert((ZIx) != NULL);
-
-		(ZIy) = fsm_addstate(fsm);
-		if ((ZIy) == NULL) {
-			goto ZL1;
-		}
-
-		fsm_setend(fsm, (ZIy), 1);
-	
-#line 2058 "src/libre/dialect/pcre/parser.c"
-		}
-		/* END OF ACTION: make-states */
-		/* BEGINNING OF INLINE: 189 */
+		/* BEGINNING OF INLINE: 188 */
 		{
 			{
 				p_expr (fsm, flags, lex_state, act_state, err, ZIx, ZIy);
@@ -2071,20 +2047,20 @@ p_re__pcre(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err e
 			{
 				/* BEGINNING OF ACTION: err-expected-alts */
 				{
-#line 1049 "src/libre/parser.act"
+#line 1033 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXALTS;
 		}
 	
-#line 2081 "src/libre/dialect/pcre/parser.c"
+#line 2057 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: err-expected-alts */
 			}
 		ZL2:;
 		}
-		/* END OF INLINE: 189 */
-		/* BEGINNING OF INLINE: 190 */
+		/* END OF INLINE: 188 */
+		/* BEGINNING OF INLINE: 189 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -2100,24 +2076,20 @@ p_re__pcre(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err e
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 1085 "src/libre/parser.act"
+#line 1069 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
 		}
 	
-#line 2110 "src/libre/dialect/pcre/parser.c"
+#line 2086 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
 		ZL4:;
 		}
-		/* END OF INLINE: 190 */
+		/* END OF INLINE: 189 */
 	}
-	return;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
 }
 
 static void
@@ -2127,7 +2099,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 170 */
+		/* BEGINNING OF INLINE: 169 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY):
@@ -2135,7 +2107,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: add-any */
 					{
-#line 860 "src/libre/parser.act"
+#line 844 "src/libre/parser.act"
 
 		struct fsm *any;
 
@@ -2153,7 +2125,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 2157 "src/libre/dialect/pcre/parser.c"
+#line 2129 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: add-any */
 				}
@@ -2176,13 +2148,13 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					}
 					/* BEGINNING OF ACTION: add-epsilon */
 					{
-#line 830 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (*ZIy))) {
 			goto ZL1;
 		}
 	
-#line 2186 "src/libre/dialect/pcre/parser.c"
+#line 2158 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: add-epsilon */
 				}
@@ -2198,7 +2170,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 				break;
 			case (TOK_OPENSUB): case (TOK_OPENCAPTURE):
 				{
-					/* BEGINNING OF INLINE: 171 */
+					/* BEGINNING OF INLINE: 170 */
 					{
 						switch (CURRENT_TERMINAL) {
 						case (TOK_OPENCAPTURE):
@@ -2215,10 +2187,10 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 							goto ZL1;
 						}
 					}
-					/* END OF INLINE: 171 */
+					/* END OF INLINE: 170 */
 					/* BEGINNING OF ACTION: push-flags */
 					{
-#line 1004 "src/libre/parser.act"
+#line 988 "src/libre/parser.act"
 
 		struct flags *n = malloc(sizeof *n);
 		if (n == NULL) {
@@ -2228,7 +2200,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 		n->flags = flags->flags;
 		flags = n;
 	
-#line 2232 "src/libre/dialect/pcre/parser.c"
+#line 2204 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: push-flags */
 					p_expr (fsm, flags, lex_state, act_state, err, ZIx, *ZIy);
@@ -2238,14 +2210,14 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					}
 					/* BEGINNING OF ACTION: pop-flags */
 					{
-#line 1016 "src/libre/parser.act"
+#line 1000 "src/libre/parser.act"
 
 		struct flags *t = flags->parent;
 		assert(t != NULL);
 		free(flags);
 		flags = t;
 	
-#line 2249 "src/libre/dialect/pcre/parser.c"
+#line 2221 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: pop-flags */
 					switch (CURRENT_TERMINAL) {
@@ -2261,24 +2233,24 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 170 */
-		/* BEGINNING OF INLINE: 172 */
+		/* END OF INLINE: 169 */
+		/* BEGINNING OF INLINE: 171 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_OPENCOUNT):
 				{
+					t_pos ZI215;
 					t_pos ZI216;
-					t_pos ZI217;
-					t_unsigned ZI218;
+					t_unsigned ZI217;
 
 					/* BEGINNING OF EXTRACT: OPENCOUNT */
 					{
 #line 454 "src/libre/parser.act"
 
-		ZI216 = lex_state->lx.start;
-		ZI217   = lex_state->lx.end;
+		ZI215 = lex_state->lx.start;
+		ZI216   = lex_state->lx.end;
 	
-#line 2282 "src/libre/dialect/pcre/parser.c"
+#line 2254 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OPENCOUNT */
 					ADVANCE_LEXER;
@@ -2304,9 +2276,9 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL5;
 		}
 
-		ZI218 = (unsigned int) u;
+		ZI217 = (unsigned int) u;
 	
-#line 2310 "src/libre/dialect/pcre/parser.c"
+#line 2282 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF EXTRACT: COUNT */
 						break;
@@ -2314,7 +2286,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 						goto ZL5;
 					}
 					ADVANCE_LEXER;
-					p_219 (fsm, flags, lex_state, act_state, err, &ZIx, ZIy, &ZI216, &ZI218);
+					p_218 (fsm, flags, lex_state, act_state, err, &ZIx, ZIy, &ZI215, &ZI217);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL5;
@@ -2326,13 +2298,13 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: count-0-or-1 */
 					{
-#line 940 "src/libre/parser.act"
+#line 924 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (*ZIy))) {
 			goto ZL5;
 		}
 	
-#line 2336 "src/libre/dialect/pcre/parser.c"
+#line 2308 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: count-0-or-1 */
 				}
@@ -2342,7 +2314,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: count-1-or-many */
 					{
-#line 973 "src/libre/parser.act"
+#line 957 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (*ZIy), (ZIx))) {
 			goto ZL5;
@@ -2365,7 +2337,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 			(*ZIy) = z;
 		}
 	
-#line 2369 "src/libre/dialect/pcre/parser.c"
+#line 2341 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: count-1-or-many */
 				}
@@ -2375,7 +2347,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: count-0-or-many */
 					{
-#line 946 "src/libre/parser.act"
+#line 930 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (*ZIy))) {
 			goto ZL5;
@@ -2402,7 +2374,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 			(*ZIy) = z;
 		}
 	
-#line 2406 "src/libre/dialect/pcre/parser.c"
+#line 2378 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: count-0-or-many */
 				}
@@ -2411,12 +2383,12 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 				{
 					/* BEGINNING OF ACTION: count-1 */
 					{
-#line 996 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 		(void) (ZIx);
 		(void) (*ZIy);
 	
-#line 2420 "src/libre/dialect/pcre/parser.c"
+#line 2392 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: count-1 */
 				}
@@ -2427,19 +2399,19 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 			{
 				/* BEGINNING OF ACTION: err-expected-count */
 				{
-#line 1037 "src/libre/parser.act"
+#line 1021 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCOUNT;
 		}
 	
-#line 2437 "src/libre/dialect/pcre/parser.c"
+#line 2409 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: err-expected-count */
 			}
 		ZL4:;
 		}
-		/* END OF INLINE: 172 */
+		/* END OF INLINE: 171 */
 	}
 	return;
 ZL1:;
@@ -2456,13 +2428,13 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 	{
 		t_char ZIc;
 
-		/* BEGINNING OF INLINE: 146 */
+		/* BEGINNING OF INLINE: 145 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CHAR):
 				{
+					t_pos ZI150;
 					t_pos ZI151;
-					t_pos ZI152;
 
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
@@ -2471,12 +2443,12 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 		assert(lex_state->buf.a[0] != '\0');
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI151 = lex_state->lx.start;
-		ZI152   = lex_state->lx.end;
+		ZI150 = lex_state->lx.start;
+		ZI151   = lex_state->lx.end;
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 2480 "src/libre/dialect/pcre/parser.c"
+#line 2452 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CHAR */
 					ADVANCE_LEXER;
@@ -2503,7 +2475,7 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 		default:             break;
 		}
 	
-#line 2507 "src/libre/dialect/pcre/parser.c"
+#line 2479 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: ESC */
 					ADVANCE_LEXER;
@@ -2511,8 +2483,8 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 				break;
 			case (TOK_HEX):
 				{
+					t_pos ZI148;
 					t_pos ZI149;
-					t_pos ZI150;
 
 					/* BEGINNING OF EXTRACT: HEX */
 					{
@@ -2524,8 +2496,8 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 		assert(0 == strncmp(lex_state->buf.a, "\\x", 2));
 		assert(strlen(lex_state->buf.a) >= 3);
 
-		ZI149 = lex_state->lx.start;
-		ZI150   = lex_state->lx.end;
+		ZI148 = lex_state->lx.start;
+		ZI149   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -2544,7 +2516,7 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 2548 "src/libre/dialect/pcre/parser.c"
+#line 2520 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: HEX */
 					ADVANCE_LEXER;
@@ -2552,8 +2524,8 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 				break;
 			case (TOK_OCT):
 				{
+					t_pos ZI146;
 					t_pos ZI147;
-					t_pos ZI148;
 
 					/* BEGINNING OF EXTRACT: OCT */
 					{
@@ -2565,8 +2537,8 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
 		assert(strlen(lex_state->buf.a) >= 2);
 
-		ZI147 = lex_state->lx.start;
-		ZI148   = lex_state->lx.end;
+		ZI146 = lex_state->lx.start;
+		ZI147   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -2585,7 +2557,7 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 2589 "src/libre/dialect/pcre/parser.c"
+#line 2561 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OCT */
 					ADVANCE_LEXER;
@@ -2595,10 +2567,10 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 146 */
+		/* END OF INLINE: 145 */
 		/* BEGINNING OF ACTION: add-literal */
 		{
-#line 847 "src/libre/parser.act"
+#line 831 "src/libre/parser.act"
 
 		assert((ZIx) != NULL);
 		assert((ZIy) != NULL);
@@ -2609,7 +2581,7 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 			goto ZL1;
 		}
 	
-#line 2613 "src/libre/dialect/pcre/parser.c"
+#line 2585 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: add-literal */
 	}
@@ -2621,7 +2593,7 @@ ZL1:;
 
 /* BEGINNING OF TRAILER */
 
-#line 1257 "src/libre/parser.act"
+#line 1259 "src/libre/parser.act"
 
 
 	static int
@@ -2641,9 +2613,11 @@ ZL1:;
 
 	static int
 	parse(int (*f)(void *opaque), void *opaque,
-		void (*entry)(struct fsm *, flags, lex_state, act_state, err),
+		void (*entry)(struct fsm *, flags, lex_state, act_state, err,
+			struct fsm_state *, struct fsm_state *),
 		struct flags *flags, int overlap,
-		struct fsm *new, struct re_err *err)
+		struct fsm *new, struct re_err *err,
+		struct fsm_state *x, struct fsm_state *y)
 	{
 		struct act_state  act_state_s;
 		struct act_state *act_state;
@@ -2692,7 +2666,7 @@ ZL1:;
 		err->e = RE_ESUCCESS;
 
 		ADVANCE_LEXER;
-		entry(new, flags, lex_state, act_state, err);
+		entry(new, flags, lex_state, act_state, err, x, y);
 
 		lx->free(lx);
 
@@ -2758,6 +2732,7 @@ ZL1:;
 		struct re_err *err)
 	{
 		struct fsm *new;
+		struct fsm_state *x, *y;
 		struct flags top, *fl = &top;
 
 		top.flags = flags;
@@ -2769,14 +2744,29 @@ ZL1:;
 			return NULL;
 		}
 
-		if (-1 == parse(f, opaque, DIALECT_ENTRY, fl, overlap, new, err)) {
-			fsm_free(new);
-			return NULL;
+		x = fsm_getstart(new);
+		assert(x != NULL);
+
+		y = fsm_addstate(new);
+		if (y == NULL) {
+			goto error;
+		}
+
+		fsm_setend(new, y, 1);
+
+		if (-1 == parse(f, opaque, DIALECT_ENTRY, fl, overlap, new, err, x, y)) {
+			goto error;
 		}
 
 		return new;
+
+	error:
+
+		fsm_free(new);
+
+		return NULL;
 	}
 
-#line 2781 "src/libre/dialect/pcre/parser.c"
+#line 2771 "src/libre/dialect/pcre/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/pcre/parser.h
+++ b/src/libre/dialect/pcre/parser.h
@@ -17,20 +17,21 @@
 	typedef struct lex_state * lex_state;
 	typedef struct act_state * act_state;
 
-	typedef struct fsm *  fsm;
+	typedef struct fsm * fsm;
+	typedef struct fsm_state * t_fsm__state;
 	typedef struct flags *flags;
 	typedef struct re_err * err;
 
-#line 25 "src/libre/dialect/pcre/parser.h"
+#line 26 "src/libre/dialect/pcre/parser.h"
 
 /* BEGINNING OF FUNCTION DECLARATIONS */
 
-extern void p_re__pcre(fsm, flags, lex_state, act_state, err);
+extern void p_re__pcre(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 /* BEGINNING OF TRAILER */
 
-#line 1259 "src/libre/parser.act"
+#line 1261 "src/libre/parser.act"
 
 
-#line 35 "src/libre/dialect/pcre/parser.h"
+#line 36 "src/libre/dialect/pcre/parser.h"
 
 /* END OF FILE */

--- a/src/libre/dialect/pcre/parser.sid
+++ b/src/libre/dialect/pcre/parser.sid
@@ -69,8 +69,6 @@
 
 %productions%
 
-	<make-states>: () -> (:fsm_state, :fsm_state);
-
 	<make-group>:  () -> (:grp);
 	<invert-group>:    (:grp &) -> ();
 	<group-add-char>:  (:grp &, :char) -> ();
@@ -396,9 +394,7 @@
 		list-of-alts(x, y);
 	};
 
-	re_pcre: () -> () = {
-		(x, y) = <make-states>;
-
+	re_pcre: (x :fsm_state, y :fsm_state) -> () = {
 		{
 			expr(x, y);
 		##

--- a/src/libre/dialect/sql/parser.c
+++ b/src/libre/dialect/sql/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 138 "src/libre/parser.act"
+#line 137 "src/libre/parser.act"
 
 
 	#include <assert.h>
@@ -87,7 +87,6 @@
 
 	typedef struct lx_pos t_pos;
 	typedef struct fsm * t_fsm;
-	typedef struct fsm_state * t_fsm__state;
 	typedef enum re_flags t_re__flags;
 	typedef struct grp t_grp;
 
@@ -404,7 +403,7 @@
 		return NULL;
 	}
 
-#line 408 "src/libre/dialect/sql/parser.c"
+#line 407 "src/libre/dialect/sql/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -413,12 +412,12 @@
 
 /* BEGINNING OF FUNCTION DECLARATIONS */
 
-extern void p_re__sql(fsm, flags, lex_state, act_state, err);
+extern void p_re__sql(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 static void p_expr_C_Clist_Hof_Halts_C_Calt(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
-static void p_169(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state, t_fsm__state *, t_fsm__state *);
-static void p_174(fsm, flags, lex_state, act_state, err, t_grp *);
+static void p_168(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state, t_fsm__state *, t_fsm__state *);
+static void p_173(fsm, flags, lex_state, act_state, err, t_grp *);
 static void p_group(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
-static void p_178(fsm, flags, lex_state, act_state, err, t_grp *, t_char *, t_pos *);
+static void p_177(fsm, flags, lex_state, act_state, err, t_grp *, t_char *, t_pos *);
 static void p_group_C_Cgroup_Hbody(fsm, flags, lex_state, act_state, err, t_grp *);
 static void p_expr(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 static void p_group_C_Clist_Hof_Hterms(fsm, flags, lex_state, act_state, err, t_grp *);
@@ -434,36 +433,13 @@ static void p_literal(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm
 /* BEGINNING OF FUNCTION DEFINITIONS */
 
 void
-p_re__sql(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err)
+p_re__sql(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_fsm__state ZIx, t_fsm__state ZIy)
 {
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 		return;
 	}
 	{
-		t_fsm__state ZIx;
-		t_fsm__state ZIy;
-
-		/* BEGINNING OF ACTION: make-states */
-		{
-#line 625 "src/libre/parser.act"
-
-		assert(fsm != NULL);
-		/* TODO: assert fsm is empty */
-
-		(ZIx) = fsm_getstart(fsm);
-		assert((ZIx) != NULL);
-
-		(ZIy) = fsm_addstate(fsm);
-		if ((ZIy) == NULL) {
-			goto ZL1;
-		}
-
-		fsm_setend(fsm, (ZIy), 1);
-	
-#line 464 "src/libre/dialect/sql/parser.c"
-		}
-		/* END OF ACTION: make-states */
-		/* BEGINNING OF INLINE: 157 */
+		/* BEGINNING OF INLINE: 156 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_MANY): case (TOK_OPENSUB): case (TOK_OPENGROUP):
@@ -480,13 +456,13 @@ p_re__sql(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 				{
 					/* BEGINNING OF ACTION: add-epsilon */
 					{
-#line 830 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (ZIy))) {
 			goto ZL3;
 		}
 	
-#line 490 "src/libre/dialect/sql/parser.c"
+#line 466 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: add-epsilon */
 				}
@@ -497,20 +473,20 @@ p_re__sql(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 			{
 				/* BEGINNING OF ACTION: err-expected-alts */
 				{
-#line 1049 "src/libre/parser.act"
+#line 1033 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXALTS;
 		}
 	
-#line 507 "src/libre/dialect/sql/parser.c"
+#line 483 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: err-expected-alts */
 			}
 		ZL2:;
 		}
-		/* END OF INLINE: 157 */
-		/* BEGINNING OF INLINE: 158 */
+		/* END OF INLINE: 156 */
+		/* BEGINNING OF INLINE: 157 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -526,24 +502,20 @@ p_re__sql(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 1085 "src/libre/parser.act"
+#line 1069 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
 		}
 	
-#line 536 "src/libre/dialect/sql/parser.c"
+#line 512 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
 		ZL4:;
 		}
-		/* END OF INLINE: 158 */
+		/* END OF INLINE: 157 */
 	}
-	return;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
 }
 
 static void
@@ -557,25 +529,25 @@ p_expr_C_Clist_Hof_Halts_C_Calt(fsm fsm, flags flags, lex_state lex_state, act_s
 
 		/* BEGINNING OF ACTION: add-concat */
 		{
-#line 823 "src/libre/parser.act"
+#line 807 "src/libre/parser.act"
 
 		(ZIz) = fsm_addstate(fsm);
 		if ((ZIz) == NULL) {
 			goto ZL1;
 		}
 	
-#line 568 "src/libre/dialect/sql/parser.c"
+#line 540 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: add-concat */
 		/* BEGINNING OF ACTION: add-epsilon */
 		{
-#line 830 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (ZIz))) {
 			goto ZL1;
 		}
 	
-#line 579 "src/libre/dialect/sql/parser.c"
+#line 551 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: add-epsilon */
 		p_expr_C_Clist_Hof_Hatoms (fsm, flags, lex_state, act_state, err, ZIz, ZIy);
@@ -591,31 +563,31 @@ ZL1:;
 }
 
 static void
-p_169(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_fsm__state ZI165, t_fsm__state ZI166, t_fsm__state *ZO167, t_fsm__state *ZO168)
+p_168(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_fsm__state ZI164, t_fsm__state ZI165, t_fsm__state *ZO166, t_fsm__state *ZO167)
 {
+	t_fsm__state ZI166;
 	t_fsm__state ZI167;
-	t_fsm__state ZI168;
 
-ZL2_169:;
+ZL2_168:;
 	switch (CURRENT_TERMINAL) {
 	case (TOK_ALT):
 		{
 			ADVANCE_LEXER;
-			p_expr_C_Clist_Hof_Halts_C_Calt (fsm, flags, lex_state, act_state, err, ZI165, ZI166);
-			/* BEGINNING OF INLINE: 169 */
+			p_expr_C_Clist_Hof_Halts_C_Calt (fsm, flags, lex_state, act_state, err, ZI164, ZI165);
+			/* BEGINNING OF INLINE: 168 */
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
 			} else {
-				goto ZL2_169;
+				goto ZL2_168;
 			}
-			/* END OF INLINE: 169 */
+			/* END OF INLINE: 168 */
 		}
 		/* UNREACHED */
 	default:
 		{
+			ZI166 = ZI164;
 			ZI167 = ZI165;
-			ZI168 = ZI166;
 		}
 		break;
 	case (ERROR_TERMINAL):
@@ -626,42 +598,42 @@ ZL1:;
 	SAVE_LEXER ((ERROR_TERMINAL));
 	return;
 ZL0:;
+	*ZO166 = ZI166;
 	*ZO167 = ZI167;
-	*ZO168 = ZI168;
 }
 
 static void
-p_174(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_grp *ZIg)
+p_173(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_grp *ZIg)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_RANGE):
 		{
 			t_char ZIb;
+			t_pos ZI127;
 			t_pos ZI128;
-			t_pos ZI129;
 
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
 #line 437 "src/libre/parser.act"
 
 		ZIb = '-';
-		ZI128 = lex_state->lx.start;
-		ZI129   = lex_state->lx.end;
+		ZI127 = lex_state->lx.start;
+		ZI128   = lex_state->lx.end;
 	
-#line 652 "src/libre/dialect/sql/parser.c"
+#line 624 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: group-add-char */
 			{
-#line 672 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
 		if (-1 == group_add((ZIg), flags->flags, (ZIb))) {
 			err->e = RE_EERRNO;
 			goto ZL1;
 		}
 	
-#line 665 "src/libre/dialect/sql/parser.c"
+#line 637 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: group-add-char */
 		}
@@ -688,7 +660,7 @@ p_group(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err,
 
 		/* BEGINNING OF ACTION: make-group */
 		{
-#line 638 "src/libre/parser.act"
+#line 622 "src/libre/parser.act"
 
 		(ZIg).set = fsm_new_blank(fsm->opt);
 		if ((ZIg).set == NULL) {
@@ -701,7 +673,7 @@ p_group(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err,
 			goto ZL1;
 		}
 	
-#line 705 "src/libre/dialect/sql/parser.c"
+#line 677 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: make-group */
 		p_group_C_Cgroup_Hbm (fsm, flags, lex_state, act_state, err, &ZIg);
@@ -711,7 +683,7 @@ p_group(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err,
 		}
 		/* BEGINNING OF ACTION: group-to-states */
 		{
-#line 763 "src/libre/parser.act"
+#line 747 "src/libre/parser.act"
 
 		int r;
 
@@ -754,7 +726,7 @@ p_group(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err,
 
 		fsm_free((&ZIg)->dup);
 	
-#line 758 "src/libre/dialect/sql/parser.c"
+#line 730 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: group-to-states */
 	}
@@ -765,7 +737,7 @@ ZL1:;
 }
 
 static void
-p_178(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_grp *ZIg, t_char *ZI175, t_pos *ZI176)
+p_177(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_grp *ZIg, t_char *ZI174, t_pos *ZI175)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_RANGE):
@@ -773,12 +745,12 @@ p_178(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			t_char ZIb;
 			t_pos ZIend;
 
-			/* BEGINNING OF INLINE: 106 */
+			/* BEGINNING OF INLINE: 105 */
 			{
 				{
-					t_char ZI107;
+					t_char ZI106;
+					t_pos ZI107;
 					t_pos ZI108;
-					t_pos ZI109;
 
 					switch (CURRENT_TERMINAL) {
 					case (TOK_RANGE):
@@ -786,11 +758,11 @@ p_178(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 						{
 #line 437 "src/libre/parser.act"
 
-		ZI107 = '-';
-		ZI108 = lex_state->lx.start;
-		ZI109   = lex_state->lx.end;
+		ZI106 = '-';
+		ZI107 = lex_state->lx.start;
+		ZI108   = lex_state->lx.end;
 	
-#line 794 "src/libre/dialect/sql/parser.c"
+#line 766 "src/libre/dialect/sql/parser.c"
 						}
 						/* END OF EXTRACT: RANGE */
 						break;
@@ -804,25 +776,25 @@ p_178(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 				{
 					/* BEGINNING OF ACTION: err-expected-range */
 					{
-#line 1055 "src/libre/parser.act"
+#line 1039 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXRANGE;
 		}
 	
-#line 814 "src/libre/dialect/sql/parser.c"
+#line 786 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: err-expected-range */
 				}
 			ZL2:;
 			}
-			/* END OF INLINE: 106 */
-			/* BEGINNING OF INLINE: 110 */
+			/* END OF INLINE: 105 */
+			/* BEGINNING OF INLINE: 109 */
 			{
 				switch (CURRENT_TERMINAL) {
 				case (TOK_CHAR):
 					{
-						t_pos ZI111;
+						t_pos ZI110;
 
 						/* BEGINNING OF EXTRACT: CHAR */
 						{
@@ -831,12 +803,12 @@ p_178(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 		assert(lex_state->buf.a[0] != '\0');
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI111 = lex_state->lx.start;
+		ZI110 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 
 		ZIb = lex_state->buf.a[0];
 	
-#line 840 "src/libre/dialect/sql/parser.c"
+#line 812 "src/libre/dialect/sql/parser.c"
 						}
 						/* END OF EXTRACT: CHAR */
 						ADVANCE_LEXER;
@@ -844,17 +816,17 @@ p_178(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 					break;
 				case (TOK_RANGE):
 					{
-						t_pos ZI113;
+						t_pos ZI112;
 
 						/* BEGINNING OF EXTRACT: RANGE */
 						{
 #line 437 "src/libre/parser.act"
 
 		ZIb = '-';
-		ZI113 = lex_state->lx.start;
+		ZI112 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 858 "src/libre/dialect/sql/parser.c"
+#line 830 "src/libre/dialect/sql/parser.c"
 						}
 						/* END OF EXTRACT: RANGE */
 						ADVANCE_LEXER;
@@ -864,42 +836,42 @@ p_178(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 					goto ZL1;
 				}
 			}
-			/* END OF INLINE: 110 */
+			/* END OF INLINE: 109 */
 			/* BEGINNING OF ACTION: mark-range */
 			{
-#line 1093 "src/libre/parser.act"
+#line 1077 "src/libre/parser.act"
 
-		mark(&act_state->rangestart, &(*ZI176));
+		mark(&act_state->rangestart, &(*ZI175));
 		mark(&act_state->rangeend,   &(ZIend));
 	
-#line 876 "src/libre/dialect/sql/parser.c"
+#line 848 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: group-add-range */
 			{
-#line 741 "src/libre/parser.act"
+#line 725 "src/libre/parser.act"
 
 		int i;
 
-		if ((unsigned char) (ZIb) < (unsigned char) (*ZI175)) {
+		if ((unsigned char) (ZIb) < (unsigned char) (*ZI174)) {
 			char a[5], b[5];
 
 			assert(sizeof err->set >= 1 + sizeof a + 1 + sizeof b + 1 + 1);
 
 			sprintf(err->set, "%s-%s",
-				escchar(a, sizeof a, (*ZI175)), escchar(b, sizeof b, (ZIb)));
+				escchar(a, sizeof a, (*ZI174)), escchar(b, sizeof b, (ZIb)));
 			err->e = RE_ENEGRANGE;
 			goto ZL1;
 		}
 
-		for (i = (unsigned char) (*ZI175); i <= (unsigned char) (ZIb); i++) {
+		for (i = (unsigned char) (*ZI174); i <= (unsigned char) (ZIb); i++) {
 			if (-1 == group_add((ZIg), flags->flags, (char) i)) {
 				err->e = RE_EERRNO;
 				goto ZL1;
 			}
 		}
 	
-#line 903 "src/libre/dialect/sql/parser.c"
+#line 875 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: group-add-range */
 		}
@@ -908,14 +880,14 @@ p_178(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 		{
 			/* BEGINNING OF ACTION: group-add-char */
 			{
-#line 672 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
-		if (-1 == group_add((ZIg), flags->flags, (*ZI175))) {
+		if (-1 == group_add((ZIg), flags->flags, (*ZI174))) {
 			err->e = RE_EERRNO;
 			goto ZL1;
 		}
 	
-#line 919 "src/libre/dialect/sql/parser.c"
+#line 891 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: group-add-char */
 		}
@@ -936,40 +908,40 @@ p_group_C_Cgroup_Hbody(fsm fsm, flags flags, lex_state lex_state, act_state act_
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 121 */
+		/* BEGINNING OF INLINE: 120 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CLOSEGROUP):
 				{
-					t_char ZI171;
+					t_char ZI170;
+					t_pos ZI171;
 					t_pos ZI172;
-					t_pos ZI173;
 
 					/* BEGINNING OF EXTRACT: CLOSEGROUP */
 					{
 #line 448 "src/libre/parser.act"
 
-		ZI171 = ']';
-		ZI172 = lex_state->lx.start;
-		ZI173   = lex_state->lx.end;
+		ZI170 = ']';
+		ZI171 = lex_state->lx.start;
+		ZI172   = lex_state->lx.end;
 	
-#line 957 "src/libre/dialect/sql/parser.c"
+#line 929 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF EXTRACT: CLOSEGROUP */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: group-add-char */
 					{
-#line 672 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
-		if (-1 == group_add((ZIg), flags->flags, (ZI171))) {
+		if (-1 == group_add((ZIg), flags->flags, (ZI170))) {
 			err->e = RE_EERRNO;
 			goto ZL1;
 		}
 	
-#line 970 "src/libre/dialect/sql/parser.c"
+#line 942 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: group-add-char */
-					p_174 (fsm, flags, lex_state, act_state, err, ZIg);
+					p_173 (fsm, flags, lex_state, act_state, err, ZIg);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL1;
@@ -979,31 +951,31 @@ p_group_C_Cgroup_Hbody(fsm fsm, flags flags, lex_state lex_state, act_state act_
 			case (TOK_RANGE):
 				{
 					t_char ZIc;
+					t_pos ZI123;
 					t_pos ZI124;
-					t_pos ZI125;
 
 					/* BEGINNING OF EXTRACT: RANGE */
 					{
 #line 437 "src/libre/parser.act"
 
 		ZIc = '-';
-		ZI124 = lex_state->lx.start;
-		ZI125   = lex_state->lx.end;
+		ZI123 = lex_state->lx.start;
+		ZI124   = lex_state->lx.end;
 	
-#line 994 "src/libre/dialect/sql/parser.c"
+#line 966 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF EXTRACT: RANGE */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: group-add-char */
 					{
-#line 672 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
 		if (-1 == group_add((ZIg), flags->flags, (ZIc))) {
 			err->e = RE_EERRNO;
 			goto ZL1;
 		}
 	
-#line 1007 "src/libre/dialect/sql/parser.c"
+#line 979 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: group-add-char */
 				}
@@ -1012,16 +984,16 @@ p_group_C_Cgroup_Hbody(fsm fsm, flags flags, lex_state lex_state, act_state act_
 				break;
 			}
 		}
-		/* END OF INLINE: 121 */
+		/* END OF INLINE: 120 */
 		p_group_C_Clist_Hof_Hterms (fsm, flags, lex_state, act_state, err, ZIg);
-		/* BEGINNING OF INLINE: 130 */
+		/* BEGINNING OF INLINE: 129 */
 		{
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 130 */
+		/* END OF INLINE: 129 */
 	}
 	return;
 ZL1:;
@@ -1056,14 +1028,14 @@ p_group_C_Clist_Hof_Hterms(fsm fsm, flags flags, lex_state lex_state, act_state 
 	}
 ZL2_group_C_Clist_Hof_Hterms:;
 	{
-		/* BEGINNING OF INLINE: 117 */
+		/* BEGINNING OF INLINE: 116 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CHAR):
 				{
-					t_char ZI175;
+					t_char ZI174;
+					t_pos ZI175;
 					t_pos ZI176;
-					t_pos ZI177;
 
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
@@ -1072,16 +1044,16 @@ ZL2_group_C_Clist_Hof_Hterms:;
 		assert(lex_state->buf.a[0] != '\0');
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI176 = lex_state->lx.start;
-		ZI177   = lex_state->lx.end;
+		ZI175 = lex_state->lx.start;
+		ZI176   = lex_state->lx.end;
 
-		ZI175 = lex_state->buf.a[0];
+		ZI174 = lex_state->buf.a[0];
 	
-#line 1081 "src/libre/dialect/sql/parser.c"
+#line 1053 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF EXTRACT: CHAR */
 					ADVANCE_LEXER;
-					p_178 (fsm, flags, lex_state, act_state, err, ZIg, &ZI175, &ZI176);
+					p_177 (fsm, flags, lex_state, act_state, err, ZIg, &ZI174, &ZI175);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL4;
@@ -1102,7 +1074,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 								{
 #line 463 "src/libre/parser.act"
  ZIk = class_alnum_fsm(fsm->opt);  if (ZIk == NULL) { err->e = RE_EERRNO; goto ZL4; } 
-#line 1106 "src/libre/dialect/sql/parser.c"
+#line 1078 "src/libre/dialect/sql/parser.c"
 								}
 								/* END OF EXTRACT: CLASS_alnum */
 								ADVANCE_LEXER;
@@ -1114,7 +1086,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 								{
 #line 464 "src/libre/parser.act"
  ZIk = class_alpha_fsm(fsm->opt);  if (ZIk == NULL) { err->e = RE_EERRNO; goto ZL4; } 
-#line 1118 "src/libre/dialect/sql/parser.c"
+#line 1090 "src/libre/dialect/sql/parser.c"
 								}
 								/* END OF EXTRACT: CLASS_alpha */
 								ADVANCE_LEXER;
@@ -1126,7 +1098,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 								{
 #line 469 "src/libre/parser.act"
  ZIk = class_digit_fsm(fsm->opt);  if (ZIk == NULL) { err->e = RE_EERRNO; goto ZL4; } 
-#line 1130 "src/libre/dialect/sql/parser.c"
+#line 1102 "src/libre/dialect/sql/parser.c"
 								}
 								/* END OF EXTRACT: CLASS_digit */
 								ADVANCE_LEXER;
@@ -1138,7 +1110,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 								{
 #line 471 "src/libre/parser.act"
  ZIk = class_lower_fsm(fsm->opt);  if (ZIk == NULL) { err->e = RE_EERRNO; goto ZL4; } 
-#line 1142 "src/libre/dialect/sql/parser.c"
+#line 1114 "src/libre/dialect/sql/parser.c"
 								}
 								/* END OF EXTRACT: CLASS_lower */
 								ADVANCE_LEXER;
@@ -1150,7 +1122,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 								{
 #line 474 "src/libre/parser.act"
  ZIk = class_space_fsm(fsm->opt);  if (ZIk == NULL) { err->e = RE_EERRNO; goto ZL4; } 
-#line 1154 "src/libre/dialect/sql/parser.c"
+#line 1126 "src/libre/dialect/sql/parser.c"
 								}
 								/* END OF EXTRACT: CLASS_space */
 								ADVANCE_LEXER;
@@ -1162,7 +1134,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 								{
 #line 475 "src/libre/parser.act"
  ZIk = class_spchr_fsm(fsm->opt);  if (ZIk == NULL) { err->e = RE_EERRNO; goto ZL4; } 
-#line 1166 "src/libre/dialect/sql/parser.c"
+#line 1138 "src/libre/dialect/sql/parser.c"
 								}
 								/* END OF EXTRACT: CLASS_spchr */
 								ADVANCE_LEXER;
@@ -1174,7 +1146,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 								{
 #line 476 "src/libre/parser.act"
  ZIk = class_upper_fsm(fsm->opt);  if (ZIk == NULL) { err->e = RE_EERRNO; goto ZL4; } 
-#line 1178 "src/libre/dialect/sql/parser.c"
+#line 1150 "src/libre/dialect/sql/parser.c"
 								}
 								/* END OF EXTRACT: CLASS_upper */
 								ADVANCE_LEXER;
@@ -1187,7 +1159,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 					/* END OF INLINE: group::class */
 					/* BEGINNING OF ACTION: group-add-class */
 					{
-#line 686 "src/libre/parser.act"
+#line 670 "src/libre/parser.act"
 
 		struct fsm *q;
 		int r;
@@ -1247,7 +1219,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 			}
 		}
 	
-#line 1251 "src/libre/dialect/sql/parser.c"
+#line 1223 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: group-add-class */
 				}
@@ -1260,20 +1232,20 @@ ZL2_group_C_Clist_Hof_Hterms:;
 			{
 				/* BEGINNING OF ACTION: err-expected-term */
 				{
-#line 1031 "src/libre/parser.act"
+#line 1015 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXTERM;
 		}
 	
-#line 1270 "src/libre/dialect/sql/parser.c"
+#line 1242 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: err-expected-term */
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 117 */
-		/* BEGINNING OF INLINE: 118 */
+		/* END OF INLINE: 116 */
+		/* BEGINNING OF INLINE: 117 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CLASS__alnum): case (TOK_CLASS__alpha): case (TOK_CLASS__digit): case (TOK_CLASS__lower):
@@ -1288,7 +1260,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 				break;
 			}
 		}
-		/* END OF INLINE: 118 */
+		/* END OF INLINE: 117 */
 	}
 }
 
@@ -1304,18 +1276,18 @@ ZL2_expr_C_Clist_Hof_Hatoms:;
 
 		/* BEGINNING OF ACTION: add-concat */
 		{
-#line 823 "src/libre/parser.act"
+#line 807 "src/libre/parser.act"
 
 		(ZIz) = fsm_addstate(fsm);
 		if ((ZIz) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1315 "src/libre/dialect/sql/parser.c"
+#line 1287 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: add-concat */
 		p_expr_C_Catom (fsm, flags, lex_state, act_state, err, ZIx, &ZIz);
-		/* BEGINNING OF INLINE: 151 */
+		/* BEGINNING OF INLINE: 150 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_MANY): case (TOK_OPENSUB): case (TOK_OPENGROUP):
@@ -1331,13 +1303,13 @@ ZL2_expr_C_Clist_Hof_Hatoms:;
 				{
 					/* BEGINNING OF ACTION: add-epsilon */
 					{
-#line 830 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIz), (ZIy))) {
 			goto ZL1;
 		}
 	
-#line 1341 "src/libre/dialect/sql/parser.c"
+#line 1313 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: add-epsilon */
 				}
@@ -1347,7 +1319,7 @@ ZL2_expr_C_Clist_Hof_Hatoms:;
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 151 */
+		/* END OF INLINE: 150 */
 	}
 	return;
 ZL1:;
@@ -1363,7 +1335,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 	}
 	{
 		t_pos ZIstart;
-		t_pos ZI133;
+		t_pos ZI132;
 
 		switch (CURRENT_TERMINAL) {
 		case (TOK_OPENGROUP):
@@ -1372,9 +1344,9 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 #line 443 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
-		ZI133   = lex_state->lx.end;
+		ZI132   = lex_state->lx.end;
 	
-#line 1378 "src/libre/dialect/sql/parser.c"
+#line 1350 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: OPENGROUP */
 			break;
@@ -1382,20 +1354,20 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 			goto ZL1;
 		}
 		ADVANCE_LEXER;
-		/* BEGINNING OF INLINE: 134 */
+		/* BEGINNING OF INLINE: 133 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_INVERT):
 				{
-					t_char ZI135;
+					t_char ZI134;
 
 					/* BEGINNING OF EXTRACT: INVERT */
 					{
 #line 433 "src/libre/parser.act"
 
-		ZI135 = '^';
+		ZI134 = '^';
 	
-#line 1399 "src/libre/dialect/sql/parser.c"
+#line 1371 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF EXTRACT: INVERT */
 					ADVANCE_LEXER;
@@ -1406,7 +1378,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 					}
 					/* BEGINNING OF ACTION: invert-group */
 					{
-#line 656 "src/libre/parser.act"
+#line 640 "src/libre/parser.act"
 
 		struct fsm *any;
 
@@ -1427,7 +1399,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 		 * kept in the positive.
 		 */
 	
-#line 1431 "src/libre/dialect/sql/parser.c"
+#line 1403 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: invert-group */
 				}
@@ -1447,12 +1419,12 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 134 */
-		/* BEGINNING OF INLINE: 136 */
+		/* END OF INLINE: 133 */
+		/* BEGINNING OF INLINE: 135 */
 		{
 			{
-				t_char ZI137;
-				t_pos ZI138;
+				t_char ZI136;
+				t_pos ZI137;
 				t_pos ZIend;
 
 				switch (CURRENT_TERMINAL) {
@@ -1461,11 +1433,11 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 					{
 #line 448 "src/libre/parser.act"
 
-		ZI137 = ']';
-		ZI138 = lex_state->lx.start;
+		ZI136 = ']';
+		ZI137 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1469 "src/libre/dialect/sql/parser.c"
+#line 1441 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF EXTRACT: CLOSEGROUP */
 					break;
@@ -1475,12 +1447,12 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 				ADVANCE_LEXER;
 				/* BEGINNING OF ACTION: mark-group */
 				{
-#line 1088 "src/libre/parser.act"
+#line 1072 "src/libre/parser.act"
 
 		mark(&act_state->groupstart, &(ZIstart));
 		mark(&act_state->groupend,   &(ZIend));
 	
-#line 1484 "src/libre/dialect/sql/parser.c"
+#line 1456 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: mark-group */
 			}
@@ -1489,49 +1461,49 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 			{
 				/* BEGINNING OF ACTION: err-expected-closegroup */
 				{
-#line 1061 "src/libre/parser.act"
+#line 1045 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCLOSEGROUP;
 		}
 	
-#line 1499 "src/libre/dialect/sql/parser.c"
+#line 1471 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: err-expected-closegroup */
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 136 */
+		/* END OF INLINE: 135 */
 	}
 	return;
 ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-groupbody */
 		{
-#line 1067 "src/libre/parser.act"
+#line 1051 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXGROUPBODY;
 		}
 	
-#line 1518 "src/libre/dialect/sql/parser.c"
+#line 1490 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: err-expected-groupbody */
 	}
 }
 
 static void
-p_expr_C_Clist_Hof_Halts(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_fsm__state ZI165, t_fsm__state ZI166)
+p_expr_C_Clist_Hof_Halts(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t_fsm__state ZI164, t_fsm__state ZI165)
 {
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 		return;
 	}
 	{
+		t_fsm__state ZI166;
 		t_fsm__state ZI167;
-		t_fsm__state ZI168;
 
-		p_expr_C_Clist_Hof_Halts_C_Calt (fsm, flags, lex_state, act_state, err, ZI165, ZI166);
-		p_169 (fsm, flags, lex_state, act_state, err, ZI165, ZI166, &ZI167, &ZI168);
+		p_expr_C_Clist_Hof_Halts_C_Calt (fsm, flags, lex_state, act_state, err, ZI164, ZI165);
+		p_168 (fsm, flags, lex_state, act_state, err, ZI164, ZI165, &ZI166, &ZI167);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -1550,7 +1522,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 146 */
+		/* BEGINNING OF INLINE: 145 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY):
@@ -1558,7 +1530,35 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: add-any */
 					{
-#line 860 "src/libre/parser.act"
+#line 844 "src/libre/parser.act"
+
+		struct fsm *any;
+
+		assert((ZIx) != NULL);
+		assert((*ZIy) != NULL);
+
+		any = class_any_fsm(fsm->opt);
+		if (any == NULL) {
+			err->e = RE_EERRNO;
+			goto ZL1;
+		}
+
+		if (!fsm_unionxy(fsm, any, (ZIx), (*ZIy))) {
+			err->e = RE_EERRNO;
+			goto ZL1;
+		}
+	
+#line 1552 "src/libre/dialect/sql/parser.c"
+					}
+					/* END OF ACTION: add-any */
+				}
+				break;
+			case (TOK_MANY):
+				{
+					ADVANCE_LEXER;
+					/* BEGINNING OF ACTION: add-any */
+					{
+#line 844 "src/libre/parser.act"
 
 		struct fsm *any;
 
@@ -1579,37 +1579,9 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 #line 1580 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: add-any */
-				}
-				break;
-			case (TOK_MANY):
-				{
-					ADVANCE_LEXER;
-					/* BEGINNING OF ACTION: add-any */
-					{
-#line 860 "src/libre/parser.act"
-
-		struct fsm *any;
-
-		assert((ZIx) != NULL);
-		assert((*ZIy) != NULL);
-
-		any = class_any_fsm(fsm->opt);
-		if (any == NULL) {
-			err->e = RE_EERRNO;
-			goto ZL1;
-		}
-
-		if (!fsm_unionxy(fsm, any, (ZIx), (*ZIy))) {
-			err->e = RE_EERRNO;
-			goto ZL1;
-		}
-	
-#line 1608 "src/libre/dialect/sql/parser.c"
-					}
-					/* END OF ACTION: add-any */
 					/* BEGINNING OF ACTION: count-0-or-many */
 					{
-#line 946 "src/libre/parser.act"
+#line 930 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (*ZIy))) {
 			goto ZL1;
@@ -1636,7 +1608,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 			(*ZIy) = z;
 		}
 	
-#line 1640 "src/libre/dialect/sql/parser.c"
+#line 1612 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: count-0-or-many */
 				}
@@ -1679,8 +1651,8 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 146 */
-		/* BEGINNING OF INLINE: 147 */
+		/* END OF INLINE: 145 */
+		/* BEGINNING OF INLINE: 146 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_PLUS):
@@ -1688,7 +1660,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: count-1-or-many */
 					{
-#line 973 "src/libre/parser.act"
+#line 957 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (*ZIy), (ZIx))) {
 			goto ZL4;
@@ -1711,7 +1683,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 			(*ZIy) = z;
 		}
 	
-#line 1715 "src/libre/dialect/sql/parser.c"
+#line 1687 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: count-1-or-many */
 				}
@@ -1721,7 +1693,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: count-0-or-many */
 					{
-#line 946 "src/libre/parser.act"
+#line 930 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (*ZIy))) {
 			goto ZL4;
@@ -1748,7 +1720,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 			(*ZIy) = z;
 		}
 	
-#line 1752 "src/libre/dialect/sql/parser.c"
+#line 1724 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: count-0-or-many */
 				}
@@ -1757,12 +1729,12 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 				{
 					/* BEGINNING OF ACTION: count-1 */
 					{
-#line 996 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 		(void) (ZIx);
 		(void) (*ZIy);
 	
-#line 1766 "src/libre/dialect/sql/parser.c"
+#line 1738 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: count-1 */
 				}
@@ -1773,19 +1745,19 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 			{
 				/* BEGINNING OF ACTION: err-expected-count */
 				{
-#line 1037 "src/libre/parser.act"
+#line 1021 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCOUNT;
 		}
 	
-#line 1783 "src/libre/dialect/sql/parser.c"
+#line 1755 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: err-expected-count */
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 147 */
+		/* END OF INLINE: 146 */
 	}
 	return;
 ZL1:;
@@ -1802,11 +1774,11 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 	{
 		t_char ZIc;
 
-		/* BEGINNING OF INLINE: 140 */
+		/* BEGINNING OF INLINE: 139 */
 		{
 			{
+				t_pos ZI140;
 				t_pos ZI141;
-				t_pos ZI142;
 
 				switch (CURRENT_TERMINAL) {
 				case (TOK_CHAR):
@@ -1817,12 +1789,12 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 		assert(lex_state->buf.a[0] != '\0');
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI141 = lex_state->lx.start;
-		ZI142   = lex_state->lx.end;
+		ZI140 = lex_state->lx.start;
+		ZI141   = lex_state->lx.end;
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 1826 "src/libre/dialect/sql/parser.c"
+#line 1798 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF EXTRACT: CHAR */
 					break;
@@ -1832,10 +1804,10 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 				ADVANCE_LEXER;
 			}
 		}
-		/* END OF INLINE: 140 */
+		/* END OF INLINE: 139 */
 		/* BEGINNING OF ACTION: add-literal */
 		{
-#line 847 "src/libre/parser.act"
+#line 831 "src/libre/parser.act"
 
 		assert((ZIx) != NULL);
 		assert((ZIy) != NULL);
@@ -1846,7 +1818,7 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 			goto ZL1;
 		}
 	
-#line 1850 "src/libre/dialect/sql/parser.c"
+#line 1822 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: add-literal */
 	}
@@ -1858,7 +1830,7 @@ ZL1:;
 
 /* BEGINNING OF TRAILER */
 
-#line 1257 "src/libre/parser.act"
+#line 1259 "src/libre/parser.act"
 
 
 	static int
@@ -1878,9 +1850,11 @@ ZL1:;
 
 	static int
 	parse(int (*f)(void *opaque), void *opaque,
-		void (*entry)(struct fsm *, flags, lex_state, act_state, err),
+		void (*entry)(struct fsm *, flags, lex_state, act_state, err,
+			struct fsm_state *, struct fsm_state *),
 		struct flags *flags, int overlap,
-		struct fsm *new, struct re_err *err)
+		struct fsm *new, struct re_err *err,
+		struct fsm_state *x, struct fsm_state *y)
 	{
 		struct act_state  act_state_s;
 		struct act_state *act_state;
@@ -1929,7 +1903,7 @@ ZL1:;
 		err->e = RE_ESUCCESS;
 
 		ADVANCE_LEXER;
-		entry(new, flags, lex_state, act_state, err);
+		entry(new, flags, lex_state, act_state, err, x, y);
 
 		lx->free(lx);
 
@@ -1995,6 +1969,7 @@ ZL1:;
 		struct re_err *err)
 	{
 		struct fsm *new;
+		struct fsm_state *x, *y;
 		struct flags top, *fl = &top;
 
 		top.flags = flags;
@@ -2006,14 +1981,29 @@ ZL1:;
 			return NULL;
 		}
 
-		if (-1 == parse(f, opaque, DIALECT_ENTRY, fl, overlap, new, err)) {
-			fsm_free(new);
-			return NULL;
+		x = fsm_getstart(new);
+		assert(x != NULL);
+
+		y = fsm_addstate(new);
+		if (y == NULL) {
+			goto error;
+		}
+
+		fsm_setend(new, y, 1);
+
+		if (-1 == parse(f, opaque, DIALECT_ENTRY, fl, overlap, new, err, x, y)) {
+			goto error;
 		}
 
 		return new;
+
+	error:
+
+		fsm_free(new);
+
+		return NULL;
 	}
 
-#line 2018 "src/libre/dialect/sql/parser.c"
+#line 2008 "src/libre/dialect/sql/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/sql/parser.h
+++ b/src/libre/dialect/sql/parser.h
@@ -17,20 +17,21 @@
 	typedef struct lex_state * lex_state;
 	typedef struct act_state * act_state;
 
-	typedef struct fsm *  fsm;
+	typedef struct fsm * fsm;
+	typedef struct fsm_state * t_fsm__state;
 	typedef struct flags *flags;
 	typedef struct re_err * err;
 
-#line 25 "src/libre/dialect/sql/parser.h"
+#line 26 "src/libre/dialect/sql/parser.h"
 
 /* BEGINNING OF FUNCTION DECLARATIONS */
 
-extern void p_re__sql(fsm, flags, lex_state, act_state, err);
+extern void p_re__sql(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 /* BEGINNING OF TRAILER */
 
-#line 1259 "src/libre/parser.act"
+#line 1261 "src/libre/parser.act"
 
 
-#line 35 "src/libre/dialect/sql/parser.h"
+#line 36 "src/libre/dialect/sql/parser.h"
 
 /* END OF FILE */

--- a/src/libre/dialect/sql/parser.sid
+++ b/src/libre/dialect/sql/parser.sid
@@ -78,8 +78,6 @@
 
 %productions%
 
-	<make-states>: () -> (:fsm_state, :fsm_state);
-
 	<make-group>:  () -> (:grp);
 	<invert-group>:    (:grp &) -> ();
 	<group-add-char>:  (:grp &, :char) -> ();
@@ -319,9 +317,7 @@
 		list-of-alts(x, y);
 	};
 
-	re_sql: () -> () = {
-		(x, y) = <make-states>;
-
+	re_sql: (x :fsm_state, y :fsm_state) -> () = {
 		{
 			expr(x, y);
 		||

--- a/src/libre/parser.act
+++ b/src/libre/parser.act
@@ -97,7 +97,6 @@
 
 	typedef struct lx_pos t_pos;
 	typedef struct fsm * t_fsm;
-	typedef struct fsm_state * t_fsm__state;
 	typedef enum re_flags t_re__flags;
 	typedef struct grp t_grp;
 
@@ -421,7 +420,8 @@
 	typedef struct lex_state * lex_state;
 	typedef struct act_state * act_state;
 
-	typedef struct fsm *  fsm;
+	typedef struct fsm * fsm;
+	typedef struct fsm_state * t_fsm__state;
 	typedef struct flags *flags;
 	typedef struct re_err * err;
 
@@ -617,22 +617,6 @@
 	 * In some cases (e.g. counting) actions are centralised here for
 	 * the sake of DRY, at the expense of slight overkill.
 	 */
-
-	<make-states>: () -> (x :fsm_state, y :fsm_state) = @{
-		assert(fsm != NULL);
-		/* TODO: assert fsm is empty */
-
-		@x = fsm_getstart(fsm);
-		assert(@x != NULL);
-
-		@y = fsm_addstate(fsm);
-		if (@y == NULL) {
-			@!;
-		}
-
-		fsm_setend(fsm, @y, 1);
-	@};
-
 
 	<make-group>: () -> (g :grp) = @{
 		@g.set = fsm_new_blank(fsm->opt);
@@ -1118,9 +1102,11 @@
 
 	static int
 	parse(int (*f)(void *opaque), void *opaque,
-		void (*entry)(struct fsm *, flags, lex_state, act_state, err),
+		void (*entry)(struct fsm *, flags, lex_state, act_state, err,
+			struct fsm_state *, struct fsm_state *),
 		struct flags *flags, int overlap,
-		struct fsm *new, struct re_err *err)
+		struct fsm *new, struct re_err *err,
+		struct fsm_state *x, struct fsm_state *y)
 	{
 		struct act_state  act_state_s;
 		struct act_state *act_state;
@@ -1169,7 +1155,7 @@
 		err->e = RE_ESUCCESS;
 
 		ADVANCE_LEXER;
-		entry(new, flags, lex_state, act_state, err);
+		entry(new, flags, lex_state, act_state, err, x, y);
 
 		lx->free(lx);
 
@@ -1235,6 +1221,7 @@
 		struct re_err *err)
 	{
 		struct fsm *new;
+		struct fsm_state *x, *y;
 		struct flags top, *fl = &top;
 
 		top.flags = flags;
@@ -1246,12 +1233,27 @@
 			return NULL;
 		}
 
-		if (-1 == parse(f, opaque, DIALECT_ENTRY, fl, overlap, new, err)) {
-			fsm_free(new);
-			return NULL;
+		x = fsm_getstart(new);
+		assert(x != NULL);
+
+		y = fsm_addstate(new);
+		if (y == NULL) {
+			goto error;
+		}
+
+		fsm_setend(new, y, 1);
+
+		if (-1 == parse(f, opaque, DIALECT_ENTRY, fl, overlap, new, err, x, y)) {
+			goto error;
 		}
 
 		return new;
+
+	error:
+
+		fsm_free(new);
+
+		return NULL;
 	}
 
 @}, @{


### PR DESCRIPTION
The end state was not marked for an empty regexp, because marking the end state depended on parsing something at all. This PR avoids that by creating those states before parse.