### PR TITLE
Remove generated buffer pop

### DIFF
--- a/src/fsm/lexer.h
+++ b/src/fsm/lexer.h
@@ -42,7 +42,6 @@ struct lx {
 
 	void *buf;
 	int  (*push) (struct lx *lx, char c);
-	void (*pop)  (struct lx *lx);
 	int  (*clear)(struct lx *lx);
 	void (*free) (struct lx *lx);
 
@@ -94,7 +93,6 @@ enum lx_token lx_next(struct lx *lx);
 int lx_fgetc(struct lx *lx);
 
 int  lx_dynpush(struct lx *lx, char c);
-void lx_dynpop(struct lx *lx);
 int  lx_dynclear(struct lx *lx);
 void lx_dynfree(struct lx *lx);
 

--- a/src/fsm/parser.act
+++ b/src/fsm/parser.act
@@ -339,7 +339,6 @@
 
 		lx->buf   = &lex_state->buf;
 		lx->push  = lx_dynpush;
-		lx->pop   = lx_dynpop;
 		lx->clear = lx_dynclear;
 		lx->free  = lx_dynfree;
 

--- a/src/fsm/parser.c
+++ b/src/fsm/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 87 "src/fsm/parser.act"
+#line 93 "src/fsm/parser.act"
 
 
 	#include <assert.h>
@@ -117,7 +117,7 @@ p_label(fsm fsm, lex_state lex_state, act_state act_state, char *ZOc)
 				{
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
-#line 176 "src/fsm/parser.act"
+#line 182 "src/fsm/parser.act"
 
 		assert(lex_state->buf.a[0] != '\0');
 		assert(lex_state->buf.a[1] == '\0');
@@ -134,7 +134,7 @@ p_label(fsm fsm, lex_state lex_state, act_state act_state, char *ZOc)
 				{
 					/* BEGINNING OF EXTRACT: ESC */
 					{
-#line 104 "src/fsm/parser.act"
+#line 110 "src/fsm/parser.act"
 
 		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
 		assert(2 == strlen(lex_state->buf.a));
@@ -162,7 +162,7 @@ p_label(fsm fsm, lex_state lex_state, act_state act_state, char *ZOc)
 				{
 					/* BEGINNING OF EXTRACT: HEX */
 					{
-#line 169 "src/fsm/parser.act"
+#line 175 "src/fsm/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -199,7 +199,7 @@ p_label(fsm fsm, lex_state lex_state, act_state act_state, char *ZOc)
 				{
 					/* BEGINNING OF EXTRACT: OCT */
 					{
-#line 142 "src/fsm/parser.act"
+#line 148 "src/fsm/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -301,7 +301,7 @@ p_edges_C_Cedge(fsm fsm, lex_state lex_state, act_state act_state)
 				case (TOK_IDENT):
 					/* BEGINNING OF EXTRACT: IDENT */
 					{
-#line 180 "src/fsm/parser.act"
+#line 186 "src/fsm/parser.act"
 
 		ZIa = xstrdup(lex_state->buf.a);
 		if (ZIa == NULL) {
@@ -334,7 +334,7 @@ p_edges_C_Cedge(fsm fsm, lex_state lex_state, act_state act_state)
 				case (TOK_IDENT):
 					/* BEGINNING OF EXTRACT: IDENT */
 					{
-#line 180 "src/fsm/parser.act"
+#line 186 "src/fsm/parser.act"
 
 		ZIb = xstrdup(lex_state->buf.a);
 		if (ZIb == NULL) {
@@ -355,7 +355,7 @@ p_edges_C_Cedge(fsm fsm, lex_state lex_state, act_state act_state)
 		/* END OF INLINE: id */
 		/* BEGINNING OF ACTION: add-state */
 		{
-#line 192 "src/fsm/parser.act"
+#line 198 "src/fsm/parser.act"
 
 		struct act_statelist *p;
 
@@ -403,7 +403,7 @@ p_edges_C_Cedge(fsm fsm, lex_state lex_state, act_state act_state)
 		/* END OF ACTION: add-state */
 		/* BEGINNING OF ACTION: add-state */
 		{
-#line 192 "src/fsm/parser.act"
+#line 198 "src/fsm/parser.act"
 
 		struct act_statelist *p;
 
@@ -451,7 +451,7 @@ p_edges_C_Cedge(fsm fsm, lex_state lex_state, act_state act_state)
 		/* END OF ACTION: add-state */
 		/* BEGINNING OF ACTION: free */
 		{
-#line 245 "src/fsm/parser.act"
+#line 251 "src/fsm/parser.act"
 
 		free((ZIa));
 	
@@ -460,7 +460,7 @@ p_edges_C_Cedge(fsm fsm, lex_state lex_state, act_state act_state)
 		/* END OF ACTION: free */
 		/* BEGINNING OF ACTION: free */
 		{
-#line 245 "src/fsm/parser.act"
+#line 251 "src/fsm/parser.act"
 
 		free((ZIb));
 	
@@ -475,7 +475,7 @@ p_edges_C_Cedge(fsm fsm, lex_state lex_state, act_state act_state)
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: add-edge-any */
 					{
-#line 270 "src/fsm/parser.act"
+#line 276 "src/fsm/parser.act"
 
 		if (!fsm_addedge_any(fsm, (ZIx), (ZIy))) {
 			perror("fsm_addedge_any");
@@ -498,7 +498,7 @@ p_edges_C_Cedge(fsm fsm, lex_state lex_state, act_state act_state)
 					}
 					/* BEGINNING OF ACTION: add-edge-literal */
 					{
-#line 263 "src/fsm/parser.act"
+#line 269 "src/fsm/parser.act"
 
 		if (!fsm_addedge_literal(fsm, (ZIx), (ZIy), (ZIc))) {
 			perror("fsm_addedge_literal");
@@ -514,7 +514,7 @@ p_edges_C_Cedge(fsm fsm, lex_state lex_state, act_state act_state)
 				{
 					/* BEGINNING OF ACTION: add-edge-epsilon */
 					{
-#line 277 "src/fsm/parser.act"
+#line 283 "src/fsm/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (ZIy))) {
 			perror("fsm_addedge_epsilon");
@@ -532,7 +532,7 @@ p_edges_C_Cedge(fsm fsm, lex_state lex_state, act_state act_state)
 			{
 				/* BEGINNING OF ACTION: err-expected-trans */
 				{
-#line 290 "src/fsm/parser.act"
+#line 296 "src/fsm/parser.act"
 
 		err_expected(lex_state, "transition");
 	
@@ -580,7 +580,7 @@ p_xstart(fsm fsm, lex_state lex_state, act_state act_state)
 				{
 					/* BEGINNING OF ACTION: err-expected-start */
 					{
-#line 298 "src/fsm/parser.act"
+#line 304 "src/fsm/parser.act"
 
 		err_expected(lex_state, "'start:'");
 	
@@ -598,7 +598,7 @@ p_xstart(fsm fsm, lex_state lex_state, act_state act_state)
 					case (TOK_IDENT):
 						/* BEGINNING OF EXTRACT: IDENT */
 						{
-#line 180 "src/fsm/parser.act"
+#line 186 "src/fsm/parser.act"
 
 		ZIn = xstrdup(lex_state->buf.a);
 		if (ZIn == NULL) {
@@ -624,7 +624,7 @@ p_xstart(fsm fsm, lex_state lex_state, act_state act_state)
 			}
 			/* BEGINNING OF ACTION: add-state */
 			{
-#line 192 "src/fsm/parser.act"
+#line 198 "src/fsm/parser.act"
 
 		struct act_statelist *p;
 
@@ -672,7 +672,7 @@ p_xstart(fsm fsm, lex_state lex_state, act_state act_state)
 			/* END OF ACTION: add-state */
 			/* BEGINNING OF ACTION: mark-start */
 			{
-#line 233 "src/fsm/parser.act"
+#line 239 "src/fsm/parser.act"
 
 		assert((ZIs) != NULL);
 
@@ -683,7 +683,7 @@ p_xstart(fsm fsm, lex_state lex_state, act_state act_state)
 			/* END OF ACTION: mark-start */
 			/* BEGINNING OF ACTION: free */
 			{
-#line 245 "src/fsm/parser.act"
+#line 251 "src/fsm/parser.act"
 
 		free((ZIn));
 	
@@ -725,7 +725,7 @@ p_xend(fsm fsm, lex_state lex_state, act_state act_state)
 				{
 					/* BEGINNING OF ACTION: err-expected-end */
 					{
-#line 302 "src/fsm/parser.act"
+#line 308 "src/fsm/parser.act"
 
 		err_expected(lex_state, "'end:'");
 	
@@ -775,7 +775,7 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-sep */
 		{
-#line 286 "src/fsm/parser.act"
+#line 292 "src/fsm/parser.act"
 
 		err_expected(lex_state, "';'");
 	
@@ -807,7 +807,7 @@ p_fsm(fsm fsm, lex_state lex_state, act_state act_state)
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: free-statelist */
 		{
-#line 260 "src/fsm/parser.act"
+#line 266 "src/fsm/parser.act"
 
 		struct act_statelist *p;
 		struct act_statelist *next;
@@ -830,7 +830,7 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-syntax */
 		{
-#line 307 "src/fsm/parser.act"
+#line 313 "src/fsm/parser.act"
 
 		err(lex_state, "Syntax error");
 		exit(EXIT_FAILURE);
@@ -871,7 +871,7 @@ ZL2_xend_C_Cend_Hids:;
 						{
 							/* BEGINNING OF ACTION: err-expected-comma */
 							{
-#line 294 "src/fsm/parser.act"
+#line 300 "src/fsm/parser.act"
 
 		err_expected(lex_state, "','");
 	
@@ -919,7 +919,7 @@ p_xend_C_Cend_Hid(fsm fsm, lex_state lex_state, act_state act_state)
 				case (TOK_IDENT):
 					/* BEGINNING OF EXTRACT: IDENT */
 					{
-#line 180 "src/fsm/parser.act"
+#line 186 "src/fsm/parser.act"
 
 		ZIn = xstrdup(lex_state->buf.a);
 		if (ZIn == NULL) {
@@ -940,7 +940,7 @@ p_xend_C_Cend_Hid(fsm fsm, lex_state lex_state, act_state act_state)
 		/* END OF INLINE: id */
 		/* BEGINNING OF ACTION: add-state */
 		{
-#line 192 "src/fsm/parser.act"
+#line 198 "src/fsm/parser.act"
 
 		struct act_statelist *p;
 
@@ -988,7 +988,7 @@ p_xend_C_Cend_Hid(fsm fsm, lex_state lex_state, act_state act_state)
 		/* END OF ACTION: add-state */
 		/* BEGINNING OF ACTION: mark-end */
 		{
-#line 239 "src/fsm/parser.act"
+#line 245 "src/fsm/parser.act"
 
 		assert((ZIs) != NULL);
 
@@ -999,7 +999,7 @@ p_xend_C_Cend_Hid(fsm fsm, lex_state lex_state, act_state act_state)
 		/* END OF ACTION: mark-end */
 		/* BEGINNING OF ACTION: free */
 		{
-#line 245 "src/fsm/parser.act"
+#line 251 "src/fsm/parser.act"
 
 		free((ZIn));
 	
@@ -1015,7 +1015,7 @@ ZL1:;
 
 /* BEGINNING OF TRAILER */
 
-#line 360 "src/fsm/parser.act"
+#line 365 "src/fsm/parser.act"
 
 
 	struct fsm *fsm_parse(FILE *f, const struct fsm_options *opt) {
@@ -1043,7 +1043,6 @@ ZL1:;
 
 		lx->buf   = &lex_state->buf;
 		lx->push  = lx_dynpush;
-		lx->pop   = lx_dynpop;
 		lx->clear = lx_dynclear;
 		lx->free  = lx_dynfree;
 
@@ -1067,6 +1066,6 @@ ZL1:;
 		return new;
 	}
 
-#line 1071 "src/fsm/parser.c"
+#line 1070 "src/fsm/parser.c"
 
 /* END OF FILE */

--- a/src/fsm/parser.h
+++ b/src/fsm/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 96 "src/fsm/parser.act"
+#line 102 "src/fsm/parser.act"
 
 
 	typedef struct lex_state * lex_state;
@@ -26,7 +26,7 @@
 extern void p_fsm(fsm, lex_state, act_state);
 /* BEGINNING OF TRAILER */
 
-#line 361 "src/fsm/parser.act"
+#line 366 "src/fsm/parser.act"
 
 #line 32 "src/fsm/parser.h"
 

--- a/src/libfsm/out/c.c
+++ b/src/libfsm/out/c.c
@@ -194,7 +194,7 @@ singlecase(FILE *f, const struct fsm *fsm,
 			if (mode.state != state) {
 				fprintf(f, "state = S%u; ", indexof(fsm, mode.state));
 			}
-			fprintf(f, "continue;\n");
+			fprintf(f, "break;\n");
 			return;
 		}
 	}
@@ -269,7 +269,7 @@ singlecase(FILE *f, const struct fsm *fsm,
 			if (s != state) {
 				fprintf(f, " state = S%u;", indexof(fsm, s));
 			}
-			fprintf(f, " continue;\n");
+			fprintf(f, " break;\n");
 
 			/* TODO: if greedy, and fsm_isend(fsm, state->edges[i].sl->state) then:
 				fprintf(f, "         return %s%s;\n", prefix.tok, state->edges[i].sl->state's token);
@@ -281,7 +281,7 @@ singlecase(FILE *f, const struct fsm *fsm,
 			if (mode.state != state) {
 				fprintf(f, "state = S%u; ", indexof(fsm, mode.state));
 			}
-			fprintf(f, "continue;\n");
+			fprintf(f, "break;\n");
 		} else {
 			fprintf(f, "\t\t\tdefault:  ");
 			leaf(f, fsm, state, opaque);
@@ -290,6 +290,8 @@ singlecase(FILE *f, const struct fsm *fsm,
 	}
 
 	fprintf(f, "\t\t\t}\n");
+
+	fprintf(f, "\t\t\tbreak;\n");
 }
 
 static void

--- a/src/libre/dialect/glob/lexer.h
+++ b/src/libre/dialect/glob/lexer.h
@@ -33,7 +33,6 @@ struct lx_glob_lx {
 
 	void *buf;
 	int  (*push) (struct lx_glob_lx *lx, char c);
-	void (*pop)  (struct lx_glob_lx *lx);
 	int  (*clear)(struct lx_glob_lx *lx);
 	void (*free) (struct lx_glob_lx *lx);
 
@@ -83,7 +82,6 @@ void lx_glob_init(struct lx_glob_lx *lx);
 enum lx_glob_token lx_glob_next(struct lx_glob_lx *lx);
 
 int  lx_glob_dynpush(struct lx_glob_lx *lx, char c);
-void lx_glob_dynpop(struct lx_glob_lx *lx);
 int  lx_glob_dynclear(struct lx_glob_lx *lx);
 void lx_glob_dynfree(struct lx_glob_lx *lx);
 

--- a/src/libre/dialect/glob/parser.c
+++ b/src/libre/dialect/glob/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 23 "src/libre/parser.act"
+#line 137 "src/libre/parser.act"
 
 
 	#include <assert.h>
@@ -439,7 +439,7 @@ p_list_Hof_Hatoms_C_Cliteral(fsm fsm, flags flags, lex_state lex_state, act_stat
 		case (TOK_CHAR):
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
-#line 553 "src/libre/parser.act"
+#line 557 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -459,7 +459,7 @@ p_list_Hof_Hatoms_C_Cliteral(fsm fsm, flags flags, lex_state lex_state, act_stat
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: add-literal */
 		{
-#line 830 "src/libre/parser.act"
+#line 831 "src/libre/parser.act"
 
 		assert((ZIx) != NULL);
 		assert((ZIy) != NULL);
@@ -492,7 +492,7 @@ ZL2_list_Hof_Hatoms:;
 
 		/* BEGINNING OF ACTION: add-concat */
 		{
-#line 806 "src/libre/parser.act"
+#line 807 "src/libre/parser.act"
 
 		(ZIz) = fsm_addstate(fsm);
 		if ((ZIz) == NULL) {
@@ -518,7 +518,7 @@ ZL2_list_Hof_Hatoms:;
 				{
 					/* BEGINNING OF ACTION: add-epsilon */
 					{
-#line 813 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIz), (ZIy))) {
 			goto ZL1;
@@ -555,7 +555,7 @@ p_list_Hof_Hatoms_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state a
 			}
 			/* BEGINNING OF ACTION: count-1 */
 			{
-#line 979 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 		(void) (ZIx);
 		(void) (*ZIy);
@@ -574,7 +574,7 @@ p_list_Hof_Hatoms_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state a
 			}
 			/* BEGINNING OF ACTION: count-1 */
 			{
-#line 979 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 		(void) (ZIx);
 		(void) (*ZIy);
@@ -593,7 +593,7 @@ p_list_Hof_Hatoms_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state a
 			}
 			/* BEGINNING OF ACTION: count-0-or-many */
 			{
-#line 929 "src/libre/parser.act"
+#line 930 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (*ZIy))) {
 			goto ZL1;
@@ -652,7 +652,7 @@ p_list_Hof_Hatoms_C_Cmany(fsm fsm, flags flags, lex_state lex_state, act_state a
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: add-any */
 		{
-#line 841 "src/libre/parser.act"
+#line 844 "src/libre/parser.act"
 
 		struct fsm *any;
 
@@ -696,7 +696,7 @@ p_list_Hof_Hatoms_C_Cany(fsm fsm, flags flags, lex_state lex_state, act_state ac
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: add-any */
 		{
-#line 841 "src/libre/parser.act"
+#line 844 "src/libre/parser.act"
 
 		struct fsm *any;
 
@@ -747,7 +747,7 @@ p_re__glob(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err e
 				{
 					/* BEGINNING OF ACTION: add-epsilon */
 					{
-#line 813 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (ZIy))) {
 			goto ZL3;
@@ -764,7 +764,7 @@ p_re__glob(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err e
 			{
 				/* BEGINNING OF ACTION: err-expected-atoms */
 				{
-#line 1025 "src/libre/parser.act"
+#line 1029 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXATOMS;
@@ -794,7 +794,7 @@ p_re__glob(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err e
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 1074 "src/libre/parser.act"
+#line 1078 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
@@ -817,7 +817,7 @@ ZL1:;
 
 /* BEGINNING OF TRAILER */
 
-#line 1096 "src/libre/parser.act"
+#line 1268 "src/libre/parser.act"
 
 
 	static int
@@ -878,7 +878,6 @@ ZL1:;
 		/* (except for pushing "[" and "]" around ::group-$dialect) */
 		lx->buf   = &lex_state->buf;
 		lx->push  = CAT(LX_PREFIX, _dynpush);
-		lx->pop   = CAT(LX_PREFIX, _dynpop);
 		lx->clear = CAT(LX_PREFIX, _dynclear);
 		lx->free  = CAT(LX_PREFIX, _dynfree);
 
@@ -991,6 +990,6 @@ ZL1:;
 		return NULL;
 	}
 
-#line 995 "src/libre/dialect/glob/parser.c"
+#line 994 "src/libre/dialect/glob/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/glob/parser.h
+++ b/src/libre/dialect/glob/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 416 "src/libre/parser.act"
+#line 428 "src/libre/parser.act"
 
 
 	#include <re/re.h>
@@ -29,7 +29,7 @@
 extern void p_re__glob(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 /* BEGINNING OF TRAILER */
 
-#line 1269 "src/libre/parser.act"
+#line 1270 "src/libre/parser.act"
 
 
 #line 36 "src/libre/dialect/glob/parser.h"

--- a/src/libre/dialect/like/lexer.c
+++ b/src/libre/dialect/like/lexer.c
@@ -52,9 +52,6 @@ lx_like_ungetc(struct lx_like_lx *lx, int c)
 
 	lx->c = c;
 
-	if (lx->pop != NULL) {
-		lx->pop(lx);
-	}
 
 	lx->end.byte--;
 	lx->end.col--;
@@ -111,26 +108,6 @@ lx_like_dynpush(struct lx_like_lx *lx, char c)
 	return 0;
 }
 
-void
-lx_like_dynpop(struct lx_like_lx *lx)
-{
-	struct lx_dynbuf *t;
-
-	assert(lx != NULL);
-
-	t = lx->buf;
-
-	assert(t != NULL);
-	assert(t->a != NULL);
-	assert(t->p >= t->a);
-
-	if (t->p == t->a) {
-		return;
-	}
-
-	t->p--;
-}
-
 int
 lx_like_dynclear(struct lx_like_lx *lx)
 {
@@ -181,7 +158,7 @@ z0(struct lx_like_lx *lx)
 	int c;
 
 	enum {
-		NONE, S0, S1, S2, S3
+		S0, S1, S2, S3, NONE
 	} state;
 
 	assert(lx != NULL);
@@ -197,12 +174,6 @@ z0(struct lx_like_lx *lx)
 	while (c = lx_getc(lx), c != EOF) {
 		if (state == NONE) {
 			state = S0;
-		}
-
-		if (lx->push != NULL) {
-			if (-1 == lx->push(lx, c)) {
-				return TOK_ERROR;
-			}
 		}
 
 		switch (state) {
@@ -244,8 +215,8 @@ z0(struct lx_like_lx *lx)
 			case '!':
 			case '"':
 			case '#':
-			case '$': state = S1; continue;
-			case '%': state = S2; continue;
+			case '$': state = S1; break;
+			case '%': state = S2; break;
 			case '&':
 			case '\'':
 			case '(':
@@ -302,8 +273,8 @@ z0(struct lx_like_lx *lx)
 			case '[':
 			case '\\':
 			case ']':
-			case '^': state = S1; continue;
-			case '_': state = S3; continue;
+			case '^': state = S1; break;
+			case '_': state = S3; break;
 			case '`':
 			case 'a':
 			case 'b':
@@ -463,9 +434,10 @@ z0(struct lx_like_lx *lx)
 			case 0xfc:
 			case 0xfd:
 			case 0xfe:
-			case 0xff: state = S1; continue;
+			case 0xff: state = S1; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
+			break;
 
 		case S1: /* e.g. "a" */
 			lx_like_ungetc(lx, c); return TOK_CHAR;
@@ -475,6 +447,15 @@ z0(struct lx_like_lx *lx)
 
 		case S3: /* e.g. "_" */
 			lx_like_ungetc(lx, c); return TOK_ANY;
+
+		default:
+			; /* unreached */
+		}
+
+		if (lx->push != NULL) {
+			if (-1 == lx->push(lx, c)) {
+				return TOK_ERROR;
+			}
 		}
 	}
 

--- a/src/libre/dialect/like/lexer.h
+++ b/src/libre/dialect/like/lexer.h
@@ -33,7 +33,6 @@ struct lx_like_lx {
 
 	void *buf;
 	int  (*push) (struct lx_like_lx *lx, char c);
-	void (*pop)  (struct lx_like_lx *lx);
 	int  (*clear)(struct lx_like_lx *lx);
 	void (*free) (struct lx_like_lx *lx);
 
@@ -83,7 +82,6 @@ void lx_like_init(struct lx_like_lx *lx);
 enum lx_like_token lx_like_next(struct lx_like_lx *lx);
 
 int  lx_like_dynpush(struct lx_like_lx *lx, char c);
-void lx_like_dynpop(struct lx_like_lx *lx);
 int  lx_like_dynclear(struct lx_like_lx *lx);
 void lx_like_dynfree(struct lx_like_lx *lx);
 

--- a/src/libre/dialect/like/parser.c
+++ b/src/libre/dialect/like/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 23 "src/libre/parser.act"
+#line 137 "src/libre/parser.act"
 
 
 	#include <assert.h>
@@ -439,7 +439,7 @@ p_list_Hof_Hatoms_C_Cliteral(fsm fsm, flags flags, lex_state lex_state, act_stat
 		case (TOK_CHAR):
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
-#line 553 "src/libre/parser.act"
+#line 557 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -459,7 +459,7 @@ p_list_Hof_Hatoms_C_Cliteral(fsm fsm, flags flags, lex_state lex_state, act_stat
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: add-literal */
 		{
-#line 830 "src/libre/parser.act"
+#line 831 "src/libre/parser.act"
 
 		assert((ZIx) != NULL);
 		assert((ZIy) != NULL);
@@ -492,7 +492,7 @@ ZL2_list_Hof_Hatoms:;
 
 		/* BEGINNING OF ACTION: add-concat */
 		{
-#line 806 "src/libre/parser.act"
+#line 807 "src/libre/parser.act"
 
 		(ZIz) = fsm_addstate(fsm);
 		if ((ZIz) == NULL) {
@@ -518,7 +518,7 @@ ZL2_list_Hof_Hatoms:;
 				{
 					/* BEGINNING OF ACTION: add-epsilon */
 					{
-#line 813 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIz), (ZIy))) {
 			goto ZL1;
@@ -555,7 +555,7 @@ p_list_Hof_Hatoms_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state a
 			}
 			/* BEGINNING OF ACTION: count-1 */
 			{
-#line 979 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 		(void) (ZIx);
 		(void) (*ZIy);
@@ -574,7 +574,7 @@ p_list_Hof_Hatoms_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state a
 			}
 			/* BEGINNING OF ACTION: count-1 */
 			{
-#line 979 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 		(void) (ZIx);
 		(void) (*ZIy);
@@ -593,7 +593,7 @@ p_list_Hof_Hatoms_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state a
 			}
 			/* BEGINNING OF ACTION: count-0-or-many */
 			{
-#line 929 "src/libre/parser.act"
+#line 930 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (*ZIy))) {
 			goto ZL1;
@@ -652,7 +652,7 @@ p_list_Hof_Hatoms_C_Cmany(fsm fsm, flags flags, lex_state lex_state, act_state a
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: add-any */
 		{
-#line 841 "src/libre/parser.act"
+#line 844 "src/libre/parser.act"
 
 		struct fsm *any;
 
@@ -696,7 +696,7 @@ p_list_Hof_Hatoms_C_Cany(fsm fsm, flags flags, lex_state lex_state, act_state ac
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: add-any */
 		{
-#line 841 "src/libre/parser.act"
+#line 844 "src/libre/parser.act"
 
 		struct fsm *any;
 
@@ -747,7 +747,7 @@ p_re__like(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err e
 				{
 					/* BEGINNING OF ACTION: add-epsilon */
 					{
-#line 813 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (ZIy))) {
 			goto ZL3;
@@ -764,7 +764,7 @@ p_re__like(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err e
 			{
 				/* BEGINNING OF ACTION: err-expected-atoms */
 				{
-#line 1025 "src/libre/parser.act"
+#line 1029 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXATOMS;
@@ -794,7 +794,7 @@ p_re__like(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err e
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 1074 "src/libre/parser.act"
+#line 1078 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
@@ -817,7 +817,7 @@ ZL1:;
 
 /* BEGINNING OF TRAILER */
 
-#line 1096 "src/libre/parser.act"
+#line 1268 "src/libre/parser.act"
 
 
 	static int
@@ -878,7 +878,6 @@ ZL1:;
 		/* (except for pushing "[" and "]" around ::group-$dialect) */
 		lx->buf   = &lex_state->buf;
 		lx->push  = CAT(LX_PREFIX, _dynpush);
-		lx->pop   = CAT(LX_PREFIX, _dynpop);
 		lx->clear = CAT(LX_PREFIX, _dynclear);
 		lx->free  = CAT(LX_PREFIX, _dynfree);
 
@@ -991,6 +990,6 @@ ZL1:;
 		return NULL;
 	}
 
-#line 995 "src/libre/dialect/like/parser.c"
+#line 994 "src/libre/dialect/like/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/like/parser.h
+++ b/src/libre/dialect/like/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 416 "src/libre/parser.act"
+#line 428 "src/libre/parser.act"
 
 
 	#include <re/re.h>
@@ -29,7 +29,7 @@
 extern void p_re__like(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 /* BEGINNING OF TRAILER */
 
-#line 1269 "src/libre/parser.act"
+#line 1270 "src/libre/parser.act"
 
 
 #line 36 "src/libre/dialect/like/parser.h"

--- a/src/libre/dialect/literal/lexer.h
+++ b/src/libre/dialect/literal/lexer.h
@@ -31,7 +31,6 @@ struct lx_literal_lx {
 
 	void *buf;
 	int  (*push) (struct lx_literal_lx *lx, char c);
-	void (*pop)  (struct lx_literal_lx *lx);
 	int  (*clear)(struct lx_literal_lx *lx);
 	void (*free) (struct lx_literal_lx *lx);
 
@@ -81,7 +80,6 @@ void lx_literal_init(struct lx_literal_lx *lx);
 enum lx_literal_token lx_literal_next(struct lx_literal_lx *lx);
 
 int  lx_literal_dynpush(struct lx_literal_lx *lx, char c);
-void lx_literal_dynpop(struct lx_literal_lx *lx);
 int  lx_literal_dynclear(struct lx_literal_lx *lx);
 void lx_literal_dynfree(struct lx_literal_lx *lx);
 

--- a/src/libre/dialect/literal/parser.c
+++ b/src/libre/dialect/literal/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 23 "src/libre/parser.act"
+#line 137 "src/libre/parser.act"
 
 
 	#include <assert.h>
@@ -444,7 +444,7 @@ p_re__literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, er
 				{
 					/* BEGINNING OF ACTION: add-epsilon */
 					{
-#line 813 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (ZIy))) {
 			goto ZL3;
@@ -461,7 +461,7 @@ p_re__literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, er
 			{
 				/* BEGINNING OF ACTION: err-expected-atoms */
 				{
-#line 1025 "src/libre/parser.act"
+#line 1029 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXATOMS;
@@ -491,7 +491,7 @@ p_re__literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, er
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 1074 "src/libre/parser.act"
+#line 1078 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
@@ -527,7 +527,7 @@ p_list_Hof_Hliterals_C_Cliteral(fsm fsm, flags flags, lex_state lex_state, act_s
 		case (TOK_CHAR):
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
-#line 553 "src/libre/parser.act"
+#line 557 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -547,7 +547,7 @@ p_list_Hof_Hliterals_C_Cliteral(fsm fsm, flags flags, lex_state lex_state, act_s
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: add-literal */
 		{
-#line 830 "src/libre/parser.act"
+#line 831 "src/libre/parser.act"
 
 		assert((ZIx) != NULL);
 		assert((ZIy) != NULL);
@@ -563,7 +563,7 @@ p_list_Hof_Hliterals_C_Cliteral(fsm fsm, flags flags, lex_state lex_state, act_s
 		/* END OF ACTION: add-literal */
 		/* BEGINNING OF ACTION: count-1 */
 		{
-#line 979 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 		(void) (ZIx);
 		(void) (ZIy);
@@ -590,7 +590,7 @@ ZL2_list_Hof_Hliterals:;
 
 		/* BEGINNING OF ACTION: add-concat */
 		{
-#line 806 "src/libre/parser.act"
+#line 807 "src/libre/parser.act"
 
 		(ZIz) = fsm_addstate(fsm);
 		if ((ZIz) == NULL) {
@@ -616,7 +616,7 @@ ZL2_list_Hof_Hliterals:;
 				{
 					/* BEGINNING OF ACTION: add-epsilon */
 					{
-#line 813 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIz), (ZIy))) {
 			goto ZL1;
@@ -642,7 +642,7 @@ ZL1:;
 
 /* BEGINNING OF TRAILER */
 
-#line 1096 "src/libre/parser.act"
+#line 1268 "src/libre/parser.act"
 
 
 	static int
@@ -703,7 +703,6 @@ ZL1:;
 		/* (except for pushing "[" and "]" around ::group-$dialect) */
 		lx->buf   = &lex_state->buf;
 		lx->push  = CAT(LX_PREFIX, _dynpush);
-		lx->pop   = CAT(LX_PREFIX, _dynpop);
 		lx->clear = CAT(LX_PREFIX, _dynclear);
 		lx->free  = CAT(LX_PREFIX, _dynfree);
 
@@ -816,6 +815,6 @@ ZL1:;
 		return NULL;
 	}
 
-#line 820 "src/libre/dialect/literal/parser.c"
+#line 819 "src/libre/dialect/literal/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/literal/parser.h
+++ b/src/libre/dialect/literal/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 416 "src/libre/parser.act"
+#line 428 "src/libre/parser.act"
 
 
 	#include <re/re.h>
@@ -29,7 +29,7 @@
 extern void p_re__literal(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 /* BEGINNING OF TRAILER */
 
-#line 1269 "src/libre/parser.act"
+#line 1270 "src/libre/parser.act"
 
 
 #line 36 "src/libre/dialect/literal/parser.h"

--- a/src/libre/dialect/native/lexer.h
+++ b/src/libre/dialect/native/lexer.h
@@ -65,7 +65,6 @@ struct lx_native_lx {
 
 	void *buf;
 	int  (*push) (struct lx_native_lx *lx, char c);
-	void (*pop)  (struct lx_native_lx *lx);
 	int  (*clear)(struct lx_native_lx *lx);
 	void (*free) (struct lx_native_lx *lx);
 
@@ -115,7 +114,6 @@ void lx_native_init(struct lx_native_lx *lx);
 enum lx_native_token lx_native_next(struct lx_native_lx *lx);
 
 int  lx_native_dynpush(struct lx_native_lx *lx, char c);
-void lx_native_dynpop(struct lx_native_lx *lx);
 int  lx_native_dynclear(struct lx_native_lx *lx);
 void lx_native_dynfree(struct lx_native_lx *lx);
 

--- a/src/libre/dialect/native/parser.c
+++ b/src/libre/dialect/native/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 23 "src/libre/parser.act"
+#line 137 "src/libre/parser.act"
 
 
 	#include <assert.h>
@@ -450,7 +450,7 @@ p_anchor(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err
 				{
 					/* BEGINNING OF EXTRACT: END */
 					{
-#line 575 "src/libre/parser.act"
+#line 577 "src/libre/parser.act"
 
 		switch (flags->flags & RE_ANCHOR) {
 		case RE_TEXT:  ZIp = RE_EOT; break;
@@ -472,7 +472,7 @@ p_anchor(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err
 				{
 					/* BEGINNING OF EXTRACT: START */
 					{
-#line 563 "src/libre/parser.act"
+#line 565 "src/libre/parser.act"
 
 		switch (flags->flags & RE_ANCHOR) {
 		case RE_TEXT:  ZIp = RE_SOT; break;
@@ -497,7 +497,7 @@ p_anchor(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err
 		/* END OF INLINE: 155 */
 		/* BEGINNING OF ACTION: add-pred */
 		{
-#line 819 "src/libre/parser.act"
+#line 820 "src/libre/parser.act"
 
 		assert((ZIx) != NULL);
 		assert((ZIy) != NULL);
@@ -529,7 +529,7 @@ p_expr_C_Clist_Hof_Halts_C_Calt(fsm fsm, flags flags, lex_state lex_state, act_s
 
 		/* BEGINNING OF ACTION: add-concat */
 		{
-#line 806 "src/libre/parser.act"
+#line 807 "src/libre/parser.act"
 
 		(ZIz) = fsm_addstate(fsm);
 		if ((ZIz) == NULL) {
@@ -541,7 +541,7 @@ p_expr_C_Clist_Hof_Halts_C_Calt(fsm fsm, flags flags, lex_state lex_state, act_s
 		/* END OF ACTION: add-concat */
 		/* BEGINNING OF ACTION: add-epsilon */
 		{
-#line 813 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (ZIz))) {
 			goto ZL1;
@@ -573,7 +573,7 @@ p_group(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err,
 
 		/* BEGINNING OF ACTION: make-group */
 		{
-#line 621 "src/libre/parser.act"
+#line 622 "src/libre/parser.act"
 
 		(ZIg).set = fsm_new_blank(fsm->opt);
 		if ((ZIg).set == NULL) {
@@ -596,7 +596,7 @@ p_group(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err,
 		}
 		/* BEGINNING OF ACTION: group-to-states */
 		{
-#line 744 "src/libre/parser.act"
+#line 747 "src/libre/parser.act"
 
 		int r;
 
@@ -667,7 +667,7 @@ p_group_C_Cgroup_Hbody(fsm fsm, flags flags, lex_state lex_state, act_state act_
 
 					/* BEGINNING OF EXTRACT: CLOSEGROUP */
 					{
-#line 447 "src/libre/parser.act"
+#line 448 "src/libre/parser.act"
 
 		ZI189 = ']';
 		ZI190 = lex_state->lx.start;
@@ -679,7 +679,7 @@ p_group_C_Cgroup_Hbody(fsm fsm, flags flags, lex_state lex_state, act_state act_
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: group-add-char */
 					{
-#line 655 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
 		if (-1 == group_add((ZIg), flags->flags, (ZI189))) {
 			err->e = RE_EERRNO;
@@ -704,7 +704,7 @@ p_group_C_Cgroup_Hbody(fsm fsm, flags flags, lex_state lex_state, act_state act_
 
 					/* BEGINNING OF EXTRACT: RANGE */
 					{
-#line 436 "src/libre/parser.act"
+#line 437 "src/libre/parser.act"
 
 		ZIc = '-';
 		ZI131 = lex_state->lx.start;
@@ -716,7 +716,7 @@ p_group_C_Cgroup_Hbody(fsm fsm, flags flags, lex_state lex_state, act_state act_
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: group-add-char */
 					{
-#line 655 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
 		if (-1 == group_add((ZIg), flags->flags, (ZIc))) {
 			err->e = RE_EERRNO;
@@ -801,7 +801,7 @@ p_192(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 436 "src/libre/parser.act"
+#line 437 "src/libre/parser.act"
 
 		ZIb = '-';
 		ZI135 = lex_state->lx.start;
@@ -813,7 +813,7 @@ p_192(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: group-add-char */
 			{
-#line 655 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
 		if (-1 == group_add((ZIg), flags->flags, (ZIb))) {
 			err->e = RE_EERRNO;
@@ -880,7 +880,7 @@ p_re__native(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err
 				{
 					/* BEGINNING OF ACTION: add-epsilon */
 					{
-#line 813 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (ZIy))) {
 			goto ZL3;
@@ -897,7 +897,7 @@ p_re__native(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err
 			{
 				/* BEGINNING OF ACTION: err-expected-alts */
 				{
-#line 1032 "src/libre/parser.act"
+#line 1036 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXALTS;
@@ -927,7 +927,7 @@ p_re__native(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 1074 "src/libre/parser.act"
+#line 1078 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
@@ -967,7 +967,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
-#line 553 "src/libre/parser.act"
+#line 557 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -994,7 +994,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 
 					/* BEGINNING OF EXTRACT: ESC */
 					{
-#line 480 "src/libre/parser.act"
+#line 485 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -1017,7 +1017,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: group-add-char */
 					{
-#line 655 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
 		if (-1 == group_add((ZIg), flags->flags, (ZIc))) {
 			err->e = RE_EERRNO;
@@ -1037,7 +1037,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 
 					/* BEGINNING OF EXTRACT: HEX */
 					{
-#line 525 "src/libre/parser.act"
+#line 532 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -1084,7 +1084,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 
 					/* BEGINNING OF EXTRACT: OCT */
 					{
-#line 497 "src/libre/parser.act"
+#line 504 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -1308,7 +1308,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 					/* END OF INLINE: group::class */
 					/* BEGINNING OF ACTION: group-add-class */
 					{
-#line 662 "src/libre/parser.act"
+#line 670 "src/libre/parser.act"
 
 		struct fsm *q;
 		int r;
@@ -1381,7 +1381,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 			{
 				/* BEGINNING OF ACTION: err-expected-term */
 				{
-#line 1011 "src/libre/parser.act"
+#line 1015 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXTERM;
@@ -1441,7 +1441,7 @@ p_204(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 					case (TOK_RANGE):
 						/* BEGINNING OF EXTRACT: RANGE */
 						{
-#line 436 "src/libre/parser.act"
+#line 437 "src/libre/parser.act"
 
 		ZI112 = '-';
 		ZI113 = lex_state->lx.start;
@@ -1461,7 +1461,7 @@ p_204(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 				{
 					/* BEGINNING OF ACTION: err-expected-range */
 					{
-#line 1039 "src/libre/parser.act"
+#line 1043 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXRANGE;
@@ -1484,7 +1484,7 @@ p_204(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 
 						/* BEGINNING OF EXTRACT: CHAR */
 						{
-#line 553 "src/libre/parser.act"
+#line 557 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -1506,7 +1506,7 @@ p_204(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 
 						/* BEGINNING OF EXTRACT: HEX */
 						{
-#line 525 "src/libre/parser.act"
+#line 532 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -1546,7 +1546,7 @@ p_204(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 
 						/* BEGINNING OF EXTRACT: OCT */
 						{
-#line 497 "src/libre/parser.act"
+#line 504 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -1586,7 +1586,7 @@ p_204(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 
 						/* BEGINNING OF EXTRACT: RANGE */
 						{
-#line 436 "src/libre/parser.act"
+#line 437 "src/libre/parser.act"
 
 		ZIb = '-';
 		ZI120 = lex_state->lx.start;
@@ -1605,7 +1605,7 @@ p_204(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			/* END OF INLINE: 115 */
 			/* BEGINNING OF ACTION: mark-range */
 			{
-#line 1086 "src/libre/parser.act"
+#line 1087 "src/libre/parser.act"
 
 		mark(&act_state->rangestart, &(*ZI202));
 		mark(&act_state->rangeend,   &(ZIend));
@@ -1615,7 +1615,7 @@ p_204(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: group-add-range */
 			{
-#line 722 "src/libre/parser.act"
+#line 725 "src/libre/parser.act"
 
 		int i;
 
@@ -1646,7 +1646,7 @@ p_204(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 		{
 			/* BEGINNING OF ACTION: group-add-char */
 			{
-#line 655 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
 		if (-1 == group_add((ZIg), flags->flags, (*ZI201))) {
 			err->e = RE_EERRNO;
@@ -1679,7 +1679,7 @@ ZL2_expr_C_Clist_Hof_Hatoms:;
 
 		/* BEGINNING OF ACTION: add-concat */
 		{
-#line 806 "src/libre/parser.act"
+#line 807 "src/libre/parser.act"
 
 		(ZIz) = fsm_addstate(fsm);
 		if ((ZIz) == NULL) {
@@ -1733,7 +1733,7 @@ ZL2_expr_C_Clist_Hof_Hatoms:;
 				{
 					/* BEGINNING OF ACTION: add-epsilon */
 					{
-#line 813 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIz), (ZIy))) {
 			goto ZL1;
@@ -1765,7 +1765,7 @@ p_208(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 
 			/* BEGINNING OF EXTRACT: CLOSECOUNT */
 			{
-#line 458 "src/libre/parser.act"
+#line 459 "src/libre/parser.act"
 
 		ZI164 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
@@ -1776,7 +1776,7 @@ p_208(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 1091 "src/libre/parser.act"
+#line 1092 "src/libre/parser.act"
 
 		mark(&act_state->countstart, &(*ZI205));
 		mark(&act_state->countend,   &(ZIend));
@@ -1786,7 +1786,7 @@ p_208(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-m-to-n */
 			{
-#line 880 "src/libre/parser.act"
+#line 885 "src/libre/parser.act"
 
 		unsigned i;
 		struct fsm_state *a;
@@ -1845,7 +1845,7 @@ p_208(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			case (TOK_COUNT):
 				/* BEGINNING OF EXTRACT: COUNT */
 				{
-#line 587 "src/libre/parser.act"
+#line 596 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -1877,7 +1877,7 @@ p_208(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			case (TOK_CLOSECOUNT):
 				/* BEGINNING OF EXTRACT: CLOSECOUNT */
 				{
-#line 458 "src/libre/parser.act"
+#line 459 "src/libre/parser.act"
 
 		ZIend = lex_state->lx.start;
 		ZI167   = lex_state->lx.end;
@@ -1892,7 +1892,7 @@ p_208(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 1091 "src/libre/parser.act"
+#line 1092 "src/libre/parser.act"
 
 		mark(&act_state->countstart, &(*ZI205));
 		mark(&act_state->countend,   &(ZIend));
@@ -1902,7 +1902,7 @@ p_208(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-m-to-n */
 			{
-#line 880 "src/libre/parser.act"
+#line 885 "src/libre/parser.act"
 
 		unsigned i;
 		struct fsm_state *a;
@@ -1975,7 +1975,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 		case (TOK_OPENGROUP):
 			/* BEGINNING OF EXTRACT: OPENGROUP */
 			{
-#line 442 "src/libre/parser.act"
+#line 443 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
 		ZI140   = lex_state->lx.end;
@@ -1997,7 +1997,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 
 					/* BEGINNING OF EXTRACT: INVERT */
 					{
-#line 432 "src/libre/parser.act"
+#line 433 "src/libre/parser.act"
 
 		ZI142 = '^';
 	
@@ -2012,7 +2012,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 					}
 					/* BEGINNING OF ACTION: invert-group */
 					{
-#line 634 "src/libre/parser.act"
+#line 640 "src/libre/parser.act"
 
 		struct fsm *any;
 
@@ -2067,7 +2067,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 				case (TOK_CLOSEGROUP):
 					/* BEGINNING OF EXTRACT: CLOSEGROUP */
 					{
-#line 447 "src/libre/parser.act"
+#line 448 "src/libre/parser.act"
 
 		ZI144 = ']';
 		ZI145 = lex_state->lx.start;
@@ -2083,7 +2083,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 				ADVANCE_LEXER;
 				/* BEGINNING OF ACTION: mark-group */
 				{
-#line 1081 "src/libre/parser.act"
+#line 1082 "src/libre/parser.act"
 
 		mark(&act_state->groupstart, &(ZIstart));
 		mark(&act_state->groupend,   &(ZIend));
@@ -2097,7 +2097,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 			{
 				/* BEGINNING OF ACTION: err-expected-closegroup */
 				{
-#line 1046 "src/libre/parser.act"
+#line 1050 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCLOSEGROUP;
@@ -2117,7 +2117,7 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-groupbody */
 		{
-#line 1053 "src/libre/parser.act"
+#line 1057 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXGROUPBODY;
@@ -2173,7 +2173,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: add-any */
 					{
-#line 841 "src/libre/parser.act"
+#line 844 "src/libre/parser.act"
 
 		struct fsm *any;
 
@@ -2246,7 +2246,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 
 					/* BEGINNING OF EXTRACT: OPENCOUNT */
 					{
-#line 453 "src/libre/parser.act"
+#line 454 "src/libre/parser.act"
 
 		ZI205 = lex_state->lx.start;
 		ZI206   = lex_state->lx.end;
@@ -2259,7 +2259,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					case (TOK_COUNT):
 						/* BEGINNING OF EXTRACT: COUNT */
 						{
-#line 587 "src/libre/parser.act"
+#line 596 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -2299,7 +2299,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: count-0-or-1 */
 					{
-#line 923 "src/libre/parser.act"
+#line 924 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (*ZIy))) {
 			goto ZL4;
@@ -2315,7 +2315,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: count-1-or-many */
 					{
-#line 956 "src/libre/parser.act"
+#line 957 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (*ZIy), (ZIx))) {
 			goto ZL4;
@@ -2348,7 +2348,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: count-0-or-many */
 					{
-#line 929 "src/libre/parser.act"
+#line 930 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (*ZIy))) {
 			goto ZL4;
@@ -2384,7 +2384,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 				{
 					/* BEGINNING OF ACTION: count-1 */
 					{
-#line 979 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 		(void) (ZIx);
 		(void) (*ZIy);
@@ -2400,7 +2400,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 			{
 				/* BEGINNING OF ACTION: err-expected-count */
 				{
-#line 1018 "src/libre/parser.act"
+#line 1022 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCOUNT;
@@ -2440,7 +2440,7 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
-#line 553 "src/libre/parser.act"
+#line 557 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -2460,7 +2460,7 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 				{
 					/* BEGINNING OF EXTRACT: ESC */
 					{
-#line 480 "src/libre/parser.act"
+#line 485 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -2490,7 +2490,7 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 
 					/* BEGINNING OF EXTRACT: HEX */
 					{
-#line 525 "src/libre/parser.act"
+#line 532 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -2531,7 +2531,7 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 
 					/* BEGINNING OF EXTRACT: OCT */
 					{
-#line 497 "src/libre/parser.act"
+#line 504 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -2572,7 +2572,7 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 		/* END OF INLINE: 147 */
 		/* BEGINNING OF ACTION: add-literal */
 		{
-#line 830 "src/libre/parser.act"
+#line 831 "src/libre/parser.act"
 
 		assert((ZIx) != NULL);
 		assert((ZIy) != NULL);
@@ -2595,7 +2595,7 @@ ZL1:;
 
 /* BEGINNING OF TRAILER */
 
-#line 1096 "src/libre/parser.act"
+#line 1268 "src/libre/parser.act"
 
 
 	static int
@@ -2656,7 +2656,6 @@ ZL1:;
 		/* (except for pushing "[" and "]" around ::group-$dialect) */
 		lx->buf   = &lex_state->buf;
 		lx->push  = CAT(LX_PREFIX, _dynpush);
-		lx->pop   = CAT(LX_PREFIX, _dynpop);
 		lx->clear = CAT(LX_PREFIX, _dynclear);
 		lx->free  = CAT(LX_PREFIX, _dynfree);
 
@@ -2769,6 +2768,6 @@ ZL1:;
 		return NULL;
 	}
 
-#line 2773 "src/libre/dialect/native/parser.c"
+#line 2772 "src/libre/dialect/native/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/native/parser.h
+++ b/src/libre/dialect/native/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 416 "src/libre/parser.act"
+#line 428 "src/libre/parser.act"
 
 
 	#include <re/re.h>
@@ -29,7 +29,7 @@
 extern void p_re__native(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 /* BEGINNING OF TRAILER */
 
-#line 1269 "src/libre/parser.act"
+#line 1270 "src/libre/parser.act"
 
 
 #line 36 "src/libre/dialect/native/parser.h"

--- a/src/libre/dialect/pcre/lexer.h
+++ b/src/libre/dialect/pcre/lexer.h
@@ -57,7 +57,6 @@ struct lx_pcre_lx {
 
 	void *buf;
 	int  (*push) (struct lx_pcre_lx *lx, char c);
-	void (*pop)  (struct lx_pcre_lx *lx);
 	int  (*clear)(struct lx_pcre_lx *lx);
 	void (*free) (struct lx_pcre_lx *lx);
 
@@ -107,7 +106,6 @@ void lx_pcre_init(struct lx_pcre_lx *lx);
 enum lx_pcre_token lx_pcre_next(struct lx_pcre_lx *lx);
 
 int  lx_pcre_dynpush(struct lx_pcre_lx *lx, char c);
-void lx_pcre_dynpop(struct lx_pcre_lx *lx);
 int  lx_pcre_dynclear(struct lx_pcre_lx *lx);
 void lx_pcre_dynfree(struct lx_pcre_lx *lx);
 

--- a/src/libre/dialect/pcre/parser.c
+++ b/src/libre/dialect/pcre/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 23 "src/libre/parser.act"
+#line 137 "src/libre/parser.act"
 
 
 	#include <assert.h>
@@ -452,7 +452,7 @@ p_anchor(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err
 				{
 					/* BEGINNING OF EXTRACT: END */
 					{
-#line 575 "src/libre/parser.act"
+#line 577 "src/libre/parser.act"
 
 		switch (flags->flags & RE_ANCHOR) {
 		case RE_TEXT:  ZIp = RE_EOT; break;
@@ -474,7 +474,7 @@ p_anchor(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err
 				{
 					/* BEGINNING OF EXTRACT: START */
 					{
-#line 563 "src/libre/parser.act"
+#line 565 "src/libre/parser.act"
 
 		switch (flags->flags & RE_ANCHOR) {
 		case RE_TEXT:  ZIp = RE_SOT; break;
@@ -499,7 +499,7 @@ p_anchor(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err
 		/* END OF INLINE: 153 */
 		/* BEGINNING OF ACTION: add-pred */
 		{
-#line 819 "src/libre/parser.act"
+#line 820 "src/libre/parser.act"
 
 		assert((ZIx) != NULL);
 		assert((ZIy) != NULL);
@@ -537,7 +537,7 @@ ZL2_inline_Hflags_C_Cnegative:;
 
 					/* BEGINNING OF EXTRACT: FLAG_INSENSITIVE */
 					{
-#line 607 "src/libre/parser.act"
+#line 608 "src/libre/parser.act"
 
 		ZIc = RE_ICASE;
 	
@@ -547,7 +547,7 @@ ZL2_inline_Hflags_C_Cnegative:;
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: clear-flag */
 					{
-#line 1006 "src/libre/parser.act"
+#line 1007 "src/libre/parser.act"
 
 		flags->flags &= ~(ZIc);
 	
@@ -561,7 +561,7 @@ ZL2_inline_Hflags_C_Cnegative:;
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: err-unknown-flag */
 					{
-#line 1060 "src/libre/parser.act"
+#line 1064 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EFLAG;
@@ -612,7 +612,7 @@ p_expr_C_Clist_Hof_Halts_C_Calt(fsm fsm, flags flags, lex_state lex_state, act_s
 
 			/* BEGINNING OF ACTION: add-concat */
 			{
-#line 806 "src/libre/parser.act"
+#line 807 "src/libre/parser.act"
 
 		(ZIz) = fsm_addstate(fsm);
 		if ((ZIz) == NULL) {
@@ -624,7 +624,7 @@ p_expr_C_Clist_Hof_Halts_C_Calt(fsm fsm, flags flags, lex_state lex_state, act_s
 			/* END OF ACTION: add-concat */
 			/* BEGINNING OF ACTION: add-epsilon */
 			{
-#line 813 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (ZIz))) {
 			goto ZL1;
@@ -644,7 +644,7 @@ p_expr_C_Clist_Hof_Halts_C_Calt(fsm fsm, flags flags, lex_state lex_state, act_s
 		{
 			/* BEGINNING OF ACTION: add-epsilon */
 			{
-#line 813 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (ZIy))) {
 			goto ZL1;
@@ -675,7 +675,7 @@ p_group(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err,
 
 		/* BEGINNING OF ACTION: make-group */
 		{
-#line 621 "src/libre/parser.act"
+#line 622 "src/libre/parser.act"
 
 		(ZIg).set = fsm_new_blank(fsm->opt);
 		if ((ZIg).set == NULL) {
@@ -698,7 +698,7 @@ p_group(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err,
 		}
 		/* BEGINNING OF ACTION: group-to-states */
 		{
-#line 744 "src/libre/parser.act"
+#line 747 "src/libre/parser.act"
 
 		int r;
 
@@ -769,7 +769,7 @@ p_group_C_Cgroup_Hbody(fsm fsm, flags flags, lex_state lex_state, act_state act_
 
 					/* BEGINNING OF EXTRACT: CLOSEGROUP */
 					{
-#line 447 "src/libre/parser.act"
+#line 448 "src/libre/parser.act"
 
 		ZI199 = ']';
 		ZI200 = lex_state->lx.start;
@@ -781,7 +781,7 @@ p_group_C_Cgroup_Hbody(fsm fsm, flags flags, lex_state lex_state, act_state act_
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: group-add-char */
 					{
-#line 655 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
 		if (-1 == group_add((ZIg), flags->flags, (ZI199))) {
 			err->e = RE_EERRNO;
@@ -806,7 +806,7 @@ p_group_C_Cgroup_Hbody(fsm fsm, flags flags, lex_state lex_state, act_state act_
 
 					/* BEGINNING OF EXTRACT: RANGE */
 					{
-#line 436 "src/libre/parser.act"
+#line 437 "src/libre/parser.act"
 
 		ZIc = '-';
 		ZI129 = lex_state->lx.start;
@@ -818,7 +818,7 @@ p_group_C_Cgroup_Hbody(fsm fsm, flags flags, lex_state lex_state, act_state act_
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: group-add-char */
 					{
-#line 655 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
 		if (-1 == group_add((ZIg), flags->flags, (ZIc))) {
 			err->e = RE_EERRNO;
@@ -883,7 +883,7 @@ p_inline_Hflags(fsm fsm, flags flags, lex_state lex_state, act_state act_state, 
 
 										/* BEGINNING OF EXTRACT: FLAG_INSENSITIVE */
 										{
-#line 607 "src/libre/parser.act"
+#line 608 "src/libre/parser.act"
 
 		ZIc = RE_ICASE;
 	
@@ -893,7 +893,7 @@ p_inline_Hflags(fsm fsm, flags flags, lex_state lex_state, act_state act_state, 
 										ADVANCE_LEXER;
 										/* BEGINNING OF ACTION: set-flag */
 										{
-#line 1002 "src/libre/parser.act"
+#line 1003 "src/libre/parser.act"
 
 		flags->flags |= (ZIc);
 	
@@ -907,7 +907,7 @@ p_inline_Hflags(fsm fsm, flags flags, lex_state lex_state, act_state act_state, 
 										ADVANCE_LEXER;
 										/* BEGINNING OF ACTION: err-unknown-flag */
 										{
-#line 1060 "src/libre/parser.act"
+#line 1064 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EFLAG;
@@ -969,7 +969,7 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-closeflags */
 		{
-#line 1067 "src/libre/parser.act"
+#line 1071 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCLOSEFLAGS;
@@ -1065,7 +1065,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
-#line 553 "src/libre/parser.act"
+#line 557 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -1092,7 +1092,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 
 					/* BEGINNING OF EXTRACT: ESC */
 					{
-#line 480 "src/libre/parser.act"
+#line 485 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -1115,7 +1115,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: group-add-char */
 					{
-#line 655 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
 		if (-1 == group_add((ZIg), flags->flags, (ZIc))) {
 			err->e = RE_EERRNO;
@@ -1135,7 +1135,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 
 					/* BEGINNING OF EXTRACT: HEX */
 					{
-#line 525 "src/libre/parser.act"
+#line 532 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -1182,7 +1182,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 
 					/* BEGINNING OF EXTRACT: OCT */
 					{
-#line 497 "src/libre/parser.act"
+#line 504 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -1229,7 +1229,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 			{
 				/* BEGINNING OF ACTION: err-expected-term */
 				{
-#line 1011 "src/libre/parser.act"
+#line 1015 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXTERM;
@@ -1277,7 +1277,7 @@ p_202(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 436 "src/libre/parser.act"
+#line 437 "src/libre/parser.act"
 
 		ZIb = '-';
 		ZI133 = lex_state->lx.start;
@@ -1289,7 +1289,7 @@ p_202(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: group-add-char */
 			{
-#line 655 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
 		if (-1 == group_add((ZIg), flags->flags, (ZIb))) {
 			err->e = RE_EERRNO;
@@ -1324,7 +1324,7 @@ ZL2_expr_C_Clist_Hof_Hatoms:;
 
 		/* BEGINNING OF ACTION: add-concat */
 		{
-#line 806 "src/libre/parser.act"
+#line 807 "src/libre/parser.act"
 
 		(ZIz) = fsm_addstate(fsm);
 		if ((ZIz) == NULL) {
@@ -1379,7 +1379,7 @@ ZL2_expr_C_Clist_Hof_Hatoms:;
 				{
 					/* BEGINNING OF ACTION: add-epsilon */
 					{
-#line 813 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIz), (ZIy))) {
 			goto ZL1;
@@ -1414,7 +1414,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 		case (TOK_OPENGROUP):
 			/* BEGINNING OF EXTRACT: OPENGROUP */
 			{
-#line 442 "src/libre/parser.act"
+#line 443 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
 		ZI138   = lex_state->lx.end;
@@ -1436,7 +1436,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 
 					/* BEGINNING OF EXTRACT: INVERT */
 					{
-#line 432 "src/libre/parser.act"
+#line 433 "src/libre/parser.act"
 
 		ZI140 = '^';
 	
@@ -1451,7 +1451,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 					}
 					/* BEGINNING OF ACTION: invert-group */
 					{
-#line 634 "src/libre/parser.act"
+#line 640 "src/libre/parser.act"
 
 		struct fsm *any;
 
@@ -1503,7 +1503,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 				case (TOK_CLOSEGROUP):
 					/* BEGINNING OF EXTRACT: CLOSEGROUP */
 					{
-#line 447 "src/libre/parser.act"
+#line 448 "src/libre/parser.act"
 
 		ZI142 = ']';
 		ZI143 = lex_state->lx.start;
@@ -1519,7 +1519,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 				ADVANCE_LEXER;
 				/* BEGINNING OF ACTION: mark-group */
 				{
-#line 1081 "src/libre/parser.act"
+#line 1082 "src/libre/parser.act"
 
 		mark(&act_state->groupstart, &(ZIstart));
 		mark(&act_state->groupend,   &(ZIend));
@@ -1533,7 +1533,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 			{
 				/* BEGINNING OF ACTION: err-expected-closegroup */
 				{
-#line 1046 "src/libre/parser.act"
+#line 1050 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCLOSEGROUP;
@@ -1553,7 +1553,7 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-groupbody */
 		{
-#line 1053 "src/libre/parser.act"
+#line 1057 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXGROUPBODY;
@@ -1591,7 +1591,7 @@ p_214(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 					case (TOK_RANGE):
 						/* BEGINNING OF EXTRACT: RANGE */
 						{
-#line 436 "src/libre/parser.act"
+#line 437 "src/libre/parser.act"
 
 		ZI110 = '-';
 		ZI111 = lex_state->lx.start;
@@ -1611,7 +1611,7 @@ p_214(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 				{
 					/* BEGINNING OF ACTION: err-expected-range */
 					{
-#line 1039 "src/libre/parser.act"
+#line 1043 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXRANGE;
@@ -1634,7 +1634,7 @@ p_214(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 
 						/* BEGINNING OF EXTRACT: CHAR */
 						{
-#line 553 "src/libre/parser.act"
+#line 557 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -1656,7 +1656,7 @@ p_214(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 
 						/* BEGINNING OF EXTRACT: HEX */
 						{
-#line 525 "src/libre/parser.act"
+#line 532 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -1696,7 +1696,7 @@ p_214(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 
 						/* BEGINNING OF EXTRACT: OCT */
 						{
-#line 497 "src/libre/parser.act"
+#line 504 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -1736,7 +1736,7 @@ p_214(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 
 						/* BEGINNING OF EXTRACT: RANGE */
 						{
-#line 436 "src/libre/parser.act"
+#line 437 "src/libre/parser.act"
 
 		ZIb = '-';
 		ZI118 = lex_state->lx.start;
@@ -1755,7 +1755,7 @@ p_214(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			/* END OF INLINE: 113 */
 			/* BEGINNING OF ACTION: mark-range */
 			{
-#line 1086 "src/libre/parser.act"
+#line 1087 "src/libre/parser.act"
 
 		mark(&act_state->rangestart, &(*ZI212));
 		mark(&act_state->rangeend,   &(ZIend));
@@ -1765,7 +1765,7 @@ p_214(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: group-add-range */
 			{
-#line 722 "src/libre/parser.act"
+#line 725 "src/libre/parser.act"
 
 		int i;
 
@@ -1796,7 +1796,7 @@ p_214(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 		{
 			/* BEGINNING OF ACTION: group-add-char */
 			{
-#line 655 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
 		if (-1 == group_add((ZIg), flags->flags, (*ZI211))) {
 			err->e = RE_EERRNO;
@@ -1828,7 +1828,7 @@ p_218(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 
 			/* BEGINNING OF EXTRACT: CLOSECOUNT */
 			{
-#line 458 "src/libre/parser.act"
+#line 459 "src/libre/parser.act"
 
 		ZI174 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
@@ -1839,7 +1839,7 @@ p_218(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 1091 "src/libre/parser.act"
+#line 1092 "src/libre/parser.act"
 
 		mark(&act_state->countstart, &(*ZI215));
 		mark(&act_state->countend,   &(ZIend));
@@ -1849,7 +1849,7 @@ p_218(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-m-to-n */
 			{
-#line 880 "src/libre/parser.act"
+#line 885 "src/libre/parser.act"
 
 		unsigned i;
 		struct fsm_state *a;
@@ -1908,7 +1908,7 @@ p_218(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			case (TOK_COUNT):
 				/* BEGINNING OF EXTRACT: COUNT */
 				{
-#line 587 "src/libre/parser.act"
+#line 596 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -1940,7 +1940,7 @@ p_218(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			case (TOK_CLOSECOUNT):
 				/* BEGINNING OF EXTRACT: CLOSECOUNT */
 				{
-#line 458 "src/libre/parser.act"
+#line 459 "src/libre/parser.act"
 
 		ZIend = lex_state->lx.start;
 		ZI177   = lex_state->lx.end;
@@ -1955,7 +1955,7 @@ p_218(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 1091 "src/libre/parser.act"
+#line 1092 "src/libre/parser.act"
 
 		mark(&act_state->countstart, &(*ZI215));
 		mark(&act_state->countend,   &(ZIend));
@@ -1965,7 +1965,7 @@ p_218(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-m-to-n */
 			{
-#line 880 "src/libre/parser.act"
+#line 885 "src/libre/parser.act"
 
 		unsigned i;
 		struct fsm_state *a;
@@ -2068,7 +2068,7 @@ p_re__pcre(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err e
 			{
 				/* BEGINNING OF ACTION: err-expected-alts */
 				{
-#line 1032 "src/libre/parser.act"
+#line 1036 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXALTS;
@@ -2098,7 +2098,7 @@ p_re__pcre(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err e
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 1074 "src/libre/parser.act"
+#line 1078 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
@@ -2134,7 +2134,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: add-any */
 					{
-#line 841 "src/libre/parser.act"
+#line 844 "src/libre/parser.act"
 
 		struct fsm *any;
 
@@ -2175,7 +2175,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					}
 					/* BEGINNING OF ACTION: add-epsilon */
 					{
-#line 813 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (*ZIy))) {
 			goto ZL1;
@@ -2217,7 +2217,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					/* END OF INLINE: 170 */
 					/* BEGINNING OF ACTION: push-flags */
 					{
-#line 985 "src/libre/parser.act"
+#line 988 "src/libre/parser.act"
 
 		struct flags *n = malloc(sizeof *n);
 		if (n == NULL) {
@@ -2237,7 +2237,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					}
 					/* BEGINNING OF ACTION: pop-flags */
 					{
-#line 995 "src/libre/parser.act"
+#line 1000 "src/libre/parser.act"
 
 		struct flags *t = flags->parent;
 		assert(t != NULL);
@@ -2272,7 +2272,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 
 					/* BEGINNING OF EXTRACT: OPENCOUNT */
 					{
-#line 453 "src/libre/parser.act"
+#line 454 "src/libre/parser.act"
 
 		ZI215 = lex_state->lx.start;
 		ZI216   = lex_state->lx.end;
@@ -2285,7 +2285,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					case (TOK_COUNT):
 						/* BEGINNING OF EXTRACT: COUNT */
 						{
-#line 587 "src/libre/parser.act"
+#line 596 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -2325,7 +2325,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: count-0-or-1 */
 					{
-#line 923 "src/libre/parser.act"
+#line 924 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (*ZIy))) {
 			goto ZL5;
@@ -2341,7 +2341,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: count-1-or-many */
 					{
-#line 956 "src/libre/parser.act"
+#line 957 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (*ZIy), (ZIx))) {
 			goto ZL5;
@@ -2374,7 +2374,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: count-0-or-many */
 					{
-#line 929 "src/libre/parser.act"
+#line 930 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (*ZIy))) {
 			goto ZL5;
@@ -2410,7 +2410,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 				{
 					/* BEGINNING OF ACTION: count-1 */
 					{
-#line 979 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 		(void) (ZIx);
 		(void) (*ZIy);
@@ -2426,7 +2426,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 			{
 				/* BEGINNING OF ACTION: err-expected-count */
 				{
-#line 1018 "src/libre/parser.act"
+#line 1022 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCOUNT;
@@ -2466,7 +2466,7 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
-#line 553 "src/libre/parser.act"
+#line 557 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -2486,7 +2486,7 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 				{
 					/* BEGINNING OF EXTRACT: ESC */
 					{
-#line 480 "src/libre/parser.act"
+#line 485 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -2516,7 +2516,7 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 
 					/* BEGINNING OF EXTRACT: HEX */
 					{
-#line 525 "src/libre/parser.act"
+#line 532 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -2557,7 +2557,7 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 
 					/* BEGINNING OF EXTRACT: OCT */
 					{
-#line 497 "src/libre/parser.act"
+#line 504 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -2598,7 +2598,7 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 		/* END OF INLINE: 145 */
 		/* BEGINNING OF ACTION: add-literal */
 		{
-#line 830 "src/libre/parser.act"
+#line 831 "src/libre/parser.act"
 
 		assert((ZIx) != NULL);
 		assert((ZIy) != NULL);
@@ -2621,7 +2621,7 @@ ZL1:;
 
 /* BEGINNING OF TRAILER */
 
-#line 1096 "src/libre/parser.act"
+#line 1268 "src/libre/parser.act"
 
 
 	static int
@@ -2682,7 +2682,6 @@ ZL1:;
 		/* (except for pushing "[" and "]" around ::group-$dialect) */
 		lx->buf   = &lex_state->buf;
 		lx->push  = CAT(LX_PREFIX, _dynpush);
-		lx->pop   = CAT(LX_PREFIX, _dynpop);
 		lx->clear = CAT(LX_PREFIX, _dynclear);
 		lx->free  = CAT(LX_PREFIX, _dynfree);
 
@@ -2795,6 +2794,6 @@ ZL1:;
 		return NULL;
 	}
 
-#line 2799 "src/libre/dialect/pcre/parser.c"
+#line 2798 "src/libre/dialect/pcre/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/pcre/parser.h
+++ b/src/libre/dialect/pcre/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 416 "src/libre/parser.act"
+#line 428 "src/libre/parser.act"
 
 
 	#include <re/re.h>
@@ -29,7 +29,7 @@
 extern void p_re__pcre(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 /* BEGINNING OF TRAILER */
 
-#line 1269 "src/libre/parser.act"
+#line 1270 "src/libre/parser.act"
 
 
 #line 36 "src/libre/dialect/pcre/parser.h"

--- a/src/libre/dialect/sql/lexer.h
+++ b/src/libre/dialect/sql/lexer.h
@@ -50,7 +50,6 @@ struct lx_sql_lx {
 
 	void *buf;
 	int  (*push) (struct lx_sql_lx *lx, char c);
-	void (*pop)  (struct lx_sql_lx *lx);
 	int  (*clear)(struct lx_sql_lx *lx);
 	void (*free) (struct lx_sql_lx *lx);
 
@@ -100,7 +99,6 @@ void lx_sql_init(struct lx_sql_lx *lx);
 enum lx_sql_token lx_sql_next(struct lx_sql_lx *lx);
 
 int  lx_sql_dynpush(struct lx_sql_lx *lx, char c);
-void lx_sql_dynpop(struct lx_sql_lx *lx);
 int  lx_sql_dynclear(struct lx_sql_lx *lx);
 void lx_sql_dynfree(struct lx_sql_lx *lx);
 

--- a/src/libre/dialect/sql/parser.c
+++ b/src/libre/dialect/sql/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 23 "src/libre/parser.act"
+#line 137 "src/libre/parser.act"
 
 
 	#include <assert.h>
@@ -456,7 +456,7 @@ p_re__sql(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 				{
 					/* BEGINNING OF ACTION: add-epsilon */
 					{
-#line 813 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (ZIy))) {
 			goto ZL3;
@@ -473,7 +473,7 @@ p_re__sql(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 			{
 				/* BEGINNING OF ACTION: err-expected-alts */
 				{
-#line 1032 "src/libre/parser.act"
+#line 1036 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXALTS;
@@ -503,7 +503,7 @@ p_re__sql(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 1074 "src/libre/parser.act"
+#line 1078 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
@@ -535,7 +535,7 @@ p_expr_C_Clist_Hof_Halts_C_Calt(fsm fsm, flags flags, lex_state lex_state, act_s
 
 		/* BEGINNING OF ACTION: add-concat */
 		{
-#line 806 "src/libre/parser.act"
+#line 807 "src/libre/parser.act"
 
 		(ZIz) = fsm_addstate(fsm);
 		if ((ZIz) == NULL) {
@@ -547,7 +547,7 @@ p_expr_C_Clist_Hof_Halts_C_Calt(fsm fsm, flags flags, lex_state lex_state, act_s
 		/* END OF ACTION: add-concat */
 		/* BEGINNING OF ACTION: add-epsilon */
 		{
-#line 813 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (ZIz))) {
 			goto ZL1;
@@ -620,7 +620,7 @@ p_173(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 436 "src/libre/parser.act"
+#line 437 "src/libre/parser.act"
 
 		ZIb = '-';
 		ZI127 = lex_state->lx.start;
@@ -632,7 +632,7 @@ p_173(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: group-add-char */
 			{
-#line 655 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
 		if (-1 == group_add((ZIg), flags->flags, (ZIb))) {
 			err->e = RE_EERRNO;
@@ -666,7 +666,7 @@ p_group(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err,
 
 		/* BEGINNING OF ACTION: make-group */
 		{
-#line 621 "src/libre/parser.act"
+#line 622 "src/libre/parser.act"
 
 		(ZIg).set = fsm_new_blank(fsm->opt);
 		if ((ZIg).set == NULL) {
@@ -689,7 +689,7 @@ p_group(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err,
 		}
 		/* BEGINNING OF ACTION: group-to-states */
 		{
-#line 744 "src/libre/parser.act"
+#line 747 "src/libre/parser.act"
 
 		int r;
 
@@ -762,7 +762,7 @@ p_177(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 					case (TOK_RANGE):
 						/* BEGINNING OF EXTRACT: RANGE */
 						{
-#line 436 "src/libre/parser.act"
+#line 437 "src/libre/parser.act"
 
 		ZI106 = '-';
 		ZI107 = lex_state->lx.start;
@@ -782,7 +782,7 @@ p_177(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 				{
 					/* BEGINNING OF ACTION: err-expected-range */
 					{
-#line 1039 "src/libre/parser.act"
+#line 1043 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXRANGE;
@@ -805,7 +805,7 @@ p_177(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 
 						/* BEGINNING OF EXTRACT: CHAR */
 						{
-#line 553 "src/libre/parser.act"
+#line 557 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -827,7 +827,7 @@ p_177(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 
 						/* BEGINNING OF EXTRACT: RANGE */
 						{
-#line 436 "src/libre/parser.act"
+#line 437 "src/libre/parser.act"
 
 		ZIb = '-';
 		ZI112 = lex_state->lx.start;
@@ -846,7 +846,7 @@ p_177(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			/* END OF INLINE: 109 */
 			/* BEGINNING OF ACTION: mark-range */
 			{
-#line 1086 "src/libre/parser.act"
+#line 1087 "src/libre/parser.act"
 
 		mark(&act_state->rangestart, &(*ZI175));
 		mark(&act_state->rangeend,   &(ZIend));
@@ -856,7 +856,7 @@ p_177(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: group-add-range */
 			{
-#line 722 "src/libre/parser.act"
+#line 725 "src/libre/parser.act"
 
 		int i;
 
@@ -887,7 +887,7 @@ p_177(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err err, t
 		{
 			/* BEGINNING OF ACTION: group-add-char */
 			{
-#line 655 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
 		if (-1 == group_add((ZIg), flags->flags, (*ZI174))) {
 			err->e = RE_EERRNO;
@@ -926,7 +926,7 @@ p_group_C_Cgroup_Hbody(fsm fsm, flags flags, lex_state lex_state, act_state act_
 
 					/* BEGINNING OF EXTRACT: CLOSEGROUP */
 					{
-#line 447 "src/libre/parser.act"
+#line 448 "src/libre/parser.act"
 
 		ZI170 = ']';
 		ZI171 = lex_state->lx.start;
@@ -938,7 +938,7 @@ p_group_C_Cgroup_Hbody(fsm fsm, flags flags, lex_state lex_state, act_state act_
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: group-add-char */
 					{
-#line 655 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
 		if (-1 == group_add((ZIg), flags->flags, (ZI170))) {
 			err->e = RE_EERRNO;
@@ -963,7 +963,7 @@ p_group_C_Cgroup_Hbody(fsm fsm, flags flags, lex_state lex_state, act_state act_
 
 					/* BEGINNING OF EXTRACT: RANGE */
 					{
-#line 436 "src/libre/parser.act"
+#line 437 "src/libre/parser.act"
 
 		ZIc = '-';
 		ZI123 = lex_state->lx.start;
@@ -975,7 +975,7 @@ p_group_C_Cgroup_Hbody(fsm fsm, flags flags, lex_state lex_state, act_state act_
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: group-add-char */
 					{
-#line 655 "src/libre/parser.act"
+#line 656 "src/libre/parser.act"
 
 		if (-1 == group_add((ZIg), flags->flags, (ZIc))) {
 			err->e = RE_EERRNO;
@@ -1046,7 +1046,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
-#line 553 "src/libre/parser.act"
+#line 557 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -1166,7 +1166,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 					/* END OF INLINE: group::class */
 					/* BEGINNING OF ACTION: group-add-class */
 					{
-#line 662 "src/libre/parser.act"
+#line 670 "src/libre/parser.act"
 
 		struct fsm *q;
 		int r;
@@ -1239,7 +1239,7 @@ ZL2_group_C_Clist_Hof_Hterms:;
 			{
 				/* BEGINNING OF ACTION: err-expected-term */
 				{
-#line 1011 "src/libre/parser.act"
+#line 1015 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXTERM;
@@ -1288,7 +1288,7 @@ ZL2_expr_C_Clist_Hof_Hatoms:;
 
 		/* BEGINNING OF ACTION: add-concat */
 		{
-#line 806 "src/libre/parser.act"
+#line 807 "src/libre/parser.act"
 
 		(ZIz) = fsm_addstate(fsm);
 		if ((ZIz) == NULL) {
@@ -1315,7 +1315,7 @@ ZL2_expr_C_Clist_Hof_Hatoms:;
 				{
 					/* BEGINNING OF ACTION: add-epsilon */
 					{
-#line 813 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIz), (ZIy))) {
 			goto ZL1;
@@ -1353,7 +1353,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 		case (TOK_OPENGROUP):
 			/* BEGINNING OF EXTRACT: OPENGROUP */
 			{
-#line 442 "src/libre/parser.act"
+#line 443 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
 		ZI132   = lex_state->lx.end;
@@ -1375,7 +1375,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 
 					/* BEGINNING OF EXTRACT: INVERT */
 					{
-#line 432 "src/libre/parser.act"
+#line 433 "src/libre/parser.act"
 
 		ZI134 = '^';
 	
@@ -1390,7 +1390,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 					}
 					/* BEGINNING OF ACTION: invert-group */
 					{
-#line 634 "src/libre/parser.act"
+#line 640 "src/libre/parser.act"
 
 		struct fsm *any;
 
@@ -1443,7 +1443,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 				case (TOK_CLOSEGROUP):
 					/* BEGINNING OF EXTRACT: CLOSEGROUP */
 					{
-#line 447 "src/libre/parser.act"
+#line 448 "src/libre/parser.act"
 
 		ZI136 = ']';
 		ZI137 = lex_state->lx.start;
@@ -1459,7 +1459,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 				ADVANCE_LEXER;
 				/* BEGINNING OF ACTION: mark-group */
 				{
-#line 1081 "src/libre/parser.act"
+#line 1082 "src/libre/parser.act"
 
 		mark(&act_state->groupstart, &(ZIstart));
 		mark(&act_state->groupend,   &(ZIend));
@@ -1473,7 +1473,7 @@ p_group_C_Cgroup_Hbm(fsm fsm, flags flags, lex_state lex_state, act_state act_st
 			{
 				/* BEGINNING OF ACTION: err-expected-closegroup */
 				{
-#line 1046 "src/libre/parser.act"
+#line 1050 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCLOSEGROUP;
@@ -1493,7 +1493,7 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-groupbody */
 		{
-#line 1053 "src/libre/parser.act"
+#line 1057 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXGROUPBODY;
@@ -1549,7 +1549,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: add-any */
 					{
-#line 841 "src/libre/parser.act"
+#line 844 "src/libre/parser.act"
 
 		struct fsm *any;
 
@@ -1577,7 +1577,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: add-any */
 					{
-#line 841 "src/libre/parser.act"
+#line 844 "src/libre/parser.act"
 
 		struct fsm *any;
 
@@ -1600,7 +1600,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					/* END OF ACTION: add-any */
 					/* BEGINNING OF ACTION: count-0-or-many */
 					{
-#line 929 "src/libre/parser.act"
+#line 930 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (*ZIy))) {
 			goto ZL1;
@@ -1679,7 +1679,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: count-1-or-many */
 					{
-#line 956 "src/libre/parser.act"
+#line 957 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (*ZIy), (ZIx))) {
 			goto ZL4;
@@ -1712,7 +1712,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: count-0-or-many */
 					{
-#line 929 "src/libre/parser.act"
+#line 930 "src/libre/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (*ZIy))) {
 			goto ZL4;
@@ -1748,7 +1748,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 				{
 					/* BEGINNING OF ACTION: count-1 */
 					{
-#line 979 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 		(void) (ZIx);
 		(void) (*ZIy);
@@ -1764,7 +1764,7 @@ p_expr_C_Catom(fsm fsm, flags flags, lex_state lex_state, act_state act_state, e
 			{
 				/* BEGINNING OF ACTION: err-expected-count */
 				{
-#line 1018 "src/libre/parser.act"
+#line 1022 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCOUNT;
@@ -1804,7 +1804,7 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 				case (TOK_CHAR):
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
-#line 553 "src/libre/parser.act"
+#line 557 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -1827,7 +1827,7 @@ p_literal(fsm fsm, flags flags, lex_state lex_state, act_state act_state, err er
 		/* END OF INLINE: 139 */
 		/* BEGINNING OF ACTION: add-literal */
 		{
-#line 830 "src/libre/parser.act"
+#line 831 "src/libre/parser.act"
 
 		assert((ZIx) != NULL);
 		assert((ZIy) != NULL);
@@ -1850,7 +1850,7 @@ ZL1:;
 
 /* BEGINNING OF TRAILER */
 
-#line 1096 "src/libre/parser.act"
+#line 1268 "src/libre/parser.act"
 
 
 	static int
@@ -1911,7 +1911,6 @@ ZL1:;
 		/* (except for pushing "[" and "]" around ::group-$dialect) */
 		lx->buf   = &lex_state->buf;
 		lx->push  = CAT(LX_PREFIX, _dynpush);
-		lx->pop   = CAT(LX_PREFIX, _dynpop);
 		lx->clear = CAT(LX_PREFIX, _dynclear);
 		lx->free  = CAT(LX_PREFIX, _dynfree);
 
@@ -2024,6 +2023,6 @@ ZL1:;
 		return NULL;
 	}
 
-#line 2028 "src/libre/dialect/sql/parser.c"
+#line 2027 "src/libre/dialect/sql/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/sql/parser.h
+++ b/src/libre/dialect/sql/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 416 "src/libre/parser.act"
+#line 428 "src/libre/parser.act"
 
 
 	#include <re/re.h>
@@ -29,7 +29,7 @@
 extern void p_re__sql(fsm, flags, lex_state, act_state, err, t_fsm__state, t_fsm__state);
 /* BEGINNING OF TRAILER */
 
-#line 1269 "src/libre/parser.act"
+#line 1270 "src/libre/parser.act"
 
 
 #line 36 "src/libre/dialect/sql/parser.h"

--- a/src/libre/parser.act
+++ b/src/libre/parser.act
@@ -1153,7 +1153,6 @@
 		/* (except for pushing "[" and "]" around ::group-$dialect) */
 		lx->buf   = &lex_state->buf;
 		lx->push  = CAT(LX_PREFIX, _dynpush);
-		lx->pop   = CAT(LX_PREFIX, _dynpop);
 		lx->clear = CAT(LX_PREFIX, _dynclear);
 		lx->free  = CAT(LX_PREFIX, _dynfree);
 

--- a/src/lx/lexer.h
+++ b/src/lx/lexer.h
@@ -56,7 +56,6 @@ struct lx {
 
 	void *buf;
 	int  (*push) (struct lx *lx, char c);
-	void (*pop)  (struct lx *lx);
 	int  (*clear)(struct lx *lx);
 	void (*free) (struct lx *lx);
 
@@ -108,7 +107,6 @@ enum lx_token lx_next(struct lx *lx);
 int lx_fgetc(struct lx *lx);
 
 int  lx_dynpush(struct lx *lx, char c);
-void lx_dynpop(struct lx *lx);
 int  lx_dynclear(struct lx *lx);
 void lx_dynfree(struct lx *lx);
 

--- a/src/lx/out/c.c
+++ b/src/lx/out/c.c
@@ -572,27 +572,6 @@ out_buf(FILE *f)
 		fprintf(f, "}\n");
 		fprintf(f, "\n");
 
-		fprintf(f, "void\n");
-		fprintf(f, "%sdynpop(struct %slx *lx)\n", prefix.api, prefix.lx);
-		fprintf(f, "{\n");
-		fprintf(f, "\tstruct lx_dynbuf *t;\n");
-		fprintf(f, "\n");
-		fprintf(f, "\tassert(lx != NULL);\n");
-		fprintf(f, "\n");
-		fprintf(f, "\tt = lx->buf;\n");
-		fprintf(f, "\n");
-		fprintf(f, "\tassert(t != NULL);\n");
-		fprintf(f, "\tassert(t->a != NULL);\n");
-		fprintf(f, "\tassert(t->p >= t->a);\n");
-		fprintf(f, "\n");
-		fprintf(f, "\tif (t->p == t->a) {\n");
-		fprintf(f, "\t\treturn;\n");
-		fprintf(f, "\t}\n");
-		fprintf(f, "\n");
-		fprintf(f, "\tt->p--;\n");
-		fprintf(f, "}\n");
-		fprintf(f, "\n");
-
 		fprintf(f, "int\n");
 		fprintf(f, "%sdynclear(struct %slx *lx)\n", prefix.api, prefix.lx);
 		fprintf(f, "{\n");
@@ -666,27 +645,6 @@ out_buf(FILE *f)
 		fprintf(f, "\t*t->p++ = c;\n");
 		fprintf(f, "\n");
 		fprintf(f, "\treturn 0;\n");
-		fprintf(f, "}\n");
-		fprintf(f, "\n");
-
-		fprintf(f, "void\n");
-		fprintf(f, "%sfixedpop(struct %slx *lx)\n", prefix.api, prefix.lx);
-		fprintf(f, "{\n");
-		fprintf(f, "\tstruct lx_fixedbuf *t;\n");
-		fprintf(f, "\n");
-		fprintf(f, "\tassert(lx != NULL);\n");
-		fprintf(f, "\n");
-		fprintf(f, "\tt = lx->buf;\n");
-		fprintf(f, "\n");
-		fprintf(f, "\tassert(t != NULL);\n");
-		fprintf(f, "\tassert(t->a != NULL);\n");
-		fprintf(f, "\tassert(t->p >= t->a);\n");
-		fprintf(f, "\n");
-		fprintf(f, "\tif (t->p == t->a) {\n");
-		fprintf(f, "\t\treturn;\n");
-		fprintf(f, "\t}\n");
-		fprintf(f, "\n");
-		fprintf(f, "\tt->p--;\n");
 		fprintf(f, "}\n");
 		fprintf(f, "\n");
 

--- a/src/lx/out/c.c
+++ b/src/lx/out/c.c
@@ -799,7 +799,7 @@ out_zone(FILE *f, const struct ast *ast, const struct ast_zone *z)
 	fprintf(f, "\t\t}\n");
 	fprintf(f, "\n");
 
-	{
+	if (~api_exclude & API_BUF) {
 		struct fsm_state *s;
 		int has_skips;
 
@@ -845,26 +845,22 @@ out_zone(FILE *f, const struct ast *ast, const struct ast_zone *z)
 			fprintf(f, "\n");
 
 			fprintf(f, "\t\tdefault:\n");
-			if (~api_exclude & API_BUF) {
-				fprintf(f, "\t\t\tif (lx->push != NULL) {\n");
-				fprintf(f, "\t\t\t\tif (-1 == lx->push(lx, %s)) {\n", opt.cp);
-				fprintf(f, "\t\t\t\t\treturn %sERROR;\n", prefix.tok);
-				fprintf(f, "\t\t\t\t}\n");
-				fprintf(f, "\t\t\t}\n");
-			}
+			fprintf(f, "\t\t\tif (lx->push != NULL) {\n");
+			fprintf(f, "\t\t\t\tif (-1 == lx->push(lx, %s)) {\n", opt.cp);
+			fprintf(f, "\t\t\t\t\treturn %sERROR;\n", prefix.tok);
+			fprintf(f, "\t\t\t\t}\n");
+			fprintf(f, "\t\t\t}\n");
 			fprintf(f, "\t\t\tbreak;\n");
 			fprintf(f, "\n");
 
 			fprintf(f, "\t\t}\n");
 			fprintf(f, "\n");
 		} else {
-			if (~api_exclude & API_BUF) {
-				fprintf(f, "\t\tif (lx->push != NULL) {\n");
-				fprintf(f, "\t\t\tif (-1 == lx->push(lx, %s)) {\n", opt.cp);
-				fprintf(f, "\t\t\t\treturn %sERROR;\n", prefix.tok);
-				fprintf(f, "\t\t\t}\n");
-				fprintf(f, "\t\t}\n");
-			}
+			fprintf(f, "\t\tif (lx->push != NULL) {\n");
+			fprintf(f, "\t\t\tif (-1 == lx->push(lx, %s)) {\n", opt.cp);
+			fprintf(f, "\t\t\t\treturn %sERROR;\n", prefix.tok);
+			fprintf(f, "\t\t\t}\n");
+			fprintf(f, "\t\t}\n");
 			fprintf(f, "\n");
 		}
 	}

--- a/src/lx/out/dump.c
+++ b/src/lx/out/dump.c
@@ -198,7 +198,6 @@ out_dump(FILE *f)
 
 		fprintf(f, "\tlx.buf   = &buf;\n");
 		fprintf(f, "\tlx.push  = lx_dynpush;\n");
-		fprintf(f, "\tlx.pop   = lx_dynpop;\n");
 		fprintf(f, "\tlx.clear = lx_dynclear;\n");
 		fprintf(f, "\tlx.free  = lx_dynfree;\n");
 		fprintf(f, "\n");
@@ -212,7 +211,6 @@ out_dump(FILE *f)
 
 		fprintf(f, "\tlx.buf   = &buf;\n");
 		fprintf(f, "\tlx.push  = lx_fixedpush;\n");
-		fprintf(f, "\tlx.pop   = lx_fixedpop;\n");
 		fprintf(f, "\tlx.clear = lx_fixedclear;\n");
 		fprintf(f, "\tlx.free  = NULL;\n");
 		fprintf(f, "\n");

--- a/src/lx/out/h.c
+++ b/src/lx/out/h.c
@@ -113,7 +113,6 @@ lx_out_h(const struct ast *ast, FILE *f)
 	if (~api_exclude & API_BUF) {
 		fprintf(f, "\tvoid *buf;\n");
 		fprintf(f, "\tint  (*push) (struct %slx *lx, char c);\n", prefix.lx);
-		fprintf(f, "\tvoid (*pop)  (struct %slx *lx);\n", prefix.lx);
 		fprintf(f, "\tint  (*clear)(struct %slx *lx);\n", prefix.lx);
 		fprintf(f, "\tvoid (*free) (struct %slx *lx);\n", prefix.lx);
 		fprintf(f, "\n");
@@ -234,7 +233,6 @@ lx_out_h(const struct ast *ast, FILE *f)
 
 	if (api_tokbuf & API_DYNBUF) {
 		fprintf(f, "int  %sdynpush(struct %slx *lx, char c);\n", prefix.api, prefix.lx);
-		fprintf(f, "void %sdynpop(struct %slx *lx);\n", prefix.api, prefix.lx);
 		fprintf(f, "int  %sdynclear(struct %slx *lx);\n", prefix.api, prefix.lx);
 		fprintf(f, "void %sdynfree(struct %slx *lx);\n", prefix.api, prefix.lx);
 		fprintf(f, "\n");
@@ -242,7 +240,6 @@ lx_out_h(const struct ast *ast, FILE *f)
 
 	if (api_tokbuf & API_FIXEDBUF) {
 		fprintf(f, "int  %sfixedpush(struct %slx *lx, char c);\n", prefix.api, prefix.lx);
-		fprintf(f, "void %sfixedpop(struct %slx *lx);\n", prefix.api, prefix.lx);
 		fprintf(f, "int  %sfixedclear(struct %slx *lx);\n", prefix.api, prefix.lx);
 		fprintf(f, "\n");
 	}

--- a/src/lx/parser.act
+++ b/src/lx/parser.act
@@ -843,7 +843,6 @@
 
 		lx->buf   = &lex_state->buf;
 		lx->push  = lx_dynpush;
-		lx->pop   = lx_dynpop;
 		lx->clear = lx_dynclear;
 		lx->free  = lx_dynfree;
 

--- a/src/lx/parser.c
+++ b/src/lx/parser.c
@@ -3184,7 +3184,7 @@ ZL1:;
 
 /* BEGINNING OF TRAILER */
 
-#line 869 "src/lx/parser.act"
+#line 868 "src/lx/parser.act"
 
 
 	struct ast *lx_parse(FILE *f, const struct fsm_options *opt) {
@@ -3213,7 +3213,6 @@ ZL1:;
 
 		lx->buf   = &lex_state->buf;
 		lx->push  = lx_dynpush;
-		lx->pop   = lx_dynpop;
 		lx->clear = lx_dynclear;
 		lx->free  = lx_dynfree;
 
@@ -3236,6 +3235,6 @@ ZL1:;
 		return ast;
 	}
 
-#line 3240 "src/lx/parser.c"
+#line 3239 "src/lx/parser.c"
 
 /* END OF FILE */

--- a/src/lx/parser.h
+++ b/src/lx/parser.h
@@ -29,7 +29,7 @@
 extern void p_lx(lex_state, act_state, ast *);
 /* BEGINNING OF TRAILER */
 
-#line 871 "src/lx/parser.act"
+#line 870 "src/lx/parser.act"
 
 
 #line 36 "src/lx/parser.h"


### PR DESCRIPTION
This is redundant; the generated FSM has been rearranged such that characters are only pushed to the buffer if they're known to be present there. Thus `.pop()` is no longer called from `ungetc()`. Note `ungetc()` itself still exists; this is to replace a single character from the input stream, not from the output to the capturing buffer.