### PR TITLE
Skip to avoid numeric values of 0 for set items.

### DIFF
--- a/fuzz/fuzz_adt_set.c
+++ b/fuzz/fuzz_adt_set.c
@@ -12,7 +12,7 @@
 struct model {
 	struct set_hook_env *env;
 	size_t bit_count;
-	uint64_t bits[]; /* 0-based */
+	uint64_t bits[];
 };
 
 static enum theft_trial_res prop_set_operations(struct theft *t, void *arg1);
@@ -136,8 +136,11 @@ static enum theft_trial_res prop_set_equality(struct theft *t, void *arg1)
 	set_b = set_create(cmp_item);
 
 	for (i = 0; i < seq->count; i++) {
-		(void) set_add(&set_a, (void *) ((uintptr_t) seq->values[i] + 1U)); /* XXX */
-		(void) set_add(&set_b, (void *) ((uintptr_t) permuted[i]    + 1U));
+		assert(seq->values[i] != 0);
+		assert(permuted[i] != 0);
+
+		(void) set_add(&set_a, (void *) ((uintptr_t) seq->values[i])); /* XXX */
+		(void) set_add(&set_b, (void *) ((uintptr_t) permuted[i]));
 	}
 
 	if (!set_equal(set_a, set_b)) {
@@ -178,7 +181,9 @@ op_add(struct model *m, struct set_op *op, struct set **set)
 
 	old_s = *set;
 
-	(void) set_add(set, (void *) ((uintptr_t) op->u.add.item + 1U)); /* XXX */
+	assert(op->u.add.item != 0);
+
+	(void) set_add(set, (void *) ((uintptr_t) op->u.add.item)); /* XXX */
 
 	if (m->env->verbosity > 0) {
 		fprintf(stderr, "ITEM IS %zu (decimal)\n", (size_t) op->u.add.item);
@@ -202,7 +207,9 @@ op_remove(struct model *m, struct set_op *op, struct set **set)
 
 	old_s = *set;
 
-	set_remove(set, (void *) ((uintptr_t) op->u.remove.item + 1U));
+	assert(op->u.remove.item != 0);
+
+	set_remove(set, (void *) ((uintptr_t) op->u.remove.item));
 
 	if (m->env->verbosity > 0) {
 		fprintf(stderr, "REMOVE 0x%" PRIxPTR " to %p => %p\n",
@@ -278,7 +285,7 @@ postcondition(struct model *m, struct set *set)
 			.set = set,
 		};
 
-		uintptr_t first_item = (uintptr_t) set_first(set, &it) - 1U;
+		uintptr_t first_item = (uintptr_t) set_first(set, &it);
 
 		if (model_first == (size_t) -1) {
 			/* this is a bit weird */

--- a/fuzz/type_info_adt_set.c
+++ b/fuzz/type_info_adt_set.c
@@ -45,10 +45,16 @@ alloc_scen(struct theft *t, void *type_env, void **output)
 		switch (op->t) {
 		case SET_OP_ADD:
 			op->u.add.item = theft_random_bits(t, env->item_bits);
+			if (op->u.add.item == 0) {
+				return THEFT_ALLOC_SKIP;
+			}
 			break;
 
 		case SET_OP_REMOVE:
 			op->u.remove.item = theft_random_bits(t, env->item_bits);
+			if (op->u.remove.item == 0) {
+				return THEFT_ALLOC_SKIP;
+			}
 			break;
 
 		case SET_OP_CLEAR:
@@ -136,6 +142,9 @@ alloc_seq(struct theft *t, void *type_env, void **output)
 
 	for (size_t i = 0; i < count; i++) {
 		res->values[i] = theft_random_bits(t, 16);
+		if (res->values[i] == 0) {
+			return THEFT_ALLOC_SKIP;
+		}
 	}
 
 	*output = res;

--- a/fuzz/type_info_adt_set.c
+++ b/fuzz/type_info_adt_set.c
@@ -46,14 +46,14 @@ alloc_scen(struct theft *t, void *type_env, void **output)
 		case SET_OP_ADD:
 			op->u.add.item = theft_random_bits(t, env->item_bits);
 			if (op->u.add.item == 0) {
-				return THEFT_ALLOC_SKIP;
+				goto skip;
 			}
 			break;
 
 		case SET_OP_REMOVE:
 			op->u.remove.item = theft_random_bits(t, env->item_bits);
 			if (op->u.remove.item == 0) {
-				return THEFT_ALLOC_SKIP;
+				goto skip;
 			}
 			break;
 
@@ -69,6 +69,12 @@ alloc_scen(struct theft *t, void *type_env, void **output)
 	*output = res;
 
 	return THEFT_ALLOC_OK;
+
+skip:
+
+	free(res);
+
+	return THEFT_ALLOC_SKIP;
 }
 
 static void
@@ -143,13 +149,19 @@ alloc_seq(struct theft *t, void *type_env, void **output)
 	for (size_t i = 0; i < count; i++) {
 		res->values[i] = theft_random_bits(t, 16);
 		if (res->values[i] == 0) {
-			return THEFT_ALLOC_SKIP;
+			goto skip;
 		}
 	}
 
 	*output = res;
 
 	return THEFT_ALLOC_OK;
+
+skip:
+
+	free(res);
+
+	return THEFT_ALLOC_SKIP;
 }
 
 static void

--- a/fuzz/type_info_adt_set.h
+++ b/fuzz/type_info_adt_set.h
@@ -21,10 +21,10 @@ struct set_op {
 	enum set_op_type t;
 	union {
 		struct {
-			uintptr_t item;
+			uintptr_t item; /* 0-based */
 		} add;
 		struct {
-			uintptr_t item;
+			uintptr_t item; /* 0-based */
 		} remove;
 	} u;
 };

--- a/fuzz/type_info_adt_set.h
+++ b/fuzz/type_info_adt_set.h
@@ -21,10 +21,10 @@ struct set_op {
 	enum set_op_type t;
 	union {
 		struct {
-			uintptr_t item; /* 0-based */
+			uintptr_t item;
 		} add;
 		struct {
-			uintptr_t item; /* 0-based */
+			uintptr_t item;
 		} remove;
 	} u;
 };


### PR DESCRIPTION
These are disallowed by the set API since it depends on returning `NULL` for errors.

Here I'm slightly sloppily assuming that `uintptr_t` is larger than `uint16_t`. I didn't feel like introducing a compile-time assertion for that.