### PR TITLE
fsm: fix compilation on FreeBSD

### DIFF
--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -4,7 +4,7 @@
  * See LICENCE for the full copyright terms.
  */
 
-#define _POSIX_C_SOURCE 199309L
+#define _POSIX_C_SOURCE 200112L
 
 #include <unistd.h>
 


### PR DESCRIPTION
FreeBSD fails to compile the fsm(1) utility because it doesn't
define the proper POSIX source version to use the macros for the
clock_gettime(2) family functions.