### PR TITLE
Introduce Allocation Function wrappers

### DIFF
--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -48,6 +48,28 @@ void
 fsm_free(struct fsm *fsm);
 
 /*
+ * Internal free function that invokes free(3) by default, or a user-provided
+ * free function to free memory and perform any custom memory tracking or handling
+ */
+void
+f_free(const struct fsm *fsm, void *p);
+
+/*
+ * Internal malloc function that invokes malloc(3) by default, or a user-provided
+ * malloc function to allocate memory and perform any custom memory tracking or handling
+ */
+void *
+f_malloc(const struct fsm *fsm, size_t sz);
+
+/*
+ * Internal realloc function that invokes realloc(3) by default, or a user-provided
+ * realloc function to re-allocate memory to the specified size and perform
+ * any custom memory tracking or handling
+ */
+void *
+f_realloc(const struct fsm *fsm, void *p, size_t sz);
+
+/*
  * Duplicate an FSM.
  */
 struct fsm *

--- a/include/fsm/options.h
+++ b/include/fsm/options.h
@@ -82,7 +82,7 @@ struct fsm_options {
 		struct fsm *, struct fsm_state *);
 
 	/* closure for custom allocation functions */
-	struct fsm_allocator *allocator;
+	const struct fsm_allocator *allocator;
 };
 
 #endif

--- a/include/fsm/options.h
+++ b/include/fsm/options.h
@@ -82,7 +82,7 @@ struct fsm_options {
 		struct fsm *, struct fsm_state *);
 
 	/* closure for custom allocation functions */
-	const struct fsm_allocator *allocator;
+	const struct fsm_allocator allocator;
 };
 
 #endif

--- a/include/fsm/options.h
+++ b/include/fsm/options.h
@@ -18,6 +18,13 @@ enum fsm_io {
 	FSM_IO_PAIR
 };
 
+struct fsm_allocator {
+	void (*free)(void *opaque, void *p);
+	void *(*malloc)(void *opaque, size_t sz);
+	void *(*realloc)(void *opaque, void *p, size_t sz);
+	void *opaque;
+};
+
 struct fsm_options {
 	/* boolean: true indicates to go to extra lengths in order to produce
 	 * neater-looking FSMs for certian operations. This usually means finding
@@ -73,6 +80,9 @@ struct fsm_options {
 	/* TODO: explain */
 	void (*carryopaque)(const struct fsm_state **, size_t,
 		struct fsm *, struct fsm_state *);
+
+	/* closure for custom allocation functions */
+	struct fsm_allocator *allocator;
 };
 
 #endif

--- a/src/libfsm/fsm.c
+++ b/src/libfsm/fsm.c
@@ -84,11 +84,11 @@ free_contents(struct fsm *fsm)
 
 		for (e = set_first(s->edges, &it); e != NULL; e = set_next(&it)) {
 			set_free(e->sl);
-			free(e);
+			f_free(fsm, e);
 		}
 
 		set_free(s->edges);
-		free(s);
+		f_free(fsm, s);
 	}
 }
 
@@ -96,13 +96,15 @@ struct fsm *
 fsm_new(const struct fsm_options *opt)
 {
 	static const struct fsm_options defaults;
-	struct fsm *new;
+	struct fsm *new, f;
 
 	if (opt == NULL) {
 		opt = &defaults;
 	}
 
-	new = malloc(sizeof *new);
+	f.opt = opt;
+
+	new = f_malloc(&f, sizeof *new);
 	if (new == NULL) {
 		return NULL;
 	}
@@ -129,7 +131,7 @@ fsm_free(struct fsm *fsm)
 
 	free_contents(fsm);
 
-	free(fsm);
+	f_free(fsm, fsm);
 }
 
 const struct fsm_options *
@@ -162,7 +164,7 @@ fsm_move(struct fsm *dst, struct fsm *src)
 	dst->start    = src->start;
 	dst->endcount = src->endcount;
 
-	free(src);
+	f_free(src, src);
 }
 
 void

--- a/src/libfsm/fsm.c
+++ b/src/libfsm/fsm.c
@@ -22,14 +22,14 @@
 void
 f_free(const struct fsm *fsm, void *p)
 {
-	const struct fsm_allocator *a;
+	struct fsm_allocator a;
 
 	assert(fsm != NULL);
 	assert(fsm->opt != NULL);
 
 	a = fsm->opt->allocator;
-	if (a->free != NULL) {
-		a->free(a->opaque, p);
+	if (a.free != NULL) {
+		a.free(a.opaque, p);
 		return;
 	}
 
@@ -39,14 +39,14 @@ f_free(const struct fsm *fsm, void *p)
 void *
 f_malloc(const struct fsm *fsm, size_t sz)
 {
-	const struct fsm_allocator *a;
+	struct fsm_allocator a;
 
 	assert(fsm != NULL);
 	assert(fsm->opt != NULL);
 
 	a = fsm->opt->allocator;
-	if (a->malloc != NULL) {
-		return (a->malloc(a->opaque, sz));
+	if (a.malloc != NULL) {
+		return (a.malloc(a.opaque, sz));
 	}
 
 	return malloc(sz);
@@ -55,14 +55,14 @@ f_malloc(const struct fsm *fsm, size_t sz)
 void *
 f_realloc(const struct fsm*fsm, void *p, size_t sz)
 {
-	const struct fsm_allocator *a;
+	struct fsm_allocator a;
 
 	assert(fsm != NULL);
 	assert(fsm->opt != NULL);
 
 	a = fsm->opt->allocator;
-	if (a->realloc != NULL) {
-		return a->realloc(a->opaque, p, sz);
+	if (a.realloc != NULL) {
+		return a.realloc(a.opaque, p, sz);
 	}
 
 	return realloc(p, sz);

--- a/src/libfsm/fsm.c
+++ b/src/libfsm/fsm.c
@@ -19,7 +19,57 @@
 #define ctassert(pred) \
 	switch (0) { case 0: case (pred):; }
 
-static void
+void
+f_free(const struct fsm *fsm, void *p)
+{
+	const struct fsm_allocator *a;
+
+	assert(fsm != NULL);
+	assert(fsm->opt != NULL);
+
+	a = fsm->opt->allocator;
+	if (a->free != NULL) {
+		a->free(a->opaque, p);
+		return;
+	}
+
+	free(p);
+}
+
+void *
+f_malloc(const struct fsm *fsm, size_t sz)
+{
+	const struct fsm_allocator *a;
+
+	assert(fsm != NULL);
+	assert(fsm->opt != NULL);
+
+	a = fsm->opt->allocator;
+	if (a->malloc != NULL) {
+		return (a->malloc(a->opaque, sz));
+	}
+
+	return malloc(sz);
+}
+
+void *
+f_realloc(const struct fsm*fsm, void *p, size_t sz)
+{
+	const struct fsm_allocator *a;
+
+	assert(fsm != NULL);
+	assert(fsm->opt != NULL);
+
+	a = fsm->opt->allocator;
+	if (a->realloc != NULL) {
+		return a->realloc(a->opaque, p, sz);
+	}
+
+	return realloc(p, sz);
+}
+
+
+void
 free_contents(struct fsm *fsm)
 {
 	struct fsm_state *next;

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -8,8 +8,10 @@
 #define FSM_INTERNAL_H
 
 #include <limits.h>
+#include <stdlib.h>
 
 #include <fsm/fsm.h>
+#include <fsm/options.h>
 
 #define FSM_ENDCOUNT_MAX ULONG_MAX
 

--- a/src/libfsm/print/api.c
+++ b/src/libfsm/print/api.c
@@ -115,7 +115,7 @@ fsm_print_api(FILE *f, const struct fsm *fsm)
 	fprintf(f, "\t}\n");
 	fprintf(f, "\n");
 
-	a = malloc(n * sizeof *a);
+	a = f_malloc(fsm, n * sizeof *a);
 	if (a == NULL) {
 		/* XXX */
 		return;
@@ -192,7 +192,7 @@ fsm_print_api(FILE *f, const struct fsm *fsm)
 		}
 	}
 
-	free(a);
+	f_free(fsm, a);
 
 	fprintf(f, "\n");
 

--- a/src/libfsm/print/c.c
+++ b/src/libfsm/print/c.c
@@ -453,6 +453,6 @@ fsm_print_c(FILE *f, const struct fsm *fsm)
 	fprintf(f, "}\n");
 	fprintf(f, "\n");
 
-	free_ir(ir);
+	free_ir(fsm, ir);
 }
 

--- a/src/libfsm/print/ir.h
+++ b/src/libfsm/print/ir.h
@@ -101,7 +101,7 @@ struct ir *
 make_ir(const struct fsm *fsm);
 
 void
-free_ir(struct ir *ir);
+free_ir(const struct fsm *fsm, struct ir *ir);
 
 #endif
 

--- a/src/libfsm/print/irdot.c
+++ b/src/libfsm/print/irdot.c
@@ -326,6 +326,6 @@ fsm_print_ir(FILE *f, const struct fsm *fsm)
 
 	fprintf(f, "}\n");
 
-	free_ir(ir);
+	free_ir(fsm, ir);
 }
 

--- a/src/libfsm/print/irjson.c
+++ b/src/libfsm/print/irjson.c
@@ -218,6 +218,6 @@ fsm_print_irjson(FILE *f, const struct fsm *fsm)
 
 	fprintf(f, "}\n");
 
-	free_ir(ir);
+	free_ir(fsm, ir);
 }
 

--- a/src/libfsm/state.c
+++ b/src/libfsm/state.c
@@ -37,7 +37,7 @@ fsm_addstate(struct fsm *fsm)
 
 	assert(fsm != NULL);
 
-	new = malloc(sizeof *new);
+	new = f_malloc(fsm, sizeof *new);
 	if (new == NULL) {
 		return NULL;
 	}
@@ -78,7 +78,7 @@ fsm_removestate(struct fsm *fsm, struct fsm_state *state)
 
 	for (e = set_first(state->edges, &it); e != NULL; e = set_next(&it)) {
 		set_free(e->sl);
-		free(e);
+		f_free(fsm, e);
 	}
 	set_free(state->edges);
 
@@ -101,7 +101,7 @@ fsm_removestate(struct fsm *fsm, struct fsm_state *state)
 				}
 
 				next = (*p)->next;
-				free(*p);
+				f_free(fsm, *p);
 				*p = next;
 				break;
 			}

--- a/src/libfsm/subgraph.c
+++ b/src/libfsm/subgraph.c
@@ -43,14 +43,14 @@ mapping_ensure(struct fsm *fsm, struct mapping **head, struct fsm_state *old)
 
 	/* Otherwise, make a new one */
 	{
-		m = malloc(sizeof *m);
+		m = f_malloc(fsm, sizeof *m);
 		if (m == NULL) {
 			return 0;
 		}
 
 		m->new = fsm_addstate(fsm);
 		if (m->new == NULL) {
-			free(m);
+			f_free(fsm, m);
 			return 0;
 		}
 
@@ -67,7 +67,7 @@ mapping_ensure(struct fsm *fsm, struct mapping **head, struct fsm_state *old)
 }
 
 static void
-mapping_free(struct mapping *mapping)
+mapping_free(const struct fsm *fsm, struct mapping *mapping)
 {
 	struct mapping *next;
 	struct mapping *m;
@@ -75,7 +75,7 @@ mapping_free(struct mapping *mapping)
 	for (m = mapping; m != NULL; m = next) {
 		next = m->next;
 
-		free(m);
+		f_free(fsm, m);
 	}
 }
 
@@ -144,7 +144,7 @@ fsm_state_duplicatesubgraphx(struct fsm *fsm, struct fsm_state *state,
 
 				to = mapping_ensure(fsm, &mappings, s);
 				if (to == NULL) {
-					mapping_free(mappings);
+					mapping_free(fsm, mappings);
 					return NULL;
 				}
 
@@ -158,7 +158,7 @@ fsm_state_duplicatesubgraphx(struct fsm *fsm, struct fsm_state *state,
 	}
 
 	res = start->new;
-	mapping_free(mappings);
+	mapping_free(fsm, mappings);
 
 	return res;
 }

--- a/src/libfsm/walk2.c
+++ b/src/libfsm/walk2.c
@@ -107,13 +107,13 @@ fsm_walk2_data_free(struct fsm_walk2_data *data)
 		set_free(data->states);
 	}
 
-	if (data->new) {
-		fsm_free(data->new);
-	}
-
 	for (p = data->head; p != NULL; p = next) {
 		next = p->next;
-		free(p);
+		f_free(data->new, p);
+	}
+
+	if (data->new) {
+		fsm_free(data->new);
 	}
 }
 
@@ -140,7 +140,7 @@ alloc_walk2_tuple(struct fsm_walk2_data *data)
 
 new_pool:
 
-	pool = malloc(sizeof *pool);
+	pool = f_malloc(data->new, sizeof *pool);
 	if (pool == NULL) {
 		return NULL;
 	}

--- a/src/libfsm/walk2.c
+++ b/src/libfsm/walk2.c
@@ -99,7 +99,7 @@ struct fsm_walk2_tuple_pool {
 };
 
 static void
-fsm_walk2_data_free(struct fsm_walk2_data *data)
+fsm_walk2_data_free(const struct fsm *fsm, struct fsm_walk2_data *data)
 {
 	struct fsm_walk2_tuple_pool *p, *next;
 
@@ -109,7 +109,7 @@ fsm_walk2_data_free(struct fsm_walk2_data *data)
 
 	for (p = data->head; p != NULL; p = next) {
 		next = p->next;
-		f_free(data->new, p);
+		f_free(fsm, p);
 	}
 
 	if (data->new) {
@@ -526,13 +526,13 @@ done:
 	/* reset all equiv fields in the states */
 	fsm_walk2_mark_equiv_null(new);
 
-	fsm_walk2_data_free(&data);
+	fsm_walk2_data_free(a, &data);
 
 	return new;
 
 error:
 
-	fsm_walk2_data_free(&data);
+	fsm_walk2_data_free(a, &data);
 
 	return NULL;
 }

--- a/src/lx/print/c.c
+++ b/src/lx/print/c.c
@@ -696,7 +696,7 @@ print_zone(FILE *f, const struct ast *ast, const struct ast_zone *z)
 		(void) fsm_print_cfrag(f, ir, &o, opt.cp,
 			z->fsm->opt->leaf != NULL ? z->fsm->opt->leaf : leaf, z->fsm->opt->leaf_opaque);
 
-		free_ir(ir);
+		free_ir(z->fsm, ir);
 
 		z->fsm->opt = tmp;
 	}


### PR DESCRIPTION
This PR introduces custom free/malloc/realloc function wrappers to be used for memory management and tracking in libfsm. The reason for this PR change is to allow user-provided allocation functions to define custom malloc/realloc/free directives.

The way this PR defines custom allocation wrapper functions is by introducing `f_free()`, `f_malloc()` and `f_realloc()` to use in the place of `free()`, `malloc()`, and `realloc()` respectively. The `f_*` functions take a `struct fsm *` along with the necessary data to perform the allocation: `fsm_options` is inspected (via the `struct fsm *`) and if it contains a user-defined allocation function, that function will be used, otherwise the default (libc) allocator is used. 

The following decisions formed this approach:

- Minimize the amount of consideration callers of the `f_` functions need in order to use them (ie minimize the amount of changes or data accesses around using these functions)
- Make the functions look familiar to the standard libc functions so that they can be easier to use.
- Future developers do not need to worry about setting default allocation functions when creating a `struct fsm_options` or `struct fsm`: the `f_` function will automatically take care of using the default libc functions if a user-defined allocator function is not available.
- Localize the custom user-defined allocation functions to `struct fsm *`: for example, if we want to move where/how we store function pointers within `struct fsm`, the necessary changes to do so can be confined to changing the `f_` function definition.

The changes are contained within src/libfsm - but if they need to be extended to other areas of the repository, let me know.