### PR TITLE
Exclude NFA start state from its own epsilon closure for reversed FSM with multiple end states

### DIFF
--- a/include/fsm/pred.h
+++ b/include/fsm/pred.h
@@ -37,5 +37,11 @@ fsm_hasincoming(const struct fsm *fsm, const struct fsm_state *state);
 int
 fsm_hasoutgoing(const struct fsm *fsm, const struct fsm_state *state);
 
+/*
+ * True iff there are outgoing edges and all are epsilons.
+ */
+int
+fsm_epsilonsonly(const struct fsm *fsm, const struct fsm_state *state);
+
 #endif
 

--- a/src/libfsm/pred/Makefile
+++ b/src/libfsm/pred/Makefile
@@ -5,6 +5,7 @@ SRC += src/libfsm/pred/isany.c
 SRC += src/libfsm/pred/isdfa.c
 SRC += src/libfsm/pred/isend.c
 SRC += src/libfsm/pred/iscomplete.c
+SRC += src/libfsm/pred/epsilonsonly.c
 SRC += src/libfsm/pred/hasincoming.c
 SRC += src/libfsm/pred/hasoutgoing.c
 

--- a/src/libfsm/pred/epsilonsonly.c
+++ b/src/libfsm/pred/epsilonsonly.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2008-2017 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stddef.h>
+
+#include <adt/set.h>
+
+#include <fsm/pred.h>
+
+#include "../internal.h"
+
+int
+fsm_epsilonsonly(const struct fsm *fsm, const struct fsm_state *state)
+{
+	struct fsm_edge *e, s;
+	struct set_iter it;
+
+	assert(fsm != NULL);
+	assert(state != NULL);
+
+	(void) fsm;
+
+	s.symbol = FSM_EDGE_EPSILON;
+	e = set_contains(state->edges, &s);
+	if (e == NULL || set_empty(e->sl)) {
+		return 0;
+	}
+
+	for (e = set_first(state->edges, &it); e != NULL; e = set_next(&it)) {
+		if (e->symbol == FSM_EDGE_EPSILON) {
+			continue;
+		}
+
+		if (!set_empty(e->sl)) {
+			return 0;
+		}
+	}
+
+	return 1;
+}
+


### PR DESCRIPTION
This addresses the situation described by #62.