### PR TITLE
Fixes off-by-one error in set_remove

### DIFF
--- a/src/adt/set.c
+++ b/src/adt/set.c
@@ -174,7 +174,7 @@ set_remove(struct set **set, void *item)
 	i = set_search(s, item);
 	if (s->cmp(item, s->a[i]) == 0) {
 		if (i < s->i) {
-			memmove(&s->a[i], &s->a[i + 1], (s->i - i) * (sizeof *s->a));
+			memmove(&s->a[i], &s->a[i + 1], (s->i - i - 1) * (sizeof *s->a));
 		}
 
 		s->i--;


### PR DESCRIPTION
asan detected a heap buffer overflow associated with the memmove in
set_remove.  There was an off-by-one error in the number of elements
moved.  The memmove is moving elements i+1 ... s->i-1 to i ... s->i-2, a
total of s->i - i - 1 elements.