### PR TITLE
A couple of scripts for fuzzing regexp and lx syntax

### DIFF
--- a/fuzz/genlx
+++ b/fuzz/genlx
@@ -1,7 +1,7 @@
 #!/usr/bin/awk -f
 
 function usage() {
-	print("genlx <seed> <max_things> <zone_limit>\n");
+	print("genlx <seed> <max_things> <max_atoms> <zone_limit>\n");
 	exit(1)
 }
 
@@ -52,7 +52,8 @@ function print_var() {
 function genregex(dialect, quote) {
 	printf("%c", quote);
 
-	system(sprintf("%s %u %s %u %u", genregex_path, randint(1000), dialect, 5, 3));
+	system(sprintf("%s %u %s %u %u", genregex_path, randint(1000),
+		dialect, max_atoms, 1 + max_atoms / 2));
 	# TODO: escape stuff appropriately
 
 	# TODO: exclude regexps which match the empty string, invoke re(1) to test
@@ -207,17 +208,18 @@ function thing_ncgroup() {
 BEGIN {
 	def["seed"]       = 210881
 	def["max_things"] = 20
+	def["max_atoms"]  = 5
 	def["zone_limit"] = 50
 
 	seed       = shift_arg("seed") + 0
 	max_things = shift_arg("max_things") + 0
+	max_atoms  = shift_arg("max_atoms") + 0
 	zone_limit = shift_arg("zone_limit") + 0
 
 	prob_to   = 0.8; # XXX: make configurable
 	prob_skip = 0.5; # XXX: make configurable
 	prob_exit = 0.9; # XXX: make configurable
 
-# TODO: find from argv
 	genregex_path = "./genregex";
 
 	srand(seed);
@@ -252,6 +254,7 @@ BEGIN {
 
 	printf("# seed = %u\n", seed);
 	printf("# max_things = %u\n", max_things);
+	printf("# max_atoms  = %u\n", max_atoms);
 	printf("# zone_limit = %u\n", zone_limit);
 	printf("\n");
 

--- a/fuzz/genlx
+++ b/fuzz/genlx
@@ -75,12 +75,17 @@ function tok_ref() {
 	printf("$t%u", randint(tokid));
 }
 
-function genregex(dialect, quote) {
+function genregex(dialect, quote,    cmd) {
 	printf("%c", quote);
 
-	system(sprintf("%s %u %s %u %u", genregex_path, randint(1000),
-		dialect, max_atoms, 1 + max_atoms / 2));
-	# TODO: escape stuff appropriately
+	cmd = sprintf("%s %u %s %u %u", genregex_path, randint(1000),
+		dialect, max_atoms, 1 + max_atoms / 2);
+	while ((cmd | getline) > 0) {
+		if (quote != "'") {
+			gsub(quote, "\\" quote, $0);
+		}
+		printf("%s", $0);
+	}
 
 	# TODO: exclude regexps which match the empty string, invoke re(1) to test
 

--- a/fuzz/genlx
+++ b/fuzz/genlx
@@ -15,6 +15,15 @@ function randint(x) {
 	return int(rand() * x)
 }
 
+function randindex(a,    tmp, n, i) {
+	n = 0;
+	for (i in a) {
+		tmp[++n] = i;
+	}
+
+	return tmp[randint(n)];
+}
+
 function populate(prob, d) {
 	n = 0;
 	for (f in prob) {
@@ -23,6 +32,12 @@ function populate(prob, d) {
 			n++;
 		}
 	}
+}
+
+function enable(prob, d, name) {
+	prob[name] = 1;
+	delete d;
+	populate(prob, d);
 }
 
 function dispatch(d) {
@@ -38,15 +53,26 @@ function print_indent(indent) {
 	}
 }
 
-function print_token() {
-	printf("$")
-	printf("t%u", randint(53)); # XXX
+function var_def() {
+	var[varid] = varid; # XXX: bool?
+	printf("v%u", varid);
 }
 
-function print_var() {
-	printf("v%u", randint(53)); # XXX
-	# TODO: keep stack of variables for zone scope, use when referencing a variable
-	# index by [zone, var]
+function var_ref() {
+	printf("v%u", randindex(var));
+}
+
+function tok_def() {
+	if (rand() < 0.5) {
+		tokid++;
+	}
+
+	printf("$")
+	printf("t%u", randint(tokid));
+}
+
+function tok_ref() {
+	printf("$t%u", randint(tokid));
 }
 
 function genregex(dialect, quote) {
@@ -64,6 +90,10 @@ function genregex(dialect, quote) {
 function pattern_single() { genregex("literal", "'");  }
 function pattern_double() { genregex("literal", "\""); }
 function pattern_regexp() { genregex("native",  "/");  }
+
+function term_item() {
+	dispatch(d_item);
+}
 
 function term_parens() {
 	printf("(");
@@ -125,15 +155,21 @@ function print_mapping() {
 
 	if (rand() < prob_to) {
 		printf(" -> ");
-		print_token();
+		tok_def();
+
+		if (tokid == 0) {
+			enable(prob_item, d_item, "tok_ref");
+		}
+
+		tokid++;
 	}
 }
 
 function print_body(zone,    n) {
-	if (zone + 1 > zone_limit) {
-		prob_thing["thing_zone"] = 0;
-		delete d_thing;
-		populate(prob_thing, d_thing);
+	zoneid++;
+
+	if (zoneid > zone_limit) {
+		enable(prob_thing, d_thing, "thing_zone");
 	}
 
 	n = randint(max_things)
@@ -142,6 +178,7 @@ function print_body(zone,    n) {
 	}
 
 	# need at least one thing in a zone
+	print_indent(zone);
 	dispatch(d_thing);
 
 	while (n-- > zone * 2) { # fewer things for deeper zones
@@ -164,23 +201,43 @@ function thing_skip() {
 	print ";"
 }
 
-function thing_zone() {
+function thing_zone(    i, start) {
 	print_mapping();
 	if (rand() < prob_exit) {
 		printf(" .. ");
 		print_mapping();
 	}
+
 	print " {"
+
+	# We keep a single array, var[], for all active variables.
+	# varid is the next index to populate. Before printing a zone body,
+	# the current index is stored. Then when exiting the zone, all entries
+	# between those two values are removed.
+	# In this way we use the function call stack to implement block scope.
+	start = varid;
+
 	print_body(++zone);
 	print_indent(--zone);
+
 	print "}"
+
+	for (i = start; i < varid; i++) {
+		delete var[i];
+	}
 }
 
 function thing_bind() {
-	print_var();
+	var_def();
 	printf(" = ");
 	print_expr();
 	print ";"
+
+	if (varid == 0) {
+		enable(prob_item, d_item, "var_ref");
+	}
+
+	varid++;
 }
 
 function thing_special() {
@@ -229,10 +286,13 @@ BEGIN {
 	prob_thing["thing_zone"]    = 1;
 	prob_thing["thing_bind"]    = 2;
 
-	prob_term["pattern_single"] = 5;
-	prob_term["pattern_double"] = 5;
-	prob_term["pattern_regexp"] = 8;
+	prob_item["pattern_single"] = 1;
+	prob_item["pattern_double"] = 1;
+	prob_item["pattern_regexp"] = 2;
+	prob_item["var_ref"]        = 0;
+	prob_item["tok_ref"]        = 0;
 
+	prob_term["term_item"]   = 8;
 	prob_term["term_parens"] = 2;
 	prob_term["term_star"]   = 2;
 	prob_term["term_cross"]  = 2;
@@ -251,12 +311,17 @@ BEGIN {
 
 	populate(prob_thing, d_thing);
 	populate(prob_term, d_term);
+	populate(prob_item, d_item);
 
 	printf("# seed = %u\n", seed);
 	printf("# max_things = %u\n", max_things);
 	printf("# max_atoms  = %u\n", max_atoms);
 	printf("# zone_limit = %u\n", zone_limit);
 	printf("\n");
+
+	zoneid = 0;
+	tokid  = 0;
+	varid  = 0;
 
 	print_body(0);
 }

--- a/fuzz/genlx
+++ b/fuzz/genlx
@@ -1,7 +1,7 @@
 #!/usr/bin/awk -f
 
 function usage() {
-	print("genlx <seed> <max_things>\n");
+	print("genlx <seed> <max_things> <zone_limit>\n");
 	exit(1)
 }
 
@@ -52,10 +52,10 @@ function print_var() {
 function genregex(dialect, quote) {
 	printf("%c", quote);
 
-# TODO: pass suitable parameters
-# print("gengraph <seed> <dialect> <max_terms> <max_class> <max_m> <max_n> <labels>\n");
-system("./genregex " randint(100) " " dialect " 5");
-# TODO: escape stuff appropriately
+	system(sprintf("%s %u %s %u %u", genregex_path, randint(1000), dialect, 5, 3));
+	# TODO: escape stuff appropriately
+
+	# TODO: exclude regexps which match the empty string, invoke re(1) to test
 
 	printf("%c", quote);
 }
@@ -64,9 +64,59 @@ function pattern_single() { genregex("literal", "'");  }
 function pattern_double() { genregex("literal", "\""); }
 function pattern_regexp() { genregex("native",  "/");  }
 
-function print_expr() {
+function term_parens() {
+	printf("(");
+	print_term();
+	printf(")");
+}
+
+function print_prefix(op) {
+	printf("%s", op);
+	print_term();
+}
+
+function print_suffix(op) {
+	print_term();
+	printf("%s", op);
+	# XXX: can generate x++
+}
+
+function print_binop(op) {
+	print_term();
+	printf(" %s ", op);
+	print_term();
+}
+
+function term_tilde() { print_prefix("~"); }
+function term_bang()  { print_prefix("!"); }
+function term_hat()   { print_prefix("^"); }
+
+function term_qmark() { print_suffix("?"); }
+function term_cross() { print_suffix("+"); }
+function term_star()  { print_suffix("*"); }
+
+function term_dash()  { print_binop("-");  }
+function term_dot()   { print_binop(".");  }
+function term_pipe()  { print_binop("|");  }
+function term_and()   { print_binop("&");  }
+
+function print_term()
+{
+	# XXX: should split grouped vs. atomic clauses
+	# but !/x/? should still be possible
+	dispatch(d_term);
+}
+
+function print_expr(    n) {
+	print_term();
+
+	n = randint(3) + 1; # XXX: configurable
+
 	# TODO: recursive grammar for expressions
-	dispatch(d_pattern);
+	while (n-- > zone * 2) { # fewer things for deeper zones
+		printf(" ");
+		print_term();
+	}
 }
 
 function print_mapping() {
@@ -79,12 +129,21 @@ function print_mapping() {
 }
 
 function print_body(zone,    n) {
+	if (zone + 1 > zone_limit) {
+		prob_thing["thing_zone"] = 0;
+		delete d_thing;
+		populate(prob_thing, d_thing);
+	}
+
 	n = randint(max_things)
 	if (n == 0 && max_things >= 1 && rand() > 0.1) {
 		n = 1;
 	}
 
-	while (n-- > 0) {
+	# need at least one thing in a zone
+	dispatch(d_thing);
+
+	while (n-- > zone * 2) { # fewer things for deeper zones
 		print_indent(zone);
 		dispatch(d_thing);
 	}
@@ -147,28 +206,54 @@ function thing_ncgroup() {
 
 BEGIN {
 	def["seed"]       = 210881
-	def["max_things"] = 50
+	def["max_things"] = 20
+	def["zone_limit"] = 50
 
 	seed       = shift_arg("seed") + 0
 	max_things = shift_arg("max_things") + 0
+	zone_limit = shift_arg("zone_limit") + 0
 
 	prob_to   = 0.8; # XXX: make configurable
 	prob_skip = 0.5; # XXX: make configurable
 	prob_exit = 0.9; # XXX: make configurable
 
+# TODO: find from argv
+	genregex_path = "./genregex";
+
 	srand(seed);
 
-	prob_pattern["pattern_single"] = 1;
-	prob_pattern["pattern_double"] = 1;
-	prob_pattern["pattern_regexp"] = 2;
-
 	prob_thing["thing_mapping"] = 4;
-	prob_thing["thing_skip"]    = 1;
+	prob_thing["thing_skip"]    = 2;
 	prob_thing["thing_zone"]    = 1;
-	prob_thing["thing_bind"]    = 1;
+	prob_thing["thing_bind"]    = 2;
 
-	populate(prob_pattern, d_pattern);
+	prob_term["pattern_single"] = 5;
+	prob_term["pattern_double"] = 5;
+	prob_term["pattern_regexp"] = 8;
+
+	prob_term["term_parens"] = 2;
+	prob_term["term_star"]   = 2;
+	prob_term["term_cross"]  = 2;
+	prob_term["term_qmark"]  = 2;
+
+	# prefix
+	prob_term["term_tilde"]  = 2;
+	prob_term["term_bang"]   = 2;
+	prob_term["term_hat"]    = 2;
+
+	# binary
+	prob_term["term_dash"]   = 1;
+#	prob_term["term_dot"]    = 0; # XXX: unimplemented
+	prob_term["term_pipe"]   = 1;
+	prob_term["term_and"]    = 1;
+
 	populate(prob_thing, d_thing);
+	populate(prob_term, d_term);
+
+	printf("# seed = %u\n", seed);
+	printf("# max_things = %u\n", max_things);
+	printf("# zone_limit = %u\n", zone_limit);
+	printf("\n");
 
 	print_body(0);
 }

--- a/fuzz/genlx
+++ b/fuzz/genlx
@@ -76,7 +76,6 @@ function tok_ref() {
 }
 
 function genregex(dialect, quote,    recmd, cmd, r) {
-	# TODO: flag to permit overlapping classes
 	recmd = sprintf("%s -r %s -y - -- ''", re_path, dialect);
 
 	do {

--- a/fuzz/genlx
+++ b/fuzz/genlx
@@ -75,21 +75,37 @@ function tok_ref() {
 	printf("$t%u", randint(tokid));
 }
 
-function genregex(dialect, quote,    cmd) {
-	printf("%c", quote);
+function genregex(dialect, quote,    recmd, cmd, r) {
+	# TODO: flag to permit overlapping classes
+	recmd = sprintf("%s -r %s -y - -- ''", re_path, dialect);
 
-	cmd = sprintf("%s %u %s %u %u", genregex_path, randint(1000),
-		dialect, max_atoms, 1 + max_atoms / 2);
-	while ((cmd | getline) > 0) {
-		if (quote != "'") {
-			gsub(quote, "\\" quote, $0);
+	do {
+		cmd = sprintf("%s %u %s %u %u", genregex_path, randint(1000),
+			dialect, max_atoms, 1 + max_atoms / 2);
+
+		if ((cmd | getline) < 0) {
+			printf("error: %s: %s\n", cmd, ERRNO);
+			exit(1);
 		}
-		printf("%s", $0);
+
+		printf("%s", $0) | recmd;
+		r = close(recmd);
+		if (r > 256 || r < 0) { # 256 is exit(1)
+			gsub("'", "\\'", $0);
+			printf("echo '%s' | %s: %s\n", $0, recmd, r);
+			exit(1);
+		}
+
+		# here we loop to skip (syntatically correct) regexps
+		# which match nothing, because those are a semantic error for lx.
+		# re(1) exit status 0 meaning a successful match.
+	} while (r == 0);
+
+	if (quote != "'") {
+		gsub(quote, "\\" quote, $0);
 	}
 
-	# TODO: exclude regexps which match the empty string, invoke re(1) to test
-
-	printf("%c", quote);
+	printf("%c%s%c", quote, $0, quote);
 }
 
 function pattern_single() { genregex("literal", "'");  }
@@ -283,6 +299,7 @@ BEGIN {
 	prob_exit = 0.9; # XXX: make configurable
 
 	genregex_path = "./genregex";
+	re_path       = "../build/bin/re";
 
 	srand(seed);
 

--- a/fuzz/genlx
+++ b/fuzz/genlx
@@ -1,0 +1,175 @@
+#!/usr/bin/awk -f
+
+function usage() {
+	print("genlx <seed> <max_things>\n");
+	exit(1)
+}
+
+function shift_arg(name) {
+	shift_arg_offset++
+	if (ARGV[shift_arg_offset] == "-h") { usage(); }
+	return (ARGC > shift_arg_offset ? ARGV[shift_arg_offset] : def[name])
+}
+
+function randint(x) {
+	return int(rand() * x)
+}
+
+function populate(prob, d) {
+	n = 0;
+	for (f in prob) {
+		for (i = 0; i < prob[f]; i++) {
+			d[n] = f;
+			n++;
+		}
+	}
+}
+
+function dispatch(d) {
+	count = length(d)
+	k = randint(count)
+	f = d[k];
+	@f();
+}
+
+function print_indent(indent) {
+	while (indent-- > 0) {
+		printf("  ");
+	}
+}
+
+function print_token() {
+	printf("$")
+	printf("t%u", randint(53)); # XXX
+}
+
+function print_var() {
+	printf("v%u", randint(53)); # XXX
+	# TODO: keep stack of variables for zone scope, use when referencing a variable
+	# index by [zone, var]
+}
+
+function genregex(dialect, quote) {
+	printf("%c", quote);
+
+# TODO: pass suitable parameters
+# print("gengraph <seed> <dialect> <max_terms> <max_class> <max_m> <max_n> <labels>\n");
+system("./genregex " randint(100) " " dialect " 5");
+# TODO: escape stuff appropriately
+
+	printf("%c", quote);
+}
+
+function pattern_single() { genregex("literal", "'");  }
+function pattern_double() { genregex("literal", "\""); }
+function pattern_regexp() { genregex("native",  "/");  }
+
+function print_expr() {
+	# TODO: recursive grammar for expressions
+	dispatch(d_pattern);
+}
+
+function print_mapping() {
+	print_expr();
+
+	if (rand() < prob_to) {
+		printf(" -> ");
+		print_token();
+	}
+}
+
+function print_body(zone,    n) {
+	n = randint(max_things)
+	if (n == 0 && max_things >= 1 && rand() > 0.1) {
+		n = 1;
+	}
+
+	while (n-- > 0) {
+		print_indent(zone);
+		dispatch(d_thing);
+	}
+}
+
+function thing_mapping() {
+	print_mapping();
+	print ";"
+}
+
+function thing_skip() {
+	print_mapping();
+	if (rand() > prob_skip) {
+		printf(" .. ");
+		print_mapping();
+	}
+	print ";"
+}
+
+function thing_zone() {
+	print_mapping();
+	if (rand() < prob_exit) {
+		printf(" .. ");
+		print_mapping();
+	}
+	print " {"
+	print_body(++zone);
+	print_indent(--zone);
+	print "}"
+}
+
+function thing_bind() {
+	print_var();
+	printf(" = ");
+	print_expr();
+	print ";"
+}
+
+function thing_special() {
+	s = "nrtvf\\";
+	count = length(s)
+	li = randint(count)
+	lbl = substr(s, li, 1)
+	printf("\\%s", lbl);
+}
+
+function thing_group() {
+	dispatch(d_op);
+
+	printf("(");
+	print_thing();
+	printf(")");
+}
+
+function thing_ncgroup() {
+	printf("(?:");
+	print_thing();
+	printf(")");
+}
+
+BEGIN {
+	def["seed"]       = 210881
+	def["max_things"] = 50
+
+	seed       = shift_arg("seed") + 0
+	max_things = shift_arg("max_things") + 0
+
+	prob_to   = 0.8; # XXX: make configurable
+	prob_skip = 0.5; # XXX: make configurable
+	prob_exit = 0.9; # XXX: make configurable
+
+	srand(seed);
+
+	prob_pattern["pattern_single"] = 1;
+	prob_pattern["pattern_double"] = 1;
+	prob_pattern["pattern_regexp"] = 2;
+
+	prob_thing["thing_mapping"] = 4;
+	prob_thing["thing_skip"]    = 1;
+	prob_thing["thing_zone"]    = 1;
+	prob_thing["thing_bind"]    = 1;
+
+	populate(prob_pattern, d_pattern);
+	populate(prob_thing, d_thing);
+
+	print_body(0);
+}
+

--- a/fuzz/genregex
+++ b/fuzz/genregex
@@ -1,7 +1,7 @@
 #!/usr/bin/awk -f
 
 function usage() {
-	print("gengraph <seed> <max_terms> <max_m> <max_n> <labels>\n");
+	print("gengraph <seed> <max_terms> <max_class> <max_m> <max_n> <labels>\n");
 	exit(1)
 }
 
@@ -32,15 +32,27 @@ function dispatch(d) {
 	@f();
 }
 
+# start is 1-based
+function print_char(labels, start) {
+	count = length(labels) - start - 1
+	li = start + randint(count)
+	printf("%c", substr(labels, li, 1));
+	return li;
+}
+
+# min is 0-based
+function print_hex(min) {
+	c = min + randint(256 - min);
+	printf("\\x%02x", c);
+	return c;
+}
+
 function atom_char() {
-	count = length(labels)
-	li = randint(count)
-	lbl = substr(labels, li, 1)
-	printf("%c", lbl);
+	print_char(labels, 1);
 }
 
 function atom_hex() {
-	printf("\\x%02x", randint(255));
+	print_hex(0);
 }
 
 function atom_special() {
@@ -53,7 +65,22 @@ function atom_special() {
 
 function atom_class() {
 	printf("[");
-	printf("TOD");
+
+	if (rand() < 0.3) { # XXX: configurable
+		printf("^");
+	}
+
+	num_class = randint(max_class)
+
+	# XXX: should be legal
+	if (num_class == 0) {
+		num_class = 1;
+	}
+
+	for (tx = 0; tx < num_class; tx++) {
+		dispatch(d_class);
+	}
+
 	printf("]");
 }
 
@@ -91,8 +118,20 @@ function op_mn() {
 	printf("{%u,%u}", randint(max_m), max_m + randint(max_n - max_m));
 }
 
+function class_range() {
+	min = print_char(labels, 1);
+	printf("-");
+	print_char(labels, min);
+}
+
+function class_hexrange() {
+	min = print_hex(0);
+	printf("-");
+	print_hex(min);
+}
+
 function print_term() {
-	if (rand() < 0.2) {
+	if (rand() < 0.2) { # XXX: configurable
 		print_term();
 		printf("|");
 		print_term();
@@ -106,12 +145,14 @@ function print_term() {
 BEGIN {
 	def["seed"]      = 210881
 	def["max_terms"] = 50
+	def["max_class"] = 5
 	def["max_m"]     = 5
 	def["max_n"]     = 10
 	def["labels"]    = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
 	seed      = shift_arg("seed") + 0
 	max_terms = shift_arg("max_terms") + 0
+	max_class = shift_arg("max_class") + 0
 	max_m     = shift_arg("max_m") + 0
 	max_n     = shift_arg("max_n") + 0
 	labels    = shift_arg("labels") ""
@@ -140,8 +181,15 @@ BEGIN {
 	prob_op["op_mx"]    = 1;
 	prob_op["op_mn"]    = 1;
 
+	prob_class["atom_char"]      = 2;
+	prob_class["atom_hex"]       = 1;
+	prob_class["atom_special"]   = 1;
+	prob_class["class_range"]    = 1;
+	prob_class["class_hexrange"] = 1;
+
 	populate(prob_atom, d_atom);
 	populate(prob_op, d_op);
+	populate(prob_class, d_class);
 
 	num_terms = randint(max_terms)
 	if (num_terms == 0 && max_terms >= 1 && rand() > 0.1) {

--- a/fuzz/genregex
+++ b/fuzz/genregex
@@ -44,6 +44,17 @@ function print_char(c,    special) {
 	special["\f"] = "f";
 	special["\\"] = "\\";
 
+	if (dialect == "native" || dialect == "pcre") {
+		special["["]  = "[";
+		special["]"]  = "]";
+		special["("]  = "(";
+		special[")"]  = ")";
+		special["|"]  = "|";
+		special["+"]  = "+";
+		special["?"]  = "?";
+		special["*"]  = "*";
+	}
+
 	if (c in special) {
 		printf("\\%s", special[c]);
 		return;
@@ -77,6 +88,8 @@ function atom_class() {
 	if (rand() < prob_not) {
 		printf("^");
 	}
+
+	delete class;
 
 	num_class = randint(max_class)
 
@@ -132,27 +145,107 @@ function op_mn() {
 	printf("{%u,%u}", randint(max_m), max_m + randint(max_n - max_m));
 }
 
-function class_char(c) {
-	c = randchar(0);
+function class_unique_char() {
+	if (length(class) == 256) {
+		return;
+	}
+
+	do {
+		c = randchar(0);
+	} while (c in class);
+
+	class[c] = c;
+
 	print_char(c);
 }
 
-function class_hex() {
-	c = randchar(0);
+function class_unique_hex() {
+	if (length(class) == 256) {
+		return;
+	}
+
+	do {
+		c = randchar(0);
+	} while (c in class);
+
+	class[c] = c;
+
 	print_hex(c);
 }
 
-function class_range(    m, n) {
-	m = randchar(0);
+function class_unique_range(    m, n, c) {
+	if (length(class) == 256) {
+		return;
+	}
+
+	do {
+		m = randchar(0);
+	} while (m in class);
+
 	n = randchar(m);
+
+	for (c = m; c < n; c++) {
+		if (c in class) {
+			n = c - 1;
+			break;
+		}
+
+		class[c] = c;
+	}
+
 	print_char(m);
 	printf("-");
 	print_char(n);
 }
 
-function class_hexrange(    c) {
+function class_unique_hexrange(    c) {
+	if (length(class) == 256) {
+		return;
+	}
+
+	do {
+		m = randchar(0);
+	} while (m in class);
+
+	n = randchar(m);
+
+	for (c = m; c < n; c++) {
+		if (c in class) {
+			n = c - 1;
+			break;
+		}
+
+		class[c] = c;
+	}
+
+	print_hex(m);
+	printf("-");
+	print_hex(n);
+}
+
+function class_nonunique_char() {
+	c = randchar(0);
+	print_char(c);
+}
+
+function class_nonunique_hex() {
+	c = randchar(0);
+	print_hex(c);
+}
+
+function class_nonunique_range(    m, n, c) {
 	m = randchar(0);
 	n = randchar(m);
+
+	print_char(m);
+	printf("-");
+	print_char(n);
+}
+
+function class_nonunique_hexrange(    c) {
+	m = randchar(0);
+	n = randchar(m);
+
 	print_hex(m);
 	printf("-");
 	print_hex(n);
@@ -217,10 +310,15 @@ BEGIN {
 	prob_op["op_mx"]    = 1;
 	prob_op["op_mn"]    = 1;
 
-	prob_class["class_char"]     = 2;
-	prob_class["class_hex"]      = 1;
-	prob_class["class_range"]    = 1;
-	prob_class["class_hexrange"] = 1;
+	prob_class["class_unique_char"]     = 2;
+	prob_class["class_unique_hex"]      = 1;
+	prob_class["class_unique_range"]    = 1;
+	prob_class["class_unique_hexrange"] = 1;
+
+	prob_class["class_nonunique_char"]     = 2;
+	prob_class["class_nonunique_hex"]      = 1;
+	prob_class["class_nonunique_range"]    = 1;
+	prob_class["class_nonunique_hexrange"] = 1;
 
 	if (dialect == "literal") {
 		prob_alt = 0;
@@ -236,10 +334,18 @@ BEGIN {
 		delete prob_op["op_m"];
 		delete prob_op["op_mx"];
 		delete prob_op["op_mn"];
+
+		delete prob_class["class_nonunique_char"];
+		delete prob_class["class_nonunique_hex"];
+		delete prob_class["class_nonunique_range"];
+		delete prob_class["class_nonunique_hexrange"];
 	} else if (dialect == "native") {
 		delete prob_atom["atom_ncgroup"];
 	} else if (dialect == "pcre") {
-		# nothing to disable
+		delete prob_class["class_unique_char"];
+		delete prob_class["class_unique_hex"];
+		delete prob_class["class_unique_range"];
+		delete prob_class["class_unique_hexrange"];
 	} else {
 		printf("unsupported dialect: %s\n", dialect);
 		exit(2);

--- a/fuzz/genregex
+++ b/fuzz/genregex
@@ -1,7 +1,7 @@
 #!/usr/bin/awk -f
 
 function usage() {
-	print("gengraph <seed> <dialect> <max_terms> <max_class> <max_m> <max_n> <labels>\n");
+	print("genregex <seed> <dialect> <max_terms> <max_class> <max_m> <max_n> <labels>\n");
 	exit(1)
 }
 
@@ -137,6 +137,8 @@ function class_hexrange() {
 }
 
 function print_term() {
+	num_terms--; # fewer terms for deeper nesting
+
 	if (rand() < prob_alt) {
 		print_term();
 		printf("|");
@@ -146,11 +148,13 @@ function print_term() {
 
 	dispatch(d_atom);
 	dispatch(d_op);
+
+	num_terms++;
 }
 
 BEGIN {
 	def["seed"]      = 210881
-	def["dialect"]   = native
+	def["dialect"]   = "native"
 	def["max_terms"] = 50
 	def["max_class"] = 5
 	def["max_m"]     = 5

--- a/fuzz/genregex
+++ b/fuzz/genregex
@@ -1,7 +1,7 @@
 #!/usr/bin/awk -f
 
 function usage() {
-	print("genregex <seed> <dialect> <max_terms> <max_class> <max_m> <max_n> <labels>\n");
+	print("genregex <seed> <dialect> <max_atoms> <max_class> <max_m> <max_n> <labels>\n");
 	exit(1)
 }
 
@@ -86,13 +86,13 @@ function atom_class() {
 
 function atom_group() {
 	printf("(");
-	print_term();
+	print_atom();
 	printf(")");
 }
 
 function atom_ncgroup() {
 	printf("(?:");
-	print_term();
+	print_atom();
 	printf(")");
 }
 
@@ -136,26 +136,26 @@ function class_hexrange() {
 	print_hex(min);
 }
 
-function print_term() {
-	num_terms--; # fewer terms for deeper nesting
+function print_atom() {
+	num_atoms--; # fewer terms for deeper nesting
 
 	if (rand() < prob_alt) {
-		print_term();
+		print_atom();
 		printf("|");
-		print_term();
+		print_atom();
 		return;
 	}
 
 	dispatch(d_atom);
 	dispatch(d_op);
 
-	num_terms++;
+	num_atoms++;
 }
 
 BEGIN {
 	def["seed"]      = 210881
 	def["dialect"]   = "native"
-	def["max_terms"] = 50
+	def["max_atoms"] = 50
 	def["max_class"] = 5
 	def["max_m"]     = 5
 	def["max_n"]     = 10
@@ -164,7 +164,7 @@ BEGIN {
 
 	seed      = shift_arg("seed") + 0
 	dialect   = shift_arg("dialect") ""
-	max_terms = shift_arg("max_terms") + 0
+	max_atoms = shift_arg("max_atoms") + 0
 	max_class = shift_arg("max_class") + 0
 	max_m     = shift_arg("max_m") + 0
 	max_n     = shift_arg("max_n") + 0
@@ -233,13 +233,13 @@ BEGIN {
 	populate(prob_op, d_op);
 	populate(prob_class, d_class);
 
-	num_terms = randint(max_terms)
-	if (num_terms == 0 && max_terms >= 1 && rand() > 0.1) {
-		num_terms = 1;
+	num_atoms = randint(max_atoms)
+	if (num_atoms == 0 && max_atoms >= 1 && rand() > 0.1) {
+		num_atoms = 1;
 	}
 
-	for (t = 0; t < num_terms; t++) {
-		print_term();
+	for (t = 0; t < num_atoms; t++) {
+		print_atom();
 	}
 }
 

--- a/fuzz/genregex
+++ b/fuzz/genregex
@@ -66,7 +66,7 @@ function atom_special() {
 function atom_class() {
 	printf("[");
 
-	if (rand() < 0.3) { # XXX: configurable
+	if (rand() < prob_not) {
 		printf("^");
 	}
 
@@ -137,7 +137,7 @@ function class_hexrange() {
 }
 
 function print_term() {
-	if (rand() < 0.2) { # XXX: configurable
+	if (rand() < prob_alt) {
 		print_term();
 		printf("|");
 		print_term();
@@ -156,6 +156,7 @@ BEGIN {
 	def["max_m"]     = 5
 	def["max_n"]     = 10
 	def["labels"]    = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+	# TODO: full characterset 0..UCHAR_MAX for labels; escape special characters
 
 	seed      = shift_arg("seed") + 0
 	dialect   = shift_arg("dialect") ""
@@ -164,6 +165,10 @@ BEGIN {
 	max_m     = shift_arg("max_m") + 0
 	max_n     = shift_arg("max_n") + 0
 	labels    = shift_arg("labels") ""
+
+	# XXX: make configurable
+	prob_alt = 0.2;
+	prob_not = 0.3;
 
 	if (max_n < max_m) {
 		max_n = max_n;
@@ -196,8 +201,23 @@ BEGIN {
 	prob_class["class_range"]    = 1;
 	prob_class["class_hexrange"] = 1;
 
-	if (dialect == "native") {
-		prob_atom["atom_ncgroup"] = 0;
+	if (dialect == "literal") {
+		prob_alt = 0;
+
+		delete prob_atom["atom_hex"];
+		delete prob_atom["atom_special"];
+		delete prob_atom["atom_class"];
+		delete prob_atom["atom_group"];
+		delete prob_atom["atom_ncgroup"];
+
+		delete prob_op["op_qmark"];
+		delete prob_op["op_plus"];
+		delete prob_op["op_star"];
+		delete prob_op["op_m"];
+		delete prob_op["op_mx"];
+		delete prob_op["op_mn"];
+	} else if (dialect == "native") {
+		delete prob_atom["atom_ncgroup"];
 	} else if (dialect == "pcre") {
 		# nothing to disable
 	} else {

--- a/fuzz/genregex
+++ b/fuzz/genregex
@@ -1,7 +1,7 @@
 #!/usr/bin/awk -f
 
 function usage() {
-	print("genregex <seed> <dialect> <max_atoms> <max_class> <max_m> <max_n> <labels>\n");
+	print("genregex <seed> <dialect> <max_atoms> <max_class> <max_m> <max_n>\n");
 	exit(1)
 }
 
@@ -13,6 +13,10 @@ function shift_arg(name) {
 
 function randint(x) {
 	return int(rand() * x)
+}
+
+function randchar(min) {
+	return min + randint(256 - min);
 }
 
 function populate(prob, d) {
@@ -32,35 +36,39 @@ function dispatch(d) {
 	@f();
 }
 
-# start is 1-based
-function print_char(labels, start) {
-	count = length(labels) - start - 1
-	li = start + randint(count)
-	printf("%c", substr(labels, li, 1));
-	return li;
+function print_char(c,    special) {
+	special["\n"] = "n";
+	special["\r"] = "r";
+	special["\t"] = "t";
+	special["\v"] = "v";
+	special["\f"] = "f";
+	special["\\"] = "\\";
+
+	if (c in special) {
+		printf("\\%s", special[c]);
+		return;
+	}
+
+	if (c < 32 || c > 127) {
+		print_hex(c);
+		return;
+	}
+
+	printf("%c", c);
 }
 
-# min is 0-based
-function print_hex(min) {
-	c = min + randint(256 - min);
+function print_hex(c) {
 	printf("\\x%02x", c);
-	return c;
 }
 
-function atom_char() {
-	print_char(labels, 1);
+function atom_char(    c) {
+	c = randchar(0);
+	print_char(c);
 }
 
-function atom_hex() {
-	print_hex(0);
-}
-
-function atom_special() {
-	s = "nrtvf\\";
-	count = length(s)
-	li = randint(count)
-	lbl = substr(s, li, 1)
-	printf("\\%s", lbl);
+function atom_hex(    c) {
+	c = randchar(0);
+	print_hex(c);
 }
 
 function atom_class() {
@@ -124,16 +132,30 @@ function op_mn() {
 	printf("{%u,%u}", randint(max_m), max_m + randint(max_n - max_m));
 }
 
-function class_range() {
-	min = print_char(labels, 1);
-	printf("-");
-	print_char(labels, min);
+function class_char(c) {
+	c = randchar(0);
+	print_char(c);
 }
 
-function class_hexrange() {
-	min = print_hex(0);
+function class_hex() {
+	c = randchar(0);
+	print_hex(c);
+}
+
+function class_range(    m, n) {
+	m = randchar(0);
+	n = randchar(m);
+	print_char(m);
 	printf("-");
-	print_hex(min);
+	print_char(n);
+}
+
+function class_hexrange(    c) {
+	m = randchar(0);
+	n = randchar(m);
+	print_hex(m);
+	printf("-");
+	print_hex(n);
 }
 
 function print_atom() {
@@ -159,8 +181,6 @@ BEGIN {
 	def["max_class"] = 5
 	def["max_m"]     = 5
 	def["max_n"]     = 10
-	def["labels"]    = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-	# TODO: full characterset 0..UCHAR_MAX for labels; escape special characters
 
 	seed      = shift_arg("seed") + 0
 	dialect   = shift_arg("dialect") ""
@@ -168,7 +188,6 @@ BEGIN {
 	max_class = shift_arg("max_class") + 0
 	max_m     = shift_arg("max_m") + 0
 	max_n     = shift_arg("max_n") + 0
-	labels    = shift_arg("labels") ""
 
 	# XXX: make configurable
 	prob_alt = 0.2;
@@ -186,7 +205,6 @@ BEGIN {
 
 	prob_atom["atom_char"]    = 3;
 	prob_atom["atom_hex"]     = 1;
-	prob_atom["atom_special"] = 1;
 	prob_atom["atom_class"]   = 1;
 	prob_atom["atom_group"]   = 1;
 	prob_atom["atom_ncgroup"] = 1;
@@ -199,9 +217,8 @@ BEGIN {
 	prob_op["op_mx"]    = 1;
 	prob_op["op_mn"]    = 1;
 
-	prob_class["atom_char"]      = 2;
-	prob_class["atom_hex"]       = 1;
-	prob_class["atom_special"]   = 1;
+	prob_class["class_char"]     = 2;
+	prob_class["class_hex"]      = 1;
 	prob_class["class_range"]    = 1;
 	prob_class["class_hexrange"] = 1;
 
@@ -209,7 +226,6 @@ BEGIN {
 		prob_alt = 0;
 
 		delete prob_atom["atom_hex"];
-		delete prob_atom["atom_special"];
 		delete prob_atom["atom_class"];
 		delete prob_atom["atom_group"];
 		delete prob_atom["atom_ncgroup"];

--- a/fuzz/genregex
+++ b/fuzz/genregex
@@ -1,0 +1,155 @@
+#!/usr/bin/awk -f
+
+function usage() {
+	print("gengraph <seed> <max_terms> <max_m> <max_n> <labels>\n");
+	exit(1)
+}
+
+function shift_arg(name) {
+	shift_arg_offset++
+	if (ARGV[shift_arg_offset] == "-h") { usage(); }
+	return (ARGC > shift_arg_offset ? ARGV[shift_arg_offset] : def[name])
+}
+
+function randint(x) {
+	return int(rand() * x)
+}
+
+function populate(prob, d) {
+	n = 0;
+	for (f in prob) {
+		for (i = 0; i < prob[f]; i++) {
+			d[n] = f;
+			n++;
+		}
+	}
+}
+
+function dispatch(d) {
+	count = length(d)
+	k = randint(count)
+	f = d[k];
+	@f();
+}
+
+function atom_char() {
+	count = length(labels)
+	li = randint(count)
+	lbl = substr(labels, li, 1)
+	printf("%c", lbl);
+}
+
+function atom_hex() {
+	printf("\\x%02x", randint(255));
+}
+
+function atom_special() {
+	s = "nrtvf\\";
+	count = length(s)
+	li = randint(count)
+	lbl = substr(s, li, 1)
+	printf("\\%s", lbl);
+}
+
+function atom_class() {
+	printf("[");
+	printf("TOD");
+	printf("]");
+}
+
+function atom_group() {
+	printf("(");
+	print_term();
+	printf(")");
+}
+
+function op_cat() {
+	printf("");
+}
+
+function op_qmark() {
+	printf("?");
+}
+
+function op_plus() {
+	printf("+");
+}
+
+function op_star() {
+	printf("*");
+}
+
+function op_m() {
+	printf("{%u}", randint(max_m));
+}
+
+function op_mx() {
+# TODO:	printf("{%u,}", randint(max_m));
+}
+
+function op_mn() {
+	printf("{%u,%u}", randint(max_m), max_m + randint(max_n - max_m));
+}
+
+function print_term() {
+	if (rand() < 0.2) {
+		print_term();
+		printf("|");
+		print_term();
+		return;
+	}
+
+	dispatch(d_atom);
+	dispatch(d_op);
+}
+
+BEGIN {
+	def["seed"]      = 210881
+	def["max_terms"] = 50
+	def["max_m"]     = 5
+	def["max_n"]     = 10
+	def["labels"]    = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+	seed      = shift_arg("seed") + 0
+	max_terms = shift_arg("max_terms") + 0
+	max_m     = shift_arg("max_m") + 0
+	max_n     = shift_arg("max_n") + 0
+	labels    = shift_arg("labels") ""
+
+	if (max_n < max_m) {
+		max_n = max_n;
+	}
+
+	srand(seed);
+
+	# relative probabilities
+	# TODO: override from argv
+	# TODO: different dialects would set some of these to 0
+
+	prob_atom["atom_char"]    = 3;
+	prob_atom["atom_hex"]     = 1;
+	prob_atom["atom_special"] = 1;
+	prob_atom["atom_class"]   = 1;
+	prob_atom["atom_group"]   = 1;
+
+	prob_op["op_cat"]   = 2;
+	prob_op["op_qmark"] = 1;
+	prob_op["op_plus"]  = 1;
+	prob_op["op_star"]  = 1;
+	prob_op["op_m"]     = 1;
+	prob_op["op_mx"]    = 1;
+	prob_op["op_mn"]    = 1;
+
+	populate(prob_atom, d_atom);
+	populate(prob_op, d_op);
+
+	num_terms = randint(max_terms)
+	if (num_terms == 0 && max_terms >= 1 && rand() > 0.1) {
+		num_terms = 1;
+	}
+
+	for (t = 0; t < num_terms; t++) {
+		print_term();
+	}
+}
+

--- a/fuzz/genregex
+++ b/fuzz/genregex
@@ -1,7 +1,7 @@
 #!/usr/bin/awk -f
 
 function usage() {
-	print("gengraph <seed> <max_terms> <max_class> <max_m> <max_n> <labels>\n");
+	print("gengraph <seed> <dialect> <max_terms> <max_class> <max_m> <max_n> <labels>\n");
 	exit(1)
 }
 
@@ -90,6 +90,12 @@ function atom_group() {
 	printf(")");
 }
 
+function atom_ncgroup() {
+	printf("(?:");
+	print_term();
+	printf(")");
+}
+
 function op_cat() {
 	printf("");
 }
@@ -144,6 +150,7 @@ function print_term() {
 
 BEGIN {
 	def["seed"]      = 210881
+	def["dialect"]   = native
 	def["max_terms"] = 50
 	def["max_class"] = 5
 	def["max_m"]     = 5
@@ -151,6 +158,7 @@ BEGIN {
 	def["labels"]    = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
 	seed      = shift_arg("seed") + 0
+	dialect   = shift_arg("dialect") ""
 	max_terms = shift_arg("max_terms") + 0
 	max_class = shift_arg("max_class") + 0
 	max_m     = shift_arg("max_m") + 0
@@ -172,6 +180,7 @@ BEGIN {
 	prob_atom["atom_special"] = 1;
 	prob_atom["atom_class"]   = 1;
 	prob_atom["atom_group"]   = 1;
+	prob_atom["atom_ncgroup"] = 1;
 
 	prob_op["op_cat"]   = 2;
 	prob_op["op_qmark"] = 1;
@@ -186,6 +195,15 @@ BEGIN {
 	prob_class["atom_special"]   = 1;
 	prob_class["class_range"]    = 1;
 	prob_class["class_hexrange"] = 1;
+
+	if (dialect == "native") {
+		prob_atom["atom_ncgroup"] = 0;
+	} else if (dialect == "pcre") {
+		# nothing to disable
+	} else {
+		printf("unsupported dialect: %s\n", dialect);
+		exit(2);
+	}
 
 	populate(prob_atom, d_atom);
 	populate(prob_op, d_op);


### PR DESCRIPTION
These scripts are intended for benchmarking, not for finding crashes or debugging. (Theft makes more sense for that, especially because it can shrink cases). So the output here for both regexps and lx syntax should always be syntatically valid, but may be rejected for other reasons (for instance, token mappings conflict, or a start state accepts).

The CLI parameters are:
```
print("genregex <seed> <dialect> <max_atoms> <max_class> <max_m> <max_n> <labels>\n");
print("genlx <seed> <max_things> <max_atoms> <zone_limit>\n");
```

The `<max_atoms>` term sets an limit for the number of atoms in a regexp; the actual number is picked randomly, up to (approximately) that limit:
```
; for i in 1 5 10 20 30; do ./genregex $RANDOM native $i; echo; done
\n
[\t]K|n|Q|[K-YU]?|\x3c
\x04{1,7}
I|M\r?q(X){4}Y{4,8}x{3,8}(d+)G?\n
O*|(\x8c?)|[\xe4-\xf3]?f{1,5}\n\n{0}|\tH{3}
```
For `genlx`, the number of zones has a hard limit set by `<zone_limit>`. This can be `0`, to generate an lx file with no zones:
```
; ./genlx $RANDOM 5 5 0
# seed = 32664
# max_things = 5
# max_atoms  = 5
# zone_limit = 0

("EBi"+)? ('KFY')* -> $t47;
/(\r?)O?/ ^/t[G]+x/ -> $t42;
v17 = "kDsY" 'e' 'R' "T";
"oNm" 'xaW' /[^\r]{3,8}(([E]|\xbd?){2,6})[^U-g]/ !^^~'K' -> $t15;
```
So you can benchmark in various dimensions:
```
; ./genlx $RANDOM 50 20 0 # no zones, many things, long regexps
; ./genlx $RANDOM 20 1 100 # lots of nested zones, simple regexps
; ./genlx $RANDOM 10 20 100 # not so many zones; long regexps
; ./genlx $RANDOM 100 1 5 # very long zones, some nesting, 5 zones total. short regexps
; for i in {1..50}; ./genlx $RANDOM 10 1 1 # 50 adjacent zones, not nested
```