### PR TITLE
subgraph.c: Fix use-after-free.

### DIFF
--- a/src/libfsm/subgraph.c
+++ b/src/libfsm/subgraph.c
@@ -111,6 +111,7 @@ fsm_state_duplicatesubgraphx(struct fsm *fsm, struct fsm_state *state,
 	struct mapping *mappings;
 	struct mapping *m;
 	struct mapping *start;
+	struct fsm_state *res;
 
 	assert(fsm != NULL);
 	assert(state != NULL);
@@ -156,8 +157,9 @@ fsm_state_duplicatesubgraphx(struct fsm *fsm, struct fsm_state *state,
 		m->done = 1;
 	}
 
+	res = start->new;
 	mapping_free(mappings);
 
-	return start->new;
+	return res;
 }
 


### PR DESCRIPTION
Running `(abc){3,5}d` under valgrind while working on the `sql`
dialect found a use-after-free here. It looks like the current
implementation can free `start` during the `mapping_free(mappings);`
at the end, so the resulting state should be grabbed first.

I'm not 100% sure all the details are correct, but this change
is sufficient to eliminate the valgrind warning.