### PR TITLE
AST rendering to multiple outputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ SUBDIR += src/libfsm/walk
 SUBDIR += src/libfsm
 SUBDIR += src/libre/class
 SUBDIR += src/libre/dialect
+SUBDIR += src/libre/print
 SUBDIR += src/libre
 SUBDIR += src/fsm
 SUBDIR += src/re

--- a/include/print/esc.h
+++ b/include/print/esc.h
@@ -13,6 +13,7 @@ typedef int (escputc)(FILE *f, const struct fsm_options *opt, int c);
 
 escputc c_escputc_char;
 escputc c_escputc_str;
+escputc ebnf_escputc;
 escputc dot_escputc_html;
 escputc fsm_escputc;
 escputc json_escputc;

--- a/man/re.1/re.1.xml
+++ b/man/re.1/re.1.xml
@@ -349,6 +349,7 @@ group (for dialects which have them) (rather than a "whole" regexp)
 						&re.1; can also print an &ast; for a regular expression's
 						syntax. The &ast; is printed by specifying one of
 						<literal>ast</literal> (graphviz &dot.lit; output),
+						<literal>ebnf</literal>,
 						or <literal>tree</literal>.</para> <!-- TODO: explain more -->
 
 					<para>An &ast; may also be printed to regular expression

--- a/man/re.1/re.1.xml
+++ b/man/re.1/re.1.xml
@@ -344,6 +344,19 @@ group (for dialects which have them) (rather than a "whole" regexp)
 					<para>Set the output language for printing by &p.opt;.
 						See &fsm_lang.5fsm; for the supported language identifiers.
 						The default is <literal>fsm</literal>.</para>
+
+					<para>In addition to printing &fsm; per &fsm_lang.5fsm;,
+						&re.1; can also print an &ast; for a regular expression's
+						syntax. The &ast; is printed by specifying one of
+						<literal>ast</literal> (graphviz &dot.lit; output),
+						or <literal>tree</literal>.</para> <!-- TODO: explain more -->
+
+					<para>An &ast; may also be printed to regular expression
+						syntax, by specifying <literal>pcre</literal>.</para>
+					<!-- TODO: document under re(3) when the API is exposed -->
+
+					<para>When printing &ast; output, only a single regular
+						expression may be given.</para>
 				</listitem>
 			</varlistentry>
 

--- a/share/dtd/ent-abbr.dtd
+++ b/share/dtd/ent-abbr.dtd
@@ -7,6 +7,7 @@
 <!ENTITY iso    "<acronym>ISO</acronym>">
 
 <!-- TODO: generate from glossary! -->
+<!ENTITY ast    "<acronym role='Abstract Syntax Tree'>AST</acronym>">
 <!ENTITY fsm    "<acronym role='Finite State Machine'>FSM</acronym>">
 <!ENTITY dfa    "<acronym role='Deterministic Finite Automata'>DFA</acronym>">
 <!ENTITY nfa    "<acronym role='Non-Deterministic Finite Automata'>NFA</acronym>">

--- a/src/libre/Makefile
+++ b/src/libre/Makefile
@@ -7,7 +7,6 @@ SRC += src/libre/re_analysis.c
 SRC += src/libre/re_ast.c
 SRC += src/libre/re_comp.c
 SRC += src/libre/re_char_class.c
-SRC += src/libre/re_print.c
 
 LIB        += libre
 SYMS.libre += src/libre/libre.syms

--- a/src/libre/libre.syms
+++ b/src/libre/libre.syms
@@ -6,5 +6,6 @@ re_perror
 # XXX: for re(1)
 re_parse
 re_ast_print_dot
+re_ast_print_ebnf
 re_ast_print_pcre
 re_ast_print_tree

--- a/src/libre/libre.syms
+++ b/src/libre/libre.syms
@@ -2,3 +2,9 @@ re_comp
 re_flags
 re_strerror
 re_perror
+
+# XXX: for re(1)
+re_parse
+re_ast_print_dot
+re_ast_print_pcre
+re_ast_print_tree

--- a/src/libre/print.h
+++ b/src/libre/print.h
@@ -19,6 +19,9 @@ void
 re_ast_print_dot(FILE *f, const struct fsm_options *opt, struct ast_re *ast);
 
 void
+re_ast_print_pcre(FILE *f, const struct fsm_options *opt, struct ast_re *ast);
+
+void
 re_ast_print_tree(FILE *f, struct ast_re *ast);
 
 #endif

--- a/src/libre/print.h
+++ b/src/libre/print.h
@@ -16,6 +16,9 @@
 #define PRETTYPRINT_AST 0
 
 void
+re_ast_print_dot(FILE *f, const struct fsm_options *opt, struct ast_re *ast);
+
+void
 re_ast_print_tree(FILE *f, struct ast_re *ast);
 
 #endif

--- a/src/libre/print.h
+++ b/src/libre/print.h
@@ -16,6 +16,7 @@ typedef void (re_ast_print)(FILE *f, const struct fsm_options *opt,
 	const struct ast_re *ast);
 
 re_ast_print re_ast_print_dot;
+re_ast_print re_ast_print_ebnf;
 re_ast_print re_ast_print_pcre;
 re_ast_print re_ast_print_tree;
 

--- a/src/libre/print.h
+++ b/src/libre/print.h
@@ -7,21 +7,18 @@
 #ifndef RE_INTERNAL_PRINT_H
 #define RE_INTERNAL_PRINT_H
 
-#include <stdlib.h>
 #include <stdio.h>
-#include <assert.h>
-
-#include "re_ast.h"
 
 #define PRETTYPRINT_AST 0
 
-void
-re_ast_print_dot(FILE *f, const struct fsm_options *opt, struct ast_re *ast);
+struct ast_re;
+struct fsm_options;
 
-void
-re_ast_print_pcre(FILE *f, const struct fsm_options *opt, struct ast_re *ast);
+typedef void (re_ast_print)(FILE *f, const struct fsm_options *opt,
+	const struct ast_re *ast);
 
-void
-re_ast_print_tree(FILE *f, struct ast_re *ast);
+re_ast_print re_ast_print_dot;
+re_ast_print re_ast_print_pcre;
+re_ast_print re_ast_print_tree;
 
 #endif

--- a/src/libre/print.h
+++ b/src/libre/print.h
@@ -4,8 +4,8 @@
  * See LICENCE for the full copyright terms.
  */
 
-#ifndef RE_PRINT_H
-#define RE_PRINT_H
+#ifndef RE_INTERNAL_PRINT_H
+#define RE_INTERNAL_PRINT_H
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -16,6 +16,6 @@
 #define PRETTYPRINT_AST 0
 
 void
-re_ast_print(FILE *f, struct ast_re *ast);
+re_ast_print_tree(FILE *f, struct ast_re *ast);
 
 #endif

--- a/src/libre/print.h
+++ b/src/libre/print.h
@@ -9,8 +9,6 @@
 
 #include <stdio.h>
 
-#define PRETTYPRINT_AST 0
-
 struct ast_re;
 struct fsm_options;
 

--- a/src/libre/print/Makefile
+++ b/src/libre/print/Makefile
@@ -1,0 +1,14 @@
+.include "../../../share/mk/top.mk"
+
+SRC += src/libre/print/tree.c
+
+.for src in ${SRC:Msrc/libre/print/*.c}
+CFLAGS.${src} += -I src # XXX: for internal.h
+DFLAGS.${src} += -I src # XXX: for internal.h
+.endfor
+
+.for src in ${SRC:Msrc/libre/print/*.c}
+${BUILD}/lib/libre.o:    ${BUILD}/${src:R}.o
+${BUILD}/lib/libre.opic: ${BUILD}/${src:R}.opic
+.endfor
+

--- a/src/libre/print/Makefile
+++ b/src/libre/print/Makefile
@@ -1,5 +1,6 @@
 .include "../../../share/mk/top.mk"
 
+SRC += src/libre/print/dot.c
 SRC += src/libre/print/tree.c
 
 .for src in ${SRC:Msrc/libre/print/*.c}

--- a/src/libre/print/Makefile
+++ b/src/libre/print/Makefile
@@ -1,6 +1,7 @@
 .include "../../../share/mk/top.mk"
 
 SRC += src/libre/print/dot.c
+SRC += src/libre/print/ebnf.c
 SRC += src/libre/print/pcre.c
 SRC += src/libre/print/tree.c
 

--- a/src/libre/print/Makefile
+++ b/src/libre/print/Makefile
@@ -1,6 +1,7 @@
 .include "../../../share/mk/top.mk"
 
 SRC += src/libre/print/dot.c
+SRC += src/libre/print/pcre.c
 SRC += src/libre/print/tree.c
 
 .for src in ${SRC:Msrc/libre/print/*.c}

--- a/src/libre/print/dot.c
+++ b/src/libre/print/dot.c
@@ -9,6 +9,7 @@
 
 #include <print/esc.h>
 
+#include "../re_ast.h"
 #include "../re_char_class.h"
 #include "../print.h"
 
@@ -37,6 +38,9 @@ static void
 pp_iter(FILE *f, const struct fsm_options *opt,
 	const void *parent, struct ast_expr *n)
 {
+	assert(f != NULL);
+	assert(opt != NULL);
+
 	if (n == NULL) { return; }
 
 	if (parent != NULL) {
@@ -108,8 +112,13 @@ pp_iter(FILE *f, const struct fsm_options *opt,
 }
 
 void
-re_ast_print_dot(FILE *f, const struct fsm_options *opt, struct ast_re *ast)
+re_ast_print_dot(FILE *f, const struct fsm_options *opt,
+	const struct ast_re *ast)
 {
+	assert(f != NULL);
+	assert(opt != NULL);
+	assert(ast != NULL);
+
 	fprintf(f, "digraph G {\n");
 	fprintf(f, "\tnode [ shape = Mrecord ];\n");
 	fprintf(f, "\tedge [ dir = none ];\n");
@@ -153,6 +162,8 @@ static void
 cc_pp_iter(FILE *f, const struct fsm_options *opt,
 	const void *parent, struct re_char_class_ast *n)
 {
+	assert(f != NULL);
+	assert(opt != NULL);
 	assert(n != NULL);
 
 	if (parent != NULL) {

--- a/src/libre/print/dot.c
+++ b/src/libre/print/dot.c
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2018 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <stdio.h>
+#include <ctype.h>
+
+#include <print/esc.h>
+
+#include "../re_char_class.h"
+#include "../print.h"
+
+static void
+re_flags_print(FILE *f, enum re_flags fl);
+
+static void
+cc_pp_iter(FILE *f, const struct fsm_options *opt,
+	const void *parent, struct re_char_class_ast *n);
+
+static void
+print_range_endpoint(FILE *f, const struct fsm_options *opt,
+	const struct ast_range_endpoint *r);
+
+static void
+fprintf_count(FILE *f, unsigned count)
+{
+	if (count == AST_COUNT_UNBOUNDED) {
+		fprintf(f, "&#x221e;");
+	} else {
+		fprintf(f, "%u", count);
+	}
+}
+
+static void
+pp_iter(FILE *f, const struct fsm_options *opt,
+	const void *parent, struct ast_expr *n)
+{
+	if (n == NULL) { return; }
+
+	if (parent != NULL) {
+		fprintf(f, "\tn%p -> n%p;\n", parent, (void *) n);
+	}
+
+	switch (n->t) {
+	case AST_EXPR_EMPTY:
+		fprintf(f, "\tn%p [ label = <EMPTY> ];\n", (void *) n);
+		break;
+
+	case AST_EXPR_CONCAT:
+		fprintf(f, "\tn%p [ label = <CONCAT> ];\n", (void *) n);
+		pp_iter(f, opt, n, n->u.concat.l);
+		pp_iter(f, opt, n, n->u.concat.r);
+		break;
+
+	case AST_EXPR_ALT:
+		fprintf(f, "\tn%p [ label = <ALT> ];\n", (void *) n);
+		pp_iter(f, opt, n, n->u.alt.l);
+		pp_iter(f, opt, n, n->u.alt.r);
+		break;
+
+	case AST_EXPR_LITERAL:
+		fprintf(f, "\tn%p [ label = <LITERAL|", (void *) n);
+		dot_escputc_html(f, opt, n->u.literal.c);
+		fprintf(f, "> ];\n");
+		break;
+
+	case AST_EXPR_ANY:
+		fprintf(f, "\tn%p [ label = <ANY> ];\n", (void *) n);
+		break;
+
+	case AST_EXPR_MANY:
+		fprintf(f, "\tn%p [ label = <MANY> ];\n", (void *) n);
+		break;
+
+	case AST_EXPR_REPEATED:
+		fprintf(f, "\tn%p [ label = <REPEATED|&#x7b;", (void *) n);
+		fprintf_count(f, n->u.repeated.low);
+		fprintf(f, ", ");
+		fprintf_count(f, n->u.repeated.high);
+		fprintf(f, "&#x7d;> ];\n");
+		pp_iter(f, opt, n, n->u.repeated.e);
+		break;
+
+	case AST_EXPR_CHAR_CLASS:
+		fprintf(f, "\tn%p [ label = <CHAR_CLASS> ];\n", (void *) n);
+		cc_pp_iter(f, opt, n, n->u.char_class.cca);
+		break;
+
+	case AST_EXPR_GROUP:
+		fprintf(f, "\tn%p [ label = <GROUP|#%u> ];\n", (void *) n,
+			n->u.group.id);
+		pp_iter(f, opt, n, n->u.group.e);
+		break;
+
+	case AST_EXPR_FLAGS:
+		fprintf(f, "\tn%p [ label = <{FLAGS|{+", (void *) n);
+		re_flags_print(f, n->u.flags.pos);
+		fprintf(f, "|-");
+		re_flags_print(f, n->u.flags.neg);
+		fprintf(f, "> ];\n");
+		break;
+
+	default:
+		assert(0);
+	}
+}
+
+void
+re_ast_print_dot(FILE *f, const struct fsm_options *opt, struct ast_re *ast)
+{
+	fprintf(f, "digraph G {\n");
+	fprintf(f, "\tnode [ shape = Mrecord ];\n");
+	fprintf(f, "\tedge [ dir = none ];\n");
+	fprintf(f, "\troot = n%p;\n", (void *) ast);
+	fprintf(f, "\tsplines = false;\n");
+	fprintf(f, "\n");
+
+	pp_iter(f, opt, NULL, ast->expr);
+
+	fprintf(f, "}\n");
+}
+
+static void
+re_flags_print(FILE *f, enum re_flags fl)
+{
+	const char *sep = "";
+	if (fl & RE_ICASE) { fprintf(f, "%si", sep); sep = " "; }
+	if (fl & RE_TEXT) { fprintf(f, "%sg", sep); sep = " "; }
+	if (fl & RE_MULTI) { fprintf(f, "%sm", sep); sep = " "; }
+	if (fl & RE_REVERSE) { fprintf(f, "%sr", sep); sep = " "; }
+	if (fl & RE_SINGLE) { fprintf(f, "%ss", sep); sep = " "; }
+	if (fl & RE_ZONE) { fprintf(f, "%sz", sep); sep = " "; }
+}
+
+static void
+print_range_endpoint(FILE *f, const struct fsm_options *opt,
+	const struct ast_range_endpoint *r)
+{
+	switch (r->t) {
+	case AST_RANGE_ENDPOINT_LITERAL:
+		dot_escputc_html(f, opt, r->u.literal.c);
+		break;
+
+	default:
+		assert(0);
+		break;
+	}
+}
+
+static void
+cc_pp_iter(FILE *f, const struct fsm_options *opt,
+	const void *parent, struct re_char_class_ast *n)
+{
+	assert(n != NULL);
+
+	if (parent != NULL) {
+		fprintf(f, "\tn%p -> n%p;\n", parent, (void *) n);
+	}
+
+	fprintf(f, "\tn%p [ style = \"filled\", fillcolor = \"#eeeeee\" ];\n", (void *) n);
+
+	switch (n->t) {
+	case RE_CHAR_CLASS_AST_CONCAT:
+		fprintf(f, "\tn%p [ label = <CLASS-CONCAT> ];\n", (void *) n);
+		cc_pp_iter(f, opt, n, n->u.concat.l);
+		cc_pp_iter(f, opt, n, n->u.concat.r);
+		break;
+
+	case RE_CHAR_CLASS_AST_LITERAL:
+		fprintf(f, "\tn%p [ label = <CLASS-LITERAL|", (void *) n);
+		dot_escputc_html(f, opt, n->u.literal.c);
+		fprintf(f, "> ];\n");
+		break;
+
+	case RE_CHAR_CLASS_AST_RANGE:
+		fprintf(f, "\tn%p [ label = <CLASS-RANGE|", (void *) n);
+		print_range_endpoint(f, opt, &n->u.range.from);
+		fprintf(f, " &ndash; ");
+		print_range_endpoint(f, opt, &n->u.range.to);
+		fprintf(f, "> ];\n");
+		break;
+
+	case RE_CHAR_CLASS_AST_NAMED:
+		fprintf(f, "\tn%p [ label = <CLASS-NAMED|(opaque)> ];\n", (void *) n);
+		break;
+
+	case RE_CHAR_CLASS_AST_FLAGS:
+		fprintf(f, "\tn%p [ label = <CLASS-FLAGS|", (void *) n);
+		if (n->u.flags.f & RE_CHAR_CLASS_FLAG_INVERTED) {
+			fprintf(f, "^");
+		}
+		if (n->u.flags.f & RE_CHAR_CLASS_FLAG_MINUS) {
+			fprintf(f, "-");
+		}
+		fprintf(f, "> ];\n");
+		break;
+
+	case RE_CHAR_CLASS_AST_SUBTRACT:
+		fprintf(f, "\tn%p [ label = <{CLASS-SUBTRACT|{ast|mask}}> ];\n", (void *) n);
+		cc_pp_iter(f, opt, n, n->u.subtract.ast);
+		cc_pp_iter(f, opt, n, n->u.subtract.mask);
+		break;
+
+	default:
+		fprintf(stderr, "(MATCH FAIL)\n");
+		assert(0);
+	}
+}
+

--- a/src/libre/print/ebnf.c
+++ b/src/libre/print/ebnf.c
@@ -1,0 +1,294 @@
+/*
+ * Copyright 2018 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <stdio.h>
+#include <ctype.h>
+
+#include <print/esc.h>
+
+#include "../re_ast.h"
+#include "../re_char_class.h"
+#include "../print.h"
+
+static void
+re_flags_print(FILE *f, enum re_flags fl);
+
+static void
+cc_pp_iter(FILE *f, const struct fsm_options *opt,
+	struct re_char_class_ast *n);
+
+static void
+pp_iter(FILE *f, const struct fsm_options *opt, struct ast_expr *n);
+
+static int
+atomic(struct ast_expr *n)
+{
+	switch (n->t) {
+	case AST_EXPR_EMPTY:
+	case AST_EXPR_LITERAL:
+	case AST_EXPR_ANY:
+	case AST_EXPR_CHAR_CLASS:
+	case AST_EXPR_GROUP:
+		return 1;
+
+	case AST_EXPR_REPEATED:
+	case AST_EXPR_CONCAT:
+	case AST_EXPR_ALT:
+	case AST_EXPR_MANY:
+		return 0;
+
+	case AST_EXPR_FLAGS:
+		return 0; /* XXX */
+
+	default:
+		assert(0);
+	}
+}
+
+static void
+print_grouped(FILE *f, const struct fsm_options *opt, struct ast_expr *n)
+{
+	assert(f != NULL);
+	assert(opt != NULL);
+	assert(n != NULL);
+
+	if (atomic(n)) {
+		pp_iter(f, opt, n);
+	} else {
+		fprintf(f, "(");
+		pp_iter(f, opt, n);
+		fprintf(f, ")");
+	}
+}
+
+static void
+pp_repeat(FILE *f, const struct fsm_options *opt, struct ast_expr *n,
+	unsigned m)
+{
+	assert(f != NULL);
+	assert(opt != NULL);
+	assert(n != NULL);
+
+	if (m == 0) {
+		return;
+	}
+
+	if (m == 1) {
+		pp_iter(f, opt, n);
+		return;
+	}
+
+	fprintf(f, "%u * ", m);
+	print_grouped(f, opt, n);
+}
+
+static void
+pp_iter(FILE *f, const struct fsm_options *opt, struct ast_expr *n)
+{
+	assert(f != NULL);
+	assert(opt != NULL);
+
+	if (n == NULL) { return; }
+
+	switch (n->t) {
+	case AST_EXPR_EMPTY:
+		break;
+
+	case AST_EXPR_CONCAT:
+		pp_iter(f, opt, n->u.concat.l);
+		fprintf(f, ", ");
+		pp_iter(f, opt, n->u.concat.r);
+		break;
+
+	case AST_EXPR_ALT:
+		pp_iter(f, opt, n->u.alt.l);
+		fprintf(f, " | "); /* XXX: indent */
+		pp_iter(f, opt, n->u.alt.r);
+		break;
+
+	case AST_EXPR_LITERAL:
+		fprintf(f, "\'");
+		ebnf_escputc(f, opt, n->u.literal.c);
+		fprintf(f, "\'");
+		break;
+
+	case AST_EXPR_ANY:
+		fprintf(f, "any");
+		break;
+
+	case AST_EXPR_MANY:
+		fprintf(f, "ANY, { ANY }");
+		break;
+
+	case AST_EXPR_REPEATED: {
+		unsigned delta;
+		unsigned i;
+
+		if (n->u.repeated.high == AST_COUNT_UNBOUNDED) {
+			pp_repeat(f, opt, n->u.repeated.e, n->u.repeated.low);
+			if (n->u.repeated.low > 0) {
+				fprintf(f, ", ");
+			}
+
+			fprintf(f, "{ ");
+			pp_iter(f, opt, n->u.repeated.e);
+			fprintf(f, " }");
+
+			return;
+		}
+
+		if (n->u.repeated.low == 0 && n->u.repeated.high == 1) {
+			fprintf(f, "[ ");
+			pp_iter(f, opt, n->u.repeated.e);
+			fprintf(f, " ]");
+
+			return;
+		}
+
+		pp_repeat(f, opt, n->u.repeated.e, n->u.repeated.low);
+
+		delta = n->u.repeated.high - n->u.repeated.low;
+
+		if (n->u.repeated.low > 0 && delta > 0) {
+			fprintf(f, ", ");
+		}
+
+		for (i = 0; i < delta; i++) {
+			fprintf(f, "[ ");
+			pp_iter(f, opt, n->u.repeated.e);
+
+			if (i + 1 < delta) {
+				fprintf(f, ", ");
+			}
+		}
+		for (i = 0; i < delta; i++) {
+			fprintf(f, " ]");
+		}
+
+		break;
+	}
+
+	case AST_EXPR_CHAR_CLASS:
+		fprintf(f, "(");
+		cc_pp_iter(f, opt, n->u.char_class.cca);
+		fprintf(f, ")");
+		break;
+
+	case AST_EXPR_GROUP:
+		fprintf(f, "(");
+		pp_iter(f, opt, n->u.group.e);
+		fprintf(f, ")");
+		break;
+
+	case AST_EXPR_FLAGS:
+		abort();
+
+	default:
+		assert(0);
+	}
+}
+
+void
+re_ast_print_ebnf(FILE *f, const struct fsm_options *opt,
+	const struct ast_re *ast)
+{
+	assert(f != NULL);
+	assert(opt != NULL);
+	assert(ast != NULL);
+
+	fprintf(f, "e = ");
+
+	pp_iter(f, opt, ast->expr);
+
+	fprintf(f, "\n");
+	fprintf(f, "  ;");
+	fprintf(f, "\n");
+}
+
+static void
+re_flags_print(FILE *f, enum re_flags fl)
+{
+	const char *sep = "";
+	if (fl & RE_ICASE) { fprintf(f, "%si", sep); sep = " "; }
+	if (fl & RE_TEXT) { fprintf(f, "%sg", sep); sep = " "; }
+	if (fl & RE_MULTI) { fprintf(f, "%sm", sep); sep = " "; }
+	if (fl & RE_REVERSE) { fprintf(f, "%sr", sep); sep = " "; }
+	if (fl & RE_SINGLE) { fprintf(f, "%ss", sep); sep = " "; }
+	if (fl & RE_ZONE) { fprintf(f, "%sz", sep); sep = " "; }
+}
+
+static void
+cc_pp_iter(FILE *f, const struct fsm_options *opt, struct re_char_class_ast *n)
+{
+	assert(f != NULL);
+	assert(opt != NULL);
+	assert(n != NULL);
+
+	switch (n->t) {
+	case RE_CHAR_CLASS_AST_CONCAT:
+if (n->u.concat.l != NULL && n->u.concat.l->t == RE_CHAR_CLASS_AST_FLAGS) {
+	/* XXX */
+	cc_pp_iter(f, opt, n->u.concat.r);
+} else {
+		cc_pp_iter(f, opt, n->u.concat.l);
+		fprintf(f, " | ");
+		cc_pp_iter(f, opt, n->u.concat.r);
+}
+		break;
+
+	case RE_CHAR_CLASS_AST_LITERAL:
+		fprintf(f, "\'");
+		ebnf_escputc(f, opt, n->u.literal.c);
+		fprintf(f, "\'");
+		break;
+
+	case RE_CHAR_CLASS_AST_RANGE: {
+		int c;
+
+		if (n->u.range.from.t != AST_RANGE_ENDPOINT_LITERAL || n->u.range.to.t != AST_RANGE_ENDPOINT_LITERAL) {
+			fprintf(stderr, "non-literal range endpoint unsupported\n");
+			abort(); /* XXX */
+		}
+
+		for (c = n->u.range.from.u.literal.c; c <= n->u.range.to.u.literal.c; c++) {
+			fprintf(f, "\'");
+			ebnf_escputc(f, opt, c);
+			fprintf(f, "\'");
+
+			if (c + 1 <= n->u.range.to.u.literal.c) {
+				fprintf(f, " | ");
+			}
+		}
+		break;
+	}
+
+	case RE_CHAR_CLASS_AST_NAMED:
+		fprintf(f, "todo"); /* XXX */
+		break;
+
+	case RE_CHAR_CLASS_AST_FLAGS:
+		if (n->u.flags.f & RE_CHAR_CLASS_FLAG_INVERTED) {
+			fprintf(f, "SOL");
+		}
+		if (n->u.flags.f & RE_CHAR_CLASS_FLAG_MINUS) {
+			fprintf(f, "'-'"); /* XXX */
+		}
+		break;
+
+	case RE_CHAR_CLASS_AST_SUBTRACT:
+		fprintf(stderr, "subtract unsupported\n");
+		abort(); /* XXX */
+
+		cc_pp_iter(f, opt, n->u.subtract.ast);
+		cc_pp_iter(f, opt, n->u.subtract.mask);
+		break;
+
+	default:
+		fprintf(stderr, "(MATCH FAIL)\n");
+		assert(0);
+	}
+}
+

--- a/src/libre/print/pcre.c
+++ b/src/libre/print/pcre.c
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2018 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <stdio.h>
+#include <ctype.h>
+
+#include <print/esc.h>
+
+#include "../re_char_class.h"
+#include "../print.h"
+
+static void
+re_flags_print(FILE *f, enum re_flags fl);
+
+static void
+cc_pp_iter(FILE *f, const struct fsm_options *opt,
+	struct re_char_class_ast *n);
+
+static int
+atomic(struct ast_expr *n)
+{
+	switch (n->t) {
+	case AST_EXPR_EMPTY:
+	case AST_EXPR_LITERAL:
+	case AST_EXPR_ANY:
+	case AST_EXPR_REPEATED:
+	case AST_EXPR_CHAR_CLASS:
+	case AST_EXPR_GROUP:
+		return 1;
+
+	case AST_EXPR_CONCAT:
+	case AST_EXPR_ALT:
+	case AST_EXPR_MANY:
+		return 0;
+
+	case AST_EXPR_FLAGS:
+		return 0; /* XXX */
+
+	default:
+		assert(0);
+	}
+}
+
+static void
+pp_iter(FILE *f, const struct fsm_options *opt, struct ast_expr *n)
+{
+	if (n == NULL) { return; }
+
+	switch (n->t) {
+	case AST_EXPR_EMPTY:
+		break;
+
+	case AST_EXPR_CONCAT:
+		pp_iter(f, opt, n->u.concat.l);
+		pp_iter(f, opt, n->u.concat.r);
+		break;
+
+	case AST_EXPR_ALT:
+		pp_iter(f, opt, n->u.alt.l);
+		fprintf(f, "|");
+		pp_iter(f, opt, n->u.alt.r);
+		break;
+
+	case AST_EXPR_LITERAL:
+		pcre_escputc(f, opt, n->u.literal.c);
+		break;
+
+	case AST_EXPR_ANY:
+		fprintf(f, ".");
+		break;
+
+	case AST_EXPR_MANY:
+		fprintf(f, ".*");
+		break;
+
+	case AST_EXPR_REPEATED: {
+		size_t i;
+
+		static const struct {
+			unsigned m;
+			unsigned n;
+			const char *op;
+		} a[] = {
+#define _ AST_COUNT_UNBOUNDED
+			{ 0, 0, NULL },
+			{ 0, _, "*"  },
+			{ 0, 1, "?"  },
+			{ 1, _, "+"  },
+			{ 1, 1, NULL }
+#undef _
+		};
+
+		if (atomic(n->u.repeated.e)) {
+			pp_iter(f, opt, n->u.repeated.e);
+		} else {
+			fprintf(f, "(?:");
+			pp_iter(f, opt, n->u.repeated.e);
+			fprintf(f, ")");
+		}
+
+		assert(n->u.repeated.high == AST_COUNT_UNBOUNDED || n->u.repeated.high >= n->u.repeated.low);
+
+		for (i = 0; i < sizeof a / sizeof *a; i++) {
+			if (a[i].m == n->u.repeated.low && a[i].n == n->u.repeated.high) {
+				assert(a[i].op != NULL);
+				fprintf(f, "%s", a[i].op);
+				break;
+			}
+		}
+
+		if (i == sizeof a / sizeof *a) {
+			fprintf(f, "{");
+			fprintf(f, "%u", n->u.repeated.low);
+			if (n->u.repeated.high == n->u.repeated.low) {
+				/* nothing */
+			} else if (n->u.repeated.high == AST_COUNT_UNBOUNDED) {
+				fprintf(f, ",");
+			} else {
+				fprintf(f, ",");
+				fprintf(f, "%u", n->u.repeated.high);
+			}
+			fprintf(f, "}");
+		}
+
+		break;
+	}
+
+	case AST_EXPR_CHAR_CLASS:
+		fprintf(f, "[");
+		cc_pp_iter(f, opt, n->u.char_class.cca);
+		fprintf(f, "]");
+		break;
+
+	case AST_EXPR_GROUP:
+		fprintf(f, "(");
+		pp_iter(f, opt, n->u.group.e);
+		fprintf(f, ")");
+		break;
+
+	case AST_EXPR_FLAGS:
+		fprintf(f, "\tn%p [ label = <{FLAGS|{+", (void *) n);
+		re_flags_print(f, n->u.flags.pos);
+		fprintf(f, "|-");
+		re_flags_print(f, n->u.flags.neg);
+		fprintf(f, "> ];\n");
+		break;
+
+	default:
+		assert(0);
+	}
+}
+
+void
+re_ast_print_pcre(FILE *f, const struct fsm_options *opt, struct ast_re *ast)
+{
+	pp_iter(f, opt, ast->expr);
+
+	fprintf(f, "\n");
+}
+
+static void
+re_flags_print(FILE *f, enum re_flags fl)
+{
+	const char *sep = "";
+	if (fl & RE_ICASE) { fprintf(f, "%si", sep); sep = " "; }
+	if (fl & RE_TEXT) { fprintf(f, "%sg", sep); sep = " "; }
+	if (fl & RE_MULTI) { fprintf(f, "%sm", sep); sep = " "; }
+	if (fl & RE_REVERSE) { fprintf(f, "%sr", sep); sep = " "; }
+	if (fl & RE_SINGLE) { fprintf(f, "%ss", sep); sep = " "; }
+	if (fl & RE_ZONE) { fprintf(f, "%sz", sep); sep = " "; }
+}
+
+static void
+print_range_endpoint(FILE *f, const struct fsm_options *opt,
+	const struct ast_range_endpoint *r)
+{
+	switch (r->t) {
+	case AST_RANGE_ENDPOINT_LITERAL:
+		pcre_escputc(f, opt, r->u.literal.c);
+		break;
+
+	default:
+		assert(0);
+		break;
+	}
+}
+
+static void
+cc_pp_iter(FILE *f, const struct fsm_options *opt, struct re_char_class_ast *n)
+{
+	assert(n != NULL);
+
+	switch (n->t) {
+	case RE_CHAR_CLASS_AST_CONCAT:
+		cc_pp_iter(f, opt, n->u.concat.l);
+		cc_pp_iter(f, opt, n->u.concat.r);
+		break;
+
+	case RE_CHAR_CLASS_AST_LITERAL:
+		pcre_escputc(f, opt, n->u.literal.c);
+		break;
+
+	case RE_CHAR_CLASS_AST_RANGE:
+		print_range_endpoint(f, opt, &n->u.range.from);
+		fprintf(f, "-");
+		print_range_endpoint(f, opt, &n->u.range.to);
+		break;
+
+	case RE_CHAR_CLASS_AST_NAMED:
+		fprintf(f, "[:TODO:]"); /* XXX */
+		break;
+
+	case RE_CHAR_CLASS_AST_FLAGS:
+		if (n->u.flags.f & RE_CHAR_CLASS_FLAG_INVERTED) {
+			fprintf(f, "^");
+		}
+		if (n->u.flags.f & RE_CHAR_CLASS_FLAG_MINUS) {
+			fprintf(f, "-");
+		}
+		break;
+
+	case RE_CHAR_CLASS_AST_SUBTRACT:
+		fprintf(f, "\tn%p [ label = <{CLASS-SUBTRACT|{ast|mask}}> ];\n", (void *) n);
+		cc_pp_iter(f, opt, n->u.subtract.ast);
+		cc_pp_iter(f, opt, n->u.subtract.mask);
+		break;
+
+	default:
+		fprintf(stderr, "(MATCH FAIL)\n");
+		assert(0);
+	}
+}
+

--- a/src/libre/print/pcre.c
+++ b/src/libre/print/pcre.c
@@ -9,6 +9,7 @@
 
 #include <print/esc.h>
 
+#include "../re_ast.h"
 #include "../re_char_class.h"
 #include "../print.h"
 
@@ -47,6 +48,9 @@ atomic(struct ast_expr *n)
 static void
 pp_iter(FILE *f, const struct fsm_options *opt, struct ast_expr *n)
 {
+	assert(f != NULL);
+	assert(opt != NULL);
+
 	if (n == NULL) { return; }
 
 	switch (n->t) {
@@ -154,8 +158,13 @@ pp_iter(FILE *f, const struct fsm_options *opt, struct ast_expr *n)
 }
 
 void
-re_ast_print_pcre(FILE *f, const struct fsm_options *opt, struct ast_re *ast)
+re_ast_print_pcre(FILE *f, const struct fsm_options *opt,
+	const struct ast_re *ast)
 {
+	assert(f != NULL);
+	assert(opt != NULL);
+	assert(ast != NULL);
+
 	pp_iter(f, opt, ast->expr);
 
 	fprintf(f, "\n");
@@ -191,6 +200,8 @@ print_range_endpoint(FILE *f, const struct fsm_options *opt,
 static void
 cc_pp_iter(FILE *f, const struct fsm_options *opt, struct re_char_class_ast *n)
 {
+	assert(f != NULL);
+	assert(opt != NULL);
 	assert(n != NULL);
 
 	switch (n->t) {

--- a/src/libre/print/tree.c
+++ b/src/libre/print/tree.c
@@ -4,10 +4,10 @@
  * See LICENCE for the full copyright terms.
  */
 
-#include "re_print.h"
-#include "re_char_class.h"
-
 #include <ctype.h>
+
+#include "../re_char_class.h"
+#include "../print.h"
 
 static void
 re_flags_print(FILE *f, enum re_flags fl);
@@ -108,7 +108,7 @@ pp_iter(FILE *f, size_t indent, struct ast_expr *n)
 }
 
 void
-re_ast_print(FILE *f, struct ast_re *ast)
+re_ast_print_tree(FILE *f, struct ast_re *ast)
 {
 	pp_iter(f, 0, ast->expr);
 }

--- a/src/libre/re.c
+++ b/src/libre/re.c
@@ -87,14 +87,13 @@ re_flags(const char *s, enum re_flags *f)
 	return 0;
 }
 
-struct fsm *
-re_comp(enum re_dialect dialect, int (*getc)(void *opaque), void *opaque,
+struct ast_re *
+re_parse(enum re_dialect dialect, int (*getc)(void *opaque), void *opaque,
 	const struct fsm_options *opt,
 	enum re_flags flags, struct re_err *err)
 {
 	const struct dialect *m;
 	struct ast_re *ast;
-	struct fsm *new;
 
 	assert(getc != NULL);
 
@@ -117,6 +116,22 @@ re_comp(enum re_dialect dialect, int (*getc)(void *opaque), void *opaque,
 	/* TODO: this should be a CLI flag or something */
 	if (PRETTYPRINT_AST) {
 		re_ast_print(stderr, ast);
+	}
+
+	return ast;
+}
+
+struct fsm *
+re_comp(enum re_dialect dialect, int (*getc)(void *opaque), void *opaque,
+	const struct fsm_options *opt,
+	enum re_flags flags, struct re_err *err)
+{
+	struct ast_re *ast;
+	struct fsm *new;
+
+	ast = re_parse(dialect, getc, opaque, opt, flags, err);
+	if (ast == NULL) {
+		return NULL;
 	}
 
 	new = re_comp_ast(ast, flags, opt);

--- a/src/libre/re.c
+++ b/src/libre/re.c
@@ -113,11 +113,6 @@ re_parse(enum re_dialect dialect, int (*getc)(void *opaque), void *opaque,
 	/* Do a complete pass over the AST, filling in other details. */
 	re_ast_analysis(ast);
 
-	/* TODO: this should be a CLI flag or something */
-	if (PRETTYPRINT_AST) {
-		re_ast_print_tree(stderr, opt, ast);
-	}
-
 	return ast;
 }
 

--- a/src/libre/re.c
+++ b/src/libre/re.c
@@ -17,9 +17,9 @@
 #include "../libfsm/internal.h" /* XXX */
 
 #include "dialect/comp.h"
+#include "print.h"
 
 #include "re_ast.h"
-#include "re_print.h"
 #include "re_comp.h"
 #include "re_analysis.h"
 
@@ -115,7 +115,7 @@ re_parse(enum re_dialect dialect, int (*getc)(void *opaque), void *opaque,
 
 	/* TODO: this should be a CLI flag or something */
 	if (PRETTYPRINT_AST) {
-		re_ast_print(stderr, ast);
+		re_ast_print_tree(stderr, ast);
 	}
 
 	return ast;

--- a/src/libre/re.c
+++ b/src/libre/re.c
@@ -115,7 +115,7 @@ re_parse(enum re_dialect dialect, int (*getc)(void *opaque), void *opaque,
 
 	/* TODO: this should be a CLI flag or something */
 	if (PRETTYPRINT_AST) {
-		re_ast_print_tree(stderr, ast);
+		re_ast_print_tree(stderr, opt, ast);
 	}
 
 	return ast;

--- a/src/libre/re_comp.h
+++ b/src/libre/re_comp.h
@@ -9,6 +9,11 @@
 
 #include "re_ast.h"
 
+struct ast_re *
+re_parse(enum re_dialect dialect, int (*getc)(void *opaque), void *opaque,
+	const struct fsm_options *opt,
+	enum re_flags flags, struct re_err *err);
+
 struct fsm *
 re_comp_ast(struct ast_re *ast,
     enum re_flags flags,

--- a/src/lx/parser.c
+++ b/src/lx/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 129 "src/lx/parser.act"
+#line 27 "src/lx/parser.act"
 
 
 	#include <assert.h>
@@ -24,7 +24,6 @@
 	#include <fsm/fsm.h>
 	#include <fsm/bool.h>
 	#include <fsm/pred.h>
-	#include <fsm/out.h>
 	#include <fsm/options.h>
 
 	#include <re/re.h>
@@ -34,7 +33,7 @@
 	#include "lexer.h"
 	#include "parser.h"
 	#include "ast.h"
-	#include "out.h"
+	#include "print.h"
 	#include "var.h"
 
 	struct arr {
@@ -112,7 +111,7 @@
 		return a->len--, (unsigned char) *a->p++;
 	}
 
-#line 116 "src/lx/parser.c"
+#line 115 "src/lx/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -180,11 +179,11 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-list */
 		{
-#line 816 "src/lx/parser.act"
+#line 813 "src/lx/parser.act"
 
 		err_expected(lex_state, "list of mappings, bindings or zones");
 	
-#line 188 "src/lx/parser.c"
+#line 187 "src/lx/parser.c"
 		}
 		/* END OF ACTION: err-expected-list */
 	}
@@ -202,7 +201,7 @@ p_pattern(lex_state lex_state, act_state act_state, zone ZIz, fsm *ZOr)
 
 			/* BEGINNING OF EXTRACT: IDENT */
 			{
-#line 234 "src/lx/parser.act"
+#line 232 "src/lx/parser.act"
 
 		ZIn = xstrdup(lex_state->buf.a);
 		if (ZIn == NULL) {
@@ -210,13 +209,13 @@ p_pattern(lex_state lex_state, act_state act_state, zone ZIz, fsm *ZOr)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 214 "src/lx/parser.c"
+#line 213 "src/lx/parser.c"
 			}
 			/* END OF EXTRACT: IDENT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: deref-var */
 			{
-#line 287 "src/lx/parser.act"
+#line 283 "src/lx/parser.act"
 
 		struct ast_zone *z;
 
@@ -243,7 +242,7 @@ p_pattern(lex_state lex_state, act_state act_state, zone ZIz, fsm *ZOr)
 			goto ZL1;
 		}
 	
-#line 247 "src/lx/parser.c"
+#line 246 "src/lx/parser.c"
 			}
 			/* END OF ACTION: deref-var */
 		}
@@ -254,7 +253,7 @@ p_pattern(lex_state lex_state, act_state act_state, zone ZIz, fsm *ZOr)
 
 			/* BEGINNING OF EXTRACT: TOKEN */
 			{
-#line 226 "src/lx/parser.act"
+#line 223 "src/lx/parser.act"
 
 		/* TODO: submatch addressing */
 		ZIt = xstrdup(lex_state->buf.a + 1); /* +1 for '$' prefix */
@@ -263,13 +262,13 @@ p_pattern(lex_state lex_state, act_state act_state, zone ZIz, fsm *ZOr)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 267 "src/lx/parser.c"
+#line 266 "src/lx/parser.c"
 			}
 			/* END OF EXTRACT: TOKEN */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: deref-token */
 			{
-#line 314 "src/lx/parser.act"
+#line 310 "src/lx/parser.act"
 
 		const struct ast_mapping *m;
 
@@ -316,7 +315,7 @@ p_pattern(lex_state lex_state, act_state act_state, zone ZIz, fsm *ZOr)
 			}
 		}
 	
-#line 320 "src/lx/parser.c"
+#line 319 "src/lx/parser.c"
 			}
 			/* END OF ACTION: deref-token */
 		}
@@ -365,11 +364,11 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-open */
 		{
-#line 800 "src/lx/parser.act"
+#line 797 "src/lx/parser.act"
 
 		err_expected(lex_state, "'{'");
 	
-#line 373 "src/lx/parser.c"
+#line 372 "src/lx/parser.c"
 		}
 		/* END OF ACTION: err-expected-open */
 	}
@@ -395,11 +394,11 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-close */
 		{
-#line 804 "src/lx/parser.act"
+#line 801 "src/lx/parser.act"
 
 		err_expected(lex_state, "'}'");
 	
-#line 403 "src/lx/parser.c"
+#line 402 "src/lx/parser.c"
 		}
 		/* END OF ACTION: err-expected-close */
 	}
@@ -430,7 +429,7 @@ p_list_Hof_Hthings_C_Cthing(lex_state lex_state, act_state act_state, ast ZIa, z
 			}
 			/* BEGINNING OF ACTION: op-reverse */
 			{
-#line 670 "src/lx/parser.act"
+#line 668 "src/lx/parser.act"
 
 		assert((ZI194) != NULL);
 
@@ -439,7 +438,7 @@ p_list_Hof_Hthings_C_Cthing(lex_state lex_state, act_state act_state, ast ZIa, z
 			goto ZL1;
 		}
 	
-#line 443 "src/lx/parser.c"
+#line 442 "src/lx/parser.c"
 			}
 			/* END OF ACTION: op-reverse */
 			p_196 (lex_state, act_state, &ZIz, &ZI194, &ZI191);
@@ -454,7 +453,7 @@ p_list_Hof_Hthings_C_Cthing(lex_state lex_state, act_state act_state, ast ZIa, z
 			}
 			/* BEGINNING OF ACTION: subtract-exit */
 			{
-#line 729 "src/lx/parser.act"
+#line 727 "src/lx/parser.act"
 
 		assert((ZI210) != NULL);
 
@@ -481,7 +480,7 @@ p_list_Hof_Hthings_C_Cthing(lex_state lex_state, act_state act_state, ast ZIa, z
 			}
 		}
 	
-#line 485 "src/lx/parser.c"
+#line 484 "src/lx/parser.c"
 			}
 			/* END OF ACTION: subtract-exit */
 			p_250 (lex_state, act_state, &ZIa, &ZIz, &ZI211, &ZI212);
@@ -512,7 +511,7 @@ p_list_Hof_Hthings_C_Cthing(lex_state lex_state, act_state act_state, ast ZIa, z
 			}
 			/* BEGINNING OF ACTION: op-complete */
 			{
-#line 661 "src/lx/parser.act"
+#line 659 "src/lx/parser.act"
 
 		assert((ZI194) != NULL);
 
@@ -521,7 +520,7 @@ p_list_Hof_Hthings_C_Cthing(lex_state lex_state, act_state act_state, ast ZIa, z
 			goto ZL1;
 		}
 	
-#line 525 "src/lx/parser.c"
+#line 524 "src/lx/parser.c"
 			}
 			/* END OF ACTION: op-complete */
 			p_196 (lex_state, act_state, &ZIz, &ZI194, &ZI191);
@@ -536,7 +535,7 @@ p_list_Hof_Hthings_C_Cthing(lex_state lex_state, act_state act_state, ast ZIa, z
 			}
 			/* BEGINNING OF ACTION: subtract-exit */
 			{
-#line 729 "src/lx/parser.act"
+#line 727 "src/lx/parser.act"
 
 		assert((ZI216) != NULL);
 
@@ -563,7 +562,7 @@ p_list_Hof_Hthings_C_Cthing(lex_state lex_state, act_state act_state, ast ZIa, z
 			}
 		}
 	
-#line 567 "src/lx/parser.c"
+#line 566 "src/lx/parser.c"
 			}
 			/* END OF ACTION: subtract-exit */
 			p_250 (lex_state, act_state, &ZIa, &ZIz, &ZI217, &ZI218);
@@ -579,7 +578,7 @@ p_list_Hof_Hthings_C_Cthing(lex_state lex_state, act_state act_state, ast ZIa, z
 
 			/* BEGINNING OF EXTRACT: IDENT */
 			{
-#line 234 "src/lx/parser.act"
+#line 232 "src/lx/parser.act"
 
 		ZIn = xstrdup(lex_state->buf.a);
 		if (ZIn == NULL) {
@@ -587,7 +586,7 @@ p_list_Hof_Hthings_C_Cthing(lex_state lex_state, act_state act_state, ast ZIa, z
 			exit(EXIT_FAILURE);
 		}
 	
-#line 591 "src/lx/parser.c"
+#line 590 "src/lx/parser.c"
 			}
 			/* END OF EXTRACT: IDENT */
 			ADVANCE_LEXER;
@@ -637,7 +636,7 @@ p_list_Hof_Hthings_C_Cthing(lex_state lex_state, act_state act_state, ast ZIa, z
 			}
 			/* BEGINNING OF ACTION: subtract-exit */
 			{
-#line 729 "src/lx/parser.act"
+#line 727 "src/lx/parser.act"
 
 		assert((ZI223) != NULL);
 
@@ -664,7 +663,7 @@ p_list_Hof_Hthings_C_Cthing(lex_state lex_state, act_state act_state, ast ZIa, z
 			}
 		}
 	
-#line 668 "src/lx/parser.c"
+#line 667 "src/lx/parser.c"
 			}
 			/* END OF ACTION: subtract-exit */
 			p_250 (lex_state, act_state, &ZIa, &ZIz, &ZI224, &ZI225);
@@ -695,7 +694,7 @@ p_list_Hof_Hthings_C_Cthing(lex_state lex_state, act_state act_state, ast ZIa, z
 			}
 			/* BEGINNING OF ACTION: op-complement */
 			{
-#line 652 "src/lx/parser.act"
+#line 650 "src/lx/parser.act"
 
 		assert((ZI194) != NULL);
 
@@ -704,7 +703,7 @@ p_list_Hof_Hthings_C_Cthing(lex_state lex_state, act_state act_state, ast ZIa, z
 			goto ZL1;
 		}
 	
-#line 708 "src/lx/parser.c"
+#line 707 "src/lx/parser.c"
 			}
 			/* END OF ACTION: op-complement */
 			p_196 (lex_state, act_state, &ZIz, &ZI194, &ZI191);
@@ -719,7 +718,7 @@ p_list_Hof_Hthings_C_Cthing(lex_state lex_state, act_state act_state, ast ZIa, z
 			}
 			/* BEGINNING OF ACTION: subtract-exit */
 			{
-#line 729 "src/lx/parser.act"
+#line 727 "src/lx/parser.act"
 
 		assert((ZI204) != NULL);
 
@@ -746,7 +745,7 @@ p_list_Hof_Hthings_C_Cthing(lex_state lex_state, act_state act_state, ast ZIa, z
 			}
 		}
 	
-#line 750 "src/lx/parser.c"
+#line 749 "src/lx/parser.c"
 			}
 			/* END OF ACTION: subtract-exit */
 			p_250 (lex_state, act_state, &ZIa, &ZIz, &ZI205, &ZI206);
@@ -773,7 +772,7 @@ p_list_Hof_Hthings_C_Cthing(lex_state lex_state, act_state act_state, ast ZIa, z
 
 			/* BEGINNING OF EXTRACT: TOKEN */
 			{
-#line 226 "src/lx/parser.act"
+#line 223 "src/lx/parser.act"
 
 		/* TODO: submatch addressing */
 		ZI228 = xstrdup(lex_state->buf.a + 1); /* +1 for '$' prefix */
@@ -782,13 +781,13 @@ p_list_Hof_Hthings_C_Cthing(lex_state lex_state, act_state act_state, ast ZIa, z
 			exit(EXIT_FAILURE);
 		}
 	
-#line 786 "src/lx/parser.c"
+#line 785 "src/lx/parser.c"
 			}
 			/* END OF EXTRACT: TOKEN */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: deref-token */
 			{
-#line 314 "src/lx/parser.act"
+#line 310 "src/lx/parser.act"
 
 		const struct ast_mapping *m;
 
@@ -835,7 +834,7 @@ p_list_Hof_Hthings_C_Cthing(lex_state lex_state, act_state act_state, ast ZIa, z
 			}
 		}
 	
-#line 839 "src/lx/parser.c"
+#line 838 "src/lx/parser.c"
 			}
 			/* END OF ACTION: deref-token */
 			p_182 (lex_state, act_state, ZI229, &ZI194);
@@ -851,7 +850,7 @@ p_list_Hof_Hthings_C_Cthing(lex_state lex_state, act_state act_state, ast ZIa, z
 			}
 			/* BEGINNING OF ACTION: subtract-exit */
 			{
-#line 729 "src/lx/parser.act"
+#line 727 "src/lx/parser.act"
 
 		assert((ZI232) != NULL);
 
@@ -878,7 +877,7 @@ p_list_Hof_Hthings_C_Cthing(lex_state lex_state, act_state act_state, ast ZIa, z
 			}
 		}
 	
-#line 882 "src/lx/parser.c"
+#line 881 "src/lx/parser.c"
 			}
 			/* END OF ACTION: subtract-exit */
 			p_250 (lex_state, act_state, &ZIa, &ZIz, &ZI233, &ZI234);
@@ -918,7 +917,7 @@ p_list_Hof_Hthings_C_Cthing(lex_state lex_state, act_state act_state, ast ZIa, z
 			}
 			/* BEGINNING OF ACTION: subtract-exit */
 			{
-#line 729 "src/lx/parser.act"
+#line 727 "src/lx/parser.act"
 
 		assert((ZI239) != NULL);
 
@@ -945,7 +944,7 @@ p_list_Hof_Hthings_C_Cthing(lex_state lex_state, act_state act_state, ast ZIa, z
 			}
 		}
 	
-#line 949 "src/lx/parser.c"
+#line 948 "src/lx/parser.c"
 			}
 			/* END OF ACTION: subtract-exit */
 			p_250 (lex_state, act_state, &ZIa, &ZIz, &ZI240, &ZI241);
@@ -965,11 +964,11 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-thing */
 		{
-#line 812 "src/lx/parser.act"
+#line 809 "src/lx/parser.act"
 
 		err_expected(lex_state, "mapping, binding or zone");
 	
-#line 973 "src/lx/parser.c"
+#line 972 "src/lx/parser.c"
 		}
 		/* END OF ACTION: err-expected-thing */
 	}
@@ -1040,7 +1039,7 @@ ZL2_165:;
 			}
 			/* BEGINNING OF ACTION: op-alt */
 			{
-#line 718 "src/lx/parser.act"
+#line 716 "src/lx/parser.act"
 
 		assert((ZI162) != NULL);
 		assert((ZIb) != NULL);
@@ -1051,7 +1050,7 @@ ZL2_165:;
 			goto ZL1;
 		}
 	
-#line 1055 "src/lx/parser.c"
+#line 1054 "src/lx/parser.c"
 			}
 			/* END OF ACTION: op-alt */
 			/* BEGINNING OF INLINE: 165 */
@@ -1094,14 +1093,14 @@ ZL2_pattern_C_Cbody:;
 					{
 						/* BEGINNING OF EXTRACT: CHAR */
 						{
-#line 221 "src/lx/parser.act"
+#line 216 "src/lx/parser.act"
 
 		assert(lex_state->buf.a[0] != '\0');
 		assert(lex_state->buf.a[1] == '\0');
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 1105 "src/lx/parser.c"
+#line 1104 "src/lx/parser.c"
 						}
 						/* END OF EXTRACT: CHAR */
 						ADVANCE_LEXER;
@@ -1111,7 +1110,7 @@ ZL2_pattern_C_Cbody:;
 					{
 						/* BEGINNING OF EXTRACT: ESC */
 						{
-#line 151 "src/lx/parser.act"
+#line 144 "src/lx/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -1129,7 +1128,7 @@ ZL2_pattern_C_Cbody:;
 		default:   ZIc = '\0'; break; /* TODO: handle error */
 		}
 	
-#line 1133 "src/lx/parser.c"
+#line 1132 "src/lx/parser.c"
 						}
 						/* END OF EXTRACT: ESC */
 						ADVANCE_LEXER;
@@ -1139,7 +1138,7 @@ ZL2_pattern_C_Cbody:;
 					{
 						/* BEGINNING OF EXTRACT: HEX */
 						{
-#line 214 "src/lx/parser.act"
+#line 189 "src/lx/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -1166,7 +1165,7 @@ ZL2_pattern_C_Cbody:;
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 1170 "src/lx/parser.c"
+#line 1169 "src/lx/parser.c"
 						}
 						/* END OF EXTRACT: HEX */
 						ADVANCE_LEXER;
@@ -1176,7 +1175,7 @@ ZL2_pattern_C_Cbody:;
 					{
 						/* BEGINNING OF EXTRACT: OCT */
 						{
-#line 187 "src/lx/parser.act"
+#line 162 "src/lx/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -1203,7 +1202,7 @@ ZL2_pattern_C_Cbody:;
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 1207 "src/lx/parser.c"
+#line 1206 "src/lx/parser.c"
 						}
 						/* END OF EXTRACT: OCT */
 						ADVANCE_LEXER;
@@ -1216,12 +1215,12 @@ ZL2_pattern_C_Cbody:;
 			/* END OF INLINE: 83 */
 			/* BEGINNING OF ACTION: pattern-char */
 			{
-#line 256 "src/lx/parser.act"
+#line 253 "src/lx/parser.act"
 
 		/* TODO */
 		*lex_state->p++ = (ZIc);
 	
-#line 1225 "src/lx/parser.c"
+#line 1224 "src/lx/parser.c"
 			}
 			/* END OF ACTION: pattern-char */
 			/* BEGINNING OF INLINE: pattern::body */
@@ -1261,7 +1260,7 @@ ZL2_171:;
 			}
 			/* BEGINNING OF ACTION: op-intersect */
 			{
-#line 707 "src/lx/parser.act"
+#line 705 "src/lx/parser.act"
 
 		assert((ZI168) != NULL);
 		assert((ZIb) != NULL);
@@ -1272,7 +1271,7 @@ ZL2_171:;
 			goto ZL1;
 		}
 	
-#line 1276 "src/lx/parser.c"
+#line 1275 "src/lx/parser.c"
 			}
 			/* END OF ACTION: op-intersect */
 			/* BEGINNING OF INLINE: 171 */
@@ -1364,7 +1363,7 @@ ZL2_182:;
 						ADVANCE_LEXER;
 						/* BEGINNING OF ACTION: op-cross */
 						{
-#line 567 "src/lx/parser.act"
+#line 560 "src/lx/parser.act"
 
 		struct fsm_state *start, *end;
 		struct fsm_state *old;
@@ -1409,7 +1408,7 @@ ZL2_182:;
 
 		fsm_setstart((ZIq), start);
 	
-#line 1413 "src/lx/parser.c"
+#line 1412 "src/lx/parser.c"
 						}
 						/* END OF ACTION: op-cross */
 						/* BEGINNING OF INLINE: 182 */
@@ -1423,7 +1422,7 @@ ZL2_182:;
 						ADVANCE_LEXER;
 						/* BEGINNING OF ACTION: op-qmark */
 						{
-#line 612 "src/lx/parser.act"
+#line 605 "src/lx/parser.act"
 
 		struct fsm_state *start, *end;
 		struct fsm_state *old;
@@ -1468,7 +1467,7 @@ ZL2_182:;
 
 		fsm_setstart((ZIq), start);
 	
-#line 1472 "src/lx/parser.c"
+#line 1471 "src/lx/parser.c"
 						}
 						/* END OF ACTION: op-qmark */
 						/* BEGINNING OF INLINE: 182 */
@@ -1482,7 +1481,7 @@ ZL2_182:;
 						ADVANCE_LEXER;
 						/* BEGINNING OF ACTION: op-star */
 						{
-#line 517 "src/lx/parser.act"
+#line 510 "src/lx/parser.act"
 
 		struct fsm_state *start, *end;
 		struct fsm_state *old;
@@ -1532,7 +1531,7 @@ ZL2_182:;
 
 		fsm_setstart((ZIq), start);
 	
-#line 1536 "src/lx/parser.c"
+#line 1535 "src/lx/parser.c"
 						}
 						/* END OF ACTION: op-star */
 						/* BEGINNING OF INLINE: 182 */
@@ -1606,7 +1605,7 @@ p_expr_C_Cprefix_Hexpr(lex_state lex_state, act_state act_state, zone ZIz, fsm *
 			}
 			/* BEGINNING OF ACTION: op-reverse */
 			{
-#line 670 "src/lx/parser.act"
+#line 668 "src/lx/parser.act"
 
 		assert((ZIq) != NULL);
 
@@ -1615,7 +1614,7 @@ p_expr_C_Cprefix_Hexpr(lex_state lex_state, act_state act_state, zone ZIz, fsm *
 			goto ZL1;
 		}
 	
-#line 1619 "src/lx/parser.c"
+#line 1618 "src/lx/parser.c"
 			}
 			/* END OF ACTION: op-reverse */
 		}
@@ -1630,7 +1629,7 @@ p_expr_C_Cprefix_Hexpr(lex_state lex_state, act_state act_state, zone ZIz, fsm *
 			}
 			/* BEGINNING OF ACTION: op-complete */
 			{
-#line 661 "src/lx/parser.act"
+#line 659 "src/lx/parser.act"
 
 		assert((ZIq) != NULL);
 
@@ -1639,7 +1638,7 @@ p_expr_C_Cprefix_Hexpr(lex_state lex_state, act_state act_state, zone ZIz, fsm *
 			goto ZL1;
 		}
 	
-#line 1643 "src/lx/parser.c"
+#line 1642 "src/lx/parser.c"
 			}
 			/* END OF ACTION: op-complete */
 		}
@@ -1654,7 +1653,7 @@ p_expr_C_Cprefix_Hexpr(lex_state lex_state, act_state act_state, zone ZIz, fsm *
 			}
 			/* BEGINNING OF ACTION: op-complement */
 			{
-#line 652 "src/lx/parser.act"
+#line 650 "src/lx/parser.act"
 
 		assert((ZIq) != NULL);
 
@@ -1663,7 +1662,7 @@ p_expr_C_Cprefix_Hexpr(lex_state lex_state, act_state act_state, zone ZIz, fsm *
 			goto ZL1;
 		}
 	
-#line 1667 "src/lx/parser.c"
+#line 1666 "src/lx/parser.c"
 			}
 			/* END OF ACTION: op-complement */
 		}
@@ -1710,7 +1709,7 @@ p_190(lex_state lex_state, act_state act_state, zone *ZIz, fsm *ZI188, fsm *ZOq)
 			}
 			/* BEGINNING OF ACTION: op-subtract */
 			{
-#line 696 "src/lx/parser.act"
+#line 694 "src/lx/parser.act"
 
 		assert((*ZI188) != NULL);
 		assert((ZIb) != NULL);
@@ -1721,7 +1720,7 @@ p_190(lex_state lex_state, act_state act_state, zone *ZIz, fsm *ZI188, fsm *ZOq)
 			goto ZL1;
 		}
 	
-#line 1725 "src/lx/parser.c"
+#line 1724 "src/lx/parser.c"
 			}
 			/* END OF ACTION: op-subtract */
 		}
@@ -1761,7 +1760,7 @@ p_193(lex_state lex_state, act_state act_state, zone *ZIz, fsm *ZI191, fsm *ZOq)
 			}
 			/* BEGINNING OF ACTION: op-concat */
 			{
-#line 679 "src/lx/parser.act"
+#line 677 "src/lx/parser.act"
 
 		assert((*ZI191) != NULL);
 		assert((ZIb) != NULL);
@@ -1772,7 +1771,7 @@ p_193(lex_state lex_state, act_state act_state, zone *ZIz, fsm *ZI191, fsm *ZOq)
 			goto ZL1;
 		}
 	
-#line 1776 "src/lx/parser.c"
+#line 1775 "src/lx/parser.c"
 			}
 			/* END OF ACTION: op-concat */
 		}
@@ -1860,13 +1859,13 @@ p_196(lex_state lex_state, act_state act_state, zone *ZIz, fsm *ZI194, fsm *ZOq)
 			}
 			/* BEGINNING OF ACTION: op-product */
 			{
-#line 691 "src/lx/parser.act"
+#line 688 "src/lx/parser.act"
 
 		fprintf(stderr, "unimplemented\n");
 		(ZIq) = NULL;
 		goto ZL1;
 	
-#line 1870 "src/lx/parser.c"
+#line 1869 "src/lx/parser.c"
 			}
 			/* END OF ACTION: op-product */
 		}
@@ -1900,7 +1899,7 @@ p_200(lex_state lex_state, act_state act_state, fsm *ZOr)
 
 			/* BEGINNING OF EXTRACT: RE */
 			{
-#line 246 "src/lx/parser.act"
+#line 240 "src/lx/parser.act"
 
 		assert(lex_state->buf.a[0] == '/');
 
@@ -1911,13 +1910,13 @@ p_200(lex_state lex_state, act_state act_state, fsm *ZOr)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 1915 "src/lx/parser.c"
+#line 1914 "src/lx/parser.c"
 			}
 			/* END OF EXTRACT: RE */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: pattern-buffer */
 			{
-#line 270 "src/lx/parser.act"
+#line 258 "src/lx/parser.act"
 
 		size_t len;
 
@@ -1942,12 +1941,12 @@ p_200(lex_state lex_state, act_state act_state, fsm *ZOr)
 
 		lex_state->p = lex_state->a;
 	
-#line 1946 "src/lx/parser.c"
+#line 1945 "src/lx/parser.c"
 			}
 			/* END OF ACTION: pattern-buffer */
 			/* BEGINNING OF ACTION: compile-regex */
 			{
-#line 376 "src/lx/parser.act"
+#line 372 "src/lx/parser.act"
 
 		struct re_err err;
 
@@ -1962,16 +1961,16 @@ p_200(lex_state lex_state, act_state act_state, fsm *ZOr)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 1966 "src/lx/parser.c"
+#line 1965 "src/lx/parser.c"
 			}
 			/* END OF ACTION: compile-regex */
 			/* BEGINNING OF ACTION: free-arr */
 			{
-#line 766 "src/lx/parser.act"
+#line 764 "src/lx/parser.act"
 
 		free((ZIa));
 	
-#line 1975 "src/lx/parser.c"
+#line 1974 "src/lx/parser.c"
 			}
 			/* END OF ACTION: free-arr */
 		}
@@ -1983,7 +1982,7 @@ p_200(lex_state lex_state, act_state act_state, fsm *ZOr)
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: pattern-buffer */
 			{
-#line 270 "src/lx/parser.act"
+#line 258 "src/lx/parser.act"
 
 		size_t len;
 
@@ -2008,12 +2007,12 @@ p_200(lex_state lex_state, act_state act_state, fsm *ZOr)
 
 		lex_state->p = lex_state->a;
 	
-#line 2012 "src/lx/parser.c"
+#line 2011 "src/lx/parser.c"
 			}
 			/* END OF ACTION: pattern-buffer */
 			/* BEGINNING OF ACTION: compile-literal */
 			{
-#line 361 "src/lx/parser.act"
+#line 357 "src/lx/parser.act"
 
 		struct re_err err;
 
@@ -2028,16 +2027,16 @@ p_200(lex_state lex_state, act_state act_state, fsm *ZOr)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 2032 "src/lx/parser.c"
+#line 2031 "src/lx/parser.c"
 			}
 			/* END OF ACTION: compile-literal */
 			/* BEGINNING OF ACTION: free-arr */
 			{
-#line 766 "src/lx/parser.act"
+#line 764 "src/lx/parser.act"
 
 		free((ZIa));
 	
-#line 2041 "src/lx/parser.c"
+#line 2040 "src/lx/parser.c"
 			}
 			/* END OF ACTION: free-arr */
 		}
@@ -2130,11 +2129,11 @@ p_227(lex_state lex_state, act_state act_state, ast *ZIa, zone *ZIz, fsm *ZIexit
 				{
 					/* BEGINNING OF ACTION: err-expected-bind */
 					{
-#line 788 "src/lx/parser.act"
+#line 785 "src/lx/parser.act"
 
 		err_expected(lex_state, "'='");
 	
-#line 2138 "src/lx/parser.c"
+#line 2137 "src/lx/parser.c"
 					}
 					/* END OF ACTION: err-expected-bind */
 				}
@@ -2148,7 +2147,7 @@ p_227(lex_state lex_state, act_state act_state, ast *ZIa, zone *ZIz, fsm *ZIexit
 			}
 			/* BEGINNING OF ACTION: subtract-exit */
 			{
-#line 729 "src/lx/parser.act"
+#line 727 "src/lx/parser.act"
 
 		assert((ZIr) != NULL);
 
@@ -2175,7 +2174,7 @@ p_227(lex_state lex_state, act_state act_state, ast *ZIa, zone *ZIz, fsm *ZIexit
 			}
 		}
 	
-#line 2179 "src/lx/parser.c"
+#line 2178 "src/lx/parser.c"
 			}
 			/* END OF ACTION: subtract-exit */
 			p_121 (lex_state, act_state);
@@ -2185,7 +2184,7 @@ p_227(lex_state lex_state, act_state act_state, ast *ZIa, zone *ZIz, fsm *ZIexit
 			}
 			/* BEGINNING OF ACTION: add-binding */
 			{
-#line 478 "src/lx/parser.act"
+#line 474 "src/lx/parser.act"
 
 		struct var *v;
 
@@ -2202,7 +2201,7 @@ p_227(lex_state lex_state, act_state act_state, ast *ZIa, zone *ZIz, fsm *ZIexit
 			goto ZL1;
 		}
 	
-#line 2206 "src/lx/parser.c"
+#line 2205 "src/lx/parser.c"
 			}
 			/* END OF ACTION: add-binding */
 		}
@@ -2228,7 +2227,7 @@ p_227(lex_state lex_state, act_state act_state, ast *ZIa, zone *ZIz, fsm *ZIexit
 
 			/* BEGINNING OF ACTION: deref-var */
 			{
-#line 287 "src/lx/parser.act"
+#line 283 "src/lx/parser.act"
 
 		struct ast_zone *z;
 
@@ -2255,7 +2254,7 @@ p_227(lex_state lex_state, act_state act_state, ast *ZIa, zone *ZIz, fsm *ZIexit
 			goto ZL1;
 		}
 	
-#line 2259 "src/lx/parser.c"
+#line 2258 "src/lx/parser.c"
 			}
 			/* END OF ACTION: deref-var */
 			p_182 (lex_state, act_state, ZI244, &ZI194);
@@ -2271,7 +2270,7 @@ p_227(lex_state lex_state, act_state act_state, ast *ZIa, zone *ZIz, fsm *ZIexit
 			}
 			/* BEGINNING OF ACTION: subtract-exit */
 			{
-#line 729 "src/lx/parser.act"
+#line 727 "src/lx/parser.act"
 
 		assert((ZI247) != NULL);
 
@@ -2298,7 +2297,7 @@ p_227(lex_state lex_state, act_state act_state, ast *ZIa, zone *ZIz, fsm *ZIexit
 			}
 		}
 	
-#line 2302 "src/lx/parser.c"
+#line 2301 "src/lx/parser.c"
 			}
 			/* END OF ACTION: subtract-exit */
 			p_250 (lex_state, act_state, ZIa, ZIz, &ZI248, &ZI249);
@@ -2334,16 +2333,16 @@ p_lx(lex_state lex_state, act_state act_state, ast *ZOa)
 
 		/* BEGINNING OF ACTION: no-zone */
 		{
-#line 508 "src/lx/parser.act"
+#line 506 "src/lx/parser.act"
 
 		(ZIparent) = NULL;
 	
-#line 2342 "src/lx/parser.c"
+#line 2341 "src/lx/parser.c"
 		}
 		/* END OF ACTION: no-zone */
 		/* BEGINNING OF ACTION: make-ast */
 		{
-#line 417 "src/lx/parser.act"
+#line 415 "src/lx/parser.act"
 
 		(ZIa) = ast_new();
 		if ((ZIa) == NULL) {
@@ -2351,12 +2350,12 @@ p_lx(lex_state lex_state, act_state act_state, ast *ZOa)
 			goto ZL1;
 		}
 	
-#line 2355 "src/lx/parser.c"
+#line 2354 "src/lx/parser.c"
 		}
 		/* END OF ACTION: make-ast */
 		/* BEGINNING OF ACTION: make-zone */
 		{
-#line 425 "src/lx/parser.act"
+#line 423 "src/lx/parser.act"
 
 		assert((ZIa) != NULL);
 
@@ -2374,28 +2373,28 @@ p_lx(lex_state lex_state, act_state act_state, ast *ZOa)
 			goto ZL1;
 		}
 	
-#line 2378 "src/lx/parser.c"
+#line 2377 "src/lx/parser.c"
 		}
 		/* END OF ACTION: make-zone */
 		/* BEGINNING OF ACTION: no-exit */
 		{
-#line 504 "src/lx/parser.act"
+#line 502 "src/lx/parser.act"
 
 		(ZIexit) = NULL;
 	
-#line 2387 "src/lx/parser.c"
+#line 2386 "src/lx/parser.c"
 		}
 		/* END OF ACTION: no-exit */
 		/* BEGINNING OF ACTION: set-globalzone */
 		{
-#line 493 "src/lx/parser.act"
+#line 491 "src/lx/parser.act"
 
 		assert((ZIa) != NULL);
 		assert((ZIz) != NULL);
 
 		(ZIa)->global = (ZIz);
 	
-#line 2399 "src/lx/parser.c"
+#line 2398 "src/lx/parser.c"
 		}
 		/* END OF ACTION: set-globalzone */
 		p_list_Hof_Hthings (lex_state, act_state, ZIa, ZIz, ZIexit);
@@ -2419,11 +2418,11 @@ p_lx(lex_state lex_state, act_state act_state, ast *ZOa)
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 808 "src/lx/parser.act"
+#line 805 "src/lx/parser.act"
 
 		err_expected(lex_state, "EOF");
 	
-#line 2427 "src/lx/parser.c"
+#line 2426 "src/lx/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
@@ -2436,7 +2435,7 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: make-ast */
 		{
-#line 417 "src/lx/parser.act"
+#line 415 "src/lx/parser.act"
 
 		(ZIa) = ast_new();
 		if ((ZIa) == NULL) {
@@ -2444,17 +2443,17 @@ ZL1:;
 			goto ZL4;
 		}
 	
-#line 2448 "src/lx/parser.c"
+#line 2447 "src/lx/parser.c"
 		}
 		/* END OF ACTION: make-ast */
 		/* BEGINNING OF ACTION: err-syntax */
 		{
-#line 776 "src/lx/parser.act"
+#line 772 "src/lx/parser.act"
 
 		err(lex_state, "Syntax error");
 		exit(EXIT_FAILURE);
 	
-#line 2458 "src/lx/parser.c"
+#line 2457 "src/lx/parser.c"
 		}
 		/* END OF ACTION: err-syntax */
 	}
@@ -2516,11 +2515,11 @@ p_111(lex_state lex_state, act_state act_state, string *ZOt)
 				{
 					/* BEGINNING OF ACTION: err-expected-map */
 					{
-#line 784 "src/lx/parser.act"
+#line 781 "src/lx/parser.act"
 
 		err_expected(lex_state, "'->'");
 	
-#line 2524 "src/lx/parser.c"
+#line 2523 "src/lx/parser.c"
 					}
 					/* END OF ACTION: err-expected-map */
 				}
@@ -2531,7 +2530,7 @@ p_111(lex_state lex_state, act_state act_state, string *ZOt)
 			case (TOK_TOKEN):
 				/* BEGINNING OF EXTRACT: TOKEN */
 				{
-#line 226 "src/lx/parser.act"
+#line 223 "src/lx/parser.act"
 
 		/* TODO: submatch addressing */
 		ZIt = xstrdup(lex_state->buf.a + 1); /* +1 for '$' prefix */
@@ -2540,7 +2539,7 @@ p_111(lex_state lex_state, act_state act_state, string *ZOt)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 2544 "src/lx/parser.c"
+#line 2543 "src/lx/parser.c"
 				}
 				/* END OF EXTRACT: TOKEN */
 				break;
@@ -2554,11 +2553,11 @@ p_111(lex_state lex_state, act_state act_state, string *ZOt)
 		{
 			/* BEGINNING OF ACTION: no-token */
 			{
-#line 500 "src/lx/parser.act"
+#line 498 "src/lx/parser.act"
 
 		(ZIt) = NULL;
 	
-#line 2562 "src/lx/parser.c"
+#line 2561 "src/lx/parser.c"
 			}
 			/* END OF ACTION: no-token */
 		}
@@ -2647,11 +2646,11 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-semi */
 		{
-#line 792 "src/lx/parser.act"
+#line 789 "src/lx/parser.act"
 
 		err_expected(lex_state, "';'");
 	
-#line 2655 "src/lx/parser.c"
+#line 2654 "src/lx/parser.c"
 		}
 		/* END OF ACTION: err-expected-semi */
 	}
@@ -2698,16 +2697,16 @@ p_250(lex_state lex_state, act_state act_state, ast *ZIa, zone *ZIz, string *ZI2
 			}
 			/* BEGINNING OF ACTION: no-zone */
 			{
-#line 508 "src/lx/parser.act"
+#line 506 "src/lx/parser.act"
 
 		(ZIto) = NULL;
 	
-#line 2706 "src/lx/parser.c"
+#line 2705 "src/lx/parser.c"
 			}
 			/* END OF ACTION: no-zone */
 			/* BEGINNING OF ACTION: add-mapping */
 			{
-#line 446 "src/lx/parser.act"
+#line 441 "src/lx/parser.act"
 
 		struct ast_token *t;
 		struct ast_mapping *m;
@@ -2740,7 +2739,7 @@ p_250(lex_state lex_state, act_state act_state, ast *ZIa, zone *ZIz, string *ZI2
 			nmappings++;
 		}
 	
-#line 2744 "src/lx/parser.c"
+#line 2743 "src/lx/parser.c"
 			}
 			/* END OF ACTION: add-mapping */
 		}
@@ -2767,11 +2766,11 @@ p_250(lex_state lex_state, act_state act_state, ast *ZIa, zone *ZIz, string *ZI2
 				{
 					/* BEGINNING OF ACTION: err-expected-to */
 					{
-#line 796 "src/lx/parser.act"
+#line 793 "src/lx/parser.act"
 
 		err_expected(lex_state, "'..'");
 	
-#line 2775 "src/lx/parser.c"
+#line 2774 "src/lx/parser.c"
 					}
 					/* END OF ACTION: err-expected-to */
 				}
@@ -2785,7 +2784,7 @@ p_250(lex_state lex_state, act_state act_state, ast *ZIa, zone *ZIz, string *ZI2
 			}
 			/* BEGINNING OF ACTION: make-zone */
 			{
-#line 425 "src/lx/parser.act"
+#line 423 "src/lx/parser.act"
 
 		assert((*ZIa) != NULL);
 
@@ -2803,12 +2802,12 @@ p_250(lex_state lex_state, act_state act_state, ast *ZIa, zone *ZIz, string *ZI2
 			goto ZL1;
 		}
 	
-#line 2807 "src/lx/parser.c"
+#line 2806 "src/lx/parser.c"
 			}
 			/* END OF ACTION: make-zone */
 			/* BEGINNING OF ACTION: add-mapping */
 			{
-#line 446 "src/lx/parser.act"
+#line 441 "src/lx/parser.act"
 
 		struct ast_token *t;
 		struct ast_mapping *m;
@@ -2841,12 +2840,12 @@ p_250(lex_state lex_state, act_state act_state, ast *ZIa, zone *ZIz, string *ZI2
 			nmappings++;
 		}
 	
-#line 2845 "src/lx/parser.c"
+#line 2844 "src/lx/parser.c"
 			}
 			/* END OF ACTION: add-mapping */
 			/* BEGINNING OF ACTION: add-mapping */
 			{
-#line 446 "src/lx/parser.act"
+#line 441 "src/lx/parser.act"
 
 		struct ast_token *t;
 		struct ast_mapping *m;
@@ -2879,7 +2878,7 @@ p_250(lex_state lex_state, act_state act_state, ast *ZIa, zone *ZIz, string *ZI2
 			nmappings++;
 		}
 	
-#line 2883 "src/lx/parser.c"
+#line 2882 "src/lx/parser.c"
 			}
 			/* END OF ACTION: add-mapping */
 			/* BEGINNING OF INLINE: 137 */
@@ -2900,25 +2899,25 @@ p_250(lex_state lex_state, act_state act_state, ast *ZIa, zone *ZIz, string *ZI2
 						}
 						/* BEGINNING OF ACTION: no-zone */
 						{
-#line 508 "src/lx/parser.act"
+#line 506 "src/lx/parser.act"
 
 		(ZIx) = NULL;
 	
-#line 2908 "src/lx/parser.c"
+#line 2907 "src/lx/parser.c"
 						}
 						/* END OF ACTION: no-zone */
 						/* BEGINNING OF ACTION: no-token */
 						{
-#line 500 "src/lx/parser.act"
+#line 498 "src/lx/parser.act"
 
 		(ZIy) = NULL;
 	
-#line 2917 "src/lx/parser.c"
+#line 2916 "src/lx/parser.c"
 						}
 						/* END OF ACTION: no-token */
 						/* BEGINNING OF ACTION: clone */
 						{
-#line 756 "src/lx/parser.act"
+#line 754 "src/lx/parser.act"
 
 		assert((ZIr2) != NULL);
 
@@ -2928,12 +2927,12 @@ p_250(lex_state lex_state, act_state act_state, ast *ZIa, zone *ZIz, string *ZI2
 			goto ZL5;
 		}
 	
-#line 2932 "src/lx/parser.c"
+#line 2931 "src/lx/parser.c"
 						}
 						/* END OF ACTION: clone */
 						/* BEGINNING OF ACTION: regex-any */
 						{
-#line 392 "src/lx/parser.act"
+#line 388 "src/lx/parser.act"
 
 		struct fsm_state *start, *end;
 
@@ -2960,12 +2959,12 @@ p_250(lex_state lex_state, act_state act_state, ast *ZIa, zone *ZIz, string *ZI2
 		fsm_setstart((ZIw), start);
 		fsm_setend((ZIw), end, 1);
 	
-#line 2964 "src/lx/parser.c"
+#line 2963 "src/lx/parser.c"
 						}
 						/* END OF ACTION: regex-any */
 						/* BEGINNING OF ACTION: subtract-exit */
 						{
-#line 729 "src/lx/parser.act"
+#line 727 "src/lx/parser.act"
 
 		assert((ZIw) != NULL);
 
@@ -2992,12 +2991,12 @@ p_250(lex_state lex_state, act_state act_state, ast *ZIa, zone *ZIz, string *ZI2
 			}
 		}
 	
-#line 2996 "src/lx/parser.c"
+#line 2995 "src/lx/parser.c"
 						}
 						/* END OF ACTION: subtract-exit */
 						/* BEGINNING OF ACTION: add-mapping */
 						{
-#line 446 "src/lx/parser.act"
+#line 441 "src/lx/parser.act"
 
 		struct ast_token *t;
 		struct ast_mapping *m;
@@ -3030,7 +3029,7 @@ p_250(lex_state lex_state, act_state act_state, ast *ZIa, zone *ZIz, string *ZI2
 			nmappings++;
 		}
 	
-#line 3034 "src/lx/parser.c"
+#line 3033 "src/lx/parser.c"
 						}
 						/* END OF ACTION: add-mapping */
 					}
@@ -3054,11 +3053,11 @@ p_250(lex_state lex_state, act_state act_state, ast *ZIa, zone *ZIz, string *ZI2
 				{
 					/* BEGINNING OF ACTION: err-expected-list */
 					{
-#line 816 "src/lx/parser.act"
+#line 813 "src/lx/parser.act"
 
 		err_expected(lex_state, "list of mappings, bindings or zones");
 	
-#line 3062 "src/lx/parser.c"
+#line 3061 "src/lx/parser.c"
 					}
 					/* END OF ACTION: err-expected-list */
 				}
@@ -3074,16 +3073,16 @@ p_250(lex_state lex_state, act_state act_state, ast *ZIa, zone *ZIz, string *ZI2
 
 			/* BEGINNING OF ACTION: no-exit */
 			{
-#line 504 "src/lx/parser.act"
+#line 502 "src/lx/parser.act"
 
 		(ZIr2) = NULL;
 	
-#line 3082 "src/lx/parser.c"
+#line 3081 "src/lx/parser.c"
 			}
 			/* END OF ACTION: no-exit */
 			/* BEGINNING OF ACTION: make-zone */
 			{
-#line 425 "src/lx/parser.act"
+#line 423 "src/lx/parser.act"
 
 		assert((*ZIa) != NULL);
 
@@ -3101,12 +3100,12 @@ p_250(lex_state lex_state, act_state act_state, ast *ZIa, zone *ZIz, string *ZI2
 			goto ZL1;
 		}
 	
-#line 3105 "src/lx/parser.c"
+#line 3104 "src/lx/parser.c"
 			}
 			/* END OF ACTION: make-zone */
 			/* BEGINNING OF ACTION: add-mapping */
 			{
-#line 446 "src/lx/parser.act"
+#line 441 "src/lx/parser.act"
 
 		struct ast_token *t;
 		struct ast_mapping *m;
@@ -3139,7 +3138,7 @@ p_250(lex_state lex_state, act_state act_state, ast *ZIa, zone *ZIz, string *ZI2
 			nmappings++;
 		}
 	
-#line 3143 "src/lx/parser.c"
+#line 3142 "src/lx/parser.c"
 			}
 			/* END OF ACTION: add-mapping */
 			/* BEGINNING OF INLINE: 130 */
@@ -3158,11 +3157,11 @@ p_250(lex_state lex_state, act_state act_state, ast *ZIa, zone *ZIz, string *ZI2
 				{
 					/* BEGINNING OF ACTION: err-expected-list */
 					{
-#line 816 "src/lx/parser.act"
+#line 813 "src/lx/parser.act"
 
 		err_expected(lex_state, "list of mappings, bindings or zones");
 	
-#line 3166 "src/lx/parser.c"
+#line 3165 "src/lx/parser.c"
 					}
 					/* END OF ACTION: err-expected-list */
 				}
@@ -3184,7 +3183,7 @@ ZL1:;
 
 /* BEGINNING OF TRAILER */
 
-#line 868 "src/lx/parser.act"
+#line 817 "src/lx/parser.act"
 
 
 	struct ast *lx_parse(FILE *f, const struct fsm_options *opt) {
@@ -3235,6 +3234,6 @@ ZL1:;
 		return ast;
 	}
 
-#line 3239 "src/lx/parser.c"
+#line 3238 "src/lx/parser.c"
 
 /* END OF FILE */

--- a/src/lx/parser.h
+++ b/src/lx/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 141 "src/lx/parser.act"
+#line 128 "src/lx/parser.act"
 
 
 	#include <stdio.h>
@@ -29,7 +29,7 @@
 extern void p_lx(lex_state, act_state, ast *);
 /* BEGINNING OF TRAILER */
 
-#line 870 "src/lx/parser.act"
+#line 867 "src/lx/parser.act"
 
 
 #line 36 "src/lx/parser.h"

--- a/src/print/Makefile
+++ b/src/print/Makefile
@@ -4,6 +4,7 @@ SRC += src/print/c.c
 SRC += src/print/dot.c
 SRC += src/print/fsm.c
 SRC += src/print/json.c
+SRC += src/print/pcre.c
 SRC += src/print/puts.c
 SRC += src/print/tok.c
 

--- a/src/print/Makefile
+++ b/src/print/Makefile
@@ -2,6 +2,7 @@
 
 SRC += src/print/c.c
 SRC += src/print/dot.c
+SRC += src/print/ebnf.c
 SRC += src/print/fsm.c
 SRC += src/print/json.c
 SRC += src/print/pcre.c

--- a/src/print/ebnf.c
+++ b/src/print/ebnf.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2008-2017 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <ctype.h>
+#include <assert.h>
+#include <limits.h>
+#include <stdio.h>
+
+#include <fsm/options.h>
+
+#include <print/esc.h>
+
+int
+ebnf_escputc(FILE *f, const struct fsm_options *opt, int c)
+{
+	assert(f != NULL);
+	assert(opt != NULL);
+	assert(c >= 0 && c <= UCHAR_MAX);
+
+	if (opt->always_hex) {
+		return fprintf(f, "\\x%02x", (unsigned char) c);
+	}
+
+	switch (c) {
+	case '\"': return fputs("\\\"", f);
+
+	case '\f': return fputs("\\f", f);
+	case '\n': return fputs("\\n", f);
+	case '\r': return fputs("\\r", f);
+	case '\t': return fputs("\\t", f);
+	case '\v': return fputs("\\v", f);
+
+	default:
+		break;
+	}
+
+	if (!isprint((unsigned char) c)) {
+		return fprintf(f, "\\x%02x", (unsigned char) c);
+	}
+
+	return fprintf(f, "%c", c);
+}
+

--- a/src/print/pcre.c
+++ b/src/print/pcre.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2008-2017 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <ctype.h>
+#include <assert.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <fsm/options.h>
+
+#include <print/esc.h>
+
+int
+pcre_escputc(FILE *f, const struct fsm_options *opt, int c)
+{
+	assert(f != NULL);
+	assert(opt != NULL);
+	assert(c >= 0 && c <= UCHAR_MAX);
+
+	if (opt->always_hex) {
+		return fprintf(f, "\\x%02x", (unsigned char) c);
+	}
+
+	switch (c) {
+	case '^': return fputs("\\^", f);
+	case '$': return fputs("\\$", f);
+	case '(': return fputs("\\(", f);
+	case ')': return fputs("\\)", f);
+
+	case '|': return fputs("\\|", f);
+	case '[': return fputs("\\[", f);
+	case ']': return fputs("\\]", f);
+	case '+': return fputs("\\+", f);
+	case '*': return fputs("\\*", f);
+	case '?': return fputs("\\?", f);
+	case '.': return fputs("\\.", f);
+
+	case '\f': return fputs("\\f", f);
+	case '\n': return fputs("\\n", f);
+	case '\r': return fputs("\\r", f);
+	case '\t': return fputs("\\t", f);
+
+	/* TODO: probably others; this is a cursory attempt */
+
+	case '\\': return fputs("\\\\", f);
+
+	default:
+		break;
+	}
+
+	if (!isprint((unsigned char) c)) {
+		return fprintf(f, "\\%02x", (unsigned char) c);
+	}
+
+	return fprintf(f, "%c", c);
+}
+

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -102,6 +102,7 @@ print_name(const char *name,
 		{ "json", fsm_print_json, NULL },
 
 		{ "tree", NULL, re_ast_print_tree },
+		{ "ebnf", NULL, re_ast_print_ebnf },
 		{ "ast",  NULL, re_ast_print_dot  },
 		{ "pcre", NULL, re_ast_print_pcre }
 	};

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -23,6 +23,8 @@
 #include <re/re.h>
 
 #include "libfsm/internal.h" /* XXX */
+#include "libre/re_comp.h" /* XXX */
+#include "libre/print.h" /* XXX */
 
 /*
  * TODO: accepting a delimiter would be useful: /abc/. perhaps provide that as
@@ -82,27 +84,37 @@ io(const char *name)
 	exit(EXIT_FAILURE);
 }
 
-static fsm_print *
-print_name(const char *name)
+static void
+print_name(const char *name,
+	fsm_print **print_fsm, re_ast_print **print_ast)
 {
 	size_t i;
 
 	struct {
 		const char *name;
-		fsm_print *f;
+		fsm_print    *print_fsm;
+		re_ast_print *print_ast;
 	} a[] = {
-		{ "api",  fsm_print_api  },
-		{ "c",    fsm_print_c    },
-		{ "dot",  fsm_print_dot  },
-		{ "fsm",  fsm_print_fsm  },
-		{ "json", fsm_print_json }
+		{ "api",  fsm_print_api,  NULL },
+		{ "c",    fsm_print_c,    NULL },
+		{ "dot",  fsm_print_dot,  NULL },
+		{ "fsm",  fsm_print_fsm,  NULL },
+		{ "json", fsm_print_json, NULL },
+
+		{ "tree", NULL, re_ast_print_tree },
+		{ "ast",  NULL, re_ast_print_dot  },
+		{ "pcre", NULL, re_ast_print_pcre }
 	};
 
 	assert(name != NULL);
+	assert(print_fsm != NULL);
+	assert(print_ast != NULL);
 
 	for (i = 0; i < sizeof a / sizeof *a; i++) {
 		if (0 == strcmp(a[i].name, name)) {
-			return a[i].f;
+			*print_fsm = a[i].print_fsm;
+			*print_ast = a[i].print_ast;
+			return;
 		}
 	}
 
@@ -376,7 +388,8 @@ main(int argc, char *argv[])
 {
 	struct fsm *(*join)(struct fsm *, struct fsm *);
 	int (*query)(const struct fsm *, const struct fsm *);
-	fsm_print *print;
+	fsm_print *print_fsm;
+	re_ast_print *print_ast;
 	enum re_dialect dialect;
 	struct fsm *fsm;
 	enum re_flags flags;
@@ -393,17 +406,18 @@ main(int argc, char *argv[])
 	opt.comments          = 1;
 	opt.io                = FSM_IO_GETC;
 
-	flags    = 0U;
-	xfiles   = 0;
-	yfiles   = 0;
-	example  = 0;
-	keep_nfa = 0;
-	patterns = 0;
-	ambig    = 0;
-	print    = NULL;
-	query    = NULL;
-	join     = fsm_union;
-	dialect  = RE_NATIVE;
+	flags     = 0U;
+	xfiles    = 0;
+	yfiles    = 0;
+	example   = 0;
+	keep_nfa  = 0;
+	patterns  = 0;
+	ambig     = 0;
+	print_fsm = NULL;
+	print_ast = NULL;
+	query     = NULL;
+	join      = fsm_union;
+	dialect   = RE_NATIVE;
 
 	{
 		int c;
@@ -423,10 +437,13 @@ main(int argc, char *argv[])
 				join = fsm_concat;
 				break;
 
-			case 'l': print   = print_name(optarg);       break;
-			case 'p': print   = fsm_print_fsm;            break;
-			case 'q': query   = comparison(optarg);       break;
-			case 'r': dialect = dialect_name(optarg);     break;
+			case 'l':
+				print_name(optarg, &print_fsm, &print_ast);
+				break;
+
+			case 'p': print_fsm = fsm_print_fsm;        break;
+			case 'q': query     = comparison(optarg);   break;
+			case 'r': dialect   = dialect_name(optarg); break;
 
 			case 'u': ambig    = 1; break;
 			case 'x': xfiles   = 1; break;
@@ -455,12 +472,12 @@ main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
-	if (!!print + example + !!query > 1) {
+	if (!!print_fsm + !!print_ast + example + !!query > 1) {
 		fprintf(stderr, "-m, -p and -q are mutually exclusive\n");
 		return EXIT_FAILURE;
 	}
 
-	if (!!print + example + !!query && xfiles) {
+	if (!!print_fsm + !!print_ast + example + !!query && xfiles) {
 		fprintf(stderr, "-x applies only when executing\n");
 		return EXIT_FAILURE;
 	}
@@ -475,12 +492,50 @@ main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
-	if (print == NULL) {
+	if (print_fsm == NULL) {
 		keep_nfa = 0;
 	}
 
 	if (keep_nfa) {
 		ambig = 1;
+	}
+
+	/* XXX: repetitive */
+	if (print_ast != NULL) {
+		struct ast_re *ast;
+		struct re_err err;
+
+		if (argc != 1) {
+			fprintf(stderr, "single regexp only for this output format\n");
+			return EXIT_FAILURE;
+		}
+
+		if (yfiles) {
+			FILE *f;
+
+			f = xopen(argv[0]);
+
+			ast = re_parse(dialect, fsm_fgetc, f, &opt, flags, &err);
+
+			fclose(f);
+		} else {
+			const char *s;
+
+			s = argv[0];
+
+			ast = re_parse(dialect, fsm_sgetc, &s, &opt, flags, &err);
+		}
+
+		if (ast == NULL) {
+			re_perror(dialect, &err,
+				 yfiles ? argv[0] : NULL,
+				!yfiles ? argv[0] : NULL);
+			return EXIT_FAILURE;
+		}
+
+		print_ast(stdout, &opt, ast);
+
+		return 0;
 	}
 
 	flags |= RE_MULTI;
@@ -494,7 +549,7 @@ main(int argc, char *argv[])
 	{
 		int i;
 
-		for (i = 0; i < argc - !(print || example || !!query || argc <= 1); i++) {
+		for (i = 0; i < argc - !(print_fsm || example || !!query || argc <= 1); i++) {
 			struct re_err err;
 			struct fsm *new, *q;
 
@@ -605,7 +660,7 @@ main(int argc, char *argv[])
 		return EXIT_SUCCESS;
 	}
 
-	if ((print || example) && argc > 0) {
+	if ((print_fsm || example) && argc > 0) {
 		fprintf(stderr, "too many arguments\n");
 		return EXIT_FAILURE;
 	}
@@ -677,7 +732,7 @@ main(int argc, char *argv[])
 		 * Minimise only when we don't need to keep the end state information
 		 * separated per regexp. Otherwise, convert to a DFA.
 		 */
-		if (!patterns && !example && print != fsm_print_c) {
+		if (!patterns && !example && print_fsm != fsm_print_c) {
 			if (!fsm_minimise(fsm)) {
 				perror("fsm_minimise");
 				return EXIT_FAILURE;
@@ -726,7 +781,7 @@ main(int argc, char *argv[])
 		return 0;
 	}
 
-	if (print != NULL) {
+	if (print_fsm != NULL) {
 		/* TODO: print examples in comments for end states;
 		 * patterns in comments for the whole FSM */
 
@@ -737,11 +792,11 @@ main(int argc, char *argv[])
 			}
 		}
 
-		if (print == fsm_print_c) {
+		if (print_fsm == fsm_print_c) {
 			opt.endleaf = endleaf;
 		}
 
-		print(stdout, fsm);
+		print_fsm(stdout, fsm);
 
 /* XXX: free fsm */
 


### PR DESCRIPTION
This PR introduces `src/libre/print/*` for printing to various formats, exposed alongside the existing `re -l xyz` names.

These are:
* `re -pl tree` to print the existing text dump;
* `re -pl ast` for graphviz;
* `re -pl ebnf` for ISO EBNF, suitable for feeding to kgt;
* `re -pl pcre` to render to PCRE regexp syntax

None of these are particularly capable yet; I just wanted to get them in place for sake of debugging, and settling out ideas.

You can render with kgt like so:
```
; ./build/bin/re -pl ebnf 'a{3}b*[abc]|xyz' | kgt -l iso-ebnf -e rrtext
e:
    ||--v-->---- "a" ----v-->---------v--v-- "a" -->-->--||
        |  |             |  |         |  |         |  |
        |  ^--(2 times)--<  ^-- "b" --<  >-- "b" --^  |
        |                                |         |  |
        |                                >-- "c" --^  |
        |                                             |
        >------------- "x" -- "y" -- "z" -------------^
```