### PR TITLE
Link with `-lrt` for glibc < 2.17

### DIFF
--- a/src/fsm/Makefile
+++ b/src/fsm/Makefile
@@ -51,23 +51,25 @@ LDD_BLURB?= /lib/libc.so.6 2>&1
 LDD_BLURB?= ldd --version  2>&1
 .endif
 
-LDD_NAME!=                       \
-    ${LDD_BLURB}                 \
-    | { read v && case "$$v" in  \
-        *EGLIBC*) echo eglibc;;  \
-        *GLIBC*)  echo glibc;;   \
-        *GNU\ C*) echo glibc;;   \
-        *musl*)   echo musl;;    \
-        *)        echo unknown;; \
+LDD_NAME!=                          \
+    ${LDD_BLURB}                    \
+    | { read v && case "$$v" in     \
+        *EGLIBC*)    echo eglibc;;  \
+        *GLIBC*)     echo glibc;;   \
+        *GNU\ libc*) echo glibc;;   \
+        *GNU\ C*)    echo glibc;;   \
+        *musl*)      echo musl;;    \
+        *)           echo unknown;; \
     esac }
 
 LDD_VER!=                        \
     ${LDD_BLURB}                 \
     | { read v && case "$$v" in  \
-        *GLIBC*)  echo "$$v" | sed -n 's/^ldd (\(GNU libc\|.* E\?GLIBC .*\)) //p';; \
-        *GNU\ C*) echo "$$v" | sed -n 's/^.*version \(.*\), .*/\1/p';;              \
-        MUSL)     echo "$$v" | sed -n 's/^Version \(.*\)/\1/p';;                    \
-        *)        echo unknown;; \
+        *GLIBC*)     echo "$$v" | sed -n 's/^ldd (.* E\?GLIBC .*) //p';;  \
+        *GNU\ libc*) echo "$$v" | sed -n 's/^ldd (GNU libc) //p';;        \
+        *GNU\ C*)    echo "$$v" | sed -n 's/^.*version \(.*\), .*/\1/p';; \
+        MUSL)        echo "$$v" | sed -n 's/^Version \(.*\)/\1/p';;       \
+        *)           echo unknown;; \
     esac }
 
 .if ${LDD_NAME} == "glibc" || ${LDD_NAME} == "eglibc"

--- a/src/fsm/Makefile
+++ b/src/fsm/Makefile
@@ -38,3 +38,47 @@ ${BUILD}/bin/fsm: ${BUILD}/lib/${lib:R}.a
 ${BUILD}/bin/fsm: ${BUILD}/${src:R}.o
 .endfor
 
+
+UNAME ?= uname
+UNAME_SYSTEM != ${UNAME} -s
+SYSTEM ?= ${UNAME_SYSTEM}
+
+.if ${SYSTEM} == Linux
+
+.if exists(/lib/libc.so.6)
+LDD_BLURB?= /lib/libc.so.6 2>&1
+.else
+LDD_BLURB?= ldd --version  2>&1
+.endif
+
+LDD_NAME!=                       \
+    ${LDD_BLURB}                 \
+    | { read v && case "$$v" in  \
+        *EGLIBC*) echo eglibc;;  \
+        *GLIBC*)  echo glibc;;   \
+        *GNU\ C*) echo glibc;;   \
+        *musl*)   echo musl;;    \
+        *)        echo unknown;; \
+    esac }
+
+LDD_VER!=                        \
+    ${LDD_BLURB}                 \
+    | { read v && case "$$v" in  \
+        *GLIBC*)  echo "$$v" | sed -n 's/^ldd (\(GNU libc\|.* E\?GLIBC .*\)) //p';; \
+        *GNU\ C*) echo "$$v" | sed -n 's/^.*version \(.*\), .*/\1/p';;              \
+        MUSL)     echo "$$v" | sed -n 's/^Version \(.*\)/\1/p';;                    \
+        *)        echo unknown;; \
+    esac }
+
+.if ${LDD_NAME} == "glibc" || ${LDD_NAME} == "eglibc"
+
+# clock_gettime(2):
+# Link with -lrt (only for glibc versions before 2.17).
+.if ${LDD_VER} < 2.17
+LFLAGS.fsm += -lrt
+.endif
+
+.endif
+
+.endif
+


### PR DESCRIPTION
For #103.

The logic here is probably overkill. I found linking with -lrt was harmless on my glibc 2.28 system, so I think this could probably be simply:
```
.if ${SYSTEM} == Linux
.if ${LDD_NAME} == glibc || ${LDD_NAME} == eglibc
LFLAGS.fsm += -lrt
.endif
.endif
```

But regardless the libc name still needs to be found, assuming some libcs don't come with a librt.