### PR TITLE
lx: Retain/restore column position around newlines in `*getc/*ungetc`.

### DIFF
--- a/src/lx/out/c.c
+++ b/src/lx/out/c.c
@@ -478,7 +478,8 @@ out_io(FILE *f)
 		fprintf(f, "\n");
 		fprintf(f, "\tif (c == '\\n') {\n");
 		fprintf(f, "\t\tlx->end.line++;\n");
-		fprintf(f, "\t\tlx->end.col = 1;\n");
+		fprintf(f, "\t\tlx->end.saved_col = lx->end.col - 1;\n");
+		fprintf(f, "\t\tlx->end.col = 0;\n");
 		fprintf(f, "\t}\n");
 		fprintf(f, "\n");
 	}
@@ -526,7 +527,7 @@ out_io(FILE *f)
 		fprintf(f, "\n");
 		fprintf(f, "\tif (c == '\\n') {\n");
 		fprintf(f, "\t\tlx->end.line--;\n");
-		fprintf(f, "\t\tlx->end.col = 0; /* XXX: lost information */\n");
+		fprintf(f, "\t\tlx->end.col = lx->end.saved_col;\n");
 		fprintf(f, "\t}\n");
 	}
 	fprintf(f, "}\n");

--- a/src/lx/out/h.c
+++ b/src/lx/out/h.c
@@ -72,12 +72,13 @@ lx_out_h(const struct ast *ast, FILE *f)
 	if (~api_exclude & API_POS) {
 		fprintf(f, "/*\n");
 		fprintf(f, " * .byte is 0-based.\n");
-		fprintf(f, " * .line and .col are 1-based; 0 means unknown.\n");
+		fprintf(f, " * .line, .col, and .saved_col are 1-based; 0 means unknown.\n");
 		fprintf(f, " */\n");
 		fprintf(f, "struct lx_pos {\n");
 		fprintf(f, "\tunsigned byte;\n");
 		fprintf(f, "\tunsigned line;\n");
 		fprintf(f, "\tunsigned col;\n");
+		fprintf(f, "\tunsigned saved_col;\n");
 		fprintf(f, "};\n");
 		fprintf(f, "\n");
 	}


### PR DESCRIPTION
This adds a field to `struct lx_pos`, `.saved_col`, which is used to
save and restore the column position when `getc`/`ungetc` handle '\n'.

If I'm understanding the test setup correctly, this change does not
cause any new test failures. I have a small standalone test program
which uses an lx-genearted lexer with `-b dyn -k str`, sinks various
known strings into it, and checks that the line/colum/byte positions are
as expected. I could add that to the PR, but I'm not sure how to
integrate a standalone .c test program into the build/test config.

This implementation wastes an unsigned (`.saved_col` is unused in
`lx->start`), which could be avoided, but would likely complicate
the other code generation.