### PR TITLE
Adds a usable clock_gettime for older macOS versions 

### DIFF
--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -24,6 +24,33 @@
 
 #include "parser.h"
 
+#ifdef __MACH__
+#include <mach/clock.h>
+#include <mach/mach.h>
+
+/* we're running Darwin/macOS, so we don't necessarily have clock_gettime,
+ * so we do it the ugly way...
+ */
+
+#define CLOCK_MONOTONIC 0
+static int clock_gettime(int clk_id, struct timespec *ts)
+{
+	clock_serv_t cclock;
+	mach_timespec_t mts;
+
+	(void)clk_id;
+
+	host_get_clock_service(mach_host_self(), SYSTEM_CLOCK, &cclock);
+	clock_get_time(cclock, &mts);
+	mach_port_deallocate(mach_task_self(), cclock);
+
+	ts->tv_sec = mts.tv_sec;
+	ts->tv_nsec = mts.tv_nsec;
+
+	return 0;
+}
+#endif /* __MACH__ */
+
 extern int optind;
 extern char *optarg;
 

--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -24,7 +24,7 @@
 
 #include "parser.h"
 
-#ifdef __MACH__
+#if defined(__APPLE__) && defined(__MACH__) && !defined(MACOS_HAS_CLOCK_GETTME)
 #include <mach/clock.h>
 #include <mach/mach.h>
 
@@ -49,7 +49,7 @@ static int clock_gettime(int clk_id, struct timespec *ts)
 
 	return 0;
 }
-#endif /* __MACH__ */
+#endif /* defined(__APPLE__) && defined(__MACH__) && !defined(MACOS_HAS_CLOCK_GETTME) */
 
 extern int optind;
 extern char *optarg;


### PR DESCRIPTION
Versions prior to 10.12 don't have `clock_gettime`.  This adds a version that makes the appropriate Mach calls.