### PR TITLE
VCG output

### DIFF
--- a/include/fsm/print.h
+++ b/include/fsm/print.h
@@ -22,6 +22,7 @@ struct fsm;
  *  fsm_print_ir     - Codegen IR as Dot
  *  fsm_print_irjson - Codegen IR as JSON
  *  fsm_print_json   - JavaScript Object Notation
+ *  fsm_print_vcg    - VCG format, intended for rendering graphically
  *
  * The output options may be NULL, indicating to use defaults.
  *
@@ -38,6 +39,7 @@ fsm_print fsm_print_fsm;
 fsm_print fsm_print_ir;
 fsm_print fsm_print_irjson;
 fsm_print fsm_print_json;
+fsm_print fsm_print_vcg;
 
 #endif
 

--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -116,7 +116,8 @@ print_name(const char *name)
 		{ "dot",  fsm_print_dot  },
 		{ "fsm",  fsm_print_fsm  },
 		{ "ir",   fsm_print_ir   },
-		{ "json", fsm_print_json }
+		{ "json", fsm_print_json },
+		{ "vcg",  fsm_print_vcg  }
 	};
 
 	assert(name != NULL);

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -33,6 +33,7 @@ fsm_print_fsm
 fsm_print_ir
 fsm_print_irjson
 fsm_print_json
+fsm_print_vcg
 
 # <fsm/fsm.h>
 fsm_clone

--- a/src/libfsm/print/Makefile
+++ b/src/libfsm/print/Makefile
@@ -8,6 +8,7 @@ SRC += src/libfsm/print/ir.c
 SRC += src/libfsm/print/irdot.c
 SRC += src/libfsm/print/irjson.c
 SRC += src/libfsm/print/json.c
+SRC += src/libfsm/print/vcg.c
 
 .for src in ${SRC:Msrc/libfsm/print/*.c}
 CFLAGS.${src} += -I src # XXX: for internal.h

--- a/src/libfsm/print/vcg.c
+++ b/src/libfsm/print/vcg.c
@@ -1,0 +1,268 @@
+/*
+ * Copyright 2008-2017 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <limits.h>
+
+#include "libfsm/internal.h" /* XXX: up here for bitmap.h */
+
+#include <print/esc.h>
+
+#include <adt/set.h>
+#include <adt/bitmap.h>
+
+#include <fsm/fsm.h>
+#include <fsm/pred.h>
+#include <fsm/print.h>
+#include <fsm/options.h>
+
+static unsigned
+indexof(const struct fsm *fsm, const struct fsm_state *state)
+{
+	struct fsm_state *s;
+	unsigned int i;
+
+	assert(fsm != NULL);
+	assert(state != NULL);
+
+	for (s = fsm->sl, i = 0; s != NULL; s = s->next, i++) {
+		if (s == state) {
+			return i;
+		}
+	}
+
+	assert(!"unreached");
+	return 0;
+}
+
+/* Return true if the edges after o contains state */
+/* TODO: centralise */
+static int
+contains(struct set *edges, int o, struct fsm_state *state)
+{
+	struct fsm_edge *e, search;
+	struct set_iter it;
+
+	assert(edges != NULL);
+	assert(state != NULL);
+
+	search.symbol = o;
+	for (e = set_firstafter(edges, &it, &search); e != NULL; e = set_next(&it)) {
+		if (e->symbol > UCHAR_MAX) {
+			return 0;
+		}
+
+		if (set_contains(e->sl, state)) {
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+static void
+singlestate(FILE *f, const struct fsm *fsm, struct fsm_state *s)
+{
+	struct fsm_edge *e, search;
+	struct set_iter it;
+
+	assert(f != NULL);
+	assert(fsm != NULL);
+	assert(fsm->opt != NULL);
+	assert(s != NULL);
+
+	if (fsm->opt->anonymous_states) {
+		fprintf(f, "\tnode: { title:\"%u\" label: \" \" shape: ellipse }\n",
+			indexof(fsm, s));
+	} else {
+		fprintf(f, "\tnode: { title:\"%u\" shape: ellipse }\n",
+			indexof(fsm, s));
+	}
+
+#if 0
+		if (fsm_isend(fsm, s)) {
+			fprintf(f, "\t%s%u [ shape = doublecircle ];\n",
+				fsm->opt->prefix != NULL ? fsm->opt->prefix : "",
+				indexof(fsm, s));
+		}
+#endif
+
+	if (!fsm->opt->consolidate_edges) {
+		for (e = set_first(s->edges, &it); e != NULL; e = set_next(&it)) {
+			struct fsm_state *st;
+			struct set_iter jt;
+
+			for (st = set_first(e->sl, &jt); st != NULL; st = set_next(&jt)) {
+				assert(st != NULL);
+
+				fprintf(f, "\tedge: { sourcename: \"%u\" targetname: \"%u\" label = \"",
+					indexof(fsm, s),
+					indexof(fsm, st));
+
+				if (e->symbol <= UCHAR_MAX) {
+					dot_escputc_html(f, fsm->opt, e->symbol);
+				} else if (e->symbol == FSM_EDGE_EPSILON) {
+					fputs("&#x3B5;", f);
+				} else {
+					assert(!"unrecognised special edge");
+					abort();
+				}
+
+				fprintf(f, "\" }\n");
+			}
+		}
+
+		return;
+	}
+
+	/*
+	 * The consolidate_edges option is an aesthetic optimisation.
+	 * For a state which has multiple edges all transitioning to the same state,
+	 * all these edges are combined into a single edge, labelled with a more
+	 * concise form of all their values.
+	 *
+	 * To implement this, we loop through all unique states, rather than
+	 * looping through each edge.
+	 */
+	/* TODO: handle special edges upto FSM_EDGE_MAX separately */
+	for (e = set_first(s->edges, &it); e != NULL; e = set_next(&it)) {
+		struct fsm_state *st;
+		struct set_iter jt;
+
+		if (e->symbol > UCHAR_MAX) {
+			break;
+		}
+
+		for (st = set_first(e->sl, &jt); st != NULL; st = set_next(&jt)) {
+			struct fsm_edge *ne;
+			struct set_iter kt;
+			struct bm bm;
+
+			assert(st != NULL);
+
+			/* unique states only */
+			if (contains(s->edges, e->symbol, st)) {
+				continue;
+			}
+
+			bm_clear(&bm);
+
+			/* find all edges which go from this state to the same target state */
+			for (ne = set_first(s->edges, &kt); ne != NULL; ne = set_next(&kt)) {
+				if (ne->symbol > UCHAR_MAX) {
+					break;
+				}
+
+				if (set_contains(ne->sl, st)) {
+					bm_set(&bm, ne->symbol);
+				}
+			}
+
+			fprintf(f, "\tedge: { sourcename: \"%u\" targetname: \"%u\" ",
+				indexof(fsm, s),
+				indexof(fsm, st));
+
+#if 0
+			if (bm_count(&bm) > 4) {
+				fprintf(f, "weight = 3, ");
+			}
+#endif
+
+			fprintf(f, "label: \"");
+
+			(void) bm_print(f, fsm->opt, &bm, 0, dot_escputc_html);
+
+			fprintf(f, "\" }\n");
+		}
+	}
+
+	/*
+	 * Special edges are not consolidated above
+	 */
+	search.symbol = UCHAR_MAX;
+	for (e = set_firstafter(s->edges, &it, &search); e != NULL; e = set_next(&it)) {
+		struct fsm_state *st;
+		struct set_iter jt;
+
+		for (st = set_first(e->sl, &jt); st != NULL; st = set_next(&jt)) {
+			fprintf(f, "\tedge: { sourcename: \"%u\" targetname: \"%u\" label: \"",
+				fsm->opt->prefix != NULL ? fsm->opt->prefix : "",
+				indexof(fsm, s),
+				fsm->opt->prefix != NULL ? fsm->opt->prefix : "",
+				indexof(fsm, st));
+
+			assert(e->symbol > UCHAR_MAX);
+			if (e->symbol == FSM_EDGE_EPSILON) {
+				fputs("&#x3B5;", f);
+			} else {
+				assert(!"unrecognised special edge");
+				abort();
+			}
+
+			fprintf(f, "\" }\n");
+		}
+	}
+}
+
+static void
+print_vcgfrag(FILE *f, const struct fsm *fsm)
+{
+	struct fsm_state *s;
+
+	assert(f != NULL);
+	assert(fsm != NULL);
+	assert(fsm->opt != NULL);
+
+	for (s = fsm->sl; s != NULL; s = s->next) {
+		singlestate(f, fsm, s);
+	}
+}
+
+void
+fsm_print_vcg(FILE *f, const struct fsm *fsm)
+{
+	struct fsm_state *start;
+
+	assert(f != NULL);
+	assert(fsm != NULL);
+	assert(fsm->opt != NULL);
+
+	if (fsm->opt->fragment) {
+		print_vcgfrag(f, fsm);
+		return;
+	}
+
+	fprintf(f, "graph: {\n");
+
+	fprintf(f, "\tlayoutalgorithm: minbackward\n");
+	fprintf(f, "\tdisplay_edge_labels: yes\n");
+	fprintf(f, "\tsplines: yes\n");
+	fprintf(f, "\tsplinefactor: 2\n");
+	fprintf(f, "\torientation: left_to_right\n");
+	fprintf(f, "\tnode_alignment: center\n");
+	fprintf(f, "\tdirty_edge_labels: yes\n");
+	fprintf(f, "\n");
+
+#if 0
+	fprintf(f, "\tstart [ shape = none, label = \"\" ];\n");
+
+	start = fsm_getstart(fsm);
+	fprintf(f, "\tstart -> %s%u;\n",
+		fsm->opt->prefix != NULL ? fsm->opt->prefix : "",
+		 start != NULL ? indexof(fsm, start) : 0U);
+
+	fprintf(f, "\n");
+#endif
+
+	print_vcgfrag(f, fsm);
+
+	fprintf(f, "}\n");
+	fprintf(f, "\n");
+}
+

--- a/src/libre/dialect/glob/parser.c
+++ b/src/libre/dialect/glob/parser.c
@@ -512,13 +512,15 @@ ZL0:;
 		return lex_state->f(lex_state->opaque);
 	}
 
-	static int
-	parse(re_getchar_fun *f, void *opaque,
-		void (*entry)(flags, lex_state, act_state, err,
-			struct ast_expr **),
-		struct flags *flags, int overlap,
-		struct ast_re *new, struct re_err *err)
+	struct ast_re *
+	DIALECT_PARSE(re_getchar_fun *f, void *opaque,
+		const struct fsm_options *opt,
+		enum re_flags flags, int overlap,
+		struct re_err *err)
 	{
+		struct ast_re *ast;
+		struct flags top, *fl = &top;
+
 		struct act_state  act_state_s;
 		struct act_state *act_state;
 		struct lex_state  lex_state_s;
@@ -527,8 +529,11 @@ ZL0:;
 
 		struct LX_STATE *lx;
 
+		top.flags = flags;
+
 		assert(f != NULL);
-		assert(entry != NULL);
+
+		ast = re_ast_new();
 
 		if (err == NULL) {
 			err = &dummy;
@@ -565,7 +570,7 @@ ZL0:;
 		err->e = RE_ESUCCESS;
 
 		ADVANCE_LEXER;
-		entry(flags, lex_state, act_state, err, &new->expr);
+		DIALECT_ENTRY(fl, lex_state, act_state, err, &ast->expr);
 
 		lx->free(lx->buf_opaque);
 
@@ -574,7 +579,14 @@ ZL0:;
 			goto error;
 		}
 
-		return 0;
+		if (ast->expr == NULL) {
+			/* We shouldn't get here, it means there's error
+			 * checking missing elsewhere. */
+			if (err->e == RE_ESUCCESS) { assert(0); }
+			goto error;
+		}
+
+		return ast;
 
 	error:
 
@@ -621,43 +633,11 @@ ZL0:;
 			break;
 		}
 
-		return -1;
-	}
-
-	struct ast_re *
-	DIALECT_PARSE(re_getchar_fun *f, void *opaque,
-		const struct fsm_options *opt,
-		enum re_flags flags, int overlap,
-		struct re_err *err)
-	{
-		struct ast_re *ast;
-		struct flags top, *fl = &top;
-
-		top.flags = flags;
-
-		assert(f != NULL);
-
-		ast = re_ast_new();
-
-		if (-1 == parse(f, opaque, DIALECT_ENTRY, fl, overlap, ast, err)) {
-			goto error;
-		}
-
-		if (ast->expr == NULL) {
-			/* We shouldn't get here, it means there's error
-			 * checking missing elsewhere. */
-			if (err->e == RE_ESUCCESS) { assert(0); }
-			goto error;
-		}
-
-		return ast;
-
-	error:
 		re_ast_free(ast);
 
 		return NULL;
 	}
 
-#line 662 "src/libre/dialect/glob/parser.c"
+#line 642 "src/libre/dialect/glob/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/glob/parser.h
+++ b/src/libre/dialect/glob/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__glob(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 946 "src/libre/parser.act"
+#line 926 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/glob/parser.h"

--- a/src/libre/dialect/like/parser.c
+++ b/src/libre/dialect/like/parser.c
@@ -512,13 +512,15 @@ ZL0:;
 		return lex_state->f(lex_state->opaque);
 	}
 
-	static int
-	parse(re_getchar_fun *f, void *opaque,
-		void (*entry)(flags, lex_state, act_state, err,
-			struct ast_expr **),
-		struct flags *flags, int overlap,
-		struct ast_re *new, struct re_err *err)
+	struct ast_re *
+	DIALECT_PARSE(re_getchar_fun *f, void *opaque,
+		const struct fsm_options *opt,
+		enum re_flags flags, int overlap,
+		struct re_err *err)
 	{
+		struct ast_re *ast;
+		struct flags top, *fl = &top;
+
 		struct act_state  act_state_s;
 		struct act_state *act_state;
 		struct lex_state  lex_state_s;
@@ -527,8 +529,11 @@ ZL0:;
 
 		struct LX_STATE *lx;
 
+		top.flags = flags;
+
 		assert(f != NULL);
-		assert(entry != NULL);
+
+		ast = re_ast_new();
 
 		if (err == NULL) {
 			err = &dummy;
@@ -565,7 +570,7 @@ ZL0:;
 		err->e = RE_ESUCCESS;
 
 		ADVANCE_LEXER;
-		entry(flags, lex_state, act_state, err, &new->expr);
+		DIALECT_ENTRY(fl, lex_state, act_state, err, &ast->expr);
 
 		lx->free(lx->buf_opaque);
 
@@ -574,7 +579,14 @@ ZL0:;
 			goto error;
 		}
 
-		return 0;
+		if (ast->expr == NULL) {
+			/* We shouldn't get here, it means there's error
+			 * checking missing elsewhere. */
+			if (err->e == RE_ESUCCESS) { assert(0); }
+			goto error;
+		}
+
+		return ast;
 
 	error:
 
@@ -621,43 +633,11 @@ ZL0:;
 			break;
 		}
 
-		return -1;
-	}
-
-	struct ast_re *
-	DIALECT_PARSE(re_getchar_fun *f, void *opaque,
-		const struct fsm_options *opt,
-		enum re_flags flags, int overlap,
-		struct re_err *err)
-	{
-		struct ast_re *ast;
-		struct flags top, *fl = &top;
-
-		top.flags = flags;
-
-		assert(f != NULL);
-
-		ast = re_ast_new();
-
-		if (-1 == parse(f, opaque, DIALECT_ENTRY, fl, overlap, ast, err)) {
-			goto error;
-		}
-
-		if (ast->expr == NULL) {
-			/* We shouldn't get here, it means there's error
-			 * checking missing elsewhere. */
-			if (err->e == RE_ESUCCESS) { assert(0); }
-			goto error;
-		}
-
-		return ast;
-
-	error:
 		re_ast_free(ast);
 
 		return NULL;
 	}
 
-#line 662 "src/libre/dialect/like/parser.c"
+#line 642 "src/libre/dialect/like/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/like/parser.h
+++ b/src/libre/dialect/like/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__like(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 946 "src/libre/parser.act"
+#line 926 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/like/parser.h"

--- a/src/libre/dialect/literal/parser.h
+++ b/src/libre/dialect/literal/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__literal(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 946 "src/libre/parser.act"
+#line 926 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/literal/parser.h"

--- a/src/libre/dialect/native/parser.c
+++ b/src/libre/dialect/native/parser.c
@@ -2124,13 +2124,15 @@ ZL0:;
 		return lex_state->f(lex_state->opaque);
 	}
 
-	static int
-	parse(re_getchar_fun *f, void *opaque,
-		void (*entry)(flags, lex_state, act_state, err,
-			struct ast_expr **),
-		struct flags *flags, int overlap,
-		struct ast_re *new, struct re_err *err)
+	struct ast_re *
+	DIALECT_PARSE(re_getchar_fun *f, void *opaque,
+		const struct fsm_options *opt,
+		enum re_flags flags, int overlap,
+		struct re_err *err)
 	{
+		struct ast_re *ast;
+		struct flags top, *fl = &top;
+
 		struct act_state  act_state_s;
 		struct act_state *act_state;
 		struct lex_state  lex_state_s;
@@ -2139,8 +2141,11 @@ ZL0:;
 
 		struct LX_STATE *lx;
 
+		top.flags = flags;
+
 		assert(f != NULL);
-		assert(entry != NULL);
+
+		ast = re_ast_new();
 
 		if (err == NULL) {
 			err = &dummy;
@@ -2177,7 +2182,7 @@ ZL0:;
 		err->e = RE_ESUCCESS;
 
 		ADVANCE_LEXER;
-		entry(flags, lex_state, act_state, err, &new->expr);
+		DIALECT_ENTRY(fl, lex_state, act_state, err, &ast->expr);
 
 		lx->free(lx->buf_opaque);
 
@@ -2186,7 +2191,14 @@ ZL0:;
 			goto error;
 		}
 
-		return 0;
+		if (ast->expr == NULL) {
+			/* We shouldn't get here, it means there's error
+			 * checking missing elsewhere. */
+			if (err->e == RE_ESUCCESS) { assert(0); }
+			goto error;
+		}
+
+		return ast;
 
 	error:
 
@@ -2233,43 +2245,11 @@ ZL0:;
 			break;
 		}
 
-		return -1;
-	}
-
-	struct ast_re *
-	DIALECT_PARSE(re_getchar_fun *f, void *opaque,
-		const struct fsm_options *opt,
-		enum re_flags flags, int overlap,
-		struct re_err *err)
-	{
-		struct ast_re *ast;
-		struct flags top, *fl = &top;
-
-		top.flags = flags;
-
-		assert(f != NULL);
-
-		ast = re_ast_new();
-
-		if (-1 == parse(f, opaque, DIALECT_ENTRY, fl, overlap, ast, err)) {
-			goto error;
-		}
-
-		if (ast->expr == NULL) {
-			/* We shouldn't get here, it means there's error
-			 * checking missing elsewhere. */
-			if (err->e == RE_ESUCCESS) { assert(0); }
-			goto error;
-		}
-
-		return ast;
-
-	error:
 		re_ast_free(ast);
 
 		return NULL;
 	}
 
-#line 2274 "src/libre/dialect/native/parser.c"
+#line 2254 "src/libre/dialect/native/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/native/parser.h
+++ b/src/libre/dialect/native/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__native(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 946 "src/libre/parser.act"
+#line 926 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/native/parser.h"

--- a/src/libre/dialect/pcre/parser.c
+++ b/src/libre/dialect/pcre/parser.c
@@ -2826,13 +2826,15 @@ ZL0:;
 		return lex_state->f(lex_state->opaque);
 	}
 
-	static int
-	parse(re_getchar_fun *f, void *opaque,
-		void (*entry)(flags, lex_state, act_state, err,
-			struct ast_expr **),
-		struct flags *flags, int overlap,
-		struct ast_re *new, struct re_err *err)
+	struct ast_re *
+	DIALECT_PARSE(re_getchar_fun *f, void *opaque,
+		const struct fsm_options *opt,
+		enum re_flags flags, int overlap,
+		struct re_err *err)
 	{
+		struct ast_re *ast;
+		struct flags top, *fl = &top;
+
 		struct act_state  act_state_s;
 		struct act_state *act_state;
 		struct lex_state  lex_state_s;
@@ -2841,8 +2843,11 @@ ZL0:;
 
 		struct LX_STATE *lx;
 
+		top.flags = flags;
+
 		assert(f != NULL);
-		assert(entry != NULL);
+
+		ast = re_ast_new();
 
 		if (err == NULL) {
 			err = &dummy;
@@ -2879,7 +2884,7 @@ ZL0:;
 		err->e = RE_ESUCCESS;
 
 		ADVANCE_LEXER;
-		entry(flags, lex_state, act_state, err, &new->expr);
+		DIALECT_ENTRY(fl, lex_state, act_state, err, &ast->expr);
 
 		lx->free(lx->buf_opaque);
 
@@ -2888,7 +2893,14 @@ ZL0:;
 			goto error;
 		}
 
-		return 0;
+		if (ast->expr == NULL) {
+			/* We shouldn't get here, it means there's error
+			 * checking missing elsewhere. */
+			if (err->e == RE_ESUCCESS) { assert(0); }
+			goto error;
+		}
+
+		return ast;
 
 	error:
 
@@ -2935,43 +2947,11 @@ ZL0:;
 			break;
 		}
 
-		return -1;
-	}
-
-	struct ast_re *
-	DIALECT_PARSE(re_getchar_fun *f, void *opaque,
-		const struct fsm_options *opt,
-		enum re_flags flags, int overlap,
-		struct re_err *err)
-	{
-		struct ast_re *ast;
-		struct flags top, *fl = &top;
-
-		top.flags = flags;
-
-		assert(f != NULL);
-
-		ast = re_ast_new();
-
-		if (-1 == parse(f, opaque, DIALECT_ENTRY, fl, overlap, ast, err)) {
-			goto error;
-		}
-
-		if (ast->expr == NULL) {
-			/* We shouldn't get here, it means there's error
-			 * checking missing elsewhere. */
-			if (err->e == RE_ESUCCESS) { assert(0); }
-			goto error;
-		}
-
-		return ast;
-
-	error:
 		re_ast_free(ast);
 
 		return NULL;
 	}
 
-#line 2976 "src/libre/dialect/pcre/parser.c"
+#line 2956 "src/libre/dialect/pcre/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/pcre/parser.h
+++ b/src/libre/dialect/pcre/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__pcre(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 946 "src/libre/parser.act"
+#line 926 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/pcre/parser.h"

--- a/src/libre/dialect/sql/parser.c
+++ b/src/libre/dialect/sql/parser.c
@@ -1806,13 +1806,15 @@ ZL0:;
 		return lex_state->f(lex_state->opaque);
 	}
 
-	static int
-	parse(re_getchar_fun *f, void *opaque,
-		void (*entry)(flags, lex_state, act_state, err,
-			struct ast_expr **),
-		struct flags *flags, int overlap,
-		struct ast_re *new, struct re_err *err)
+	struct ast_re *
+	DIALECT_PARSE(re_getchar_fun *f, void *opaque,
+		const struct fsm_options *opt,
+		enum re_flags flags, int overlap,
+		struct re_err *err)
 	{
+		struct ast_re *ast;
+		struct flags top, *fl = &top;
+
 		struct act_state  act_state_s;
 		struct act_state *act_state;
 		struct lex_state  lex_state_s;
@@ -1821,8 +1823,11 @@ ZL0:;
 
 		struct LX_STATE *lx;
 
+		top.flags = flags;
+
 		assert(f != NULL);
-		assert(entry != NULL);
+
+		ast = re_ast_new();
 
 		if (err == NULL) {
 			err = &dummy;
@@ -1859,7 +1864,7 @@ ZL0:;
 		err->e = RE_ESUCCESS;
 
 		ADVANCE_LEXER;
-		entry(flags, lex_state, act_state, err, &new->expr);
+		DIALECT_ENTRY(fl, lex_state, act_state, err, &ast->expr);
 
 		lx->free(lx->buf_opaque);
 
@@ -1868,7 +1873,14 @@ ZL0:;
 			goto error;
 		}
 
-		return 0;
+		if (ast->expr == NULL) {
+			/* We shouldn't get here, it means there's error
+			 * checking missing elsewhere. */
+			if (err->e == RE_ESUCCESS) { assert(0); }
+			goto error;
+		}
+
+		return ast;
 
 	error:
 
@@ -1915,43 +1927,11 @@ ZL0:;
 			break;
 		}
 
-		return -1;
-	}
-
-	struct ast_re *
-	DIALECT_PARSE(re_getchar_fun *f, void *opaque,
-		const struct fsm_options *opt,
-		enum re_flags flags, int overlap,
-		struct re_err *err)
-	{
-		struct ast_re *ast;
-		struct flags top, *fl = &top;
-
-		top.flags = flags;
-
-		assert(f != NULL);
-
-		ast = re_ast_new();
-
-		if (-1 == parse(f, opaque, DIALECT_ENTRY, fl, overlap, ast, err)) {
-			goto error;
-		}
-
-		if (ast->expr == NULL) {
-			/* We shouldn't get here, it means there's error
-			 * checking missing elsewhere. */
-			if (err->e == RE_ESUCCESS) { assert(0); }
-			goto error;
-		}
-
-		return ast;
-
-	error:
 		re_ast_free(ast);
 
 		return NULL;
 	}
 
-#line 1956 "src/libre/dialect/sql/parser.c"
+#line 1936 "src/libre/dialect/sql/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/sql/parser.h
+++ b/src/libre/dialect/sql/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__sql(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 946 "src/libre/parser.act"
+#line 926 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/sql/parser.h"

--- a/src/libre/parser.act
+++ b/src/libre/parser.act
@@ -797,13 +797,15 @@
 		return lex_state->f(lex_state->opaque);
 	}
 
-	static int
-	parse(re_getchar_fun *f, void *opaque,
-		void (*entry)(flags, lex_state, act_state, err,
-			struct ast_expr **),
-		struct flags *flags, int overlap,
-		struct ast_re *new, struct re_err *err)
+	struct ast_re *
+	DIALECT_PARSE(re_getchar_fun *f, void *opaque,
+		const struct fsm_options *opt,
+		enum re_flags flags, int overlap,
+		struct re_err *err)
 	{
+		struct ast_re *ast;
+		struct flags top, *fl = &top;
+
 		struct act_state  act_state_s;
 		struct act_state *act_state;
 		struct lex_state  lex_state_s;
@@ -812,8 +814,11 @@
 
 		struct LX_STATE *lx;
 
+		top.flags = flags;
+
 		assert(f != NULL);
-		assert(entry != NULL);
+
+		ast = re_ast_new();
 
 		if (err == NULL) {
 			err = &dummy;
@@ -850,7 +855,7 @@
 		err->e = RE_ESUCCESS;
 
 		ADVANCE_LEXER;
-		entry(flags, lex_state, act_state, err, &new->expr);
+		DIALECT_ENTRY(fl, lex_state, act_state, err, &ast->expr);
 
 		lx->free(lx->buf_opaque);
 
@@ -859,7 +864,14 @@
 			goto error;
 		}
 
-		return 0;
+		if (ast->expr == NULL) {
+			/* We shouldn't get here, it means there's error
+			 * checking missing elsewhere. */
+			if (err->e == RE_ESUCCESS) { assert(0); }
+			goto error;
+		}
+
+		return ast;
 
 	error:
 
@@ -906,38 +918,6 @@
 			break;
 		}
 
-		return -1;
-	}
-
-	struct ast_re *
-	DIALECT_PARSE(re_getchar_fun *f, void *opaque,
-		const struct fsm_options *opt,
-		enum re_flags flags, int overlap,
-		struct re_err *err)
-	{
-		struct ast_re *ast;
-		struct flags top, *fl = &top;
-
-		top.flags = flags;
-
-		assert(f != NULL);
-
-		ast = re_ast_new();
-
-		if (-1 == parse(f, opaque, DIALECT_ENTRY, fl, overlap, ast, err)) {
-			goto error;
-		}
-
-		if (ast->expr == NULL) {
-			/* We shouldn't get here, it means there's error
-			 * checking missing elsewhere. */
-			if (err->e == RE_ESUCCESS) { assert(0); }
-			goto error;
-		}
-
-		return ast;
-
-	error:
 		re_ast_free(ast);
 
 		return NULL;

--- a/src/libre/print.h
+++ b/src/libre/print.h
@@ -19,5 +19,6 @@ re_ast_print re_ast_print_dot;
 re_ast_print re_ast_print_ebnf;
 re_ast_print re_ast_print_pcre;
 re_ast_print re_ast_print_tree;
+re_ast_print re_ast_print_vcg;
 
 #endif

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -102,6 +102,7 @@ print_name(const char *name,
 		{ "ir",     fsm_print_ir,     NULL  },
 		{ "irjson", fsm_print_irjson, NULL  },
 		{ "json",   fsm_print_json,   NULL  },
+		{ "vcg",    fsm_print_vcg,    NULL  },
 
 		{ "tree",   NULL, re_ast_print_tree },
 		{ "ebnf",   NULL, re_ast_print_ebnf },


### PR DESCRIPTION
This is a quick sketch of output for Georg Sander's VCG format. VCG is a tool for rendering graph datastructures, geared especially to showing diagrams for compiler use (ASTs and the like). However it doesn't quite suit FSM for rendering in the conventional diagramatic manner; I couldn't find a way to produce double circles for end states, for instance.

The output looks a little janky:
![x](https://user-images.githubusercontent.com/1371085/43584704-0f6ffe7e-965b-11e8-880e-e357e2ecc0a3.png)

I think I'm calling this inappropriate for rendering for visual purposes; VCG format _might_ serve as a graph description for serialising semantic content, but I don't think any other tools actually read its format. So I'm making this PR mostly to record the attempt. I don't see any reason to keep this.

I'd wondered if the layout algorithm might suit node placement, and then to use graphviz for edge drawing. I'm trying very hard to avoid implementing graph layout in libfsm itself. I think we should live with graphviz for now.

http://www.rw.cdl.uni-saarland.de/private/sander/html/gsvcg1.html