### PR TITLE
Remove `AST_EXPR_MANY`

### DIFF
--- a/src/libre/dialect/glob/parser.c
+++ b/src/libre/dialect/glob/parser.c
@@ -243,7 +243,7 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 	{
 		t_ast__expr ZIl;
 
-		/* BEGINNING OF INLINE: 100 */
+		/* BEGINNING OF INLINE: 98 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY):
@@ -279,8 +279,8 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 					/* BEGINNING OF INLINE: list-of-nodes::literal */
 					{
 						{
-							t_pos ZI94;
-							t_pos ZI95;
+							t_pos ZI92;
+							t_pos ZI93;
 
 							switch (CURRENT_TERMINAL) {
 							case (TOK_CHAR):
@@ -291,8 +291,8 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI94 = lex_state->lx.start;
-		ZI95   = lex_state->lx.end;
+		ZI92 = lex_state->lx.start;
+		ZI93   = lex_state->lx.end;
 
 		ZIc = lex_state->buf.a[0];
 	
@@ -320,6 +320,9 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 				break;
 			case (TOK_MANY):
 				{
+					t_ast__expr ZIe;
+					t_ast__count ZIc;
+
 					/* BEGINNING OF INLINE: list-of-nodes::many */
 					{
 						{
@@ -333,23 +336,41 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 						}
 					}
 					/* END OF INLINE: list-of-nodes::many */
-					/* BEGINNING OF ACTION: ast-expr-many */
+					/* BEGINNING OF ACTION: ast-expr-any */
 					{
-#line 603 "src/libre/parser.act"
+#line 599 "src/libre/parser.act"
 
-		(ZIl) = re_ast_expr_many();
+		(ZIe) = re_ast_expr_any();
 	
-#line 343 "src/libre/dialect/glob/parser.c"
+#line 346 "src/libre/dialect/glob/parser.c"
 					}
-					/* END OF ACTION: ast-expr-many */
+					/* END OF ACTION: ast-expr-any */
+					/* BEGINNING OF ACTION: atom-kleene */
+					{
+#line 617 "src/libre/parser.act"
+
+		(ZIc) = ast_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
+	
+#line 355 "src/libre/dialect/glob/parser.c"
+					}
+					/* END OF ACTION: atom-kleene */
+					/* BEGINNING OF ACTION: ast-expr-atom */
+					{
+#line 613 "src/libre/parser.act"
+
+		(ZIl) = re_ast_expr_with_count((ZIe), (ZIc));
+	
+#line 364 "src/libre/dialect/glob/parser.c"
+					}
+					/* END OF ACTION: ast-expr-atom */
 				}
 				break;
 			default:
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 100 */
-		/* BEGINNING OF INLINE: 102 */
+		/* END OF INLINE: 98 */
+		/* BEGINNING OF INLINE: 101 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_MANY): case (TOK_CHAR):
@@ -367,7 +388,7 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 
 		(ZInode) = re_ast_expr_concat((ZIl), (ZIr));
 	
-#line 371 "src/libre/dialect/glob/parser.c"
+#line 392 "src/libre/dialect/glob/parser.c"
 					}
 					/* END OF ACTION: ast-expr-concat */
 				}
@@ -379,7 +400,7 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 				break;
 			}
 		}
-		/* END OF INLINE: 102 */
+		/* END OF INLINE: 101 */
 	}
 	goto ZL0;
 ZL1:;
@@ -398,7 +419,7 @@ p_re__glob(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 106 */
+		/* BEGINNING OF INLINE: 105 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_MANY): case (TOK_CHAR):
@@ -418,15 +439,15 @@ p_re__glob(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 
 		(ZInode) = re_ast_expr_empty();
 	
-#line 422 "src/libre/dialect/glob/parser.c"
+#line 443 "src/libre/dialect/glob/parser.c"
 					}
 					/* END OF ACTION: ast-expr-empty */
 				}
 				break;
 			}
 		}
-		/* END OF INLINE: 106 */
-		/* BEGINNING OF INLINE: 107 */
+		/* END OF INLINE: 105 */
+		/* BEGINNING OF INLINE: 106 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -449,13 +470,13 @@ p_re__glob(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 		}
 		goto ZL1;
 	
-#line 453 "src/libre/dialect/glob/parser.c"
+#line 474 "src/libre/dialect/glob/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 107 */
+		/* END OF INLINE: 106 */
 	}
 	goto ZL0;
 ZL1:;
@@ -467,7 +488,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 757 "src/libre/parser.act"
+#line 747 "src/libre/parser.act"
 
 
 	static int
@@ -624,6 +645,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 628 "src/libre/dialect/glob/parser.c"
+#line 649 "src/libre/dialect/glob/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/glob/parser.h
+++ b/src/libre/dialect/glob/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__glob(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 913 "src/libre/parser.act"
+#line 903 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/glob/parser.h"

--- a/src/libre/dialect/glob/parser.sid
+++ b/src/libre/dialect/glob/parser.sid
@@ -13,7 +13,7 @@
 	!re_flags;
 	!err;
 	ast_expr;
-	!ast_count;
+	ast_count;
         !ast_char_class_id;
         !ast_char_type_id;
 	!char_class_ast;
@@ -64,16 +64,14 @@
 	<ast-expr-concat>: (:ast_expr, :ast_expr) -> (:ast_expr);
 	!<ast-expr-alt>: (:ast_expr, :ast_expr) -> (:ast_expr);
 	<ast-expr-any>: () -> (:ast_expr);
-	<ast-expr-many>: () -> (:ast_expr);
 
-        !<ast-expr-atom>: (:ast_expr, :ast_count) -> (:ast_expr);
+        <ast-expr-atom>: (:ast_expr, :ast_count) -> (:ast_expr);
         !<ast-expr-atom-any>: (:ast_count) -> (:ast_expr);
-        !<ast-expr-atom-many>: (:ast_count) -> (:ast_expr);
 	!<ast-expr-char-class>: (:char_class_ast, :pos, :pos) -> (:ast_expr);
         !<ast-expr-group>: (:ast_expr) -> (:ast_expr);
 	!<ast-expr-re-flags>: (:re_flags, :re_flags) -> (:ast_expr);
 
-        !<atom-kleene>: () -> (:ast_count);
+        <atom-kleene>: () -> (:ast_count);
         !<atom-plus>: () -> (:ast_count);
         !<atom-one>: () -> (:ast_count);
         !<atom-opt>: () -> (:ast_count);
@@ -133,8 +131,10 @@
 			any();
 			l = <ast-expr-any>();
 		||
-		        many();
-			l = <ast-expr-many>();
+			many();
+			e = <ast-expr-any>();
+			c = <atom-kleene>();
+			l = <ast-expr-atom>(e, c);
 		};
 
 		{

--- a/src/libre/dialect/like/parser.c
+++ b/src/libre/dialect/like/parser.c
@@ -243,7 +243,7 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 	{
 		t_ast__expr ZIl;
 
-		/* BEGINNING OF INLINE: 101 */
+		/* BEGINNING OF INLINE: 99 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY):
@@ -279,8 +279,8 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 					/* BEGINNING OF INLINE: list-of-nodes::literal */
 					{
 						{
-							t_pos ZI95;
-							t_pos ZI96;
+							t_pos ZI93;
+							t_pos ZI94;
 
 							switch (CURRENT_TERMINAL) {
 							case (TOK_CHAR):
@@ -291,8 +291,8 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI95 = lex_state->lx.start;
-		ZI96   = lex_state->lx.end;
+		ZI93 = lex_state->lx.start;
+		ZI94   = lex_state->lx.end;
 
 		ZIc = lex_state->buf.a[0];
 	
@@ -320,6 +320,9 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 				break;
 			case (TOK_MANY):
 				{
+					t_ast__expr ZIe;
+					t_ast__count ZIc;
+
 					/* BEGINNING OF INLINE: list-of-nodes::many */
 					{
 						{
@@ -333,23 +336,41 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 						}
 					}
 					/* END OF INLINE: list-of-nodes::many */
-					/* BEGINNING OF ACTION: ast-expr-many */
+					/* BEGINNING OF ACTION: ast-expr-any */
 					{
-#line 603 "src/libre/parser.act"
+#line 599 "src/libre/parser.act"
 
-		(ZIl) = re_ast_expr_many();
+		(ZIe) = re_ast_expr_any();
 	
-#line 343 "src/libre/dialect/like/parser.c"
+#line 346 "src/libre/dialect/like/parser.c"
 					}
-					/* END OF ACTION: ast-expr-many */
+					/* END OF ACTION: ast-expr-any */
+					/* BEGINNING OF ACTION: atom-kleene */
+					{
+#line 617 "src/libre/parser.act"
+
+		(ZIc) = ast_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
+	
+#line 355 "src/libre/dialect/like/parser.c"
+					}
+					/* END OF ACTION: atom-kleene */
+					/* BEGINNING OF ACTION: ast-expr-atom */
+					{
+#line 613 "src/libre/parser.act"
+
+		(ZIl) = re_ast_expr_with_count((ZIe), (ZIc));
+	
+#line 364 "src/libre/dialect/like/parser.c"
+					}
+					/* END OF ACTION: ast-expr-atom */
 				}
 				break;
 			default:
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 101 */
-		/* BEGINNING OF INLINE: 103 */
+		/* END OF INLINE: 99 */
+		/* BEGINNING OF INLINE: 102 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_MANY): case (TOK_CHAR):
@@ -367,7 +388,7 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 
 		(ZInode) = re_ast_expr_concat((ZIl), (ZIr));
 	
-#line 371 "src/libre/dialect/like/parser.c"
+#line 392 "src/libre/dialect/like/parser.c"
 					}
 					/* END OF ACTION: ast-expr-concat */
 				}
@@ -379,7 +400,7 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 				break;
 			}
 		}
-		/* END OF INLINE: 103 */
+		/* END OF INLINE: 102 */
 	}
 	goto ZL0;
 ZL1:;
@@ -398,7 +419,7 @@ p_re__like(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 107 */
+		/* BEGINNING OF INLINE: 106 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_MANY): case (TOK_CHAR):
@@ -418,15 +439,15 @@ p_re__like(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 
 		(ZInode) = re_ast_expr_empty();
 	
-#line 422 "src/libre/dialect/like/parser.c"
+#line 443 "src/libre/dialect/like/parser.c"
 					}
 					/* END OF ACTION: ast-expr-empty */
 				}
 				break;
 			}
 		}
-		/* END OF INLINE: 107 */
-		/* BEGINNING OF INLINE: 108 */
+		/* END OF INLINE: 106 */
+		/* BEGINNING OF INLINE: 107 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -449,13 +470,13 @@ p_re__like(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 		}
 		goto ZL1;
 	
-#line 453 "src/libre/dialect/like/parser.c"
+#line 474 "src/libre/dialect/like/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 108 */
+		/* END OF INLINE: 107 */
 	}
 	goto ZL0;
 ZL1:;
@@ -467,7 +488,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 757 "src/libre/parser.act"
+#line 747 "src/libre/parser.act"
 
 
 	static int
@@ -624,6 +645,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 628 "src/libre/dialect/like/parser.c"
+#line 649 "src/libre/dialect/like/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/like/parser.h
+++ b/src/libre/dialect/like/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__like(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 913 "src/libre/parser.act"
+#line 903 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/like/parser.h"

--- a/src/libre/dialect/like/parser.sid
+++ b/src/libre/dialect/like/parser.sid
@@ -13,7 +13,7 @@
 	!re_flags;
 	!err;
 	ast_expr;
-	!ast_count;
+	ast_count;
 	!atom_count_flag;
         !ast_char_class_id;
         !ast_char_type_id;
@@ -65,16 +65,14 @@
 	<ast-expr-concat>: (:ast_expr, :ast_expr) -> (:ast_expr);
 	!<ast-expr-alt>: (:ast_expr, :ast_expr) -> (:ast_expr);
 	<ast-expr-any>: () -> (:ast_expr);
-	<ast-expr-many>: () -> (:ast_expr);
 
-        !<ast-expr-atom>: (:ast_expr, :ast_count) -> (:ast_expr);
+        <ast-expr-atom>: (:ast_expr, :ast_count) -> (:ast_expr);
         !<ast-expr-atom-any>: (:ast_count) -> (:ast_expr);
-        !<ast-expr-atom-many>: (:ast_count) -> (:ast_expr);
 	!<ast-expr-char-class>: (:char_class_ast, :pos, :pos) -> (:ast_expr);
         !<ast-expr-group>: (:ast_expr) -> (:ast_expr);
 	!<ast-expr-re-flags>: (:re_flags, :re_flags) -> (:ast_expr);
 
-        !<atom-kleene>: () -> (:ast_count);
+        <atom-kleene>: () -> (:ast_count);
         !<atom-plus>: () -> (:ast_count);
         !<atom-one>: () -> (:ast_count);
         !<atom-opt>: () -> (:ast_count);
@@ -134,8 +132,10 @@
 			any();
 			l = <ast-expr-any>();
 		||
-		        many();
-			l = <ast-expr-many>();
+			many();
+			e = <ast-expr-any>();
+			c = <atom-kleene>();
+			l = <ast-expr-atom>(e, c);
 		};
 
 		{

--- a/src/libre/dialect/literal/parser.c
+++ b/src/libre/dialect/literal/parser.c
@@ -247,8 +247,8 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 		/* BEGINNING OF INLINE: list-of-nodes::literal */
 		{
 			{
-				t_pos ZI95;
-				t_pos ZI96;
+				t_pos ZI93;
+				t_pos ZI94;
 
 				switch (CURRENT_TERMINAL) {
 				case (TOK_CHAR):
@@ -259,8 +259,8 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI95 = lex_state->lx.start;
-		ZI96   = lex_state->lx.end;
+		ZI93 = lex_state->lx.start;
+		ZI94   = lex_state->lx.end;
 
 		ZIc = lex_state->buf.a[0];
 	
@@ -284,7 +284,7 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 #line 285 "src/libre/dialect/literal/parser.c"
 		}
 		/* END OF ACTION: ast-expr-literal */
-		/* BEGINNING OF INLINE: 98 */
+		/* BEGINNING OF INLINE: 96 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CHAR):
@@ -314,7 +314,7 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 				break;
 			}
 		}
-		/* END OF INLINE: 98 */
+		/* END OF INLINE: 96 */
 	}
 	goto ZL0;
 ZL1:;
@@ -333,7 +333,7 @@ p_re__literal(flags flags, lex_state lex_state, act_state act_state, err err, t_
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 102 */
+		/* BEGINNING OF INLINE: 100 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CHAR):
@@ -360,8 +360,8 @@ p_re__literal(flags flags, lex_state lex_state, act_state act_state, err err, t_
 				break;
 			}
 		}
-		/* END OF INLINE: 102 */
-		/* BEGINNING OF INLINE: 103 */
+		/* END OF INLINE: 100 */
+		/* BEGINNING OF INLINE: 101 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -390,7 +390,7 @@ p_re__literal(flags flags, lex_state lex_state, act_state act_state, err err, t_
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 103 */
+		/* END OF INLINE: 101 */
 	}
 	goto ZL0;
 ZL1:;
@@ -402,7 +402,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 757 "src/libre/parser.act"
+#line 747 "src/libre/parser.act"
 
 
 	static int

--- a/src/libre/dialect/literal/parser.h
+++ b/src/libre/dialect/literal/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__literal(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 913 "src/libre/parser.act"
+#line 903 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/literal/parser.h"

--- a/src/libre/dialect/literal/parser.sid
+++ b/src/libre/dialect/literal/parser.sid
@@ -65,11 +65,9 @@
 	<ast-expr-concat>: (:ast_expr, :ast_expr) -> (:ast_expr);
 	!<ast-expr-alt>: (:ast_expr, :ast_expr) -> (:ast_expr);
 	!<ast-expr-any>: () -> (:ast_expr);
-	!<ast-expr-many>: () -> (:ast_expr);
 
         !<ast-expr-atom>: (:ast_expr, :ast_count) -> (:ast_expr);
         !<ast-expr-atom-any>: (:ast_count) -> (:ast_expr);
-        !<ast-expr-atom-many>: (:ast_count) -> (:ast_expr);
 	!<ast-expr-char-class>: (:char_class_ast, :pos, :pos) -> (:ast_expr);
         !<ast-expr-group>: (:ast_expr) -> (:ast_expr);
 	!<ast-expr-re-flags>: (:re_flags, :re_flags) -> (:ast_expr);

--- a/src/libre/dialect/native/parser.c
+++ b/src/libre/dialect/native/parser.c
@@ -228,14 +228,14 @@ static void p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags, lex_state, act_state, er
 static void p_expr_C_Cchar_Hclass(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Cliteral(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Cchar_Hclass_C_Cchar_Hclass_Hhead(flags, lex_state, act_state, err, t_char__class__ast *);
+static void p_193(flags, lex_state, act_state, err, t_ast__expr *, t_ast__expr *);
 static void p_expr(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_195(flags, lex_state, act_state, err, t_ast__expr *, t_ast__expr *);
 extern void p_re__native(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_198(flags, lex_state, act_state, err, t_ast__expr *, t_ast__expr *);
+static void p_196(flags, lex_state, act_state, err, t_ast__expr *, t_ast__expr *);
 static void p_expr_C_Cchar_Hclass_C_Clist_Hof_Hchar_Hclass_Hterms(flags, lex_state, act_state, err, t_char__class__ast *);
 static void p_expr_C_Clist_Hof_Hatoms(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_210(flags, lex_state, act_state, err, t_char *, t_pos *, t_char__class__ast *);
-static void p_213(flags, lex_state, act_state, err, t_ast__expr *, t_pos *, t_unsigned *, t_ast__expr *);
+static void p_208(flags, lex_state, act_state, err, t_char *, t_pos *, t_char__class__ast *);
+static void p_211(flags, lex_state, act_state, err, t_ast__expr *, t_pos *, t_unsigned *, t_ast__expr *);
 static void p_expr_C_Clist_Hof_Halts(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Catom(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Calt(flags, lex_state, act_state, err, t_ast__expr *);
@@ -253,9 +253,9 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CHAR):
 		{
-			t_char ZI207;
-			t_pos ZI208;
-			t_pos ZI209;
+			t_char ZI205;
+			t_pos ZI206;
+			t_pos ZI207;
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
@@ -264,16 +264,16 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI208 = lex_state->lx.start;
-		ZI209   = lex_state->lx.end;
+		ZI206 = lex_state->lx.start;
+		ZI207   = lex_state->lx.end;
 
-		ZI207 = lex_state->buf.a[0];
+		ZI205 = lex_state->buf.a[0];
 	
 #line 273 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
-			p_210 (flags, lex_state, act_state, err, &ZI207, &ZI208, &ZInode);
+			p_208 (flags, lex_state, act_state, err, &ZI205, &ZI206, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -283,8 +283,8 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 	case (TOK_ESC):
 		{
 			t_char ZIc;
-			t_pos ZI111;
-			t_pos ZI112;
+			t_pos ZI109;
+			t_pos ZI110;
 
 			/* BEGINNING OF EXTRACT: ESC */
 			{
@@ -306,8 +306,8 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 		default:             break;
 		}
 
-		ZI111 = lex_state->lx.start;
-		ZI112   = lex_state->lx.end;
+		ZI109 = lex_state->lx.start;
+		ZI110   = lex_state->lx.end;
 	
 #line 313 "src/libre/dialect/native/parser.c"
 			}
@@ -315,7 +315,7 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: char-class-ast-literal */
 			{
-#line 659 "src/libre/parser.act"
+#line 649 "src/libre/parser.act"
 
 		(ZInode) = re_char_class_ast_literal((ZIc));
 	
@@ -326,9 +326,9 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 		break;
 	case (TOK_HEX):
 		{
-			t_char ZI203;
-			t_pos ZI204;
-			t_pos ZI205;
+			t_char ZI201;
+			t_pos ZI202;
+			t_pos ZI203;
 
 			/* BEGINNING OF EXTRACT: HEX */
 			{
@@ -341,8 +341,8 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 		assert(0 == strncmp(lex_state->buf.a, "\\x", 2));
 		assert(strlen(lex_state->buf.a) >= 3);
 
-		ZI204 = lex_state->lx.start;
-		ZI205   = lex_state->lx.end;
+		ZI202 = lex_state->lx.start;
+		ZI203   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -370,13 +370,13 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 			goto ZL1;
 		}
 
-		ZI203 = (char) (unsigned char) u;
+		ZI201 = (char) (unsigned char) u;
 	
 #line 376 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: HEX */
 			ADVANCE_LEXER;
-			p_210 (flags, lex_state, act_state, err, &ZI203, &ZI204, &ZInode);
+			p_208 (flags, lex_state, act_state, err, &ZI201, &ZI202, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -385,9 +385,9 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 		break;
 	case (TOK_OCT):
 		{
-			t_char ZI199;
-			t_pos ZI200;
-			t_pos ZI201;
+			t_char ZI197;
+			t_pos ZI198;
+			t_pos ZI199;
 
 			/* BEGINNING OF EXTRACT: OCT */
 			{
@@ -400,8 +400,8 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
 		assert(strlen(lex_state->buf.a) >= 2);
 
-		ZI200 = lex_state->lx.start;
-		ZI201   = lex_state->lx.end;
+		ZI198 = lex_state->lx.start;
+		ZI199   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -429,13 +429,13 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 			goto ZL1;
 		}
 
-		ZI199 = (char) (unsigned char) u;
+		ZI197 = (char) (unsigned char) u;
 	
 #line 435 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: OCT */
 			ADVANCE_LEXER;
-			p_210 (flags, lex_state, act_state, err, &ZI199, &ZI200, &ZInode);
+			p_208 (flags, lex_state, act_state, err, &ZI197, &ZI198, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -449,8 +449,8 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 			/* BEGINNING OF INLINE: expr::char-class::class-named */
 			{
 				{
-					t_pos ZI143;
-					t_pos ZI144;
+					t_pos ZI141;
+					t_pos ZI142;
 
 					switch (CURRENT_TERMINAL) {
 					case (TOK_NAMED__CHAR__CLASS):
@@ -474,8 +474,8 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 			break;
 		}
 
-		ZI143 = lex_state->lx.start;
-		ZI144   = lex_state->lx.end;
+		ZI141 = lex_state->lx.start;
+		ZI142   = lex_state->lx.end;
 	
 #line 481 "src/libre/dialect/native/parser.c"
 						}
@@ -490,7 +490,7 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 			/* END OF INLINE: expr::char-class::class-named */
 			/* BEGINNING OF ACTION: char-class-ast-named-class */
 			{
-#line 701 "src/libre/parser.act"
+#line 691 "src/libre/parser.act"
 
 		(ZInode) = re_char_class_ast_named_class((ZIid));
 	
@@ -521,7 +521,7 @@ ZL1:;
 		/* END OF ACTION: err-expected-term */
 		/* BEGINNING OF ACTION: char-class-ast-flag-none */
 		{
-#line 715 "src/libre/parser.act"
+#line 705 "src/libre/parser.act"
 
 		(ZInode) = re_char_class_ast_flags(RE_CHAR_CLASS_FLAG_NONE);
 	
@@ -547,7 +547,7 @@ p_expr_C_Cchar_Hclass(flags flags, lex_state lex_state, act_state act_state, err
 	}
 	{
 		t_pos ZIstart;
-		t_pos ZI153;
+		t_pos ZI151;
 		t_char__class__ast ZIhead;
 		t_char__class__ast ZIbody;
 		t_pos ZIend;
@@ -560,7 +560,7 @@ p_expr_C_Cchar_Hclass(flags flags, lex_state lex_state, act_state act_state, err
 #line 252 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
-		ZI153   = lex_state->lx.end;
+		ZI151   = lex_state->lx.end;
 	
 #line 566 "src/libre/dialect/native/parser.c"
 			}
@@ -572,15 +572,15 @@ p_expr_C_Cchar_Hclass(flags flags, lex_state lex_state, act_state act_state, err
 		ADVANCE_LEXER;
 		p_expr_C_Cchar_Hclass_C_Cchar_Hclass_Hhead (flags, lex_state, act_state, err, &ZIhead);
 		p_expr_C_Cchar_Hclass_C_Clist_Hof_Hchar_Hclass_Hterms (flags, lex_state, act_state, err, &ZIbody);
-		/* BEGINNING OF INLINE: 156 */
+		/* BEGINNING OF INLINE: 154 */
 		{
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
 			}
 			{
-				t_char ZI157;
-				t_pos ZI158;
+				t_char ZI155;
+				t_pos ZI156;
 
 				switch (CURRENT_TERMINAL) {
 				case (TOK_CLOSEGROUP):
@@ -588,8 +588,8 @@ p_expr_C_Cchar_Hclass(flags flags, lex_state lex_state, act_state act_state, err
 					{
 #line 257 "src/libre/parser.act"
 
-		ZI157 = ']';
-		ZI158 = lex_state->lx.start;
+		ZI155 = ']';
+		ZI156 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
 #line 596 "src/libre/dialect/native/parser.c"
@@ -630,10 +630,10 @@ p_expr_C_Cchar_Hclass(flags flags, lex_state lex_state, act_state act_state, err
 			}
 		ZL2:;
 		}
-		/* END OF INLINE: 156 */
+		/* END OF INLINE: 154 */
 		/* BEGINNING OF ACTION: char-class-ast-concat */
 		{
-#line 693 "src/libre/parser.act"
+#line 683 "src/libre/parser.act"
 
 		(ZIhb) = re_char_class_ast_concat((ZIhead), (ZIbody));
 	
@@ -642,7 +642,7 @@ p_expr_C_Cchar_Hclass(flags flags, lex_state lex_state, act_state act_state, err
 		/* END OF ACTION: char-class-ast-concat */
 		/* BEGINNING OF ACTION: ast-expr-char-class */
 		{
-#line 705 "src/libre/parser.act"
+#line 695 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		AST_POS_OF_LX_POS(ast_start, (ZIstart));
@@ -675,13 +675,13 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 	{
 		t_char ZIc;
 
-		/* BEGINNING OF INLINE: 92 */
+		/* BEGINNING OF INLINE: 90 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CHAR):
 				{
-					t_pos ZI100;
-					t_pos ZI101;
+					t_pos ZI98;
+					t_pos ZI99;
 
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
@@ -690,8 +690,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI100 = lex_state->lx.start;
-		ZI101   = lex_state->lx.end;
+		ZI98 = lex_state->lx.start;
+		ZI99   = lex_state->lx.end;
 
 		ZIc = lex_state->buf.a[0];
 	
@@ -703,8 +703,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				break;
 			case (TOK_ESC):
 				{
-					t_pos ZI94;
-					t_pos ZI95;
+					t_pos ZI92;
+					t_pos ZI93;
 
 					/* BEGINNING OF EXTRACT: ESC */
 					{
@@ -726,8 +726,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		default:             break;
 		}
 
-		ZI94 = lex_state->lx.start;
-		ZI95   = lex_state->lx.end;
+		ZI92 = lex_state->lx.start;
+		ZI93   = lex_state->lx.end;
 	
 #line 733 "src/libre/dialect/native/parser.c"
 					}
@@ -737,8 +737,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				break;
 			case (TOK_HEX):
 				{
-					t_pos ZI98;
-					t_pos ZI99;
+					t_pos ZI96;
+					t_pos ZI97;
 
 					/* BEGINNING OF EXTRACT: HEX */
 					{
@@ -751,8 +751,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		assert(0 == strncmp(lex_state->buf.a, "\\x", 2));
 		assert(strlen(lex_state->buf.a) >= 3);
 
-		ZI98 = lex_state->lx.start;
-		ZI99   = lex_state->lx.end;
+		ZI96 = lex_state->lx.start;
+		ZI97   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -790,8 +790,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				break;
 			case (TOK_OCT):
 				{
-					t_pos ZI96;
-					t_pos ZI97;
+					t_pos ZI94;
+					t_pos ZI95;
 
 					/* BEGINNING OF EXTRACT: OCT */
 					{
@@ -804,8 +804,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
 		assert(strlen(lex_state->buf.a) >= 2);
 
-		ZI96 = lex_state->lx.start;
-		ZI97   = lex_state->lx.end;
+		ZI94 = lex_state->lx.start;
+		ZI95   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -845,7 +845,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 92 */
+		/* END OF INLINE: 90 */
 		/* BEGINNING OF ACTION: ast-expr-literal */
 		{
 #line 595 "src/libre/parser.act"
@@ -872,13 +872,13 @@ p_expr_C_Cchar_Hclass_C_Cchar_Hclass_Hhead(flags flags, lex_state lex_state, act
 	switch (CURRENT_TERMINAL) {
 	case (TOK_INVERT):
 		{
-			t_char ZI107;
+			t_char ZI105;
 
 			/* BEGINNING OF EXTRACT: INVERT */
 			{
 #line 242 "src/libre/parser.act"
 
-		ZI107 = '^';
+		ZI105 = '^';
 	
 #line 884 "src/libre/dialect/native/parser.c"
 			}
@@ -886,7 +886,7 @@ p_expr_C_Cchar_Hclass_C_Cchar_Hclass_Hhead(flags flags, lex_state lex_state, act
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: char-class-ast-flag-invert */
 			{
-#line 719 "src/libre/parser.act"
+#line 709 "src/libre/parser.act"
 
 		(ZIf) = re_char_class_ast_flags(RE_CHAR_CLASS_FLAG_INVERTED);
 	
@@ -899,7 +899,7 @@ p_expr_C_Cchar_Hclass_C_Cchar_Hclass_Hhead(flags flags, lex_state lex_state, act
 		{
 			/* BEGINNING OF ACTION: char-class-ast-flag-none */
 			{
-#line 715 "src/libre/parser.act"
+#line 705 "src/libre/parser.act"
 
 		(ZIf) = re_char_class_ast_flags(RE_CHAR_CLASS_FLAG_NONE);
 	
@@ -912,6 +912,49 @@ p_expr_C_Cchar_Hclass_C_Cchar_Hclass_Hhead(flags flags, lex_state lex_state, act
 		return;
 	}
 	*ZOf = ZIf;
+}
+
+static void
+p_193(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZI191, t_ast__expr *ZOnode)
+{
+	t_ast__expr ZInode;
+
+	switch (CURRENT_TERMINAL) {
+	case (TOK_ALT):
+		{
+			t_ast__expr ZIr;
+
+			ADVANCE_LEXER;
+			p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, &ZIr);
+			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+				RESTORE_LEXER;
+				goto ZL1;
+			}
+			/* BEGINNING OF ACTION: ast-expr-alt */
+			{
+#line 591 "src/libre/parser.act"
+
+		(ZInode) = re_ast_expr_alt((*ZI191), (ZIr));
+	
+#line 940 "src/libre/dialect/native/parser.c"
+			}
+			/* END OF ACTION: ast-expr-alt */
+		}
+		break;
+	default:
+		{
+			ZInode = *ZI191;
+		}
+		break;
+	case (ERROR_TERMINAL):
+		return;
+	}
+	goto ZL0;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+ZL0:;
+	*ZOnode = ZInode;
 }
 
 static void
@@ -937,49 +980,6 @@ ZL0:;
 	*ZOnode = ZInode;
 }
 
-static void
-p_195(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZI193, t_ast__expr *ZOnode)
-{
-	t_ast__expr ZInode;
-
-	switch (CURRENT_TERMINAL) {
-	case (TOK_ALT):
-		{
-			t_ast__expr ZIr;
-
-			ADVANCE_LEXER;
-			p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, &ZIr);
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-			/* BEGINNING OF ACTION: ast-expr-alt */
-			{
-#line 591 "src/libre/parser.act"
-
-		(ZInode) = re_ast_expr_alt((*ZI193), (ZIr));
-	
-#line 963 "src/libre/dialect/native/parser.c"
-			}
-			/* END OF ACTION: ast-expr-alt */
-		}
-		break;
-	default:
-		{
-			ZInode = *ZI193;
-		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOnode = ZInode;
-}
-
 void
 p_re__native(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
 {
@@ -989,7 +989,7 @@ p_re__native(flags flags, lex_state lex_state, act_state act_state, err err, t_a
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 182 */
+		/* BEGINNING OF INLINE: 180 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_OPENSUB): case (TOK_OPENGROUP): case (TOK_ESC):
@@ -1017,8 +1017,8 @@ p_re__native(flags flags, lex_state lex_state, act_state act_state, err err, t_a
 				break;
 			}
 		}
-		/* END OF INLINE: 182 */
-		/* BEGINNING OF INLINE: 183 */
+		/* END OF INLINE: 180 */
+		/* BEGINNING OF INLINE: 181 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -1047,7 +1047,7 @@ p_re__native(flags flags, lex_state lex_state, act_state act_state, err err, t_a
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 183 */
+		/* END OF INLINE: 181 */
 	}
 	goto ZL0;
 ZL1:;
@@ -1058,7 +1058,7 @@ ZL0:;
 }
 
 static void
-p_198(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZI196, t_ast__expr *ZOnode)
+p_196(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZI194, t_ast__expr *ZOnode)
 {
 	t_ast__expr ZInode;
 
@@ -1077,7 +1077,7 @@ p_198(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			{
 #line 587 "src/libre/parser.act"
 
-		(ZInode) = re_ast_expr_concat((*ZI196), (ZIr));
+		(ZInode) = re_ast_expr_concat((*ZI194), (ZIr));
 	
 #line 1083 "src/libre/dialect/native/parser.c"
 			}
@@ -1086,7 +1086,7 @@ p_198(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 		break;
 	default:
 		{
-			ZInode = *ZI196;
+			ZInode = *ZI194;
 		}
 		break;
 	case (ERROR_TERMINAL):
@@ -1112,7 +1112,7 @@ p_expr_C_Cchar_Hclass_C_Clist_Hof_Hchar_Hclass_Hterms(flags flags, lex_state lex
 		t_char__class__ast ZIl;
 
 		p_expr_C_Cchar_Hclass_C_Cclass_Hterm (flags, lex_state, act_state, err, &ZIl);
-		/* BEGINNING OF INLINE: 150 */
+		/* BEGINNING OF INLINE: 148 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_NAMED__CHAR__CLASS): case (TOK_ESC): case (TOK_OCT): case (TOK_HEX):
@@ -1127,7 +1127,7 @@ p_expr_C_Cchar_Hclass_C_Clist_Hof_Hchar_Hclass_Hterms(flags flags, lex_state lex
 					}
 					/* BEGINNING OF ACTION: char-class-ast-concat */
 					{
-#line 693 "src/libre/parser.act"
+#line 683 "src/libre/parser.act"
 
 		(ZInode) = re_char_class_ast_concat((ZIl), (ZIr));
 	
@@ -1146,7 +1146,7 @@ p_expr_C_Cchar_Hclass_C_Clist_Hof_Hchar_Hclass_Hterms(flags flags, lex_state lex
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 150 */
+		/* END OF INLINE: 148 */
 	}
 	goto ZL0;
 ZL1:;
@@ -1165,10 +1165,10 @@ p_expr_C_Clist_Hof_Hatoms(flags flags, lex_state lex_state, act_state act_state,
 		return;
 	}
 	{
-		t_ast__expr ZI196;
+		t_ast__expr ZI194;
 
-		p_expr_C_Catom (flags, lex_state, act_state, err, &ZI196);
-		p_198 (flags, lex_state, act_state, err, &ZI196, &ZInode);
+		p_expr_C_Catom (flags, lex_state, act_state, err, &ZI194);
+		p_196 (flags, lex_state, act_state, err, &ZI194, &ZInode);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -1183,7 +1183,7 @@ ZL0:;
 }
 
 static void
-p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI207, t_pos *ZI208, t_char__class__ast *ZOnode)
+p_208(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI205, t_pos *ZI206, t_char__class__ast *ZOnode)
 {
 	t_char__class__ast ZInode;
 
@@ -1197,22 +1197,22 @@ p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 731 "src/libre/parser.act"
+#line 721 "src/libre/parser.act"
 
 		struct ast_range_endpoint range;
 		range.t = AST_RANGE_ENDPOINT_LITERAL;
-		range.u.literal.c = (*ZI207);
+		range.u.literal.c = (*ZI205);
 		(ZIa) = range;
 	
 #line 1208 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
-			/* BEGINNING OF INLINE: 128 */
+			/* BEGINNING OF INLINE: 126 */
 			{
 				{
-					t_char ZI129;
-					t_pos ZI130;
-					t_pos ZI131;
+					t_char ZI127;
+					t_pos ZI128;
+					t_pos ZI129;
 
 					switch (CURRENT_TERMINAL) {
 					case (TOK_RANGE):
@@ -1220,9 +1220,9 @@ p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 						{
 #line 246 "src/libre/parser.act"
 
-		ZI129 = '-';
-		ZI130 = lex_state->lx.start;
-		ZI131   = lex_state->lx.end;
+		ZI127 = '-';
+		ZI128 = lex_state->lx.start;
+		ZI129   = lex_state->lx.end;
 	
 #line 1228 "src/libre/dialect/native/parser.c"
 						}
@@ -1251,13 +1251,13 @@ p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 				}
 			ZL2:;
 			}
-			/* END OF INLINE: 128 */
-			/* BEGINNING OF INLINE: 132 */
+			/* END OF INLINE: 126 */
+			/* BEGINNING OF INLINE: 130 */
 			{
 				switch (CURRENT_TERMINAL) {
 				case (TOK_CHAR):
 					{
-						t_pos ZI137;
+						t_pos ZI135;
 
 						/* BEGINNING OF EXTRACT: CHAR */
 						{
@@ -1266,7 +1266,7 @@ p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI137 = lex_state->lx.start;
+		ZI135 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 
 		ZIcz = lex_state->buf.a[0];
@@ -1279,7 +1279,7 @@ p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 					break;
 				case (TOK_HEX):
 					{
-						t_pos ZI136;
+						t_pos ZI134;
 
 						/* BEGINNING OF EXTRACT: HEX */
 						{
@@ -1292,7 +1292,7 @@ p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		assert(0 == strncmp(lex_state->buf.a, "\\x", 2));
 		assert(strlen(lex_state->buf.a) >= 3);
 
-		ZI136 = lex_state->lx.start;
+		ZI134 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 
 		errno = 0;
@@ -1331,7 +1331,7 @@ p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 					break;
 				case (TOK_OCT):
 					{
-						t_pos ZI134;
+						t_pos ZI132;
 
 						/* BEGINNING OF EXTRACT: OCT */
 						{
@@ -1344,7 +1344,7 @@ p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
 		assert(strlen(lex_state->buf.a) >= 2);
 
-		ZI134 = lex_state->lx.start;
+		ZI132 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 
 		errno = 0;
@@ -1383,14 +1383,14 @@ p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 					break;
 				case (TOK_RANGE):
 					{
-						t_pos ZI138;
+						t_pos ZI136;
 
 						/* BEGINNING OF EXTRACT: RANGE */
 						{
 #line 246 "src/libre/parser.act"
 
 		ZIcz = '-';
-		ZI138 = lex_state->lx.start;
+		ZI136 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
 #line 1397 "src/libre/dialect/native/parser.c"
@@ -1403,10 +1403,10 @@ p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 					goto ZL1;
 				}
 			}
-			/* END OF INLINE: 132 */
+			/* END OF INLINE: 130 */
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 731 "src/libre/parser.act"
+#line 721 "src/libre/parser.act"
 
 		struct ast_range_endpoint range;
 		range.t = AST_RANGE_ENDPOINT_LITERAL;
@@ -1420,7 +1420,7 @@ p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			{
 #line 571 "src/libre/parser.act"
 
-		mark(&act_state->rangestart, &(*ZI208));
+		mark(&act_state->rangestart, &(*ZI206));
 		mark(&act_state->rangeend,   &(ZIend));
 	
 #line 1427 "src/libre/dialect/native/parser.c"
@@ -1428,11 +1428,11 @@ p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: char-class-ast-range */
 			{
-#line 664 "src/libre/parser.act"
+#line 654 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
-		AST_POS_OF_LX_POS(ast_start, (*ZI208));
+		AST_POS_OF_LX_POS(ast_start, (*ZI206));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		if ((ZIa).t != AST_RANGE_ENDPOINT_LITERAL ||
@@ -1466,9 +1466,9 @@ p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		{
 			/* BEGINNING OF ACTION: char-class-ast-literal */
 			{
-#line 659 "src/libre/parser.act"
+#line 649 "src/libre/parser.act"
 
-		(ZInode) = re_char_class_ast_literal((*ZI207));
+		(ZInode) = re_char_class_ast_literal((*ZI205));
 	
 #line 1474 "src/libre/dialect/native/parser.c"
 			}
@@ -1487,14 +1487,14 @@ ZL0:;
 }
 
 static void
-p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZIe, t_pos *ZI211, t_unsigned *ZIm, t_ast__expr *ZOnode)
+p_211(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZIe, t_pos *ZI209, t_unsigned *ZIm, t_ast__expr *ZOnode)
 {
 	t_ast__expr ZInode;
 
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CLOSECOUNT):
 		{
-			t_pos ZI170;
+			t_pos ZI168;
 			t_pos ZIend;
 			t_ast__count ZIc;
 
@@ -1502,7 +1502,7 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			{
 #line 268 "src/libre/parser.act"
 
-		ZI170 = lex_state->lx.start;
+		ZI168 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
 #line 1509 "src/libre/dialect/native/parser.c"
@@ -1513,7 +1513,7 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			{
 #line 576 "src/libre/parser.act"
 
-		mark(&act_state->countstart, &(*ZI211));
+		mark(&act_state->countstart, &(*ZI209));
 		mark(&act_state->countend,   &(ZIend));
 	
 #line 1520 "src/libre/dialect/native/parser.c"
@@ -1521,18 +1521,18 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: expr-count */
 			{
-#line 643 "src/libre/parser.act"
+#line 633 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		if ((*ZIm) < (*ZIm)) {
 			err->e = RE_ENEGCOUNT;
 			err->m = (*ZIm);
 			err->n = (*ZIm);
-			mark(&act_state->countstart, &(*ZI211));
+			mark(&act_state->countstart, &(*ZI209));
 			mark(&act_state->countend,   &(ZIend));
 			goto ZL1;
 		}
-		AST_POS_OF_LX_POS(ast_start, (*ZI211));
+		AST_POS_OF_LX_POS(ast_start, (*ZI209));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		(ZIc) = ast_count((*ZIm), &ast_start, (*ZIm), &ast_end);
@@ -1542,7 +1542,7 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			/* END OF ACTION: expr-count */
 			/* BEGINNING OF ACTION: ast-expr-atom */
 			{
-#line 623 "src/libre/parser.act"
+#line 613 "src/libre/parser.act"
 
 		(ZInode) = re_ast_expr_with_count((*ZIe), (ZIc));
 	
@@ -1555,7 +1555,7 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 		{
 			t_unsigned ZIn;
 			t_pos ZIend;
-			t_pos ZI173;
+			t_pos ZI171;
 			t_ast__count ZIc;
 
 			ADVANCE_LEXER;
@@ -1598,7 +1598,7 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 #line 268 "src/libre/parser.act"
 
 		ZIend = lex_state->lx.start;
-		ZI173   = lex_state->lx.end;
+		ZI171   = lex_state->lx.end;
 	
 #line 1604 "src/libre/dialect/native/parser.c"
 				}
@@ -1612,7 +1612,7 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			{
 #line 576 "src/libre/parser.act"
 
-		mark(&act_state->countstart, &(*ZI211));
+		mark(&act_state->countstart, &(*ZI209));
 		mark(&act_state->countend,   &(ZIend));
 	
 #line 1619 "src/libre/dialect/native/parser.c"
@@ -1620,18 +1620,18 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: expr-count */
 			{
-#line 643 "src/libre/parser.act"
+#line 633 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		if ((ZIn) < (*ZIm)) {
 			err->e = RE_ENEGCOUNT;
 			err->m = (*ZIm);
 			err->n = (ZIn);
-			mark(&act_state->countstart, &(*ZI211));
+			mark(&act_state->countstart, &(*ZI209));
 			mark(&act_state->countend,   &(ZIend));
 			goto ZL1;
 		}
-		AST_POS_OF_LX_POS(ast_start, (*ZI211));
+		AST_POS_OF_LX_POS(ast_start, (*ZI209));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		(ZIc) = ast_count((*ZIm), &ast_start, (ZIn), &ast_end);
@@ -1641,7 +1641,7 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			/* END OF ACTION: expr-count */
 			/* BEGINNING OF ACTION: ast-expr-atom */
 			{
-#line 623 "src/libre/parser.act"
+#line 613 "src/libre/parser.act"
 
 		(ZInode) = re_ast_expr_with_count((*ZIe), (ZIc));
 	
@@ -1672,10 +1672,10 @@ p_expr_C_Clist_Hof_Halts(flags flags, lex_state lex_state, act_state act_state, 
 		return;
 	}
 	{
-		t_ast__expr ZI193;
+		t_ast__expr ZI191;
 
-		p_expr_C_Calt (flags, lex_state, act_state, err, &ZI193);
-		p_195 (flags, lex_state, act_state, err, &ZI193, &ZInode);
+		p_expr_C_Calt (flags, lex_state, act_state, err, &ZI191);
+		p_193 (flags, lex_state, act_state, err, &ZI191, &ZInode);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -1700,7 +1700,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 	{
 		t_ast__expr ZIe;
 
-		/* BEGINNING OF INLINE: 163 */
+		/* BEGINNING OF INLINE: 161 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY):
@@ -1729,14 +1729,14 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 					}
 					/* BEGINNING OF ACTION: ast-expr-group */
 					{
-#line 619 "src/libre/parser.act"
+#line 609 "src/libre/parser.act"
 
 		(ZIe) = re_ast_expr_group((ZIg));
 	
 #line 1737 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: ast-expr-group */
-					/* BEGINNING OF INLINE: 166 */
+					/* BEGINNING OF INLINE: 164 */
 					{
 						{
 							switch (CURRENT_TERMINAL) {
@@ -1765,7 +1765,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 						}
 					ZL3:;
 					}
-					/* END OF INLINE: 166 */
+					/* END OF INLINE: 164 */
 				}
 				break;
 			case (TOK_OPENGROUP):
@@ -1790,22 +1790,22 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 163 */
-		/* BEGINNING OF INLINE: 167 */
+		/* END OF INLINE: 161 */
+		/* BEGINNING OF INLINE: 165 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_OPENCOUNT):
 				{
-					t_pos ZI211;
-					t_pos ZI212;
+					t_pos ZI209;
+					t_pos ZI210;
 					t_unsigned ZIm;
 
 					/* BEGINNING OF EXTRACT: OPENCOUNT */
 					{
 #line 263 "src/libre/parser.act"
 
-		ZI211 = lex_state->lx.start;
-		ZI212   = lex_state->lx.end;
+		ZI209 = lex_state->lx.start;
+		ZI210   = lex_state->lx.end;
 	
 #line 1811 "src/libre/dialect/native/parser.c"
 					}
@@ -1843,7 +1843,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 						goto ZL6;
 					}
 					ADVANCE_LEXER;
-					p_213 (flags, lex_state, act_state, err, &ZIe, &ZI211, &ZIm, &ZInode);
+					p_211 (flags, lex_state, act_state, err, &ZIe, &ZI209, &ZIm, &ZInode);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL6;
@@ -1857,7 +1857,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: atom-opt */
 					{
-#line 639 "src/libre/parser.act"
+#line 629 "src/libre/parser.act"
 
 		(ZIc) = ast_count(0, NULL, 1, NULL);
 	
@@ -1866,7 +1866,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 					/* END OF ACTION: atom-opt */
 					/* BEGINNING OF ACTION: ast-expr-atom */
 					{
-#line 623 "src/libre/parser.act"
+#line 613 "src/libre/parser.act"
 
 		(ZInode) = re_ast_expr_with_count((ZIe), (ZIc));
 	
@@ -1882,7 +1882,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: atom-plus */
 					{
-#line 631 "src/libre/parser.act"
+#line 621 "src/libre/parser.act"
 
 		(ZIc) = ast_count(1, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
@@ -1891,7 +1891,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 					/* END OF ACTION: atom-plus */
 					/* BEGINNING OF ACTION: ast-expr-atom */
 					{
-#line 623 "src/libre/parser.act"
+#line 613 "src/libre/parser.act"
 
 		(ZInode) = re_ast_expr_with_count((ZIe), (ZIc));
 	
@@ -1907,7 +1907,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: atom-kleene */
 					{
-#line 627 "src/libre/parser.act"
+#line 617 "src/libre/parser.act"
 
 		(ZIc) = ast_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
@@ -1916,7 +1916,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 					/* END OF ACTION: atom-kleene */
 					/* BEGINNING OF ACTION: ast-expr-atom */
 					{
-#line 623 "src/libre/parser.act"
+#line 613 "src/libre/parser.act"
 
 		(ZInode) = re_ast_expr_with_count((ZIe), (ZIc));
 	
@@ -1931,7 +1931,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 
 					/* BEGINNING OF ACTION: atom-one */
 					{
-#line 635 "src/libre/parser.act"
+#line 625 "src/libre/parser.act"
 
 		(ZIc) = ast_count(1, NULL, 1, NULL);
 	
@@ -1940,7 +1940,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 					/* END OF ACTION: atom-one */
 					/* BEGINNING OF ACTION: ast-expr-atom */
 					{
-#line 623 "src/libre/parser.act"
+#line 613 "src/libre/parser.act"
 
 		(ZInode) = re_ast_expr_with_count((ZIe), (ZIc));
 	
@@ -1969,7 +1969,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			}
 		ZL5:;
 		}
-		/* END OF INLINE: 167 */
+		/* END OF INLINE: 165 */
 	}
 	goto ZL0;
 ZL1:;
@@ -2004,7 +2004,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 757 "src/libre/parser.act"
+#line 747 "src/libre/parser.act"
 
 
 	static int

--- a/src/libre/dialect/native/parser.h
+++ b/src/libre/dialect/native/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__native(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 913 "src/libre/parser.act"
+#line 903 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/native/parser.h"

--- a/src/libre/dialect/native/parser.sid
+++ b/src/libre/dialect/native/parser.sid
@@ -68,11 +68,9 @@
 	<ast-expr-concat>: (:ast_expr, :ast_expr) -> (:ast_expr);
 	<ast-expr-alt>: (:ast_expr, :ast_expr) -> (:ast_expr);
 	<ast-expr-any>: () -> (:ast_expr);
-	!<ast-expr-many>: () -> (:ast_expr);
 
         <ast-expr-atom>: (:ast_expr, :ast_count) -> (:ast_expr);
         !<ast-expr-atom-any>: (:ast_count) -> (:ast_expr);
-        !<ast-expr-atom-many>: (:ast_count) -> (:ast_expr);
 	<ast-expr-char-class>: (:char_class_ast, :pos, :pos) -> (:ast_expr);
         <ast-expr-group>: (:ast_expr) -> (:ast_expr);
 	!<ast-expr-re-flags>: (:re_flags, :re_flags) -> (:ast_expr);

--- a/src/libre/dialect/pcre/parser.c
+++ b/src/libre/dialect/pcre/parser.c
@@ -225,29 +225,29 @@
 /* BEGINNING OF FUNCTION DECLARATIONS */
 
 static void p_expr_C_Cflags_C_Cflag__set(flags, lex_state, act_state, err, t_re__flags, t_re__flags *);
-static void p_140(flags, lex_state, act_state, err);
-static void p_144(flags, lex_state, act_state, err, t_range__endpoint *, t_pos *);
+static void p_138(flags, lex_state, act_state, err);
+static void p_142(flags, lex_state, act_state, err, t_range__endpoint *, t_pos *);
 static void p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags, lex_state, act_state, err, t_char__class__ast *);
 static void p_expr_C_Cchar_Hclass_C_Cclass_Hrange_C_Crange_Hendpoint_Hchar_Hclass(flags, lex_state, act_state, err, t_range__endpoint *, t_pos *, t_pos *);
 static void p_expr_C_Cchar_Hclass(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Cchar_Hclass_C_Cclass_Hrange_C_Crange_Hendpoint_Hliteral(flags, lex_state, act_state, err, t_range__endpoint *, t_pos *, t_pos *);
 static void p_expr_C_Cliteral(flags, lex_state, act_state, err, t_ast__expr *);
+static void p_191(flags, lex_state, act_state, err);
 static void p_expr_C_Cchar_Hclass_C_Cchar_Hclass_Hhead(flags, lex_state, act_state, err, t_char__class__ast *);
-static void p_193(flags, lex_state, act_state, err);
 static void p_expr(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Cflags(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Cchar_Hclass_C_Clist_Hof_Hchar_Hclass_Hterms(flags, lex_state, act_state, err, t_char__class__ast *);
 static void p_expr_C_Cchar_Htype(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Clist_Hof_Hatoms(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Clist_Hof_Halts(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_225(flags, lex_state, act_state, err, t_ast__expr *, t_ast__expr *);
-static void p_228(flags, lex_state, act_state, err, t_ast__expr *, t_ast__expr *);
+static void p_223(flags, lex_state, act_state, err, t_ast__expr *, t_ast__expr *);
+static void p_226(flags, lex_state, act_state, err, t_ast__expr *, t_ast__expr *);
 extern void p_re__pcre(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_232(flags, lex_state, act_state, err, t_ast__char__class__id *, t_pos *, t_char__class__ast *);
+static void p_230(flags, lex_state, act_state, err, t_ast__char__class__id *, t_pos *, t_char__class__ast *);
 static void p_expr_C_Catom(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_248(flags, lex_state, act_state, err, t_char *, t_pos *, t_char__class__ast *);
+static void p_246(flags, lex_state, act_state, err, t_char *, t_pos *, t_char__class__ast *);
+static void p_249(flags, lex_state, act_state, err, t_ast__expr *, t_pos *, t_unsigned *, t_ast__expr *);
 static void p_expr_C_Calt(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_251(flags, lex_state, act_state, err, t_ast__expr *, t_pos *, t_unsigned *, t_ast__expr *);
 
 /* BEGINNING OF STATIC VARIABLES */
 
@@ -276,7 +276,7 @@ p_expr_C_Cflags_C_Cflag__set(flags flags, lex_state lex_state, act_state act_sta
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: re-flag-union */
 			{
-#line 749 "src/libre/parser.act"
+#line 739 "src/libre/parser.act"
 
 		(ZIo) = (ZIi) | (ZIc);
 	
@@ -317,15 +317,15 @@ ZL0:;
 }
 
 static void
-p_140(flags flags, lex_state lex_state, act_state act_state, err err)
+p_138(flags flags, lex_state lex_state, act_state act_state, err err)
 {
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 		return;
 	}
 	{
-		t_char ZI141;
-		t_pos ZI142;
-		t_pos ZI143;
+		t_char ZI139;
+		t_pos ZI140;
+		t_pos ZI141;
 
 		switch (CURRENT_TERMINAL) {
 		case (TOK_RANGE):
@@ -333,9 +333,9 @@ p_140(flags flags, lex_state lex_state, act_state act_state, err err)
 			{
 #line 246 "src/libre/parser.act"
 
-		ZI141 = '-';
-		ZI142 = lex_state->lx.start;
-		ZI143   = lex_state->lx.end;
+		ZI139 = '-';
+		ZI140 = lex_state->lx.start;
+		ZI141   = lex_state->lx.end;
 	
 #line 341 "src/libre/dialect/pcre/parser.c"
 			}
@@ -370,7 +370,7 @@ ZL0:;
 }
 
 static void
-p_144(flags flags, lex_state lex_state, act_state act_state, err err, t_range__endpoint *ZOupper, t_pos *ZOu__end)
+p_142(flags flags, lex_state lex_state, act_state act_state, err err, t_range__endpoint *ZOupper, t_pos *ZOu__end)
 {
 	t_range__endpoint ZIupper;
 	t_pos ZIu__end;
@@ -395,7 +395,7 @@ p_144(flags flags, lex_state lex_state, act_state act_state, err err, t_range__e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 731 "src/libre/parser.act"
+#line 721 "src/libre/parser.act"
 
 		struct ast_range_endpoint range;
 		range.t = AST_RANGE_ENDPOINT_LITERAL;
@@ -451,9 +451,9 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CHAR):
 		{
-			t_char ZI241;
-			t_pos ZI242;
-			t_pos ZI243;
+			t_char ZI239;
+			t_pos ZI240;
+			t_pos ZI241;
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
@@ -462,16 +462,16 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI242 = lex_state->lx.start;
-		ZI243   = lex_state->lx.end;
+		ZI240 = lex_state->lx.start;
+		ZI241   = lex_state->lx.end;
 
-		ZI241 = lex_state->buf.a[0];
+		ZI239 = lex_state->buf.a[0];
 	
 #line 471 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
-			p_248 (flags, lex_state, act_state, err, &ZI241, &ZI242, &ZInode);
+			p_246 (flags, lex_state, act_state, err, &ZI239, &ZI240, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -480,9 +480,9 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 		break;
 	case (TOK_CONTROL):
 		{
-			t_char ZI245;
-			t_pos ZI246;
-			t_pos ZI247;
+			t_char ZI243;
+			t_pos ZI244;
+			t_pos ZI245;
 
 			/* BEGINNING OF EXTRACT: CONTROL */
 			{
@@ -493,14 +493,14 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 		assert(lex_state->buf.a[2] != '\0');
 		assert(lex_state->buf.a[3] == '\0');
 
-		ZI245 = lex_state->buf.a[2];
-		if ((unsigned char) ZI245 > 127) {
+		ZI243 = lex_state->buf.a[2];
+		if ((unsigned char) ZI243 > 127) {
 			goto ZL1;
 		}
-		ZI245 = (((toupper((unsigned char)ZI245)) - 64) % 128 + 128) % 128;
+		ZI243 = (((toupper((unsigned char)ZI243)) - 64) % 128 + 128) % 128;
 
-		ZI246 = lex_state->lx.start;
-		ZI247   = lex_state->lx.end;
+		ZI244 = lex_state->lx.start;
+		ZI245   = lex_state->lx.end;
 	
 #line 506 "src/libre/dialect/pcre/parser.c"
 			}
@@ -518,7 +518,7 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 #line 519 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: err-unsupported */
-			p_248 (flags, lex_state, act_state, err, &ZI245, &ZI246, &ZInode);
+			p_246 (flags, lex_state, act_state, err, &ZI243, &ZI244, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -528,8 +528,8 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 	case (TOK_ESC):
 		{
 			t_char ZIc;
-			t_pos ZI112;
-			t_pos ZI113;
+			t_pos ZI110;
+			t_pos ZI111;
 
 			/* BEGINNING OF EXTRACT: ESC */
 			{
@@ -551,8 +551,8 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 		default:             break;
 		}
 
-		ZI112 = lex_state->lx.start;
-		ZI113   = lex_state->lx.end;
+		ZI110 = lex_state->lx.start;
+		ZI111   = lex_state->lx.end;
 	
 #line 558 "src/libre/dialect/pcre/parser.c"
 			}
@@ -560,7 +560,7 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: char-class-ast-literal */
 			{
-#line 659 "src/libre/parser.act"
+#line 649 "src/libre/parser.act"
 
 		(ZInode) = re_char_class_ast_literal((ZIc));
 	
@@ -571,9 +571,9 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 		break;
 	case (TOK_HEX):
 		{
-			t_char ZI237;
-			t_pos ZI238;
-			t_pos ZI239;
+			t_char ZI235;
+			t_pos ZI236;
+			t_pos ZI237;
 
 			/* BEGINNING OF EXTRACT: HEX */
 			{
@@ -586,8 +586,8 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 		assert(0 == strncmp(lex_state->buf.a, "\\x", 2));
 		assert(strlen(lex_state->buf.a) >= 3);
 
-		ZI238 = lex_state->lx.start;
-		ZI239   = lex_state->lx.end;
+		ZI236 = lex_state->lx.start;
+		ZI237   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -615,13 +615,13 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 			goto ZL1;
 		}
 
-		ZI237 = (char) (unsigned char) u;
+		ZI235 = (char) (unsigned char) u;
 	
 #line 621 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: HEX */
 			ADVANCE_LEXER;
-			p_248 (flags, lex_state, act_state, err, &ZI237, &ZI238, &ZInode);
+			p_246 (flags, lex_state, act_state, err, &ZI235, &ZI236, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -630,9 +630,9 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 		break;
 	case (TOK_OCT):
 		{
-			t_char ZI233;
-			t_pos ZI234;
-			t_pos ZI235;
+			t_char ZI231;
+			t_pos ZI232;
+			t_pos ZI233;
 
 			/* BEGINNING OF EXTRACT: OCT */
 			{
@@ -645,8 +645,8 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
 		assert(strlen(lex_state->buf.a) >= 2);
 
-		ZI234 = lex_state->lx.start;
-		ZI235   = lex_state->lx.end;
+		ZI232 = lex_state->lx.start;
+		ZI233   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -674,13 +674,13 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 			goto ZL1;
 		}
 
-		ZI233 = (char) (unsigned char) u;
+		ZI231 = (char) (unsigned char) u;
 	
 #line 680 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: OCT */
 			ADVANCE_LEXER;
-			p_248 (flags, lex_state, act_state, err, &ZI233, &ZI234, &ZInode);
+			p_246 (flags, lex_state, act_state, err, &ZI231, &ZI232, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -689,9 +689,9 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 		break;
 	case (TOK_NAMED__CHAR__CLASS):
 		{
-			t_ast__char__class__id ZI229;
-			t_pos ZI230;
-			t_pos ZI231;
+			t_ast__char__class__id ZI227;
+			t_pos ZI228;
+			t_pos ZI229;
 
 			/* BEGINNING OF INLINE: expr::char-class::class-named */
 			{
@@ -703,7 +703,7 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 #line 455 "src/libre/parser.act"
 
 		enum re_dialect_char_class_lookup_res res;
-		res = DIALECT_CHAR_CLASS(lex_state->buf.a, &ZI229);
+		res = DIALECT_CHAR_CLASS(lex_state->buf.a, &ZI227);
 
 		switch (res) {
 		default:
@@ -718,8 +718,8 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 			break;
 		}
 
-		ZI230 = lex_state->lx.start;
-		ZI231   = lex_state->lx.end;
+		ZI228 = lex_state->lx.start;
+		ZI229   = lex_state->lx.end;
 	
 #line 725 "src/libre/dialect/pcre/parser.c"
 						}
@@ -732,7 +732,7 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state
 				}
 			}
 			/* END OF INLINE: expr::char-class::class-named */
-			p_232 (flags, lex_state, act_state, err, &ZI229, &ZI230, &ZInode);
+			p_230 (flags, lex_state, act_state, err, &ZI227, &ZI228, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -761,7 +761,7 @@ ZL1:;
 		/* END OF ACTION: err-expected-term */
 		/* BEGINNING OF ACTION: char-class-ast-flag-none */
 		{
-#line 715 "src/libre/parser.act"
+#line 705 "src/libre/parser.act"
 
 		(ZInode) = re_char_class_ast_flags(RE_CHAR_CLASS_FLAG_NONE);
 	
@@ -831,7 +831,7 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hrange_C_Crange_Hendpoint_Hchar_Hclass(flags flag
 		/* END OF INLINE: expr::char-class::class-named */
 		/* BEGINNING OF ACTION: ast-range-endpoint-char-class */
 		{
-#line 738 "src/libre/parser.act"
+#line 728 "src/libre/parser.act"
 
 		struct ast_range_endpoint range;
 		range.t = AST_RANGE_ENDPOINT_CHAR_CLASS;
@@ -862,7 +862,7 @@ p_expr_C_Cchar_Hclass(flags flags, lex_state lex_state, act_state act_state, err
 	}
 	{
 		t_pos ZIstart;
-		t_pos ZI161;
+		t_pos ZI159;
 		t_char__class__ast ZIhead;
 		t_char__class__ast ZIbody;
 		t_pos ZIend;
@@ -875,7 +875,7 @@ p_expr_C_Cchar_Hclass(flags flags, lex_state lex_state, act_state act_state, err
 #line 252 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
-		ZI161   = lex_state->lx.end;
+		ZI159   = lex_state->lx.end;
 	
 #line 881 "src/libre/dialect/pcre/parser.c"
 			}
@@ -887,15 +887,15 @@ p_expr_C_Cchar_Hclass(flags flags, lex_state lex_state, act_state act_state, err
 		ADVANCE_LEXER;
 		p_expr_C_Cchar_Hclass_C_Cchar_Hclass_Hhead (flags, lex_state, act_state, err, &ZIhead);
 		p_expr_C_Cchar_Hclass_C_Clist_Hof_Hchar_Hclass_Hterms (flags, lex_state, act_state, err, &ZIbody);
-		/* BEGINNING OF INLINE: 164 */
+		/* BEGINNING OF INLINE: 162 */
 		{
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
 			}
 			{
-				t_char ZI165;
-				t_pos ZI166;
+				t_char ZI163;
+				t_pos ZI164;
 
 				switch (CURRENT_TERMINAL) {
 				case (TOK_CLOSEGROUP):
@@ -903,8 +903,8 @@ p_expr_C_Cchar_Hclass(flags flags, lex_state lex_state, act_state act_state, err
 					{
 #line 257 "src/libre/parser.act"
 
-		ZI165 = ']';
-		ZI166 = lex_state->lx.start;
+		ZI163 = ']';
+		ZI164 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
 #line 911 "src/libre/dialect/pcre/parser.c"
@@ -945,10 +945,10 @@ p_expr_C_Cchar_Hclass(flags flags, lex_state lex_state, act_state act_state, err
 			}
 		ZL2:;
 		}
-		/* END OF INLINE: 164 */
+		/* END OF INLINE: 162 */
 		/* BEGINNING OF ACTION: char-class-ast-concat */
 		{
-#line 693 "src/libre/parser.act"
+#line 683 "src/libre/parser.act"
 
 		(ZIhb) = re_char_class_ast_concat((ZIhead), (ZIbody));
 	
@@ -957,7 +957,7 @@ p_expr_C_Cchar_Hclass(flags flags, lex_state lex_state, act_state act_state, err
 		/* END OF ACTION: char-class-ast-concat */
 		/* BEGINNING OF ACTION: ast-expr-char-class */
 		{
-#line 705 "src/libre/parser.act"
+#line 695 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		AST_POS_OF_LX_POS(ast_start, (ZIstart));
@@ -992,7 +992,7 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hrange_C_Crange_Hendpoint_Hliteral(flags flags, l
 	{
 		t_char ZIc;
 
-		/* BEGINNING OF INLINE: 132 */
+		/* BEGINNING OF INLINE: 130 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CHAR):
@@ -1157,10 +1157,10 @@ p_expr_C_Cchar_Hclass_C_Cclass_Hrange_C_Crange_Hendpoint_Hliteral(flags flags, l
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 132 */
+		/* END OF INLINE: 130 */
 		/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 		{
-#line 731 "src/libre/parser.act"
+#line 721 "src/libre/parser.act"
 
 		struct ast_range_endpoint range;
 		range.t = AST_RANGE_ENDPOINT_LITERAL;
@@ -1192,13 +1192,13 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 	{
 		t_char ZIc;
 
-		/* BEGINNING OF INLINE: 93 */
+		/* BEGINNING OF INLINE: 91 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CHAR):
 				{
-					t_pos ZI101;
-					t_pos ZI102;
+					t_pos ZI99;
+					t_pos ZI100;
 
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
@@ -1207,8 +1207,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI101 = lex_state->lx.start;
-		ZI102   = lex_state->lx.end;
+		ZI99 = lex_state->lx.start;
+		ZI100   = lex_state->lx.end;
 
 		ZIc = lex_state->buf.a[0];
 	
@@ -1220,8 +1220,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				break;
 			case (TOK_ESC):
 				{
-					t_pos ZI95;
-					t_pos ZI96;
+					t_pos ZI93;
+					t_pos ZI94;
 
 					/* BEGINNING OF EXTRACT: ESC */
 					{
@@ -1243,8 +1243,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		default:             break;
 		}
 
-		ZI95 = lex_state->lx.start;
-		ZI96   = lex_state->lx.end;
+		ZI93 = lex_state->lx.start;
+		ZI94   = lex_state->lx.end;
 	
 #line 1250 "src/libre/dialect/pcre/parser.c"
 					}
@@ -1254,8 +1254,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				break;
 			case (TOK_HEX):
 				{
-					t_pos ZI99;
-					t_pos ZI100;
+					t_pos ZI97;
+					t_pos ZI98;
 
 					/* BEGINNING OF EXTRACT: HEX */
 					{
@@ -1268,8 +1268,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		assert(0 == strncmp(lex_state->buf.a, "\\x", 2));
 		assert(strlen(lex_state->buf.a) >= 3);
 
-		ZI99 = lex_state->lx.start;
-		ZI100   = lex_state->lx.end;
+		ZI97 = lex_state->lx.start;
+		ZI98   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -1307,8 +1307,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				break;
 			case (TOK_OCT):
 				{
-					t_pos ZI97;
-					t_pos ZI98;
+					t_pos ZI95;
+					t_pos ZI96;
 
 					/* BEGINNING OF EXTRACT: OCT */
 					{
@@ -1321,8 +1321,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
 		assert(strlen(lex_state->buf.a) >= 2);
 
-		ZI97 = lex_state->lx.start;
-		ZI98   = lex_state->lx.end;
+		ZI95 = lex_state->lx.start;
+		ZI96   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -1362,7 +1362,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 93 */
+		/* END OF INLINE: 91 */
 		/* BEGINNING OF ACTION: ast-expr-literal */
 		{
 #line 595 "src/libre/parser.act"
@@ -1382,57 +1382,7 @@ ZL0:;
 }
 
 static void
-p_expr_C_Cchar_Hclass_C_Cchar_Hclass_Hhead(flags flags, lex_state lex_state, act_state act_state, err err, t_char__class__ast *ZOf)
-{
-	t_char__class__ast ZIf;
-
-	switch (CURRENT_TERMINAL) {
-	case (TOK_INVERT):
-		{
-			t_char ZI108;
-
-			/* BEGINNING OF EXTRACT: INVERT */
-			{
-#line 242 "src/libre/parser.act"
-
-		ZI108 = '^';
-	
-#line 1401 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF EXTRACT: INVERT */
-			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: char-class-ast-flag-invert */
-			{
-#line 719 "src/libre/parser.act"
-
-		(ZIf) = re_char_class_ast_flags(RE_CHAR_CLASS_FLAG_INVERTED);
-	
-#line 1411 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: char-class-ast-flag-invert */
-		}
-		break;
-	default:
-		{
-			/* BEGINNING OF ACTION: char-class-ast-flag-none */
-			{
-#line 715 "src/libre/parser.act"
-
-		(ZIf) = re_char_class_ast_flags(RE_CHAR_CLASS_FLAG_NONE);
-	
-#line 1424 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: char-class-ast-flag-none */
-		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
-	}
-	*ZOf = ZIf;
-}
-
-static void
-p_193(flags flags, lex_state lex_state, act_state act_state, err err)
+p_191(flags flags, lex_state lex_state, act_state act_state, err err)
 {
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 		return;
@@ -1458,7 +1408,7 @@ ZL1:;
 		}
 		goto ZL2;
 	
-#line 1462 "src/libre/dialect/pcre/parser.c"
+#line 1412 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
 	}
@@ -1467,6 +1417,56 @@ ZL2:;
 	SAVE_LEXER ((ERROR_TERMINAL));
 	return;
 ZL0:;
+}
+
+static void
+p_expr_C_Cchar_Hclass_C_Cchar_Hclass_Hhead(flags flags, lex_state lex_state, act_state act_state, err err, t_char__class__ast *ZOf)
+{
+	t_char__class__ast ZIf;
+
+	switch (CURRENT_TERMINAL) {
+	case (TOK_INVERT):
+		{
+			t_char ZI106;
+
+			/* BEGINNING OF EXTRACT: INVERT */
+			{
+#line 242 "src/libre/parser.act"
+
+		ZI106 = '^';
+	
+#line 1439 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF EXTRACT: INVERT */
+			ADVANCE_LEXER;
+			/* BEGINNING OF ACTION: char-class-ast-flag-invert */
+			{
+#line 709 "src/libre/parser.act"
+
+		(ZIf) = re_char_class_ast_flags(RE_CHAR_CLASS_FLAG_INVERTED);
+	
+#line 1449 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: char-class-ast-flag-invert */
+		}
+		break;
+	default:
+		{
+			/* BEGINNING OF ACTION: char-class-ast-flag-none */
+			{
+#line 705 "src/libre/parser.act"
+
+		(ZIf) = re_char_class_ast_flags(RE_CHAR_CLASS_FLAG_NONE);
+	
+#line 1462 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: char-class-ast-flag-none */
+		}
+		break;
+	case (ERROR_TERMINAL):
+		return;
+	}
+	*ZOf = ZIf;
 }
 
 static void
@@ -1515,7 +1515,7 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: re-flag-none */
 		{
-#line 745 "src/libre/parser.act"
+#line 735 "src/libre/parser.act"
 
 	        (ZIempty__pos) = RE_FLAGS_NONE;
 	
@@ -1524,14 +1524,14 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 		/* END OF ACTION: re-flag-none */
 		/* BEGINNING OF ACTION: re-flag-none */
 		{
-#line 745 "src/libre/parser.act"
+#line 735 "src/libre/parser.act"
 
 	        (ZIempty__neg) = RE_FLAGS_NONE;
 	
 #line 1532 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: re-flag-none */
-		/* BEGINNING OF INLINE: 181 */
+		/* BEGINNING OF INLINE: 179 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_FLAG__UNKNOWN): case (TOK_FLAG__INSENSITIVE):
@@ -1550,8 +1550,8 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 				break;
 			}
 		}
-		/* END OF INLINE: 181 */
-		/* BEGINNING OF INLINE: 183 */
+		/* END OF INLINE: 179 */
+		/* BEGINNING OF INLINE: 181 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_NEGATE):
@@ -1571,8 +1571,8 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 				break;
 			}
 		}
-		/* END OF INLINE: 183 */
-		/* BEGINNING OF INLINE: 186 */
+		/* END OF INLINE: 181 */
+		/* BEGINNING OF INLINE: 184 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -1584,7 +1584,7 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 				ADVANCE_LEXER;
 				/* BEGINNING OF ACTION: ast-expr-re-flags */
 				{
-#line 753 "src/libre/parser.act"
+#line 743 "src/libre/parser.act"
 
 		(ZInode) = re_ast_expr_re_flags((ZIpos), (ZIneg));
 	
@@ -1619,7 +1619,7 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 			}
 		ZL4:;
 		}
-		/* END OF INLINE: 186 */
+		/* END OF INLINE: 184 */
 	}
 	goto ZL0;
 ZL1:;
@@ -1641,7 +1641,7 @@ p_expr_C_Cchar_Hclass_C_Clist_Hof_Hchar_Hclass_Hterms(flags flags, lex_state lex
 		t_char__class__ast ZIl;
 
 		p_expr_C_Cchar_Hclass_C_Cclass_Hterm (flags, lex_state, act_state, err, &ZIl);
-		/* BEGINNING OF INLINE: 159 */
+		/* BEGINNING OF INLINE: 157 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_NAMED__CHAR__CLASS): case (TOK_ESC): case (TOK_CONTROL): case (TOK_OCT):
@@ -1656,7 +1656,7 @@ p_expr_C_Cchar_Hclass_C_Clist_Hof_Hchar_Hclass_Hterms(flags flags, lex_state lex
 					}
 					/* BEGINNING OF ACTION: char-class-ast-concat */
 					{
-#line 693 "src/libre/parser.act"
+#line 683 "src/libre/parser.act"
 
 		(ZInode) = re_char_class_ast_concat((ZIl), (ZIr));
 	
@@ -1675,7 +1675,7 @@ p_expr_C_Cchar_Hclass_C_Clist_Hof_Hchar_Hclass_Hterms(flags flags, lex_state lex
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 159 */
+		/* END OF INLINE: 157 */
 	}
 	goto ZL0;
 ZL1:;
@@ -1734,7 +1734,7 @@ p_expr_C_Cchar_Htype(flags flags, lex_state lex_state, act_state act_state, err 
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: char-class-ast-named-class */
 		{
-#line 701 "src/libre/parser.act"
+#line 691 "src/libre/parser.act"
 
 		(ZInamed) = re_char_class_ast_named_class((ZIid));
 	
@@ -1743,7 +1743,7 @@ p_expr_C_Cchar_Htype(flags flags, lex_state lex_state, act_state act_state, err 
 		/* END OF ACTION: char-class-ast-named-class */
 		/* BEGINNING OF ACTION: ast-expr-char-class */
 		{
-#line 705 "src/libre/parser.act"
+#line 695 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		AST_POS_OF_LX_POS(ast_start, (ZIstart));
@@ -1774,10 +1774,10 @@ p_expr_C_Clist_Hof_Hatoms(flags flags, lex_state lex_state, act_state act_state,
 		return;
 	}
 	{
-		t_ast__expr ZI226;
+		t_ast__expr ZI224;
 
-		p_expr_C_Catom (flags, lex_state, act_state, err, &ZI226);
-		p_228 (flags, lex_state, act_state, err, &ZI226, &ZInode);
+		p_expr_C_Catom (flags, lex_state, act_state, err, &ZI224);
+		p_226 (flags, lex_state, act_state, err, &ZI224, &ZInode);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -1801,10 +1801,10 @@ p_expr_C_Clist_Hof_Halts(flags flags, lex_state lex_state, act_state act_state, 
 	case (TOK_NAMED__CHAR__CLASS): case (TOK_OPENFLAGS): case (TOK_ESC): case (TOK_CONTROL):
 	case (TOK_OCT): case (TOK_HEX): case (TOK_CHAR):
 		{
-			t_ast__expr ZI223;
+			t_ast__expr ZI221;
 
-			p_expr_C_Calt (flags, lex_state, act_state, err, &ZI223);
-			p_225 (flags, lex_state, act_state, err, &ZI223, &ZInode);
+			p_expr_C_Calt (flags, lex_state, act_state, err, &ZI221);
+			p_223 (flags, lex_state, act_state, err, &ZI221, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1836,7 +1836,7 @@ ZL0:;
 }
 
 static void
-p_225(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZI223, t_ast__expr *ZOnode)
+p_223(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZI221, t_ast__expr *ZOnode)
 {
 	t_ast__expr ZInode;
 
@@ -1855,7 +1855,7 @@ p_225(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			{
 #line 591 "src/libre/parser.act"
 
-		(ZInode) = re_ast_expr_alt((*ZI223), (ZIr));
+		(ZInode) = re_ast_expr_alt((*ZI221), (ZIr));
 	
 #line 1861 "src/libre/dialect/pcre/parser.c"
 			}
@@ -1864,7 +1864,7 @@ p_225(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 		break;
 	default:
 		{
-			ZInode = *ZI223;
+			ZInode = *ZI221;
 		}
 		break;
 	case (ERROR_TERMINAL):
@@ -1879,7 +1879,7 @@ ZL0:;
 }
 
 static void
-p_228(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZI226, t_ast__expr *ZOnode)
+p_226(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZI224, t_ast__expr *ZOnode)
 {
 	t_ast__expr ZInode;
 
@@ -1899,7 +1899,7 @@ p_228(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			{
 #line 587 "src/libre/parser.act"
 
-		(ZInode) = re_ast_expr_concat((*ZI226), (ZIr));
+		(ZInode) = re_ast_expr_concat((*ZI224), (ZIr));
 	
 #line 1905 "src/libre/dialect/pcre/parser.c"
 			}
@@ -1908,7 +1908,7 @@ p_228(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 		break;
 	default:
 		{
-			ZInode = *ZI226;
+			ZInode = *ZI224;
 		}
 		break;
 	case (ERROR_TERMINAL):
@@ -1931,7 +1931,7 @@ p_re__pcre(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 213 */
+		/* BEGINNING OF INLINE: 211 */
 		{
 			{
 				p_expr (flags, lex_state, act_state, err, &ZInode);
@@ -1941,8 +1941,8 @@ p_re__pcre(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 				}
 			}
 		}
-		/* END OF INLINE: 213 */
-		/* BEGINNING OF INLINE: 214 */
+		/* END OF INLINE: 211 */
+		/* BEGINNING OF INLINE: 212 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -1971,7 +1971,7 @@ p_re__pcre(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 214 */
+		/* END OF INLINE: 212 */
 	}
 	goto ZL0;
 ZL1:;
@@ -1982,7 +1982,7 @@ ZL0:;
 }
 
 static void
-p_232(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__char__class__id *ZI229, t_pos *ZI230, t_char__class__ast *ZOnode)
+p_230(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__char__class__id *ZI227, t_pos *ZI228, t_char__class__ast *ZOnode)
 {
 	t_char__class__ast ZInode;
 
@@ -1992,23 +1992,23 @@ p_232(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cha
 			t_range__endpoint ZIlower;
 			t_range__endpoint ZIupper;
 			t_pos ZIu__end;
-			t_pos ZI152;
-			t_pos ZI153;
+			t_pos ZI150;
+			t_pos ZI151;
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-char-class */
 			{
-#line 738 "src/libre/parser.act"
+#line 728 "src/libre/parser.act"
 
 		struct ast_range_endpoint range;
 		range.t = AST_RANGE_ENDPOINT_CHAR_CLASS;
-		range.u.char_class.ctor = (*ZI229);
+		range.u.char_class.ctor = (*ZI227);
 		(ZIlower) = range;
 	
 #line 2008 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-char-class */
-			p_140 (flags, lex_state, act_state, err);
-			p_144 (flags, lex_state, act_state, err, &ZIupper, &ZIu__end);
+			p_138 (flags, lex_state, act_state, err);
+			p_142 (flags, lex_state, act_state, err, &ZIupper, &ZIu__end);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -2017,21 +2017,21 @@ p_232(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cha
 			{
 #line 571 "src/libre/parser.act"
 
-		mark(&act_state->rangestart, &(*ZI230));
+		mark(&act_state->rangestart, &(*ZI228));
 		mark(&act_state->rangeend,   &(ZIu__end));
 	
 #line 2024 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: mark-range */
-			ZI152 = *ZI230;
-			ZI153 = ZIu__end;
+			ZI150 = *ZI228;
+			ZI151 = ZIu__end;
 			/* BEGINNING OF ACTION: char-class-ast-range */
 			{
-#line 664 "src/libre/parser.act"
+#line 654 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
-		AST_POS_OF_LX_POS(ast_start, (*ZI230));
+		AST_POS_OF_LX_POS(ast_start, (*ZI228));
 		AST_POS_OF_LX_POS(ast_end, (ZIu__end));
 
 		if ((ZIlower).t != AST_RANGE_ENDPOINT_LITERAL ||
@@ -2065,9 +2065,9 @@ p_232(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cha
 		{
 			/* BEGINNING OF ACTION: char-class-ast-named-class */
 			{
-#line 701 "src/libre/parser.act"
+#line 691 "src/libre/parser.act"
 
-		(ZInode) = re_char_class_ast_named_class((*ZI229));
+		(ZInode) = re_char_class_ast_named_class((*ZI227));
 	
 #line 2073 "src/libre/dialect/pcre/parser.c"
 			}
@@ -2096,7 +2096,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 	{
 		t_ast__expr ZIe;
 
-		/* BEGINNING OF INLINE: 189 */
+		/* BEGINNING OF INLINE: 187 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY):
@@ -2115,9 +2115,9 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 				break;
 			case (TOK_CONTROL):
 				{
-					t_char ZI194;
-					t_pos ZI195;
-					t_pos ZI196;
+					t_char ZI192;
+					t_pos ZI193;
+					t_pos ZI194;
 
 					/* BEGINNING OF EXTRACT: CONTROL */
 					{
@@ -2128,14 +2128,14 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 		assert(lex_state->buf.a[2] != '\0');
 		assert(lex_state->buf.a[3] == '\0');
 
-		ZI194 = lex_state->buf.a[2];
-		if ((unsigned char) ZI194 > 127) {
+		ZI192 = lex_state->buf.a[2];
+		if ((unsigned char) ZI192 > 127) {
 			goto ZL1;
 		}
-		ZI194 = (((toupper((unsigned char)ZI194)) - 64) % 128 + 128) % 128;
+		ZI192 = (((toupper((unsigned char)ZI192)) - 64) % 128 + 128) % 128;
 
-		ZI195 = lex_state->lx.start;
-		ZI196   = lex_state->lx.end;
+		ZI193 = lex_state->lx.start;
+		ZI194   = lex_state->lx.end;
 	
 #line 2141 "src/libre/dialect/pcre/parser.c"
 					}
@@ -2176,14 +2176,14 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 					}
 					/* BEGINNING OF ACTION: ast-expr-group */
 					{
-#line 619 "src/libre/parser.act"
+#line 609 "src/libre/parser.act"
 
 		(ZIe) = re_ast_expr_group((ZIg));
 	
 #line 2184 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-expr-group */
-					p_193 (flags, lex_state, act_state, err);
+					p_191 (flags, lex_state, act_state, err);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL1;
@@ -2194,7 +2194,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 				{
 					ADVANCE_LEXER;
 					p_expr (flags, lex_state, act_state, err, &ZIe);
-					p_193 (flags, lex_state, act_state, err);
+					p_191 (flags, lex_state, act_state, err);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL1;
@@ -2241,22 +2241,22 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 189 */
-		/* BEGINNING OF INLINE: 197 */
+		/* END OF INLINE: 187 */
+		/* BEGINNING OF INLINE: 195 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_OPENCOUNT):
 				{
-					t_pos ZI249;
-					t_pos ZI250;
+					t_pos ZI247;
+					t_pos ZI248;
 					t_unsigned ZIm;
 
 					/* BEGINNING OF EXTRACT: OPENCOUNT */
 					{
 #line 263 "src/libre/parser.act"
 
-		ZI249 = lex_state->lx.start;
-		ZI250   = lex_state->lx.end;
+		ZI247 = lex_state->lx.start;
+		ZI248   = lex_state->lx.end;
 	
 #line 2262 "src/libre/dialect/pcre/parser.c"
 					}
@@ -2294,7 +2294,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 						goto ZL4;
 					}
 					ADVANCE_LEXER;
-					p_251 (flags, lex_state, act_state, err, &ZIe, &ZI249, &ZIm, &ZInode);
+					p_249 (flags, lex_state, act_state, err, &ZIe, &ZI247, &ZIm, &ZInode);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL4;
@@ -2308,7 +2308,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: atom-opt */
 					{
-#line 639 "src/libre/parser.act"
+#line 629 "src/libre/parser.act"
 
 		(ZIc) = ast_count(0, NULL, 1, NULL);
 	
@@ -2317,7 +2317,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 					/* END OF ACTION: atom-opt */
 					/* BEGINNING OF ACTION: ast-expr-atom */
 					{
-#line 623 "src/libre/parser.act"
+#line 613 "src/libre/parser.act"
 
 		(ZInode) = re_ast_expr_with_count((ZIe), (ZIc));
 	
@@ -2333,7 +2333,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: atom-plus */
 					{
-#line 631 "src/libre/parser.act"
+#line 621 "src/libre/parser.act"
 
 		(ZIc) = ast_count(1, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
@@ -2342,7 +2342,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 					/* END OF ACTION: atom-plus */
 					/* BEGINNING OF ACTION: ast-expr-atom */
 					{
-#line 623 "src/libre/parser.act"
+#line 613 "src/libre/parser.act"
 
 		(ZInode) = re_ast_expr_with_count((ZIe), (ZIc));
 	
@@ -2358,7 +2358,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: atom-kleene */
 					{
-#line 627 "src/libre/parser.act"
+#line 617 "src/libre/parser.act"
 
 		(ZIc) = ast_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
@@ -2367,7 +2367,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 					/* END OF ACTION: atom-kleene */
 					/* BEGINNING OF ACTION: ast-expr-atom */
 					{
-#line 623 "src/libre/parser.act"
+#line 613 "src/libre/parser.act"
 
 		(ZInode) = re_ast_expr_with_count((ZIe), (ZIc));
 	
@@ -2382,7 +2382,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 
 					/* BEGINNING OF ACTION: atom-one */
 					{
-#line 635 "src/libre/parser.act"
+#line 625 "src/libre/parser.act"
 
 		(ZIc) = ast_count(1, NULL, 1, NULL);
 	
@@ -2391,7 +2391,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 					/* END OF ACTION: atom-one */
 					/* BEGINNING OF ACTION: ast-expr-atom */
 					{
-#line 623 "src/libre/parser.act"
+#line 613 "src/libre/parser.act"
 
 		(ZInode) = re_ast_expr_with_count((ZIe), (ZIc));
 	
@@ -2420,7 +2420,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 197 */
+		/* END OF INLINE: 195 */
 	}
 	goto ZL0;
 ZL1:;
@@ -2431,7 +2431,7 @@ ZL0:;
 }
 
 static void
-p_248(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI245, t_pos *ZI246, t_char__class__ast *ZOnode)
+p_246(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI243, t_pos *ZI244, t_char__class__ast *ZOnode)
 {
 	t_char__class__ast ZInode;
 
@@ -2441,23 +2441,23 @@ p_248(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			t_range__endpoint ZIlower;
 			t_range__endpoint ZIupper;
 			t_pos ZIu__end;
-			t_pos ZI152;
-			t_pos ZI153;
+			t_pos ZI150;
+			t_pos ZI151;
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 731 "src/libre/parser.act"
+#line 721 "src/libre/parser.act"
 
 		struct ast_range_endpoint range;
 		range.t = AST_RANGE_ENDPOINT_LITERAL;
-		range.u.literal.c = (*ZI245);
+		range.u.literal.c = (*ZI243);
 		(ZIlower) = range;
 	
 #line 2457 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
-			p_140 (flags, lex_state, act_state, err);
-			p_144 (flags, lex_state, act_state, err, &ZIupper, &ZIu__end);
+			p_138 (flags, lex_state, act_state, err);
+			p_142 (flags, lex_state, act_state, err, &ZIupper, &ZIu__end);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -2466,21 +2466,21 @@ p_248(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			{
 #line 571 "src/libre/parser.act"
 
-		mark(&act_state->rangestart, &(*ZI246));
+		mark(&act_state->rangestart, &(*ZI244));
 		mark(&act_state->rangeend,   &(ZIu__end));
 	
 #line 2473 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: mark-range */
-			ZI152 = *ZI246;
-			ZI153 = ZIu__end;
+			ZI150 = *ZI244;
+			ZI151 = ZIu__end;
 			/* BEGINNING OF ACTION: char-class-ast-range */
 			{
-#line 664 "src/libre/parser.act"
+#line 654 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
-		AST_POS_OF_LX_POS(ast_start, (*ZI246));
+		AST_POS_OF_LX_POS(ast_start, (*ZI244));
 		AST_POS_OF_LX_POS(ast_end, (ZIu__end));
 
 		if ((ZIlower).t != AST_RANGE_ENDPOINT_LITERAL ||
@@ -2514,9 +2514,9 @@ p_248(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		{
 			/* BEGINNING OF ACTION: char-class-ast-literal */
 			{
-#line 659 "src/libre/parser.act"
+#line 649 "src/libre/parser.act"
 
-		(ZInode) = re_char_class_ast_literal((*ZI245));
+		(ZInode) = re_char_class_ast_literal((*ZI243));
 	
 #line 2522 "src/libre/dialect/pcre/parser.c"
 			}
@@ -2525,6 +2525,183 @@ p_248(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		break;
 	case (ERROR_TERMINAL):
 		return;
+	}
+	goto ZL0;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+ZL0:;
+	*ZOnode = ZInode;
+}
+
+static void
+p_249(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZIe, t_pos *ZI247, t_unsigned *ZIm, t_ast__expr *ZOnode)
+{
+	t_ast__expr ZInode;
+
+	switch (CURRENT_TERMINAL) {
+	case (TOK_CLOSECOUNT):
+		{
+			t_pos ZI198;
+			t_pos ZIend;
+			t_ast__count ZIc;
+
+			/* BEGINNING OF EXTRACT: CLOSECOUNT */
+			{
+#line 268 "src/libre/parser.act"
+
+		ZI198 = lex_state->lx.start;
+		ZIend   = lex_state->lx.end;
+	
+#line 2557 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF EXTRACT: CLOSECOUNT */
+			ADVANCE_LEXER;
+			/* BEGINNING OF ACTION: mark-count */
+			{
+#line 576 "src/libre/parser.act"
+
+		mark(&act_state->countstart, &(*ZI247));
+		mark(&act_state->countend,   &(ZIend));
+	
+#line 2568 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: mark-count */
+			/* BEGINNING OF ACTION: expr-count */
+			{
+#line 633 "src/libre/parser.act"
+
+		struct ast_pos ast_start, ast_end;
+		if ((*ZIm) < (*ZIm)) {
+			err->e = RE_ENEGCOUNT;
+			err->m = (*ZIm);
+			err->n = (*ZIm);
+			mark(&act_state->countstart, &(*ZI247));
+			mark(&act_state->countend,   &(ZIend));
+			goto ZL1;
+		}
+		AST_POS_OF_LX_POS(ast_start, (*ZI247));
+		AST_POS_OF_LX_POS(ast_end, (ZIend));
+
+		(ZIc) = ast_count((*ZIm), &ast_start, (*ZIm), &ast_end);
+	
+#line 2589 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: expr-count */
+			/* BEGINNING OF ACTION: ast-expr-atom */
+			{
+#line 613 "src/libre/parser.act"
+
+		(ZInode) = re_ast_expr_with_count((*ZIe), (ZIc));
+	
+#line 2598 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: ast-expr-atom */
+		}
+		break;
+	case (TOK_SEP):
+		{
+			t_unsigned ZIn;
+			t_pos ZIend;
+			t_pos ZI201;
+			t_ast__count ZIc;
+
+			ADVANCE_LEXER;
+			switch (CURRENT_TERMINAL) {
+			case (TOK_COUNT):
+				/* BEGINNING OF EXTRACT: COUNT */
+				{
+#line 435 "src/libre/parser.act"
+
+		unsigned long u;
+		char *e;
+
+		u = strtoul(lex_state->buf.a, &e, 10);
+
+		if ((u == ULONG_MAX && errno == ERANGE) || u > UINT_MAX) {
+			err->e = RE_ECOUNTRANGE;
+			snprintdots(err->esc, sizeof err->esc, lex_state->buf.a);
+			goto ZL1;
+		}
+
+		if ((u == ULONG_MAX && errno != 0) || *e != '\0') {
+			err->e = RE_EXCOUNT;
+			goto ZL1;
+		}
+
+		ZIn = (unsigned int) u;
+	
+#line 2635 "src/libre/dialect/pcre/parser.c"
+				}
+				/* END OF EXTRACT: COUNT */
+				break;
+			default:
+				goto ZL1;
+			}
+			ADVANCE_LEXER;
+			switch (CURRENT_TERMINAL) {
+			case (TOK_CLOSECOUNT):
+				/* BEGINNING OF EXTRACT: CLOSECOUNT */
+				{
+#line 268 "src/libre/parser.act"
+
+		ZIend = lex_state->lx.start;
+		ZI201   = lex_state->lx.end;
+	
+#line 2652 "src/libre/dialect/pcre/parser.c"
+				}
+				/* END OF EXTRACT: CLOSECOUNT */
+				break;
+			default:
+				goto ZL1;
+			}
+			ADVANCE_LEXER;
+			/* BEGINNING OF ACTION: mark-count */
+			{
+#line 576 "src/libre/parser.act"
+
+		mark(&act_state->countstart, &(*ZI247));
+		mark(&act_state->countend,   &(ZIend));
+	
+#line 2667 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: mark-count */
+			/* BEGINNING OF ACTION: expr-count */
+			{
+#line 633 "src/libre/parser.act"
+
+		struct ast_pos ast_start, ast_end;
+		if ((ZIn) < (*ZIm)) {
+			err->e = RE_ENEGCOUNT;
+			err->m = (*ZIm);
+			err->n = (ZIn);
+			mark(&act_state->countstart, &(*ZI247));
+			mark(&act_state->countend,   &(ZIend));
+			goto ZL1;
+		}
+		AST_POS_OF_LX_POS(ast_start, (*ZI247));
+		AST_POS_OF_LX_POS(ast_end, (ZIend));
+
+		(ZIc) = ast_count((*ZIm), &ast_start, (ZIn), &ast_end);
+	
+#line 2688 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: expr-count */
+			/* BEGINNING OF ACTION: ast-expr-atom */
+			{
+#line 613 "src/libre/parser.act"
+
+		(ZInode) = re_ast_expr_with_count((*ZIe), (ZIc));
+	
+#line 2697 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: ast-expr-atom */
+		}
+		break;
+	case (ERROR_TERMINAL):
+		return;
+	default:
+		goto ZL1;
 	}
 	goto ZL0;
 ZL1:;
@@ -2557,186 +2734,9 @@ ZL0:;
 	*ZOnode = ZInode;
 }
 
-static void
-p_251(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZIe, t_pos *ZI249, t_unsigned *ZIm, t_ast__expr *ZOnode)
-{
-	t_ast__expr ZInode;
-
-	switch (CURRENT_TERMINAL) {
-	case (TOK_CLOSECOUNT):
-		{
-			t_pos ZI200;
-			t_pos ZIend;
-			t_ast__count ZIc;
-
-			/* BEGINNING OF EXTRACT: CLOSECOUNT */
-			{
-#line 268 "src/libre/parser.act"
-
-		ZI200 = lex_state->lx.start;
-		ZIend   = lex_state->lx.end;
-	
-#line 2580 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF EXTRACT: CLOSECOUNT */
-			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: mark-count */
-			{
-#line 576 "src/libre/parser.act"
-
-		mark(&act_state->countstart, &(*ZI249));
-		mark(&act_state->countend,   &(ZIend));
-	
-#line 2591 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: mark-count */
-			/* BEGINNING OF ACTION: expr-count */
-			{
-#line 643 "src/libre/parser.act"
-
-		struct ast_pos ast_start, ast_end;
-		if ((*ZIm) < (*ZIm)) {
-			err->e = RE_ENEGCOUNT;
-			err->m = (*ZIm);
-			err->n = (*ZIm);
-			mark(&act_state->countstart, &(*ZI249));
-			mark(&act_state->countend,   &(ZIend));
-			goto ZL1;
-		}
-		AST_POS_OF_LX_POS(ast_start, (*ZI249));
-		AST_POS_OF_LX_POS(ast_end, (ZIend));
-
-		(ZIc) = ast_count((*ZIm), &ast_start, (*ZIm), &ast_end);
-	
-#line 2612 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: expr-count */
-			/* BEGINNING OF ACTION: ast-expr-atom */
-			{
-#line 623 "src/libre/parser.act"
-
-		(ZInode) = re_ast_expr_with_count((*ZIe), (ZIc));
-	
-#line 2621 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: ast-expr-atom */
-		}
-		break;
-	case (TOK_SEP):
-		{
-			t_unsigned ZIn;
-			t_pos ZIend;
-			t_pos ZI203;
-			t_ast__count ZIc;
-
-			ADVANCE_LEXER;
-			switch (CURRENT_TERMINAL) {
-			case (TOK_COUNT):
-				/* BEGINNING OF EXTRACT: COUNT */
-				{
-#line 435 "src/libre/parser.act"
-
-		unsigned long u;
-		char *e;
-
-		u = strtoul(lex_state->buf.a, &e, 10);
-
-		if ((u == ULONG_MAX && errno == ERANGE) || u > UINT_MAX) {
-			err->e = RE_ECOUNTRANGE;
-			snprintdots(err->esc, sizeof err->esc, lex_state->buf.a);
-			goto ZL1;
-		}
-
-		if ((u == ULONG_MAX && errno != 0) || *e != '\0') {
-			err->e = RE_EXCOUNT;
-			goto ZL1;
-		}
-
-		ZIn = (unsigned int) u;
-	
-#line 2658 "src/libre/dialect/pcre/parser.c"
-				}
-				/* END OF EXTRACT: COUNT */
-				break;
-			default:
-				goto ZL1;
-			}
-			ADVANCE_LEXER;
-			switch (CURRENT_TERMINAL) {
-			case (TOK_CLOSECOUNT):
-				/* BEGINNING OF EXTRACT: CLOSECOUNT */
-				{
-#line 268 "src/libre/parser.act"
-
-		ZIend = lex_state->lx.start;
-		ZI203   = lex_state->lx.end;
-	
-#line 2675 "src/libre/dialect/pcre/parser.c"
-				}
-				/* END OF EXTRACT: CLOSECOUNT */
-				break;
-			default:
-				goto ZL1;
-			}
-			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: mark-count */
-			{
-#line 576 "src/libre/parser.act"
-
-		mark(&act_state->countstart, &(*ZI249));
-		mark(&act_state->countend,   &(ZIend));
-	
-#line 2690 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: mark-count */
-			/* BEGINNING OF ACTION: expr-count */
-			{
-#line 643 "src/libre/parser.act"
-
-		struct ast_pos ast_start, ast_end;
-		if ((ZIn) < (*ZIm)) {
-			err->e = RE_ENEGCOUNT;
-			err->m = (*ZIm);
-			err->n = (ZIn);
-			mark(&act_state->countstart, &(*ZI249));
-			mark(&act_state->countend,   &(ZIend));
-			goto ZL1;
-		}
-		AST_POS_OF_LX_POS(ast_start, (*ZI249));
-		AST_POS_OF_LX_POS(ast_end, (ZIend));
-
-		(ZIc) = ast_count((*ZIm), &ast_start, (ZIn), &ast_end);
-	
-#line 2711 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: expr-count */
-			/* BEGINNING OF ACTION: ast-expr-atom */
-			{
-#line 623 "src/libre/parser.act"
-
-		(ZInode) = re_ast_expr_with_count((*ZIe), (ZIc));
-	
-#line 2720 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: ast-expr-atom */
-		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
-	default:
-		goto ZL1;
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOnode = ZInode;
-}
-
 /* BEGINNING OF TRAILER */
 
-#line 757 "src/libre/parser.act"
+#line 747 "src/libre/parser.act"
 
 
 	static int

--- a/src/libre/dialect/pcre/parser.h
+++ b/src/libre/dialect/pcre/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__pcre(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 913 "src/libre/parser.act"
+#line 903 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/pcre/parser.h"

--- a/src/libre/dialect/pcre/parser.sid
+++ b/src/libre/dialect/pcre/parser.sid
@@ -89,11 +89,9 @@
 	<ast-expr-concat>: (:ast_expr, :ast_expr) -> (:ast_expr);
 	<ast-expr-alt>: (:ast_expr, :ast_expr) -> (:ast_expr);
 	<ast-expr-any>: () -> (:ast_expr);
-	!<ast-expr-many>: () -> (:ast_expr);
 
         <ast-expr-atom>: (:ast_expr, :ast_count) -> (:ast_expr);
         !<ast-expr-atom-any>: (:ast_count) -> (:ast_expr);
-        !<ast-expr-atom-many>: (:ast_count) -> (:ast_expr);
 	<ast-expr-char-class>: (:char_class_ast, :pos, :pos) -> (:ast_expr);
         <ast-expr-group>: (:ast_expr) -> (:ast_expr);
 	<ast-expr-re-flags>: (:re_flags, :re_flags) -> (:ast_expr);

--- a/src/libre/dialect/sql/parser.c
+++ b/src/libre/dialect/sql/parser.c
@@ -228,15 +228,15 @@ extern void p_re__sql(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Cchar_Hclass(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Cliteral(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Catom_Hsuffix(flags, lex_state, act_state, err, t_ast__count *);
-static void p_190(flags, lex_state, act_state, err, t_ast__expr *, t_ast__expr *);
+static void p_188(flags, lex_state, act_state, err, t_ast__expr *, t_ast__expr *);
+static void p_191(flags, lex_state, act_state, err, t_ast__expr *, t_ast__expr *);
 static void p_expr_C_Cchar_Hclass_C_Cchar_Hclass_Hhead(flags, lex_state, act_state, err, t_char__class__ast *);
-static void p_193(flags, lex_state, act_state, err, t_ast__expr *, t_ast__expr *);
+static void p_192(flags, lex_state, act_state, err, t_pos *, t_unsigned *, t_ast__count *);
 static void p_expr(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_194(flags, lex_state, act_state, err, t_pos *, t_unsigned *, t_ast__count *);
-static void p_197(flags, lex_state, act_state, err, t_pos *, t_char__class__ast *, t_char__class__ast *, t_char__class__ast *, t_ast__expr *);
-static void p_199(flags, lex_state, act_state, err, t_char__class__ast *);
+static void p_195(flags, lex_state, act_state, err, t_pos *, t_char__class__ast *, t_char__class__ast *, t_char__class__ast *, t_ast__expr *);
+static void p_197(flags, lex_state, act_state, err, t_char__class__ast *);
+static void p_201(flags, lex_state, act_state, err, t_char *, t_pos *, t_char__class__ast *);
 static void p_expr_C_Cchar_Hclass_C_Clist_Hof_Hchar_Hclass_Hterms(flags, lex_state, act_state, err, t_char__class__ast *);
-static void p_203(flags, lex_state, act_state, err, t_char *, t_pos *, t_char__class__ast *);
 static void p_expr_C_Cchar_Hclass_C_Cterm(flags, lex_state, act_state, err, t_char__class__ast *);
 static void p_expr_C_Clist_Hof_Hatoms(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Cchar_Hclass_C_Cchar_Hclass_Htail(flags, lex_state, act_state, err, t_char__class__ast *);
@@ -259,7 +259,7 @@ p_re__sql(flags flags, lex_state lex_state, act_state act_state, err err, t_ast_
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 177 */
+		/* BEGINNING OF INLINE: 175 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_MANY): case (TOK_OPENSUB): case (TOK_OPENGROUP):
@@ -287,8 +287,8 @@ p_re__sql(flags flags, lex_state lex_state, act_state act_state, err err, t_ast_
 				break;
 			}
 		}
-		/* END OF INLINE: 177 */
-		/* BEGINNING OF INLINE: 178 */
+		/* END OF INLINE: 175 */
+		/* BEGINNING OF INLINE: 176 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -317,7 +317,7 @@ p_re__sql(flags flags, lex_state lex_state, act_state act_state, err err, t_ast_
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 178 */
+		/* END OF INLINE: 176 */
 	}
 	goto ZL0;
 ZL1:;
@@ -360,8 +360,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 	}
 	{
 		t_char ZIc;
-		t_pos ZI94;
-		t_pos ZI95;
+		t_pos ZI92;
+		t_pos ZI93;
 
 		switch (CURRENT_TERMINAL) {
 		case (TOK_CHAR):
@@ -372,8 +372,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI94 = lex_state->lx.start;
-		ZI95   = lex_state->lx.end;
+		ZI92 = lex_state->lx.start;
+		ZI93   = lex_state->lx.end;
 
 		ZIc = lex_state->buf.a[0];
 	
@@ -458,7 +458,7 @@ p_expr_C_Catom_Hsuffix(flags flags, lex_state lex_state, act_state act_state, er
 				goto ZL1;
 			}
 			ADVANCE_LEXER;
-			p_194 (flags, lex_state, act_state, err, &ZIpos__of, &ZIm, &ZIf);
+			p_192 (flags, lex_state, act_state, err, &ZIpos__of, &ZIm, &ZIf);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -470,7 +470,7 @@ p_expr_C_Catom_Hsuffix(flags flags, lex_state lex_state, act_state act_state, er
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: atom-opt */
 			{
-#line 639 "src/libre/parser.act"
+#line 629 "src/libre/parser.act"
 
 		(ZIf) = ast_count(0, NULL, 1, NULL);
 	
@@ -484,7 +484,7 @@ p_expr_C_Catom_Hsuffix(flags flags, lex_state lex_state, act_state act_state, er
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: atom-plus */
 			{
-#line 631 "src/libre/parser.act"
+#line 621 "src/libre/parser.act"
 
 		(ZIf) = ast_count(1, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
@@ -498,7 +498,7 @@ p_expr_C_Catom_Hsuffix(flags flags, lex_state lex_state, act_state act_state, er
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: atom-kleene */
 			{
-#line 627 "src/libre/parser.act"
+#line 617 "src/libre/parser.act"
 
 		(ZIf) = ast_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
@@ -511,7 +511,7 @@ p_expr_C_Catom_Hsuffix(flags flags, lex_state lex_state, act_state act_state, er
 		{
 			/* BEGINNING OF ACTION: atom-one */
 			{
-#line 635 "src/libre/parser.act"
+#line 625 "src/libre/parser.act"
 
 		(ZIf) = ast_count(1, NULL, 1, NULL);
 	
@@ -532,7 +532,7 @@ ZL0:;
 }
 
 static void
-p_190(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZI188, t_ast__expr *ZOnode)
+p_188(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZI186, t_ast__expr *ZOnode)
 {
 	t_ast__expr ZInode;
 
@@ -551,7 +551,7 @@ p_190(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			{
 #line 591 "src/libre/parser.act"
 
-		(ZInode) = re_ast_expr_alt((*ZI188), (ZIr));
+		(ZInode) = re_ast_expr_alt((*ZI186), (ZIr));
 	
 #line 557 "src/libre/dialect/sql/parser.c"
 			}
@@ -560,7 +560,50 @@ p_190(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 		break;
 	default:
 		{
-			ZInode = *ZI188;
+			ZInode = *ZI186;
+		}
+		break;
+	case (ERROR_TERMINAL):
+		return;
+	}
+	goto ZL0;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+ZL0:;
+	*ZOnode = ZInode;
+}
+
+static void
+p_191(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZI189, t_ast__expr *ZOnode)
+{
+	t_ast__expr ZInode;
+
+	switch (CURRENT_TERMINAL) {
+	case (TOK_ANY): case (TOK_MANY): case (TOK_OPENSUB): case (TOK_OPENGROUP):
+	case (TOK_CHAR):
+		{
+			t_ast__expr ZIr;
+
+			p_expr_C_Clist_Hof_Hatoms (flags, lex_state, act_state, err, &ZIr);
+			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+				RESTORE_LEXER;
+				goto ZL1;
+			}
+			/* BEGINNING OF ACTION: ast-expr-concat */
+			{
+#line 587 "src/libre/parser.act"
+
+		(ZInode) = re_ast_expr_concat((*ZI189), (ZIr));
+	
+#line 600 "src/libre/dialect/sql/parser.c"
+			}
+			/* END OF ACTION: ast-expr-concat */
+		}
+		break;
+	default:
+		{
+			ZInode = *ZI189;
 		}
 		break;
 	case (ERROR_TERMINAL):
@@ -582,19 +625,19 @@ p_expr_C_Cchar_Hclass_C_Cchar_Hclass_Hhead(flags flags, lex_state lex_state, act
 	switch (CURRENT_TERMINAL) {
 	case (TOK_INVERT):
 		{
-			t_char ZI198;
+			t_char ZI196;
 
 			/* BEGINNING OF EXTRACT: INVERT */
 			{
 #line 242 "src/libre/parser.act"
 
-		ZI198 = '^';
+		ZI196 = '^';
 	
-#line 594 "src/libre/dialect/sql/parser.c"
+#line 637 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: INVERT */
 			ADVANCE_LEXER;
-			p_199 (flags, lex_state, act_state, err, &ZIf);
+			p_197 (flags, lex_state, act_state, err, &ZIf);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -603,29 +646,29 @@ p_expr_C_Cchar_Hclass_C_Cchar_Hclass_Hhead(flags flags, lex_state lex_state, act
 		break;
 	case (TOK_RANGE):
 		{
-			t_char ZI110;
-			t_pos ZI111;
-			t_pos ZI112;
+			t_char ZI108;
+			t_pos ZI109;
+			t_pos ZI110;
 
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
 #line 246 "src/libre/parser.act"
 
-		ZI110 = '-';
-		ZI111 = lex_state->lx.start;
-		ZI112   = lex_state->lx.end;
+		ZI108 = '-';
+		ZI109 = lex_state->lx.start;
+		ZI110   = lex_state->lx.end;
 	
-#line 619 "src/libre/dialect/sql/parser.c"
+#line 662 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: char-class-ast-flag-minus */
 			{
-#line 723 "src/libre/parser.act"
+#line 713 "src/libre/parser.act"
 
 		(ZIf) = re_char_class_ast_flags(RE_CHAR_CLASS_FLAG_MINUS);
 	
-#line 629 "src/libre/dialect/sql/parser.c"
+#line 672 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: char-class-ast-flag-minus */
 		}
@@ -634,11 +677,11 @@ p_expr_C_Cchar_Hclass_C_Cchar_Hclass_Hhead(flags flags, lex_state lex_state, act
 		{
 			/* BEGINNING OF ACTION: char-class-ast-flag-none */
 			{
-#line 715 "src/libre/parser.act"
+#line 705 "src/libre/parser.act"
 
 		(ZIf) = re_char_class_ast_flags(RE_CHAR_CLASS_FLAG_NONE);
 	
-#line 642 "src/libre/dialect/sql/parser.c"
+#line 685 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: char-class-ast-flag-none */
 		}
@@ -655,73 +698,7 @@ ZL0:;
 }
 
 static void
-p_193(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZI191, t_ast__expr *ZOnode)
-{
-	t_ast__expr ZInode;
-
-	switch (CURRENT_TERMINAL) {
-	case (TOK_ANY): case (TOK_MANY): case (TOK_OPENSUB): case (TOK_OPENGROUP):
-	case (TOK_CHAR):
-		{
-			t_ast__expr ZIr;
-
-			p_expr_C_Clist_Hof_Hatoms (flags, lex_state, act_state, err, &ZIr);
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-			/* BEGINNING OF ACTION: ast-expr-concat */
-			{
-#line 587 "src/libre/parser.act"
-
-		(ZInode) = re_ast_expr_concat((*ZI191), (ZIr));
-	
-#line 680 "src/libre/dialect/sql/parser.c"
-			}
-			/* END OF ACTION: ast-expr-concat */
-		}
-		break;
-	default:
-		{
-			ZInode = *ZI191;
-		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOnode = ZInode;
-}
-
-static void
-p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
-{
-	t_ast__expr ZInode;
-
-	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-		return;
-	}
-	{
-		p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, &ZInode);
-		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-			RESTORE_LEXER;
-			goto ZL1;
-		}
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOnode = ZInode;
-}
-
-static void
-p_194(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIpos__of, t_unsigned *ZIm, t_ast__count *ZOf)
+p_192(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIpos__of, t_unsigned *ZIm, t_ast__count *ZOf)
 {
 	t_ast__count ZIf;
 
@@ -738,13 +715,13 @@ p_194(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIp
 		ZIpos__cf = lex_state->lx.start;
 		ZIpos__ct   = lex_state->lx.end;
 	
-#line 742 "src/libre/dialect/sql/parser.c"
+#line 719 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: CLOSECOUNT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: expr-count */
 			{
-#line 643 "src/libre/parser.act"
+#line 633 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		if ((*ZIm) < (*ZIm)) {
@@ -760,7 +737,7 @@ p_194(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIp
 
 		(ZIf) = ast_count((*ZIm), &ast_start, (*ZIm), &ast_end);
 	
-#line 764 "src/libre/dialect/sql/parser.c"
+#line 741 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: expr-count */
 		}
@@ -796,7 +773,7 @@ p_194(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIp
 
 		ZIn = (unsigned int) u;
 	
-#line 800 "src/libre/dialect/sql/parser.c"
+#line 777 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -813,7 +790,7 @@ p_194(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIp
 		ZIpos__cf = lex_state->lx.start;
 		ZIpos__ct   = lex_state->lx.end;
 	
-#line 817 "src/libre/dialect/sql/parser.c"
+#line 794 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: CLOSECOUNT */
 				break;
@@ -823,7 +800,7 @@ p_194(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIp
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: expr-count */
 			{
-#line 643 "src/libre/parser.act"
+#line 633 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		if ((ZIn) < (*ZIm)) {
@@ -839,7 +816,7 @@ p_194(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIp
 
 		(ZIf) = ast_count((*ZIm), &ast_start, (ZIn), &ast_end);
 	
-#line 843 "src/libre/dialect/sql/parser.c"
+#line 820 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: expr-count */
 		}
@@ -858,21 +835,44 @@ ZL0:;
 }
 
 static void
-p_197(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI195, t_char__class__ast *ZIhead, t_char__class__ast *ZIbody, t_char__class__ast *ZItail, t_ast__expr *ZOnode)
+p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
+{
+	t_ast__expr ZInode;
+
+	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+		return;
+	}
+	{
+		p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, &ZInode);
+		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+			RESTORE_LEXER;
+			goto ZL1;
+		}
+	}
+	goto ZL0;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+ZL0:;
+	*ZOnode = ZInode;
+}
+
+static void
+p_195(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI193, t_char__class__ast *ZIhead, t_char__class__ast *ZIbody, t_char__class__ast *ZItail, t_ast__expr *ZOnode)
 {
 	t_ast__expr ZInode;
 
 	switch (CURRENT_TERMINAL) {
 	case (TOK_INVERT):
 		{
-			t_char ZI156;
+			t_char ZI154;
 			t_char__class__ast ZImaskhead;
 			t_char__class__ast ZImaskbody;
 			t_char__class__ast ZImasktail;
 			t_char__class__ast ZIhb;
 			t_char__class__ast ZIhbt;
-			t_char ZI160;
-			t_pos ZI161;
+			t_char ZI158;
+			t_pos ZI159;
 			t_pos ZIend;
 			t_char__class__ast ZImhb;
 			t_char__class__ast ZImhbt;
@@ -882,7 +882,7 @@ p_197(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI1
 			{
 #line 242 "src/libre/parser.act"
 
-		ZI156 = '^';
+		ZI154 = '^';
 	
 #line 888 "src/libre/dialect/sql/parser.c"
 			}
@@ -897,7 +897,7 @@ p_197(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI1
 			}
 			/* BEGINNING OF ACTION: char-class-ast-concat */
 			{
-#line 693 "src/libre/parser.act"
+#line 683 "src/libre/parser.act"
 
 		(ZIhb) = re_char_class_ast_concat((*ZIhead), (*ZIbody));
 	
@@ -906,7 +906,7 @@ p_197(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI1
 			/* END OF ACTION: char-class-ast-concat */
 			/* BEGINNING OF ACTION: char-class-ast-concat */
 			{
-#line 693 "src/libre/parser.act"
+#line 683 "src/libre/parser.act"
 
 		(ZIhbt) = re_char_class_ast_concat((ZIhb), (*ZItail));
 	
@@ -919,8 +919,8 @@ p_197(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI1
 				{
 #line 257 "src/libre/parser.act"
 
-		ZI160 = ']';
-		ZI161 = lex_state->lx.start;
+		ZI158 = ']';
+		ZI159 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
 #line 927 "src/libre/dialect/sql/parser.c"
@@ -945,7 +945,7 @@ p_197(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI1
 			/* END OF ACTION: err-unsupported */
 			/* BEGINNING OF ACTION: char-class-ast-concat */
 			{
-#line 693 "src/libre/parser.act"
+#line 683 "src/libre/parser.act"
 
 		(ZImhb) = re_char_class_ast_concat((ZImaskhead), (ZImaskbody));
 	
@@ -954,7 +954,7 @@ p_197(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI1
 			/* END OF ACTION: char-class-ast-concat */
 			/* BEGINNING OF ACTION: char-class-ast-concat */
 			{
-#line 693 "src/libre/parser.act"
+#line 683 "src/libre/parser.act"
 
 		(ZImhbt) = re_char_class_ast_concat((ZImhb), (ZImasktail));
 	
@@ -963,7 +963,7 @@ p_197(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI1
 			/* END OF ACTION: char-class-ast-concat */
 			/* BEGINNING OF ACTION: char-class-ast-subtract */
 			{
-#line 697 "src/libre/parser.act"
+#line 687 "src/libre/parser.act"
 
 		(ZImasked) = re_char_class_ast_subtract((ZIhbt), (ZImhbt));
 	
@@ -972,12 +972,12 @@ p_197(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI1
 			/* END OF ACTION: char-class-ast-subtract */
 			/* BEGINNING OF ACTION: ast-expr-char-class */
 			{
-#line 705 "src/libre/parser.act"
+#line 695 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
-		AST_POS_OF_LX_POS(ast_start, (*ZI195));
+		AST_POS_OF_LX_POS(ast_start, (*ZI193));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
-		mark(&act_state->groupstart, &(*ZI195));
+		mark(&act_state->groupstart, &(*ZI193));
 		mark(&act_state->groupend,   &(ZIend));
 		(ZInode) = re_ast_expr_char_class((ZImasked), &ast_start, &ast_end);
 		if ((ZInode) == NULL) { goto ZL1; }
@@ -991,13 +991,13 @@ p_197(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI1
 		{
 			t_char__class__ast ZIhb;
 			t_char__class__ast ZIhbt;
-			t_char ZI153;
-			t_pos ZI154;
+			t_char ZI151;
+			t_pos ZI152;
 			t_pos ZIend;
 
 			/* BEGINNING OF ACTION: char-class-ast-concat */
 			{
-#line 693 "src/libre/parser.act"
+#line 683 "src/libre/parser.act"
 
 		(ZIhb) = re_char_class_ast_concat((*ZIhead), (*ZIbody));
 	
@@ -1006,7 +1006,7 @@ p_197(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI1
 			/* END OF ACTION: char-class-ast-concat */
 			/* BEGINNING OF ACTION: char-class-ast-concat */
 			{
-#line 693 "src/libre/parser.act"
+#line 683 "src/libre/parser.act"
 
 		(ZIhbt) = re_char_class_ast_concat((ZIhb), (*ZItail));
 	
@@ -1017,8 +1017,8 @@ p_197(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI1
 			{
 #line 257 "src/libre/parser.act"
 
-		ZI153 = ']';
-		ZI154 = lex_state->lx.start;
+		ZI151 = ']';
+		ZI152 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
 #line 1025 "src/libre/dialect/sql/parser.c"
@@ -1027,12 +1027,12 @@ p_197(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI1
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-expr-char-class */
 			{
-#line 705 "src/libre/parser.act"
+#line 695 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
-		AST_POS_OF_LX_POS(ast_start, (*ZI195));
+		AST_POS_OF_LX_POS(ast_start, (*ZI193));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
-		mark(&act_state->groupstart, &(*ZI195));
+		mark(&act_state->groupstart, &(*ZI193));
 		mark(&act_state->groupend,   &(ZIend));
 		(ZInode) = re_ast_expr_char_class((ZIhbt), &ast_start, &ast_end);
 		if ((ZInode) == NULL) { goto ZL1; }
@@ -1056,24 +1056,24 @@ ZL0:;
 }
 
 static void
-p_199(flags flags, lex_state lex_state, act_state act_state, err err, t_char__class__ast *ZOf)
+p_197(flags flags, lex_state lex_state, act_state act_state, err err, t_char__class__ast *ZOf)
 {
 	t_char__class__ast ZIf;
 
 	switch (CURRENT_TERMINAL) {
 	case (TOK_RANGE):
 		{
-			t_char ZI114;
-			t_pos ZI115;
-			t_pos ZI116;
+			t_char ZI112;
+			t_pos ZI113;
+			t_pos ZI114;
 
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
 #line 246 "src/libre/parser.act"
 
-		ZI114 = '-';
-		ZI115 = lex_state->lx.start;
-		ZI116   = lex_state->lx.end;
+		ZI112 = '-';
+		ZI113 = lex_state->lx.start;
+		ZI114   = lex_state->lx.end;
 	
 #line 1079 "src/libre/dialect/sql/parser.c"
 			}
@@ -1081,7 +1081,7 @@ p_199(flags flags, lex_state lex_state, act_state act_state, err err, t_char__cl
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: char-class-ast-flag-invert-minus */
 			{
-#line 727 "src/libre/parser.act"
+#line 717 "src/libre/parser.act"
 
 		(ZIf) = re_char_class_ast_flags(RE_CHAR_CLASS_FLAG_INVERTED | RE_CHAR_CLASS_FLAG_MINUS);
 	
@@ -1094,7 +1094,7 @@ p_199(flags flags, lex_state lex_state, act_state act_state, err err, t_char__cl
 		{
 			/* BEGINNING OF ACTION: char-class-ast-flag-invert */
 			{
-#line 719 "src/libre/parser.act"
+#line 709 "src/libre/parser.act"
 
 		(ZIf) = re_char_class_ast_flags(RE_CHAR_CLASS_FLAG_INVERTED);
 	
@@ -1110,62 +1110,7 @@ p_199(flags flags, lex_state lex_state, act_state act_state, err err, t_char__cl
 }
 
 static void
-p_expr_C_Cchar_Hclass_C_Clist_Hof_Hchar_Hclass_Hterms(flags flags, lex_state lex_state, act_state act_state, err err, t_char__class__ast *ZOnode)
-{
-	t_char__class__ast ZInode;
-
-	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-		return;
-	}
-	{
-		t_char__class__ast ZIl;
-
-		p_expr_C_Cchar_Hclass_C_Cterm (flags, lex_state, act_state, err, &ZIl);
-		/* BEGINNING OF INLINE: 142 */
-		{
-			switch (CURRENT_TERMINAL) {
-			case (TOK_NAMED__CHAR__CLASS): case (TOK_CHAR):
-				{
-					t_char__class__ast ZIr;
-
-					p_expr_C_Cchar_Hclass_C_Clist_Hof_Hchar_Hclass_Hterms (flags, lex_state, act_state, err, &ZIr);
-					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-						RESTORE_LEXER;
-						goto ZL1;
-					}
-					/* BEGINNING OF ACTION: char-class-ast-concat */
-					{
-#line 693 "src/libre/parser.act"
-
-		(ZInode) = re_char_class_ast_concat((ZIl), (ZIr));
-	
-#line 1143 "src/libre/dialect/sql/parser.c"
-					}
-					/* END OF ACTION: char-class-ast-concat */
-				}
-				break;
-			default:
-				{
-					ZInode = ZIl;
-				}
-				break;
-			case (ERROR_TERMINAL):
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-		}
-		/* END OF INLINE: 142 */
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOnode = ZInode;
-}
-
-static void
-p_203(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI200, t_pos *ZI201, t_char__class__ast *ZOnode)
+p_201(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI198, t_pos *ZI199, t_char__class__ast *ZOnode)
 {
 	t_char__class__ast ZInode;
 
@@ -1173,35 +1118,35 @@ p_203(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 	case (TOK_RANGE):
 		{
 			t_range__endpoint ZIa;
-			t_char ZI130;
-			t_pos ZI131;
-			t_pos ZI132;
+			t_char ZI128;
+			t_pos ZI129;
+			t_pos ZI130;
 			t_char ZIcz;
-			t_pos ZI134;
+			t_pos ZI132;
 			t_pos ZIend;
 			t_range__endpoint ZIz;
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 731 "src/libre/parser.act"
+#line 721 "src/libre/parser.act"
 
 		struct ast_range_endpoint range;
 		range.t = AST_RANGE_ENDPOINT_LITERAL;
-		range.u.literal.c = (*ZI200);
+		range.u.literal.c = (*ZI198);
 		(ZIa) = range;
 	
-#line 1194 "src/libre/dialect/sql/parser.c"
+#line 1139 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
 #line 246 "src/libre/parser.act"
 
-		ZI130 = '-';
-		ZI131 = lex_state->lx.start;
-		ZI132   = lex_state->lx.end;
+		ZI128 = '-';
+		ZI129 = lex_state->lx.start;
+		ZI130   = lex_state->lx.end;
 	
-#line 1205 "src/libre/dialect/sql/parser.c"
+#line 1150 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
@@ -1214,12 +1159,12 @@ p_203(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI134 = lex_state->lx.start;
+		ZI132 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 
 		ZIcz = lex_state->buf.a[0];
 	
-#line 1223 "src/libre/dialect/sql/parser.c"
+#line 1168 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: CHAR */
 				break;
@@ -1229,23 +1174,23 @@ p_203(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 731 "src/libre/parser.act"
+#line 721 "src/libre/parser.act"
 
 		struct ast_range_endpoint range;
 		range.t = AST_RANGE_ENDPOINT_LITERAL;
 		range.u.literal.c = (ZIcz);
 		(ZIz) = range;
 	
-#line 1240 "src/libre/dialect/sql/parser.c"
+#line 1185 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF ACTION: char-class-ast-range */
 			{
-#line 664 "src/libre/parser.act"
+#line 654 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
-		AST_POS_OF_LX_POS(ast_start, (*ZI201));
+		AST_POS_OF_LX_POS(ast_start, (*ZI199));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		if ((ZIa).t != AST_RANGE_ENDPOINT_LITERAL ||
@@ -1270,7 +1215,7 @@ p_203(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 		(ZInode) = re_char_class_ast_range(&(ZIa), ast_start, &(ZIz), ast_end);
 	
-#line 1274 "src/libre/dialect/sql/parser.c"
+#line 1219 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: char-class-ast-range */
 		}
@@ -1279,17 +1224,72 @@ p_203(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		{
 			/* BEGINNING OF ACTION: char-class-ast-literal */
 			{
-#line 659 "src/libre/parser.act"
+#line 649 "src/libre/parser.act"
 
-		(ZInode) = re_char_class_ast_literal((*ZI200));
+		(ZInode) = re_char_class_ast_literal((*ZI198));
 	
-#line 1287 "src/libre/dialect/sql/parser.c"
+#line 1232 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: char-class-ast-literal */
 		}
 		break;
 	case (ERROR_TERMINAL):
 		return;
+	}
+	goto ZL0;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+ZL0:;
+	*ZOnode = ZInode;
+}
+
+static void
+p_expr_C_Cchar_Hclass_C_Clist_Hof_Hchar_Hclass_Hterms(flags flags, lex_state lex_state, act_state act_state, err err, t_char__class__ast *ZOnode)
+{
+	t_char__class__ast ZInode;
+
+	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+		return;
+	}
+	{
+		t_char__class__ast ZIl;
+
+		p_expr_C_Cchar_Hclass_C_Cterm (flags, lex_state, act_state, err, &ZIl);
+		/* BEGINNING OF INLINE: 140 */
+		{
+			switch (CURRENT_TERMINAL) {
+			case (TOK_NAMED__CHAR__CLASS): case (TOK_CHAR):
+				{
+					t_char__class__ast ZIr;
+
+					p_expr_C_Cchar_Hclass_C_Clist_Hof_Hchar_Hclass_Hterms (flags, lex_state, act_state, err, &ZIr);
+					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+						RESTORE_LEXER;
+						goto ZL1;
+					}
+					/* BEGINNING OF ACTION: char-class-ast-concat */
+					{
+#line 683 "src/libre/parser.act"
+
+		(ZInode) = re_char_class_ast_concat((ZIl), (ZIr));
+	
+#line 1278 "src/libre/dialect/sql/parser.c"
+					}
+					/* END OF ACTION: char-class-ast-concat */
+				}
+				break;
+			default:
+				{
+					ZInode = ZIl;
+				}
+				break;
+			case (ERROR_TERMINAL):
+				RESTORE_LEXER;
+				goto ZL1;
+			}
+		}
+		/* END OF INLINE: 140 */
 	}
 	goto ZL0;
 ZL1:;
@@ -1307,9 +1307,9 @@ p_expr_C_Cchar_Hclass_C_Cterm(flags flags, lex_state lex_state, act_state act_st
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CHAR):
 		{
-			t_char ZI200;
-			t_pos ZI201;
-			t_pos ZI202;
+			t_char ZI198;
+			t_pos ZI199;
+			t_pos ZI200;
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
@@ -1318,16 +1318,16 @@ p_expr_C_Cchar_Hclass_C_Cterm(flags flags, lex_state lex_state, act_state act_st
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI201 = lex_state->lx.start;
-		ZI202   = lex_state->lx.end;
+		ZI199 = lex_state->lx.start;
+		ZI200   = lex_state->lx.end;
 
-		ZI200 = lex_state->buf.a[0];
+		ZI198 = lex_state->buf.a[0];
 	
 #line 1327 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
-			p_203 (flags, lex_state, act_state, err, &ZI200, &ZI201, &ZInode);
+			p_201 (flags, lex_state, act_state, err, &ZI198, &ZI199, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1341,8 +1341,8 @@ p_expr_C_Cchar_Hclass_C_Cterm(flags flags, lex_state lex_state, act_state act_st
 			/* BEGINNING OF INLINE: expr::char-class::named-class */
 			{
 				{
-					t_pos ZI122;
-					t_pos ZI123;
+					t_pos ZI120;
+					t_pos ZI121;
 
 					switch (CURRENT_TERMINAL) {
 					case (TOK_NAMED__CHAR__CLASS):
@@ -1366,8 +1366,8 @@ p_expr_C_Cchar_Hclass_C_Cterm(flags flags, lex_state lex_state, act_state act_st
 			break;
 		}
 
-		ZI122 = lex_state->lx.start;
-		ZI123   = lex_state->lx.end;
+		ZI120 = lex_state->lx.start;
+		ZI121   = lex_state->lx.end;
 	
 #line 1373 "src/libre/dialect/sql/parser.c"
 						}
@@ -1382,7 +1382,7 @@ p_expr_C_Cchar_Hclass_C_Cterm(flags flags, lex_state lex_state, act_state act_st
 			/* END OF INLINE: expr::char-class::named-class */
 			/* BEGINNING OF ACTION: char-class-ast-named-class */
 			{
-#line 701 "src/libre/parser.act"
+#line 691 "src/libre/parser.act"
 
 		(ZInode) = re_char_class_ast_named_class((ZIid));
 	
@@ -1413,7 +1413,7 @@ ZL1:;
 		/* END OF ACTION: err-expected-term */
 		/* BEGINNING OF ACTION: char-class-ast-flag-none */
 		{
-#line 715 "src/libre/parser.act"
+#line 705 "src/libre/parser.act"
 
 		(ZInode) = re_char_class_ast_flags(RE_CHAR_CLASS_FLAG_NONE);
 	
@@ -1438,10 +1438,10 @@ p_expr_C_Clist_Hof_Hatoms(flags flags, lex_state lex_state, act_state act_state,
 		return;
 	}
 	{
-		t_ast__expr ZI191;
+		t_ast__expr ZI189;
 
-		p_expr_C_Catom (flags, lex_state, act_state, err, &ZI191);
-		p_193 (flags, lex_state, act_state, err, &ZI191, &ZInode);
+		p_expr_C_Catom (flags, lex_state, act_state, err, &ZI189);
+		p_191 (flags, lex_state, act_state, err, &ZI189, &ZInode);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -1466,7 +1466,7 @@ p_expr_C_Cchar_Hclass_C_Cchar_Hclass_Htail(flags flags, lex_state lex_state, act
 	{
 		/* BEGINNING OF ACTION: char-class-ast-flag-none */
 		{
-#line 715 "src/libre/parser.act"
+#line 705 "src/libre/parser.act"
 
 		(ZIf) = re_char_class_ast_flags(RE_CHAR_CLASS_FLAG_NONE);
 	
@@ -1486,10 +1486,10 @@ p_expr_C_Clist_Hof_Halts(flags flags, lex_state lex_state, act_state act_state, 
 		return;
 	}
 	{
-		t_ast__expr ZI188;
+		t_ast__expr ZI186;
 
-		p_expr_C_Calt (flags, lex_state, act_state, err, &ZI188);
-		p_190 (flags, lex_state, act_state, err, &ZI188, &ZInode);
+		p_expr_C_Calt (flags, lex_state, act_state, err, &ZI186);
+		p_188 (flags, lex_state, act_state, err, &ZI186, &ZInode);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -1521,7 +1521,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			}
 			/* BEGINNING OF ACTION: ast-expr-atom-any */
 			{
-#line 613 "src/libre/parser.act"
+#line 603 "src/libre/parser.act"
 
 		struct ast_expr *e = re_ast_expr_any();
 		if (e == NULL) { goto ZL1; }
@@ -1535,6 +1535,8 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 	case (TOK_MANY):
 		{
 			t_ast__count ZIs;
+			t_ast__count ZIf;
+			t_ast__expr ZIe;
 
 			ADVANCE_LEXER;
 			p_expr_C_Catom_Hsuffix (flags, lex_state, act_state, err, &ZIs);
@@ -1542,17 +1544,35 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 				RESTORE_LEXER;
 				goto ZL1;
 			}
-			/* BEGINNING OF ACTION: ast-expr-atom-many */
+			/* BEGINNING OF ACTION: atom-kleene */
 			{
-#line 607 "src/libre/parser.act"
+#line 617 "src/libre/parser.act"
 
-		struct ast_expr *e = re_ast_expr_many();
-		if (e == NULL) { goto ZL1; }
-		(ZInode) = re_ast_expr_with_count(e, (ZIs));
+		(ZIf) = ast_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
 #line 1554 "src/libre/dialect/sql/parser.c"
 			}
-			/* END OF ACTION: ast-expr-atom-many */
+			/* END OF ACTION: atom-kleene */
+			/* BEGINNING OF ACTION: ast-expr-atom-any */
+			{
+#line 603 "src/libre/parser.act"
+
+		struct ast_expr *e = re_ast_expr_any();
+		if (e == NULL) { goto ZL1; }
+		(ZIe) = re_ast_expr_with_count(e, (ZIf));
+	
+#line 1565 "src/libre/dialect/sql/parser.c"
+			}
+			/* END OF ACTION: ast-expr-atom-any */
+			/* BEGINNING OF ACTION: ast-expr-atom */
+			{
+#line 613 "src/libre/parser.act"
+
+		(ZInode) = re_ast_expr_with_count((ZIe), (ZIs));
+	
+#line 1574 "src/libre/dialect/sql/parser.c"
+			}
+			/* END OF ACTION: ast-expr-atom */
 		}
 		break;
 	case (TOK_OPENSUB):
@@ -1569,11 +1589,11 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			}
 			/* BEGINNING OF ACTION: ast-expr-group */
 			{
-#line 619 "src/libre/parser.act"
+#line 609 "src/libre/parser.act"
 
 		(ZIe) = re_ast_expr_group((ZIg));
 	
-#line 1577 "src/libre/dialect/sql/parser.c"
+#line 1597 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-expr-group */
 			switch (CURRENT_TERMINAL) {
@@ -1590,11 +1610,11 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			}
 			/* BEGINNING OF ACTION: ast-expr-atom */
 			{
-#line 623 "src/libre/parser.act"
+#line 613 "src/libre/parser.act"
 
 		(ZInode) = re_ast_expr_with_count((ZIe), (ZIs));
 	
-#line 1598 "src/libre/dialect/sql/parser.c"
+#line 1618 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-expr-atom */
 		}
@@ -1612,11 +1632,11 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			}
 			/* BEGINNING OF ACTION: ast-expr-atom */
 			{
-#line 623 "src/libre/parser.act"
+#line 613 "src/libre/parser.act"
 
 		(ZInode) = re_ast_expr_with_count((ZIe), (ZIs));
 	
-#line 1620 "src/libre/dialect/sql/parser.c"
+#line 1640 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-expr-atom */
 		}
@@ -1634,11 +1654,11 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			}
 			/* BEGINNING OF ACTION: ast-expr-atom */
 			{
-#line 623 "src/libre/parser.act"
+#line 613 "src/libre/parser.act"
 
 		(ZInode) = re_ast_expr_with_count((ZIe), (ZIs));
 	
-#line 1642 "src/libre/dialect/sql/parser.c"
+#line 1662 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-expr-atom */
 		}
@@ -1665,8 +1685,8 @@ p_expr_C_Cchar_Hclass_C_Cchar_Hclass_Hast(flags flags, lex_state lex_state, act_
 		return;
 	}
 	{
-		t_pos ZI195;
-		t_pos ZI196;
+		t_pos ZI193;
+		t_pos ZI194;
 		t_char__class__ast ZIhead;
 		t_char__class__ast ZIbody;
 		t_char__class__ast ZItail;
@@ -1677,10 +1697,10 @@ p_expr_C_Cchar_Hclass_C_Cchar_Hclass_Hast(flags flags, lex_state lex_state, act_
 			{
 #line 252 "src/libre/parser.act"
 
-		ZI195 = lex_state->lx.start;
-		ZI196   = lex_state->lx.end;
+		ZI193 = lex_state->lx.start;
+		ZI194   = lex_state->lx.end;
 	
-#line 1684 "src/libre/dialect/sql/parser.c"
+#line 1704 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: OPENGROUP */
 			break;
@@ -1691,7 +1711,7 @@ p_expr_C_Cchar_Hclass_C_Cchar_Hclass_Hast(flags flags, lex_state lex_state, act_
 		p_expr_C_Cchar_Hclass_C_Cchar_Hclass_Hhead (flags, lex_state, act_state, err, &ZIhead);
 		p_expr_C_Cchar_Hclass_C_Clist_Hof_Hchar_Hclass_Hterms (flags, lex_state, act_state, err, &ZIbody);
 		p_expr_C_Cchar_Hclass_C_Cchar_Hclass_Htail (flags, lex_state, act_state, err, &ZItail);
-		p_197 (flags, lex_state, act_state, err, &ZI195, &ZIhead, &ZIbody, &ZItail, &ZInode);
+		p_195 (flags, lex_state, act_state, err, &ZI193, &ZIhead, &ZIbody, &ZItail, &ZInode);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -1730,7 +1750,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 757 "src/libre/parser.act"
+#line 747 "src/libre/parser.act"
 
 
 	static int
@@ -1887,6 +1907,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 1891 "src/libre/dialect/sql/parser.c"
+#line 1911 "src/libre/dialect/sql/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/sql/parser.h
+++ b/src/libre/dialect/sql/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__sql(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 913 "src/libre/parser.act"
+#line 903 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/sql/parser.h"

--- a/src/libre/dialect/sql/parser.sid
+++ b/src/libre/dialect/sql/parser.sid
@@ -82,12 +82,10 @@
 	<ast-expr-concat>: (:ast_expr, :ast_expr) -> (:ast_expr);
 	<ast-expr-alt>: (:ast_expr, :ast_expr) -> (:ast_expr);
 	!<ast-expr-any>: () -> (:ast_expr);
-	!<ast-expr-many>: () -> (:ast_expr);
 	!<ast-expr-re-flags>: (:re_flags, :re_flags) -> (:ast_expr);
 
         <ast-expr-atom>: (:ast_expr, :ast_count) -> (:ast_expr);
         <ast-expr-atom-any>: (:ast_count) -> (:ast_expr);
-        <ast-expr-atom-many>: (:ast_count) -> (:ast_expr);
 	<ast-expr-char-class>: (:char_class_ast, :pos, :pos) -> (:ast_expr);
         <ast-expr-group>: (:ast_expr) -> (:ast_expr);
 
@@ -290,7 +288,9 @@
 		||
 			MANY;
 			s = atom-suffix();
-			node = <ast-expr-atom-many>(s);
+			f = <atom-kleene>();
+			e = <ast-expr-atom-any>(f);
+			node = <ast-expr-atom>(e, s);
 		};
 
 		list-of-atoms: () -> (node :ast_expr) = {

--- a/src/libre/parser.act
+++ b/src/libre/parser.act
@@ -599,16 +599,6 @@
 	<ast-expr-any>: () -> (node :ast_expr) = @{
 		@node = re_ast_expr_any();
 	@};
-	
-	<ast-expr-many>: () -> (node :ast_expr) = @{
-		@node = re_ast_expr_many();
-	@};
-
-	<ast-expr-atom-many>: (c :ast_count) -> (node :ast_expr) = @{
-		struct ast_expr *e = re_ast_expr_many();
-		if (e == NULL) { @!; }
-		@node = re_ast_expr_with_count(e, @c);
-	@};
 
 	<ast-expr-atom-any>: (c :ast_count) -> (node :ast_expr) = @{
 		struct ast_expr *e = re_ast_expr_any();

--- a/src/libre/print/dot.c
+++ b/src/libre/print/dot.c
@@ -74,10 +74,6 @@ pp_iter(FILE *f, const struct fsm_options *opt,
 		fprintf(f, "\tn%p [ label = <ANY> ];\n", (void *) n);
 		break;
 
-	case AST_EXPR_MANY:
-		fprintf(f, "\tn%p [ label = <MANY> ];\n", (void *) n);
-		break;
-
 	case AST_EXPR_REPEATED:
 		fprintf(f, "\tn%p [ label = <REPEATED|&#x7b;", (void *) n);
 		fprintf_count(f, n->u.repeated.low);

--- a/src/libre/print/ebnf.c
+++ b/src/libre/print/ebnf.c
@@ -37,7 +37,6 @@ atomic(struct ast_expr *n)
 	case AST_EXPR_REPEATED:
 	case AST_EXPR_CONCAT:
 	case AST_EXPR_ALT:
-	case AST_EXPR_MANY:
 		return 0;
 
 	case AST_EXPR_FLAGS:
@@ -117,10 +116,6 @@ pp_iter(FILE *f, const struct fsm_options *opt, struct ast_expr *n)
 
 	case AST_EXPR_ANY:
 		fprintf(f, "any");
-		break;
-
-	case AST_EXPR_MANY:
-		fprintf(f, "ANY, { ANY }");
 		break;
 
 	case AST_EXPR_REPEATED: {

--- a/src/libre/print/pcre.c
+++ b/src/libre/print/pcre.c
@@ -34,7 +34,6 @@ atomic(struct ast_expr *n)
 
 	case AST_EXPR_CONCAT:
 	case AST_EXPR_ALT:
-	case AST_EXPR_MANY:
 		return 0;
 
 	case AST_EXPR_FLAGS:
@@ -74,10 +73,6 @@ pp_iter(FILE *f, const struct fsm_options *opt, struct ast_expr *n)
 
 	case AST_EXPR_ANY:
 		fprintf(f, ".");
-		break;
-
-	case AST_EXPR_MANY:
-		fprintf(f, ".*");
 		break;
 
 	case AST_EXPR_REPEATED: {

--- a/src/libre/print/tree.c
+++ b/src/libre/print/tree.c
@@ -80,9 +80,6 @@ pp_iter(FILE *f, const struct fsm_options *opt, size_t indent, struct ast_expr *
 	case AST_EXPR_ANY:
 		fprintf(f, "ANY %p:\n", (void *)n);
 		break;
-	case AST_EXPR_MANY:
-		fprintf(f, "MANY %p:\n", (void *)n);
-		break;
 	case AST_EXPR_REPEATED:
 		fprintf(f, "REPEATED %p: {", (void *)n);
 		fprintf_count(f, n->u.repeated.low);

--- a/src/libre/re_analysis.c
+++ b/src/libre/re_analysis.c
@@ -50,7 +50,6 @@ analysis_iter(struct analysis_env *env, struct ast_expr *n)
 		break;
 
 	case AST_EXPR_ANY:
-	case AST_EXPR_MANY:
 	case AST_EXPR_FLAGS:
 		break;
 

--- a/src/libre/re_ast.c
+++ b/src/libre/re_ast.c
@@ -19,7 +19,6 @@ free_iter(struct ast_expr *n)
 	case AST_EXPR_EMPTY:
 	case AST_EXPR_LITERAL:
 	case AST_EXPR_ANY:
-	case AST_EXPR_MANY:
 	case AST_EXPR_FLAGS:
 		break;
 
@@ -106,16 +105,6 @@ re_ast_expr_any(void)
 	struct ast_expr *res = calloc(1, sizeof(*res));
 	if (res == NULL) { return res; }
 	res->t = AST_EXPR_ANY;
-
-	return res;
-}
-
-struct ast_expr *
-re_ast_expr_many(void)
-{
-	struct ast_expr *res = calloc(1, sizeof(*res));
-	if (res == NULL) { return res; }
-	res->t = AST_EXPR_MANY;
 
 	return res;
 }

--- a/src/libre/re_ast.h
+++ b/src/libre/re_ast.h
@@ -34,7 +34,6 @@ enum ast_expr_type {
 	AST_EXPR_ALT,
 	AST_EXPR_LITERAL,
 	AST_EXPR_ANY,
-	AST_EXPR_MANY,
 	AST_EXPR_REPEATED,
 	AST_EXPR_CHAR_CLASS,
 	AST_EXPR_GROUP,
@@ -124,9 +123,6 @@ re_ast_expr_literal(char c);
 
 struct ast_expr *
 re_ast_expr_any(void);
-
-struct ast_expr *
-re_ast_expr_many(void);
 
 struct ast_expr *
 re_ast_expr_with_count(struct ast_expr *e, struct ast_count count);

--- a/src/libre/re_comp.c
+++ b/src/libre/re_comp.c
@@ -136,14 +136,6 @@ comp_iter(struct comp_env *env,
 		ANY(x, y);
 		break;
 
-	case AST_EXPR_MANY:
-		NEWSTATE(z);
-		EPSILON(x, z);
-		ANY(x, z);
-		EPSILON(z, x);
-		EPSILON(z, y);
-		break;
-
 	case AST_EXPR_REPEATED:
 		/* REPEATED breaks out into its own function, because
 		 * there are several special cases */
@@ -262,7 +254,6 @@ can_have_backward_epsilon_edge(const struct ast_expr *e)
 	if (e->t == AST_EXPR_LITERAL) { return 0; }
 	if (e->t == AST_EXPR_FLAGS) { return 0; }
 	if (e->t == AST_EXPR_CHAR_CLASS) { return 0; }
-	if (e->t == AST_EXPR_MANY) { return 0; }
 	if (e->t == AST_EXPR_ALT) { return 0; }
 
 	if (e->t == AST_EXPR_REPEATED) {


### PR DESCRIPTION
Construct `.*` rather than providing an explicit `AST_EXPR_MANY` node.