### PR TITLE
Fixes small UB in lexers output by lx

### DIFF
--- a/src/fsm/lexer.c
+++ b/src/fsm/lexer.c
@@ -2,6 +2,7 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <stddef.h>
 #include <stdlib.h>
 #include <errno.h>
 
@@ -89,6 +90,7 @@ lx_dynpush(struct lx *lx, char c)
 
 	if (t->p == t->a + t->len) {
 		size_t len;
+		ptrdiff_t off;
 		char *tmp;
 
 		if (t->len == 0) {
@@ -102,12 +104,13 @@ lx_dynpush(struct lx *lx, char c)
 			}
 		}
 
+		off = t->p - t->a;
 		tmp = realloc(t->a, len);
 		if (tmp == NULL) {
 			return -1;
 		}
 
-		t->p   = tmp + (t->p - t->a);
+		t->p   = tmp + off;
 		t->a   = tmp;
 		t->len = len;
 	}
@@ -1495,7 +1498,7 @@ z3(struct lx *lx)
 			case 'k':
 			case 'l':
 			case 'm': state = S7; continue;
-			case 'n': state = S13; continue;
+			case 'n': state = S18; continue;
 			case 'o':
 			case 'p':
 			case 'q':
@@ -1569,7 +1572,7 @@ z3(struct lx *lx)
 			case 'q':
 			case 'r':
 			case 's': state = S7; continue;
-			case 't': state = S16; continue;
+			case 't': state = S13; continue;
 			case 'u':
 			case 'v':
 			case 'w':
@@ -1582,7 +1585,7 @@ z3(struct lx *lx)
 		case S12: /* e.g. "->" */
 			lx_ungetc(lx, c); return TOK_TO;
 
-		case S13: /* e.g. "en" */
+		case S13: /* e.g. "st" */
 			switch ((unsigned char) c) {
 			case '0':
 			case '1':
@@ -1621,76 +1624,7 @@ z3(struct lx *lx)
 			case 'Y':
 			case 'Z': state = S7; continue;
 			case '_': state = S7; continue;
-			case 'a':
-			case 'b':
-			case 'c': state = S7; continue;
-			case 'd': state = S14; continue;
-			case 'e':
-			case 'f':
-			case 'g':
-			case 'h':
-			case 'i':
-			case 'j':
-			case 'k':
-			case 'l':
-			case 'm':
-			case 'n':
-			case 'o':
-			case 'p':
-			case 'q':
-			case 'r':
-			case 's':
-			case 't':
-			case 'u':
-			case 'v':
-			case 'w':
-			case 'x':
-			case 'y':
-			case 'z': state = S7; continue;
-			default:  lx_ungetc(lx, c); return TOK_IDENT;
-			}
-
-		case S14: /* e.g. "end" */
-			switch ((unsigned char) c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9': state = S7; continue;
-			case ':': state = S15; continue;
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F':
-			case 'G':
-			case 'H':
-			case 'I':
-			case 'J':
-			case 'K':
-			case 'L':
-			case 'M':
-			case 'N':
-			case 'O':
-			case 'P':
-			case 'Q':
-			case 'R':
-			case 'S':
-			case 'T':
-			case 'U':
-			case 'V':
-			case 'W':
-			case 'X':
-			case 'Y':
-			case 'Z': state = S7; continue;
-			case '_': state = S7; continue;
-			case 'a':
+			case 'a': state = S14; continue;
 			case 'b':
 			case 'c':
 			case 'd':
@@ -1719,78 +1653,7 @@ z3(struct lx *lx)
 			default:  lx_ungetc(lx, c); return TOK_IDENT;
 			}
 
-		case S15: /* e.g. "end:" */
-			lx_ungetc(lx, c); return TOK_END;
-
-		case S16: /* e.g. "st" */
-			switch ((unsigned char) c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9': state = S7; continue;
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F':
-			case 'G':
-			case 'H':
-			case 'I':
-			case 'J':
-			case 'K':
-			case 'L':
-			case 'M':
-			case 'N':
-			case 'O':
-			case 'P':
-			case 'Q':
-			case 'R':
-			case 'S':
-			case 'T':
-			case 'U':
-			case 'V':
-			case 'W':
-			case 'X':
-			case 'Y':
-			case 'Z': state = S7; continue;
-			case '_': state = S7; continue;
-			case 'a': state = S17; continue;
-			case 'b':
-			case 'c':
-			case 'd':
-			case 'e':
-			case 'f':
-			case 'g':
-			case 'h':
-			case 'i':
-			case 'j':
-			case 'k':
-			case 'l':
-			case 'm':
-			case 'n':
-			case 'o':
-			case 'p':
-			case 'q':
-			case 'r':
-			case 's':
-			case 't':
-			case 'u':
-			case 'v':
-			case 'w':
-			case 'x':
-			case 'y':
-			case 'z': state = S7; continue;
-			default:  lx_ungetc(lx, c); return TOK_IDENT;
-			}
-
-		case S17: /* e.g. "sta" */
+		case S14: /* e.g. "sta" */
 			switch ((unsigned char) c) {
 			case '0':
 			case '1':
@@ -1846,7 +1709,7 @@ z3(struct lx *lx)
 			case 'o':
 			case 'p':
 			case 'q': state = S7; continue;
-			case 'r': state = S18; continue;
+			case 'r': state = S15; continue;
 			case 's':
 			case 't':
 			case 'u':
@@ -1858,7 +1721,7 @@ z3(struct lx *lx)
 			default:  lx_ungetc(lx, c); return TOK_IDENT;
 			}
 
-		case S18: /* e.g. "star" */
+		case S15: /* e.g. "star" */
 			switch ((unsigned char) c) {
 			case '0':
 			case '1':
@@ -1916,7 +1779,7 @@ z3(struct lx *lx)
 			case 'q':
 			case 'r':
 			case 's': state = S7; continue;
-			case 't': state = S19; continue;
+			case 't': state = S16; continue;
 			case 'u':
 			case 'v':
 			case 'w':
@@ -1926,7 +1789,147 @@ z3(struct lx *lx)
 			default:  lx_ungetc(lx, c); return TOK_IDENT;
 			}
 
-		case S19: /* e.g. "start" */
+		case S16: /* e.g. "start" */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9': state = S7; continue;
+			case ':': state = S17; continue;
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'G':
+			case 'H':
+			case 'I':
+			case 'J':
+			case 'K':
+			case 'L':
+			case 'M':
+			case 'N':
+			case 'O':
+			case 'P':
+			case 'Q':
+			case 'R':
+			case 'S':
+			case 'T':
+			case 'U':
+			case 'V':
+			case 'W':
+			case 'X':
+			case 'Y':
+			case 'Z': state = S7; continue;
+			case '_': state = S7; continue;
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f':
+			case 'g':
+			case 'h':
+			case 'i':
+			case 'j':
+			case 'k':
+			case 'l':
+			case 'm':
+			case 'n':
+			case 'o':
+			case 'p':
+			case 'q':
+			case 'r':
+			case 's':
+			case 't':
+			case 'u':
+			case 'v':
+			case 'w':
+			case 'x':
+			case 'y':
+			case 'z': state = S7; continue;
+			default:  lx_ungetc(lx, c); return TOK_IDENT;
+			}
+
+		case S17: /* e.g. "start:" */
+			lx_ungetc(lx, c); return TOK_START;
+
+		case S18: /* e.g. "en" */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9': state = S7; continue;
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'G':
+			case 'H':
+			case 'I':
+			case 'J':
+			case 'K':
+			case 'L':
+			case 'M':
+			case 'N':
+			case 'O':
+			case 'P':
+			case 'Q':
+			case 'R':
+			case 'S':
+			case 'T':
+			case 'U':
+			case 'V':
+			case 'W':
+			case 'X':
+			case 'Y':
+			case 'Z': state = S7; continue;
+			case '_': state = S7; continue;
+			case 'a':
+			case 'b':
+			case 'c': state = S7; continue;
+			case 'd': state = S19; continue;
+			case 'e':
+			case 'f':
+			case 'g':
+			case 'h':
+			case 'i':
+			case 'j':
+			case 'k':
+			case 'l':
+			case 'm':
+			case 'n':
+			case 'o':
+			case 'p':
+			case 'q':
+			case 'r':
+			case 's':
+			case 't':
+			case 'u':
+			case 'v':
+			case 'w':
+			case 'x':
+			case 'y':
+			case 'z': state = S7; continue;
+			default:  lx_ungetc(lx, c); return TOK_IDENT;
+			}
+
+		case S19: /* e.g. "end" */
 			switch ((unsigned char) c) {
 			case '0':
 			case '1':
@@ -1995,8 +1998,8 @@ z3(struct lx *lx)
 			default:  lx_ungetc(lx, c); return TOK_IDENT;
 			}
 
-		case S20: /* e.g. "start:" */
-			lx_ungetc(lx, c); return TOK_START;
+		case S20: /* e.g. "end:" */
+			lx_ungetc(lx, c); return TOK_END;
 		}
 	}
 
@@ -2017,12 +2020,12 @@ z3(struct lx *lx)
 	case S12: return TOK_TO;
 	case S13: return TOK_IDENT;
 	case S14: return TOK_IDENT;
-	case S15: return TOK_END;
+	case S15: return TOK_IDENT;
 	case S16: return TOK_IDENT;
-	case S17: return TOK_IDENT;
+	case S17: return TOK_START;
 	case S18: return TOK_IDENT;
 	case S19: return TOK_IDENT;
-	case S20: return TOK_START;
+	case S20: return TOK_END;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
 }

--- a/src/libre/dialect/glob/lexer.c
+++ b/src/libre/dialect/glob/lexer.c
@@ -2,6 +2,7 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <stddef.h>
 #include <stdlib.h>
 #include <errno.h>
 
@@ -77,6 +78,7 @@ lx_glob_dynpush(struct lx_glob_lx *lx, char c)
 
 	if (t->p == t->a + t->len) {
 		size_t len;
+		ptrdiff_t off;
 		char *tmp;
 
 		if (t->len == 0) {
@@ -90,12 +92,13 @@ lx_glob_dynpush(struct lx_glob_lx *lx, char c)
 			}
 		}
 
+		off = t->p - t->a;
 		tmp = realloc(t->a, len);
 		if (tmp == NULL) {
 			return -1;
 		}
 
-		t->p   = tmp + (t->p - t->a);
+		t->p   = tmp + off;
 		t->a   = tmp;
 		t->len = len;
 	}

--- a/src/libre/dialect/like/lexer.c
+++ b/src/libre/dialect/like/lexer.c
@@ -2,6 +2,7 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <stddef.h>
 #include <stdlib.h>
 #include <errno.h>
 
@@ -77,6 +78,7 @@ lx_like_dynpush(struct lx_like_lx *lx, char c)
 
 	if (t->p == t->a + t->len) {
 		size_t len;
+		ptrdiff_t off;
 		char *tmp;
 
 		if (t->len == 0) {
@@ -90,12 +92,13 @@ lx_like_dynpush(struct lx_like_lx *lx, char c)
 			}
 		}
 
+		off = t->p - t->a;
 		tmp = realloc(t->a, len);
 		if (tmp == NULL) {
 			return -1;
 		}
 
-		t->p   = tmp + (t->p - t->a);
+		t->p   = tmp + off;
 		t->a   = tmp;
 		t->len = len;
 	}

--- a/src/libre/dialect/literal/lexer.c
+++ b/src/libre/dialect/literal/lexer.c
@@ -2,6 +2,7 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <stddef.h>
 #include <stdlib.h>
 #include <errno.h>
 
@@ -77,6 +78,7 @@ lx_literal_dynpush(struct lx_literal_lx *lx, char c)
 
 	if (t->p == t->a + t->len) {
 		size_t len;
+		ptrdiff_t off;
 		char *tmp;
 
 		if (t->len == 0) {
@@ -90,12 +92,13 @@ lx_literal_dynpush(struct lx_literal_lx *lx, char c)
 			}
 		}
 
+		off = t->p - t->a;
 		tmp = realloc(t->a, len);
 		if (tmp == NULL) {
 			return -1;
 		}
 
-		t->p   = tmp + (t->p - t->a);
+		t->p   = tmp + off;
 		t->a   = tmp;
 		t->len = len;
 	}

--- a/src/libre/dialect/native/lexer.c
+++ b/src/libre/dialect/native/lexer.c
@@ -2,6 +2,7 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <stddef.h>
 #include <stdlib.h>
 #include <errno.h>
 
@@ -79,6 +80,7 @@ lx_native_dynpush(struct lx_native_lx *lx, char c)
 
 	if (t->p == t->a + t->len) {
 		size_t len;
+		ptrdiff_t off;
 		char *tmp;
 
 		if (t->len == 0) {
@@ -92,12 +94,13 @@ lx_native_dynpush(struct lx_native_lx *lx, char c)
 			}
 		}
 
+		off = t->p - t->a;
 		tmp = realloc(t->a, len);
 		if (tmp == NULL) {
 			return -1;
 		}
 
-		t->p   = tmp + (t->p - t->a);
+		t->p   = tmp + off;
 		t->a   = tmp;
 		t->len = len;
 	}
@@ -693,31 +696,31 @@ z1(struct lx_native_lx *lx)
 
 		case S13: /* e.g. "[:b" */
 			switch ((unsigned char) c) {
-			case 'l': state = S29; continue;
+			case 'l': state = S24; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
 		case S14: /* e.g. "[:c" */
 			switch ((unsigned char) c) {
-			case 'n': state = S65; continue;
+			case 'n': state = S27; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
 		case S15: /* e.g. "[:d" */
 			switch ((unsigned char) c) {
-			case 'i': state = S25; continue;
+			case 'i': state = S53; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
 		case S16: /* e.g. "[:g" */
 			switch ((unsigned char) c) {
-			case 'r': state = S71; continue;
+			case 'r': state = S25; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
 		case S17: /* e.g. "[:l" */
 			switch ((unsigned char) c) {
-			case 'o': state = S49; continue;
+			case 'o': state = S42; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
@@ -730,328 +733,328 @@ z1(struct lx_native_lx *lx)
 
 		case S19: /* e.g. "[:s" */
 			switch ((unsigned char) c) {
-			case 'p': state = S38; continue;
+			case 'p': state = S23; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
 		case S20: /* e.g. "[:u" */
 			switch ((unsigned char) c) {
-			case 'p': state = S27; continue;
+			case 'p': state = S34; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
 		case S21: /* e.g. "[:w" */
 			switch ((unsigned char) c) {
-			case 'o': state = S23; continue;
+			case 'o': state = S58; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
 		case S22: /* e.g. "[:x" */
 			switch ((unsigned char) c) {
-			case 'd': state = S51; continue;
+			case 'd': state = S26; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S23: /* e.g. "[:wo" */
+		case S23: /* e.g. "[:sp" */
 			switch ((unsigned char) c) {
-			case 'r': state = S24; continue;
+			case 'a': state = S28; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S24: /* e.g. "[:wor" */
+		case S24: /* e.g. "[:bl" */
 			switch ((unsigned char) c) {
-			case 'd': state = S31; continue;
+			case 'a': state = S33; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S25: /* e.g. "[:di" */
+		case S25: /* e.g. "[:gr" */
 			switch ((unsigned char) c) {
-			case 'g': state = S26; continue;
+			case 'a': state = S48; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S26: /* e.g. "[:dig" */
+		case S26: /* e.g. "[:xd" */
 			switch ((unsigned char) c) {
-			case 'i': state = S34; continue;
+			case 'i': state = S36; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S27: /* e.g. "[:up" */
+		case S27: /* e.g. "[:cn" */
 			switch ((unsigned char) c) {
-			case 'p': state = S28; continue;
+			case 't': state = S68; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S28: /* e.g. "[:upp" */
+		case S28: /* e.g. "[:spa" */
 			switch ((unsigned char) c) {
-			case 'e': state = S40; continue;
+			case 'c': state = S29; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S29: /* e.g. "[:bl" */
+		case S29: /* e.g. "[:spac" */
 			switch ((unsigned char) c) {
-			case 'a': state = S30; continue;
+			case 'e': state = S30; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S30: /* e.g. "[:bla" */
+		case S30: /* e.g. "[:space" */
 			switch ((unsigned char) c) {
-			case 'n': state = S44; continue;
+			case ':': state = S31; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S31: /* e.g. "[:word" */
+		case S31: /* e.g. "[:space:" */
 			switch ((unsigned char) c) {
-			case ':': state = S32; continue;
+			case ']': state = S32; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S32: /* e.g. "[:word:" */
+		case S32: /* e.g. "[:space:]" */
+			lx_native_ungetc(lx, c); return TOK_CLASS_SPACE;
+
+		case S33: /* e.g. "[:bla" */
 			switch ((unsigned char) c) {
-			case ']': state = S33; continue;
+			case 'n': state = S73; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S33: /* e.g. "[:word:]" */
-			lx_native_ungetc(lx, c); return TOK_CLASS_WORD;
-
-		case S34: /* e.g. "[:digi" */
+		case S34: /* e.g. "[:up" */
 			switch ((unsigned char) c) {
-			case 't': state = S35; continue;
+			case 'p': state = S35; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S35: /* e.g. "[:digit" */
+		case S35: /* e.g. "[:upp" */
 			switch ((unsigned char) c) {
-			case ':': state = S36; continue;
+			case 'e': state = S63; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S36: /* e.g. "[:digit:" */
+		case S36: /* e.g. "[:xdi" */
 			switch ((unsigned char) c) {
-			case ']': state = S37; continue;
+			case 'g': state = S37; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S37: /* e.g. "[:digit:]" */
-			lx_native_ungetc(lx, c); return TOK_CLASS_DIGIT;
-
-		case S38: /* e.g. "[:sp" */
+		case S37: /* e.g. "[:xdig" */
 			switch ((unsigned char) c) {
-			case 'a': state = S39; continue;
+			case 'i': state = S38; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S39: /* e.g. "[:spa" */
+		case S38: /* e.g. "[:xdigi" */
 			switch ((unsigned char) c) {
-			case 'c': state = S47; continue;
+			case 't': state = S39; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S40: /* e.g. "[:uppe" */
+		case S39: /* e.g. "[:xdigit" */
 			switch ((unsigned char) c) {
-			case 'r': state = S41; continue;
+			case ':': state = S40; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S41: /* e.g. "[:upper" */
+		case S40: /* e.g. "[:xdigit:" */
 			switch ((unsigned char) c) {
-			case ':': state = S42; continue;
+			case ']': state = S41; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S42: /* e.g. "[:upper:" */
+		case S41: /* e.g. "[:xdigit:]" */
+			lx_native_ungetc(lx, c); return TOK_CLASS_XDIGIT;
+
+		case S42: /* e.g. "[:lo" */
 			switch ((unsigned char) c) {
-			case ']': state = S43; continue;
+			case 'w': state = S43; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S43: /* e.g. "[:upper:]" */
-			lx_native_ungetc(lx, c); return TOK_CLASS_UPPER;
-
-		case S44: /* e.g. "[:blan" */
+		case S43: /* e.g. "[:low" */
 			switch ((unsigned char) c) {
-			case 'k': state = S45; continue;
+			case 'e': state = S44; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S45: /* e.g. "[:blank" */
+		case S44: /* e.g. "[:lowe" */
+			switch ((unsigned char) c) {
+			case 'r': state = S45; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S45: /* e.g. "[:lower" */
 			switch ((unsigned char) c) {
 			case ':': state = S46; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S46: /* e.g. "[:blank:" */
+		case S46: /* e.g. "[:lower:" */
 			switch ((unsigned char) c) {
-			case ']': state = S53; continue;
+			case ']': state = S47; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S47: /* e.g. "[:spac" */
+		case S47: /* e.g. "[:lower:]" */
+			lx_native_ungetc(lx, c); return TOK_CLASS_LOWER;
+
+		case S48: /* e.g. "[:gra" */
 			switch ((unsigned char) c) {
-			case 'e': state = S48; continue;
+			case 'p': state = S49; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S48: /* e.g. "[:space" */
+		case S49: /* e.g. "[:grap" */
 			switch ((unsigned char) c) {
-			case ':': state = S54; continue;
+			case 'h': state = S50; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S49: /* e.g. "[:lo" */
+		case S50: /* e.g. "[:graph" */
 			switch ((unsigned char) c) {
-			case 'w': state = S50; continue;
+			case ':': state = S51; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S50: /* e.g. "[:low" */
+		case S51: /* e.g. "[:graph:" */
 			switch ((unsigned char) c) {
-			case 'e': state = S56; continue;
+			case ']': state = S52; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S51: /* e.g. "[:xd" */
+		case S52: /* e.g. "[:graph:]" */
+			lx_native_ungetc(lx, c); return TOK_CLASS_GRAPH;
+
+		case S53: /* e.g. "[:di" */
 			switch ((unsigned char) c) {
-			case 'i': state = S52; continue;
+			case 'g': state = S54; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S52: /* e.g. "[:xdi" */
+		case S54: /* e.g. "[:dig" */
 			switch ((unsigned char) c) {
-			case 'g': state = S58; continue;
+			case 'i': state = S55; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S53: /* e.g. "[:blank:]" */
-			lx_native_ungetc(lx, c); return TOK_CLASS_BLANK;
-
-		case S54: /* e.g. "[:space:" */
+		case S55: /* e.g. "[:digi" */
 			switch ((unsigned char) c) {
-			case ']': state = S55; continue;
+			case 't': state = S56; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S55: /* e.g. "[:space:]" */
-			lx_native_ungetc(lx, c); return TOK_CLASS_SPACE;
-
-		case S56: /* e.g. "[:lowe" */
+		case S56: /* e.g. "[:digit" */
 			switch ((unsigned char) c) {
-			case 'r': state = S57; continue;
+			case ':': state = S57; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S57: /* e.g. "[:lower" */
+		case S57: /* e.g. "[:digit:" */
+			switch ((unsigned char) c) {
+			case ']': state = S67; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S58: /* e.g. "[:wo" */
+			switch ((unsigned char) c) {
+			case 'r': state = S59; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S59: /* e.g. "[:wor" */
+			switch ((unsigned char) c) {
+			case 'd': state = S60; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S60: /* e.g. "[:word" */
 			switch ((unsigned char) c) {
 			case ':': state = S61; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S58: /* e.g. "[:xdig" */
-			switch ((unsigned char) c) {
-			case 'i': state = S59; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S59: /* e.g. "[:xdigi" */
-			switch ((unsigned char) c) {
-			case 't': state = S60; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S60: /* e.g. "[:xdigit" */
-			switch ((unsigned char) c) {
-			case ':': state = S63; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S61: /* e.g. "[:lower:" */
+		case S61: /* e.g. "[:word:" */
 			switch ((unsigned char) c) {
 			case ']': state = S62; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S62: /* e.g. "[:lower:]" */
-			lx_native_ungetc(lx, c); return TOK_CLASS_LOWER;
+		case S62: /* e.g. "[:word:]" */
+			lx_native_ungetc(lx, c); return TOK_CLASS_WORD;
 
-		case S63: /* e.g. "[:xdigit:" */
+		case S63: /* e.g. "[:uppe" */
 			switch ((unsigned char) c) {
-			case ']': state = S64; continue;
+			case 'r': state = S64; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S64: /* e.g. "[:xdigit:]" */
-			lx_native_ungetc(lx, c); return TOK_CLASS_XDIGIT;
-
-		case S65: /* e.g. "[:cn" */
+		case S64: /* e.g. "[:upper" */
 			switch ((unsigned char) c) {
-			case 't': state = S66; continue;
+			case ':': state = S65; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S66: /* e.g. "[:cnt" */
+		case S65: /* e.g. "[:upper:" */
 			switch ((unsigned char) c) {
-			case 'r': state = S67; continue;
+			case ']': state = S66; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S67: /* e.g. "[:cntr" */
+		case S66: /* e.g. "[:upper:]" */
+			lx_native_ungetc(lx, c); return TOK_CLASS_UPPER;
+
+		case S67: /* e.g. "[:digit:]" */
+			lx_native_ungetc(lx, c); return TOK_CLASS_DIGIT;
+
+		case S68: /* e.g. "[:cnt" */
 			switch ((unsigned char) c) {
-			case 'l': state = S68; continue;
+			case 'r': state = S69; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S68: /* e.g. "[:cntrl" */
+		case S69: /* e.g. "[:cntr" */
 			switch ((unsigned char) c) {
-			case ':': state = S69; continue;
+			case 'l': state = S70; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S69: /* e.g. "[:cntrl:" */
+		case S70: /* e.g. "[:cntrl" */
 			switch ((unsigned char) c) {
-			case ']': state = S70; continue;
+			case ':': state = S71; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S70: /* e.g. "[:cntrl:]" */
+		case S71: /* e.g. "[:cntrl:" */
+			switch ((unsigned char) c) {
+			case ']': state = S72; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S72: /* e.g. "[:cntrl:]" */
 			lx_native_ungetc(lx, c); return TOK_CLASS_CNTRL;
 
-		case S71: /* e.g. "[:gr" */
+		case S73: /* e.g. "[:blan" */
 			switch ((unsigned char) c) {
-			case 'a': state = S72; continue;
+			case 'k': state = S74; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S72: /* e.g. "[:gra" */
-			switch ((unsigned char) c) {
-			case 'p': state = S73; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S73: /* e.g. "[:grap" */
-			switch ((unsigned char) c) {
-			case 'h': state = S74; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S74: /* e.g. "[:graph" */
+		case S74: /* e.g. "[:blank" */
 			switch ((unsigned char) c) {
 			case ':': state = S75; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S75: /* e.g. "[:graph:" */
+		case S75: /* e.g. "[:blank:" */
 			switch ((unsigned char) c) {
 			case ']': state = S76; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S76: /* e.g. "[:graph:]" */
-			lx_native_ungetc(lx, c); return TOK_CLASS_GRAPH;
+		case S76: /* e.g. "[:blank:]" */
+			lx_native_ungetc(lx, c); return TOK_CLASS_BLANK;
 
 		case S77: /* e.g. "[:pr" */
 			switch ((unsigned char) c) {
-			case 'i': state = S81; continue;
+			case 'i': state = S84; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
@@ -1069,51 +1072,51 @@ z1(struct lx_native_lx *lx)
 
 		case S80: /* e.g. "[:punc" */
 			switch ((unsigned char) c) {
+			case 't': state = S81; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S81: /* e.g. "[:punct" */
+			switch ((unsigned char) c) {
+			case ':': state = S82; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S82: /* e.g. "[:punct:" */
+			switch ((unsigned char) c) {
+			case ']': state = S83; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S83: /* e.g. "[:punct:]" */
+			lx_native_ungetc(lx, c); return TOK_CLASS_PUNCT;
+
+		case S84: /* e.g. "[:pri" */
+			switch ((unsigned char) c) {
+			case 'n': state = S85; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S85: /* e.g. "[:prin" */
+			switch ((unsigned char) c) {
 			case 't': state = S86; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S81: /* e.g. "[:pri" */
-			switch ((unsigned char) c) {
-			case 'n': state = S82; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S82: /* e.g. "[:prin" */
-			switch ((unsigned char) c) {
-			case 't': state = S83; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S83: /* e.g. "[:print" */
-			switch ((unsigned char) c) {
-			case ':': state = S84; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S84: /* e.g. "[:print:" */
-			switch ((unsigned char) c) {
-			case ']': state = S85; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S85: /* e.g. "[:print:]" */
-			lx_native_ungetc(lx, c); return TOK_CLASS_PRINT;
-
-		case S86: /* e.g. "[:punct" */
+		case S86: /* e.g. "[:print" */
 			switch ((unsigned char) c) {
 			case ':': state = S87; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S87: /* e.g. "[:punct:" */
+		case S87: /* e.g. "[:print:" */
 			switch ((unsigned char) c) {
 			case ']': state = S88; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S88: /* e.g. "[:punct:]" */
-			lx_native_ungetc(lx, c); return TOK_CLASS_PUNCT;
+		case S88: /* e.g. "[:print:]" */
+			lx_native_ungetc(lx, c); return TOK_CLASS_PRINT;
 
 		case S89: /* e.g. "[:al" */
 			switch ((unsigned char) c) {
@@ -1157,48 +1160,48 @@ z1(struct lx_native_lx *lx)
 
 		case S96: /* e.g. "[:aln" */
 			switch ((unsigned char) c) {
-			case 'u': state = S98; continue;
+			case 'u': state = S102; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
 		case S97: /* e.g. "[:alp" */
 			switch ((unsigned char) c) {
-			case 'h': state = S100; continue;
+			case 'h': state = S98; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S98: /* e.g. "[:alnu" */
+		case S98: /* e.g. "[:alph" */
 			switch ((unsigned char) c) {
-			case 'm': state = S99; continue;
+			case 'a': state = S99; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S99: /* e.g. "[:alnum" */
+		case S99: /* e.g. "[:alpha" */
+			switch ((unsigned char) c) {
+			case ':': state = S100; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S100: /* e.g. "[:alpha:" */
+			switch ((unsigned char) c) {
+			case ']': state = S101; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S101: /* e.g. "[:alpha:]" */
+			lx_native_ungetc(lx, c); return TOK_CLASS_ALPHA;
+
+		case S102: /* e.g. "[:alnu" */
+			switch ((unsigned char) c) {
+			case 'm': state = S103; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S103: /* e.g. "[:alnum" */
 			switch ((unsigned char) c) {
 			case ':': state = S104; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
-
-		case S100: /* e.g. "[:alph" */
-			switch ((unsigned char) c) {
-			case 'a': state = S101; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S101: /* e.g. "[:alpha" */
-			switch ((unsigned char) c) {
-			case ':': state = S102; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S102: /* e.g. "[:alpha:" */
-			switch ((unsigned char) c) {
-			case ']': state = S103; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S103: /* e.g. "[:alpha:]" */
-			lx_native_ungetc(lx, c); return TOK_CLASS_ALPHA;
 
 		case S104: /* e.g. "[:alnum:" */
 			switch ((unsigned char) c) {
@@ -1223,19 +1226,19 @@ z1(struct lx_native_lx *lx)
 	case S7: return TOK_ESC;
 	case S8: return TOK_OCT;
 	case S10: return TOK_HEX;
-	case S33: return TOK_CLASS_WORD;
-	case S37: return TOK_CLASS_DIGIT;
-	case S43: return TOK_CLASS_UPPER;
-	case S53: return TOK_CLASS_BLANK;
-	case S55: return TOK_CLASS_SPACE;
-	case S62: return TOK_CLASS_LOWER;
-	case S64: return TOK_CLASS_XDIGIT;
-	case S70: return TOK_CLASS_CNTRL;
-	case S76: return TOK_CLASS_GRAPH;
-	case S85: return TOK_CLASS_PRINT;
-	case S88: return TOK_CLASS_PUNCT;
+	case S32: return TOK_CLASS_SPACE;
+	case S41: return TOK_CLASS_XDIGIT;
+	case S47: return TOK_CLASS_LOWER;
+	case S52: return TOK_CLASS_GRAPH;
+	case S62: return TOK_CLASS_WORD;
+	case S66: return TOK_CLASS_UPPER;
+	case S67: return TOK_CLASS_DIGIT;
+	case S72: return TOK_CLASS_CNTRL;
+	case S76: return TOK_CLASS_BLANK;
+	case S83: return TOK_CLASS_PUNCT;
+	case S88: return TOK_CLASS_PRINT;
 	case S95: return TOK_CLASS_ASCII;
-	case S103: return TOK_CLASS_ALPHA;
+	case S101: return TOK_CLASS_ALPHA;
 	case S105: return TOK_CLASS_ALNUM;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
@@ -1614,38 +1617,11 @@ z2(struct lx_native_lx *lx)
 			case '4':
 			case '5':
 			case '6':
-			case '7': state = S19; continue;
+			case '7': state = S17; continue;
 			default:  lx_native_ungetc(lx, c); return TOK_OCT;
 			}
 
 		case S16: /* e.g. "\\x" */
-			switch ((unsigned char) c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9': state = S17; continue;
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F': state = S17; continue;
-			case 'a':
-			case 'b':
-			case 'c':
-			case 'd':
-			case 'e':
-			case 'f': state = S17; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S17: /* e.g. "\\xa" */
 			switch ((unsigned char) c) {
 			case '0':
 			case '1':
@@ -1672,10 +1648,7 @@ z2(struct lx_native_lx *lx)
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S18: /* e.g. "\\xaa" */
-			lx_native_ungetc(lx, c); return TOK_HEX;
-
-		case S19: /* e.g. "\\00" */
+		case S17: /* e.g. "\\00" */
 			switch ((unsigned char) c) {
 			case '0':
 			case '1':
@@ -1687,6 +1660,36 @@ z2(struct lx_native_lx *lx)
 			case '7': state = S20; continue;
 			default:  lx_native_ungetc(lx, c); return TOK_OCT;
 			}
+
+		case S18: /* e.g. "\\xa" */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9': state = S19; continue;
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F': state = S19; continue;
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f': state = S19; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S19: /* e.g. "\\xaa" */
+			lx_native_ungetc(lx, c); return TOK_HEX;
 
 		case S20: /* e.g. "\\000" */
 			lx_native_ungetc(lx, c); return TOK_OCT;
@@ -1712,8 +1715,8 @@ z2(struct lx_native_lx *lx)
 	case S13: return TOK_ALT;
 	case S14: return TOK_ESC;
 	case S15: return TOK_OCT;
-	case S18: return TOK_HEX;
-	case S19: return TOK_OCT;
+	case S17: return TOK_OCT;
+	case S19: return TOK_HEX;
 	case S20: return TOK_OCT;
 	default: errno = EINVAL; return TOK_ERROR;
 	}

--- a/src/libre/dialect/pcre/lexer.c
+++ b/src/libre/dialect/pcre/lexer.c
@@ -2,6 +2,7 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <stddef.h>
 #include <stdlib.h>
 #include <errno.h>
 
@@ -80,6 +81,7 @@ lx_pcre_dynpush(struct lx_pcre_lx *lx, char c)
 
 	if (t->p == t->a + t->len) {
 		size_t len;
+		ptrdiff_t off;
 		char *tmp;
 
 		if (t->len == 0) {
@@ -93,12 +95,13 @@ lx_pcre_dynpush(struct lx_pcre_lx *lx, char c)
 			}
 		}
 
+		off = t->p - t->a;
 		tmp = realloc(t->a, len);
 		if (tmp == NULL) {
 			return -1;
 		}
 
-		t->p   = tmp + (t->p - t->a);
+		t->p   = tmp + off;
 		t->a   = tmp;
 		t->len = len;
 	}

--- a/src/libre/dialect/sql/lexer.c
+++ b/src/libre/dialect/sql/lexer.c
@@ -2,6 +2,7 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <stddef.h>
 #include <stdlib.h>
 #include <errno.h>
 
@@ -78,6 +79,7 @@ lx_sql_dynpush(struct lx_sql_lx *lx, char c)
 
 	if (t->p == t->a + t->len) {
 		size_t len;
+		ptrdiff_t off;
 		char *tmp;
 
 		if (t->len == 0) {
@@ -91,12 +93,13 @@ lx_sql_dynpush(struct lx_sql_lx *lx, char c)
 			}
 		}
 
+		off = t->p - t->a;
 		tmp = realloc(t->a, len);
 		if (tmp == NULL) {
 			return -1;
 		}
 
-		t->p   = tmp + (t->p - t->a);
+		t->p   = tmp + off;
 		t->a   = tmp;
 		t->len = len;
 	}
@@ -507,228 +510,228 @@ z0(struct lx_sql_lx *lx)
 
 		case S8: /* e.g. "[:D" */
 			switch ((unsigned char) c) {
-			case 'I': state = S32; continue;
+			case 'I': state = S14; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
 		case S9: /* e.g. "[:L" */
 			switch ((unsigned char) c) {
-			case 'O': state = S17; continue;
+			case 'O': state = S16; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
 		case S10: /* e.g. "[:S" */
 			switch ((unsigned char) c) {
-			case 'P': state = S23; continue;
+			case 'P': state = S27; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
 		case S11: /* e.g. "[:U" */
 			switch ((unsigned char) c) {
-			case 'P': state = S13; continue;
+			case 'P': state = S15; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
 		case S12: /* e.g. "[:W" */
 			switch ((unsigned char) c) {
-			case 'H': state = S28; continue;
+			case 'H': state = S13; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S13: /* e.g. "[:UP" */
+		case S13: /* e.g. "[:WH" */
 			switch ((unsigned char) c) {
-			case 'P': state = S14; continue;
+			case 'I': state = S18; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S14: /* e.g. "[:UPP" */
+		case S14: /* e.g. "[:DI" */
 			switch ((unsigned char) c) {
-			case 'E': state = S15; continue;
+			case 'G': state = S17; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S15: /* e.g. "[:UPPE" */
+		case S15: /* e.g. "[:UP" */
 			switch ((unsigned char) c) {
-			case 'R': state = S16; continue;
+			case 'P': state = S37; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S16: /* e.g. "[:UPPER" */
+		case S16: /* e.g. "[:LO" */
 			switch ((unsigned char) c) {
-			case ':': state = S30; continue;
+			case 'W': state = S20; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S17: /* e.g. "[:LO" */
+		case S17: /* e.g. "[:DIG" */
 			switch ((unsigned char) c) {
-			case 'W': state = S18; continue;
+			case 'I': state = S33; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S18: /* e.g. "[:LOW" */
+		case S18: /* e.g. "[:WHI" */
 			switch ((unsigned char) c) {
-			case 'E': state = S19; continue;
+			case 'T': state = S19; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S19: /* e.g. "[:LOWE" */
+		case S19: /* e.g. "[:WHIT" */
 			switch ((unsigned char) c) {
-			case 'R': state = S20; continue;
+			case 'E': state = S22; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S20: /* e.g. "[:LOWER" */
+		case S20: /* e.g. "[:LOW" */
 			switch ((unsigned char) c) {
-			case ':': state = S21; continue;
+			case 'E': state = S21; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S21: /* e.g. "[:LOWER:" */
+		case S21: /* e.g. "[:LOWE" */
 			switch ((unsigned char) c) {
-			case ']': state = S22; continue;
+			case 'R': state = S45; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S22: /* e.g. "[:LOWER:]" */
-			lx_sql_ungetc(lx, c); return TOK_CLASS_LOWER;
-
-		case S23: /* e.g. "[:SP" */
+		case S22: /* e.g. "[:WHITE" */
 			switch ((unsigned char) c) {
-			case 'A': state = S24; continue;
+			case 'S': state = S23; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S24: /* e.g. "[:SPA" */
+		case S23: /* e.g. "[:WHITES" */
 			switch ((unsigned char) c) {
-			case 'C': state = S25; continue;
+			case 'P': state = S24; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S25: /* e.g. "[:SPAC" */
+		case S24: /* e.g. "[:WHITESP" */
 			switch ((unsigned char) c) {
-			case 'E': state = S26; continue;
+			case 'A': state = S25; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S26: /* e.g. "[:SPACE" */
+		case S25: /* e.g. "[:WHITESPA" */
 			switch ((unsigned char) c) {
-			case ':': state = S27; continue;
+			case 'C': state = S26; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S27: /* e.g. "[:SPACE:" */
+		case S26: /* e.g. "[:WHITESPAC" */
+			switch ((unsigned char) c) {
+			case 'E': state = S34; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S27: /* e.g. "[:SP" */
+			switch ((unsigned char) c) {
+			case 'A': state = S28; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S28: /* e.g. "[:SPA" */
+			switch ((unsigned char) c) {
+			case 'C': state = S29; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S29: /* e.g. "[:SPAC" */
+			switch ((unsigned char) c) {
+			case 'E': state = S30; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S30: /* e.g. "[:SPACE" */
+			switch ((unsigned char) c) {
+			case ':': state = S31; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S31: /* e.g. "[:SPACE:" */
+			switch ((unsigned char) c) {
+			case ']': state = S32; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S32: /* e.g. "[:SPACE:]" */
+			lx_sql_ungetc(lx, c); return TOK_CLASS_SPCHR;
+
+		case S33: /* e.g. "[:DIGI" */
+			switch ((unsigned char) c) {
+			case 'T': state = S42; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S34: /* e.g. "[:WHITESPACE" */
+			switch ((unsigned char) c) {
+			case ':': state = S35; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S35: /* e.g. "[:WHITESPACE:" */
+			switch ((unsigned char) c) {
+			case ']': state = S36; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S36: /* e.g. "[:WHITESPACE:]" */
+			lx_sql_ungetc(lx, c); return TOK_CLASS_SPACE;
+
+		case S37: /* e.g. "[:UPP" */
+			switch ((unsigned char) c) {
+			case 'E': state = S38; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S38: /* e.g. "[:UPPE" */
+			switch ((unsigned char) c) {
+			case 'R': state = S39; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S39: /* e.g. "[:UPPER" */
+			switch ((unsigned char) c) {
+			case ':': state = S40; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S40: /* e.g. "[:UPPER:" */
+			switch ((unsigned char) c) {
+			case ']': state = S41; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S41: /* e.g. "[:UPPER:]" */
+			lx_sql_ungetc(lx, c); return TOK_CLASS_UPPER;
+
+		case S42: /* e.g. "[:DIGIT" */
+			switch ((unsigned char) c) {
+			case ':': state = S43; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S43: /* e.g. "[:DIGIT:" */
+			switch ((unsigned char) c) {
+			case ']': state = S44; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S44: /* e.g. "[:DIGIT:]" */
+			lx_sql_ungetc(lx, c); return TOK_CLASS_DIGIT;
+
+		case S45: /* e.g. "[:LOWER" */
+			switch ((unsigned char) c) {
+			case ':': state = S46; continue;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+
+		case S46: /* e.g. "[:LOWER:" */
 			switch ((unsigned char) c) {
 			case ']': state = S47; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S28: /* e.g. "[:WH" */
-			switch ((unsigned char) c) {
-			case 'I': state = S29; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S29: /* e.g. "[:WHI" */
-			switch ((unsigned char) c) {
-			case 'T': state = S38; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S30: /* e.g. "[:UPPER:" */
-			switch ((unsigned char) c) {
-			case ']': state = S31; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S31: /* e.g. "[:UPPER:]" */
-			lx_sql_ungetc(lx, c); return TOK_CLASS_UPPER;
-
-		case S32: /* e.g. "[:DI" */
-			switch ((unsigned char) c) {
-			case 'G': state = S33; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S33: /* e.g. "[:DIG" */
-			switch ((unsigned char) c) {
-			case 'I': state = S34; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S34: /* e.g. "[:DIGI" */
-			switch ((unsigned char) c) {
-			case 'T': state = S35; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S35: /* e.g. "[:DIGIT" */
-			switch ((unsigned char) c) {
-			case ':': state = S36; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S36: /* e.g. "[:DIGIT:" */
-			switch ((unsigned char) c) {
-			case ']': state = S37; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S37: /* e.g. "[:DIGIT:]" */
-			lx_sql_ungetc(lx, c); return TOK_CLASS_DIGIT;
-
-		case S38: /* e.g. "[:WHIT" */
-			switch ((unsigned char) c) {
-			case 'E': state = S39; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S39: /* e.g. "[:WHITE" */
-			switch ((unsigned char) c) {
-			case 'S': state = S40; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S40: /* e.g. "[:WHITES" */
-			switch ((unsigned char) c) {
-			case 'P': state = S41; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S41: /* e.g. "[:WHITESP" */
-			switch ((unsigned char) c) {
-			case 'A': state = S42; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S42: /* e.g. "[:WHITESPA" */
-			switch ((unsigned char) c) {
-			case 'C': state = S43; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S43: /* e.g. "[:WHITESPAC" */
-			switch ((unsigned char) c) {
-			case 'E': state = S44; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S44: /* e.g. "[:WHITESPACE" */
-			switch ((unsigned char) c) {
-			case ':': state = S45; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S45: /* e.g. "[:WHITESPACE:" */
-			switch ((unsigned char) c) {
-			case ']': state = S46; continue;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-
-		case S46: /* e.g. "[:WHITESPACE:]" */
-			lx_sql_ungetc(lx, c); return TOK_CLASS_SPACE;
-
-		case S47: /* e.g. "[:SPACE:]" */
-			lx_sql_ungetc(lx, c); return TOK_CLASS_SPCHR;
+		case S47: /* e.g. "[:LOWER:]" */
+			lx_sql_ungetc(lx, c); return TOK_CLASS_LOWER;
 
 		case S48: /* e.g. "[:AL" */
 			switch ((unsigned char) c) {
@@ -739,57 +742,57 @@ z0(struct lx_sql_lx *lx)
 
 		case S49: /* e.g. "[:ALN" */
 			switch ((unsigned char) c) {
-			case 'U': state = S51; continue;
+			case 'U': state = S55; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
 		case S50: /* e.g. "[:ALP" */
 			switch ((unsigned char) c) {
-			case 'H': state = S55; continue;
+			case 'H': state = S51; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S51: /* e.g. "[:ALNU" */
+		case S51: /* e.g. "[:ALPH" */
 			switch ((unsigned char) c) {
-			case 'M': state = S52; continue;
+			case 'A': state = S52; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S52: /* e.g. "[:ALNUM" */
+		case S52: /* e.g. "[:ALPHA" */
 			switch ((unsigned char) c) {
 			case ':': state = S53; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S53: /* e.g. "[:ALNUM:" */
+		case S53: /* e.g. "[:ALPHA:" */
 			switch ((unsigned char) c) {
 			case ']': state = S54; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S54: /* e.g. "[:ALNUM:]" */
-			lx_sql_ungetc(lx, c); return TOK_CLASS_ALNUM;
+		case S54: /* e.g. "[:ALPHA:]" */
+			lx_sql_ungetc(lx, c); return TOK_CLASS_ALPHA;
 
-		case S55: /* e.g. "[:ALPH" */
+		case S55: /* e.g. "[:ALNU" */
 			switch ((unsigned char) c) {
-			case 'A': state = S56; continue;
+			case 'M': state = S56; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S56: /* e.g. "[:ALPHA" */
+		case S56: /* e.g. "[:ALNUM" */
 			switch ((unsigned char) c) {
 			case ':': state = S57; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S57: /* e.g. "[:ALPHA:" */
+		case S57: /* e.g. "[:ALNUM:" */
 			switch ((unsigned char) c) {
 			case ']': state = S58; continue;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 
-		case S58: /* e.g. "[:ALPHA:]" */
-			lx_sql_ungetc(lx, c); return TOK_CLASS_ALPHA;
+		case S58: /* e.g. "[:ALNUM:]" */
+			lx_sql_ungetc(lx, c); return TOK_CLASS_ALNUM;
 		}
 	}
 
@@ -802,13 +805,13 @@ z0(struct lx_sql_lx *lx)
 	case S3: return TOK_CHAR;
 	case S4: return TOK_CLOSEGROUP;
 	case S5: return TOK_INVERT;
-	case S22: return TOK_CLASS_LOWER;
-	case S31: return TOK_CLASS_UPPER;
-	case S37: return TOK_CLASS_DIGIT;
-	case S46: return TOK_CLASS_SPACE;
-	case S47: return TOK_CLASS_SPCHR;
-	case S54: return TOK_CLASS_ALNUM;
-	case S58: return TOK_CLASS_ALPHA;
+	case S32: return TOK_CLASS_SPCHR;
+	case S36: return TOK_CLASS_SPACE;
+	case S41: return TOK_CLASS_UPPER;
+	case S44: return TOK_CLASS_DIGIT;
+	case S47: return TOK_CLASS_LOWER;
+	case S54: return TOK_CLASS_ALPHA;
+	case S58: return TOK_CLASS_ALNUM;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
 }

--- a/src/lx/lexer.c
+++ b/src/lx/lexer.c
@@ -2,6 +2,7 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <stddef.h>
 #include <stdlib.h>
 #include <errno.h>
 
@@ -90,6 +91,7 @@ lx_dynpush(struct lx *lx, char c)
 
 	if (t->p == t->a + t->len) {
 		size_t len;
+		ptrdiff_t off;
 		char *tmp;
 
 		if (t->len == 0) {
@@ -103,12 +105,13 @@ lx_dynpush(struct lx *lx, char c)
 			}
 		}
 
+		off = t->p - t->a;
 		tmp = realloc(t->a, len);
 		if (tmp == NULL) {
 			return -1;
 		}
 
-		t->p   = tmp + (t->p - t->a);
+		t->p   = tmp + off;
 		t->a   = tmp;
 		t->len = len;
 	}

--- a/src/lx/out/c.c
+++ b/src/lx/out/c.c
@@ -543,6 +543,7 @@ out_buf(FILE *f)
 		fprintf(f, "\n");
 		fprintf(f, "\tif (t->p == t->a + t->len) {\n");
 		fprintf(f, "\t\tsize_t len;\n");
+		fprintf(f, "\t\tptrdiff_t off;\n");
 		fprintf(f, "\t\tchar *tmp;\n");
 		fprintf(f, "\n");
 		fprintf(f, "\t\tif (t->len == 0) {\n");
@@ -556,12 +557,13 @@ out_buf(FILE *f)
 		fprintf(f, "\t\t\t}\n");
 		fprintf(f, "\t\t}\n");
 		fprintf(f, "\n");
+		fprintf(f, "\t\toff = t->p - t->a;\n");
 		fprintf(f, "\t\ttmp = realloc(t->a, len);\n");
 		fprintf(f, "\t\tif (tmp == NULL) {\n");
 		fprintf(f, "\t\t\treturn -1;\n");
 		fprintf(f, "\t\t}\n");
 		fprintf(f, "\n");
-		fprintf(f, "\t\tt->p   = tmp + (t->p - t->a);\n");
+		fprintf(f, "\t\tt->p   = tmp + off;\n");
 		fprintf(f, "\t\tt->a   = tmp;\n");
 		fprintf(f, "\t\tt->len = len;\n");
 		fprintf(f, "\t}\n");
@@ -1063,6 +1065,7 @@ lx_out_c(const struct ast *ast, FILE *f)
 	fprintf(f, "#include <assert.h>\n");
 	fprintf(f, "#include <stdio.h>\n");
 	if (api_tokbuf & API_DYNBUF) {
+		fprintf(f, "#include <stddef.h>\n");
 		fprintf(f, "#include <stdlib.h>\n");
 	}
 	fprintf(f, "#include <errno.h>\n");


### PR DESCRIPTION
In lx lexers that have a dynpush buffer, the code to increase the buffer
size would first realloc() and then determine the position in the new
buffer using pointer subtraction of the old pointer values.  This is
undefined behavior if realloc() returns a new value for the pointer,
because the old values will become indeterminate.  This patch moves the
subtraction to before the realloc() and updates the files generated by
lx