### PR TITLE
gvpr script to find max required lookahead for lx

### DIFF
--- a/share/bin/lookahead.gvpr
+++ b/share/bin/lookahead.gvpr
@@ -1,0 +1,125 @@
+#!/usr/bin/env gvpr
+
+BEGIN {
+	int accepts(node_t n) {
+		return strcmp(n.shape, "doublecircle") == 0;
+	}
+
+	int epsilon(edge_t e) {
+		return hasAttr(e, "style") && strcmp(e.style, "dashed") == 0;
+	}
+
+	string token_name(node_t n) {
+		if(index(n.label, "$") != 0)
+			return "discard";
+		return sub(n.label, "<*");
+	}
+
+	int lookahead[node_t];
+	edge_t next[node_t];
+	node_t longest_for_label[string];
+	int depth, maxdepth;
+	string l;
+	edge_t e;
+	node_t n;
+}
+
+BEG_G {
+	unset(lookahead);
+	unset(next);
+	unset(longest_for_label);
+
+	$tvroot = node($, "start");
+	$tvtype = TV_postfwd;
+}
+
+N {
+	maxdepth = 0;
+	for(e = fstout($); e; e = nxtout(e)) {
+		if(epsilon(e)) {
+			// transitioning between zones always commits to the
+			// previous accepting state first, so no lookahead is
+			// required after that
+			continue;
+		} else if(accepts(e.head)) {
+			// when transitioning to an accepting state, ignore any
+			// lookahead that might be required after that state
+			depth = 0;
+		} else if(e.head in lookahead) {
+			// since this is a post-order traversal, we've already
+			// visited all the out-edges of this node, unless one
+			// of them is a back-edge, in which case we have a
+			// cycle
+			depth = lookahead[e.head];
+		} else {
+			depth = -1;
+		}
+
+		if(depth < 0) {
+			maxdepth = -1;
+			unset(next, $);
+			break;
+		}
+
+		// add one for the edge we traversed to reach a node that had
+		// the given depth
+		++depth;
+
+		if(depth > maxdepth) {
+			maxdepth = depth;
+			next[$] = e;
+		}
+	}
+
+	lookahead[$] = maxdepth;
+
+	if(maxdepth && accepts($)) {
+		l = token_name($);
+		if(!(l in longest_for_label) || lookahead[longest_for_label[l]] < maxdepth)
+			longest_for_label[l] = $;
+	}
+}
+
+END_G {
+	maxdepth = 0;
+	for(longest_for_label[l]) {
+		n = longest_for_label[l];
+		depth = lookahead[n];
+
+		if(depth < 0)
+			continue;
+
+		if(!maxdepth)
+			printf("after accepting, a longest pattern leading to another accept is:\n");
+
+		if(maxdepth >= 0 && depth > maxdepth)
+			maxdepth = depth;
+
+		printf("- %s ", l);
+		for(e = next[n]; ; e = next[e.head]) {
+			if(strcmp(e.label, "\\") == 0)
+				printf("\\\\");
+			else
+				printf("%s", gsub(gsub(e.label, "\\&#x2423;", " "), "\\&quot;", '"'));
+			if(accepts(e.head)) {
+				printf(" %s", token_name(e.head));
+				break;
+			}
+		}
+		printf("\n");
+	}
+
+	for(longest_for_label[l]) {
+		if(lookahead[longest_for_label[l]] >= 0)
+			continue;
+
+		if(maxdepth >= 0)
+			printf("unbounded lookahead required after these tokens:\n");
+
+		maxdepth = -1;
+		printf("- %s\n", l);
+	}
+
+	if(maxdepth >= 0)
+		printf("requires %d characters of lookahead\n", maxdepth);
+}


### PR DESCRIPTION
This script analyzes the output of `lx -l dot` to compute how much input a lexer must be able to buffer after reaching an accepting state before it can determine whether there's a longer match that it should return instead. I wrote it to investigate issue #111 but I think it's a useful analysis in its own right.

Sample output from the `lx` examples:

```
$ for f in examples/lx/*.lx; do echo "$f:"; build/bin/lx -l dot < "$f" | gvpr -f share/bin/lookahead.gvpr; echo; done
examples/lx/act.lx:
after accepting, a longest pattern leading to another accept is:
- $act_assign [A-Z_a-z] $act_assign
- $act_ident [A-Z_a-z] $act_ident
- $act_label [A-Z_a-z] $act_label
- $act_ref [A-Z_a-z] $act_ref
- $act_str [^@] $act_str
- $act_token [A-Z_a-z] $act_token
- $ident [-A-Z_a-z] $ident
- discard [\t\n ] discard
requires 1 characters of lookahead

examples/lx/a.lx:
after accepting, a longest pattern leading to another accept is:
- $a bc $token
- $int [0-9] $int
- $str_char 0[0-9] $str_octal
- $str_octal [0-9] $str_octal
- discard / discard
unbounded lookahead required after these tokens:
- $string

examples/lx/c11-pp.lx:
after accepting, a longest pattern leading to another accept is:
- $chr / $block_comment_end
- $escape_hex [0-9A-Fa-f] $escape_hex
- $escape_octal [0-7] $escape_octal
- $identifier \\U[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f] $identifier
- $newline \n $newline
- $other U[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f] $identifier
- $pp_number \\U[0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f][0-9A-Fa-f] $pp_number
- $punctuator %: $punctuator
- $whitespace [\t\v\f ] $whitespace
requires 10 characters of lookahead

examples/lx/c90-pp.lx:
ambiguous mappings to $q_char_sequence, $h_char_sequence; for example on input '<a'
ambiguous mappings to $h_char_sequence, $q_char_sequence; for example on input '<a>'
after accepting, a longest pattern leading to another accept is:
- $h_char_sequence [!"#%-=?A-Z\-_a-z|}~] $h_char_sequence
- $q_char_sequence [!#%-?A-Z\-_a-z|}~] $q_char_sequence
- discard [!#%-?A-Z\-_a-z|}~] $q_char_sequence
requires 1 characters of lookahead

examples/lx/literals.lx:
after accepting, a longest pattern leading to another accept is:
- $float [Ee][+-][0-9] $float
- $int [0-9] $int
- $str_lit [^"\] $str_lit
- discard [\t\n\r ] discard
requires 3 characters of lookahead

examples/lx/longest.lx:
after accepting, a longest pattern leading to another accept is:
- $dot .. $ellipsis
requires 2 characters of lookahead

examples/lx/scheme.lx:
after accepting, a longest pattern leading to another accept is:
- $ident /./ $ident
- discard [\t\n ] discard
requires 1 characters of lookahead

examples/lx/trie.lx:
after accepting, a longest pattern leading to another accept is:
- $bye e $bye
requires 1 characters of lookahead
```