### PR TITLE
Fixes src/libfsm/libfsm.syms for OS X

### DIFF
--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -84,4 +84,5 @@ fsm_exec
 fsm_fgetc
 fsm_sgetc
 
-fsm_out_c # XXX: workaround for lx
+# XXX: workaround for lx
+fsm_out_c


### PR DESCRIPTION
Small problem with a comment in the symbol listing.  OS X doesn't
support comments prefixed with '#', and the sed command used to remove
the comments only works with comments at the beginning of the line.

Changed one of the comments so it starts at the beginning of the line.