### PR TITLE
Fix bug caused by unintended sign extension.

### DIFF
--- a/src/libfsm/exec.c
+++ b/src/libfsm/exec.c
@@ -18,7 +18,7 @@
 #include "internal.h"
 
 static struct fsm_state *
-nextstate(const struct fsm_state *state, char c)
+nextstate(const struct fsm_state *state, int c)
 {
 	struct fsm_edge *e;
 


### PR DESCRIPTION
The callback passed to `fsm_exec` returns int, to allow for EOF, but
the code paths that handled the result were inconsistent with the
sign of that value after checking it for EOF. In particular, characters
>= 0x80 could be sign-extended to 0xffffff80 between
`state = nextstate(state, c)` and `nextstate`'s call to
`fsm_hasedge`, which would lead to state match failures in an otherwise
correctly constructed FSM.

(theft found this bug.)

Note: I haven't been able to run the tests, they seem to depend on sid,
and I'm not sure this hasn't broken something else. In particular,
it may break handling of epsilon, which is defined as the max unsigned
char + 1.