### PR TITLE
Changes libfsm to use specific set types instead of `set` adt.

### DIFF
--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -20,7 +20,6 @@ struct fsm_state;
 struct fsm_edge;
 struct fsm_determinise_cache;
 struct fsm_options;
-struct set; /* XXX */
 struct path; /* XXX */
 
 /*

--- a/src/libfsm/Makefile
+++ b/src/libfsm/Makefile
@@ -1,5 +1,6 @@
 .include "../../share/mk/top.mk"
 
+SRC += src/libfsm/internal.c
 SRC += src/libfsm/collate.c
 SRC += src/libfsm/complete.c
 SRC += src/libfsm/clone.c

--- a/src/libfsm/clone.c
+++ b/src/libfsm/clone.c
@@ -54,7 +54,7 @@ fsm_clone(const struct fsm *fsm)
 		for (s = fsm->sl; s != NULL; s = s->next) {
 			struct fsm_state *equiv;
 			struct fsm_edge *e;
-			struct set_iter it;
+			struct edge_iter it;
 
 			equiv = s->equiv;
 			assert(equiv != NULL);
@@ -66,10 +66,10 @@ fsm_clone(const struct fsm *fsm)
 			fsm_setend(new, equiv, fsm_isend(fsm, s));
 			equiv->opaque = s->opaque;
 
-			for (e = set_first(s->edges, &it); e != NULL; e = set_next(&it)) {
-				struct set_iter jt;
+			for (e = edge_set_first(s->edges, &it); e != NULL; e = edge_set_next(&it)) {
+				struct state_iter jt;
 
-				for (to = set_first(e->sl, &jt); to != NULL; to = set_next(&jt)) {
+				for (to = state_set_first(e->sl, &jt); to != NULL; to = state_set_next(&jt)) {
 					struct fsm_state *newfrom;
 					struct fsm_state *newto;
 

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -29,6 +29,137 @@ struct trans {
 	char c;
 };
 
+ 
+struct trans_set {
+	struct set *set;
+};
+
+static int
+cmp_trans(const void *a, const void *b);
+
+static struct trans_set *
+trans_set_create(struct fsm *fsm)
+{
+	static const struct trans_set init;
+	struct trans_set *set;
+
+	set = f_malloc(fsm,sizeof *set); /* XXX - double check with katef */
+	*set = init;
+	set->set = set_create(cmp_trans);
+	return set;
+}
+
+static void
+trans_set_free(struct fsm *fsm, struct trans_set *set)
+{
+	if (set != NULL) {
+		if (set->set != NULL) {
+			set_free(set->set);
+			set->set = NULL;
+		}
+		f_free(fsm,set);
+	}
+}
+
+struct trans_iter {
+	struct set_iter iter;
+};
+
+static struct trans *
+trans_set_add(struct trans_set *set, struct trans *item)
+{
+	return set_add(&set->set, item);
+}
+
+static struct trans *
+trans_set_contains(const struct trans_set *set, const struct trans *item)
+{
+	return set_contains(set->set, item);
+}
+
+static void
+trans_set_clear(struct trans_set *set)
+{
+	set_clear(set->set);
+}
+
+static struct trans *
+trans_set_first(const struct trans_set *set, struct trans_iter *it)
+{
+	return set_first(set->set, &it->iter);
+}
+
+static struct trans *
+trans_set_next(struct trans_iter *it)
+{
+	return set_next(&it->iter);
+}
+
+struct mapping_set {
+	struct set *set;
+};
+
+static int
+cmp_mapping(const void *a, const void *b);
+
+struct mapping_set *
+mapping_set_create(struct fsm *fsm)
+{
+	static const struct mapping_set init;
+	struct mapping_set *set;
+
+	set = f_malloc(fsm, sizeof *set); /* XXX - double check with katef */
+	*set = init;
+	set->set = set_create(cmp_mapping);
+	return set;
+}
+
+void
+mapping_set_free(const struct fsm *fsm, struct mapping_set *set)
+{
+	if (set != NULL) {
+		if (set->set != NULL) {
+			set_free(set->set);
+			set->set = NULL;
+		}
+		f_free(fsm,set);
+	}
+}
+
+struct mapping *
+mapping_set_add(struct mapping_set *set, struct mapping *item)
+{
+	return set_add(&set->set, item);
+}
+
+struct mapping *
+mapping_set_contains(const struct mapping_set *set, const struct mapping *item)
+{
+	return set_contains(set->set, item);
+}
+
+void
+mapping_set_clear(struct mapping_set *set)
+{
+	set_clear(set->set);
+}
+
+struct mapping_iter {
+	struct set_iter iter;
+};
+
+static struct mapping *
+mapping_set_first(const struct mapping_set *set, struct mapping_iter *it)
+{
+	return set_first(set->set, &it->iter);
+}
+
+static struct mapping *
+mapping_set_next(struct mapping_iter *it)
+{
+	return set_next(&it->iter);
+}
+
 /*
  * This maps a DFA state onto its associated NFA epsilon closure, such that an
  * existing DFA state may be found given any particular set of NFA states
@@ -38,7 +169,7 @@ struct trans {
  */
 struct mapping {
 	/* The set of NFA states forming the epsilon closure for this DFA state */
-	struct set *closure;
+	struct state_set *closure;
 
 	/* The DFA state associated with this epsilon closure of NFA states */
 	struct fsm_state *dfastate;
@@ -48,35 +179,35 @@ struct mapping {
 };
 
 struct fsm_determinise_cache {
-	struct set *mappings;
-	struct set *trans;
+	struct mapping_set *mappings;
+	struct trans_set *trans;
 };
 
 static void
-clear_trans(const struct fsm *fsm, struct set *trans)
+clear_trans(const struct fsm *fsm, struct trans_set *trans)
 {
-	struct set_iter it;
+	struct trans_iter it;
 	struct trans *t;
 
-	for (t = set_first(trans, &it); t != NULL; t = set_next(&it)) {
+	for (t = trans_set_first(trans, &it); t != NULL; t = trans_set_next(&it)) {
 		f_free(fsm, t);
 	}
 
-	set_clear(trans);
+	trans_set_clear(trans);
 }
 
 static void
-clear_mappings(const struct fsm *fsm, struct set *mappings)
+clear_mappings(const struct fsm *fsm, struct mapping_set *mappings)
 {
-	struct set_iter it;
+	struct mapping_iter it;
 	struct mapping *m;
 
-	for (m = set_first(mappings, &it); m != NULL; m = set_next(&it)) {
-		set_free(m->closure);
+	for (m = mapping_set_first(mappings, &it); m != NULL; m = mapping_set_next(&it)) {
+		state_set_free(m->closure);
 		f_free(fsm, m);
 	}
 
-	set_clear(mappings);
+	mapping_set_clear(mappings);
 }
 
 static int
@@ -104,7 +235,7 @@ cmp_mapping(const void *a, const void *b)
 	ma = a;
 	mb = b;
 
-	return set_cmp(ma->closure, mb->closure);
+	return state_set_cmp(ma->closure, mb->closure);
 }
 
 /*
@@ -115,14 +246,14 @@ cmp_mapping(const void *a, const void *b)
  * the mapping set for future reference.
  */
 static struct mapping *
-addtomappings(struct set *mappings, struct fsm *dfa, struct set *closure)
+addtomappings(struct mapping_set *mappings, struct fsm *dfa, struct state_set *closure)
 {
 	struct mapping *m, search;
 
 	/* Use an existing mapping if present */
 	search.closure = closure;
-	if ((m = set_contains(mappings, &search))) {
-		set_free(closure);
+	if ((m = mapping_set_contains(mappings, &search))) {
+		state_set_free(closure);
 		return m;
 	}
 
@@ -142,7 +273,7 @@ addtomappings(struct set *mappings, struct fsm *dfa, struct set *closure)
 
 	m->done = 0;
 
-	if (!set_add(&mappings, m)) {
+	if (!mapping_set_add(mappings, m)) {
 		f_free(dfa, m);
 		return NULL;
 	}
@@ -164,28 +295,28 @@ addtomappings(struct set *mappings, struct fsm *dfa, struct set *closure)
  *
  * Returns closure on success, NULL on error.
  */
-static struct set **
-epsilon_closure(const struct fsm_state *state, struct set **closure)
+static struct state_set *
+epsilon_closure(const struct fsm_state *state, struct state_set *closure)
 {
 	struct fsm_state *s;
 	struct fsm_edge *e;
-	struct set_iter it;
+	struct state_iter it;
 
 	assert(state != NULL);
 	assert(closure != NULL);
 
 	/* Find if the given state is already in the closure */
-	if (set_contains(*closure, state)) {
+	if (state_set_contains(closure, state)) {
 		return closure;
 	}
 
-	if (!set_add(closure, (void *) state)) {
+	if (!state_set_add(closure, (void *) state)) {
 		return NULL;
 	}
 
 	/* Follow each epsilon transition */
 	if ((e = fsm_hasedge(state, FSM_EDGE_EPSILON)) != NULL) {
-		for (s = set_first(e->sl, &it); s != NULL; s = set_next(&it)) {
+		for (s = state_set_first(e->sl, &it); s != NULL; s = state_set_next(&it)) {
 			assert(s != NULL);
 
 			if (epsilon_closure(s, closure) == NULL) {
@@ -202,29 +333,29 @@ epsilon_closure(const struct fsm_state *state, struct set **closure)
  * Create the DFA state if neccessary.
  */
 static struct fsm_state *
-state_closure(struct set *mappings, struct fsm *dfa, const struct fsm_state *nfastate,
+state_closure(struct mapping_set *mappings, struct fsm *dfa, const struct fsm_state *nfastate,
 	int includeself)
 {
 	struct mapping *m;
-	struct set *ec;
+	struct state_set *ec;
 
 	assert(dfa != NULL);
 	assert(nfastate != NULL);
 	assert(mappings != NULL);
 
-	ec = NULL;
-	if (epsilon_closure(nfastate, &ec) == NULL) {
-		set_free(ec);
+	ec = state_set_create();
+	if (epsilon_closure(nfastate, ec) == NULL) {
+		state_set_free(ec);
 		return NULL;
 	}
 
 	if (!includeself) {
-		set_remove(&ec, (void *) nfastate);
+		state_set_remove(ec, (void *) nfastate);
+	}
 
-		if (set_count(ec) == 0) {
-			set_free(ec);
-			ec = NULL;
-		}
+	if (state_set_count(ec) == 0) {
+		state_set_free(ec);
+		return NULL;
 	}
 
 	if (ec == NULL) {
@@ -244,20 +375,20 @@ state_closure(struct set *mappings, struct fsm *dfa, const struct fsm_state *nfa
  * states. Create the DFA state if neccessary.
  */
 static struct fsm_state *
-set_closure(struct set *mappings, struct fsm *dfa, struct set *set)
+set_closure(struct mapping_set *mappings, struct fsm *dfa, struct state_set *set)
 {
-	struct set_iter it;
-	struct set *ec;
+	struct state_iter it;
+	struct state_set *ec;
 	struct mapping *m;
 	struct fsm_state *s;
 
 	assert(set != NULL);
 	assert(mappings != NULL);
 
-	ec = NULL;
-	for (s = set_first(set, &it); s != NULL; s = set_next(&it)) {
-		if (epsilon_closure(s, &ec) == NULL) {
-			set_free(ec);
+	ec = state_set_create();
+	for (s = state_set_first(set, &it); s != NULL; s = state_set_next(&it)) {
+		if (epsilon_closure(s, ec) == NULL) {
+			state_set_free(ec);
 			return NULL;
 		}
 	}
@@ -268,8 +399,8 @@ set_closure(struct set *mappings, struct fsm *dfa, struct set *set)
 	return m->dfastate;
 }
 
-struct set_iter_save {
-	struct set_iter iter;
+struct mapping_iter_save {
+	struct mapping_iter iter;
 	int saved;
 };
 
@@ -277,9 +408,9 @@ struct set_iter_save {
  * Return an arbitary mapping which isn't marked "done" yet.
  */
 static struct mapping *
-nextnotdone(struct set *mappings, struct set_iter_save *sv)
+nextnotdone(struct mapping_set *mappings, struct mapping_iter_save *sv)
 {
-	struct set_iter it;
+	struct mapping_iter it;
 	struct mapping *m;
 	int do_rescan = sv->saved;
 
@@ -287,13 +418,13 @@ nextnotdone(struct set *mappings, struct set_iter_save *sv)
 
 	if (sv->saved) {
 		it = sv->iter;
-		m = set_next(&it);
+		m = mapping_set_next(&it);
 	} else {
-		m = set_first(mappings, &it);
+		m = mapping_set_first(mappings, &it);
 	}
 
 rescan:
-	for (; m != NULL; m = set_next(&it)) {
+	for (; m != NULL; m = mapping_set_next(&it)) {
 		if (!m->done) {
 			sv->saved = 1;
 			sv->iter = it;
@@ -302,7 +433,7 @@ rescan:
 	}
 
 	if (do_rescan) {
-		m = set_first(mappings, &it);
+		m = mapping_set_first(mappings, &it);
 		do_rescan = 0;
 		goto rescan;
 	}
@@ -317,34 +448,34 @@ rescan:
  * TODO: maybe simpler to just return the set, rather than take a double pointer
  */
 static int
-listnonepsilonstates(const struct fsm *fsm ,struct set *trans, struct set *set)
+listnonepsilonstates(const struct fsm *fsm, struct trans_set *trans, struct state_set *set)
 {
 	struct fsm_state *s;
-	struct set_iter it;
+	struct state_iter it;
 
 	assert(set != NULL);
 	assert(trans != NULL);
 
-	for (s = set_first(set, &it); s != NULL; s = set_next(&it)) {
+	for (s = state_set_first(set, &it); s != NULL; s = state_set_next(&it)) {
 		struct fsm_edge *e;
-		struct set_iter jt;
+		struct edge_iter jt;
 
-		for (e = set_first(s->edges, &jt); e != NULL; e = set_next(&jt)) {
+		for (e = edge_set_first(s->edges, &jt); e != NULL; e = edge_set_next(&jt)) {
 			struct fsm_state *st;
-			struct set_iter kt;
+			struct state_iter kt;
 
 			if (e->symbol > UCHAR_MAX) {
 				break;
 			}
 
-			for (st = set_first(e->sl, &kt); st != NULL; st = set_next(&kt)) {
+			for (st = state_set_first(e->sl, &kt); st != NULL; st = state_set_next(&kt)) {
 				struct trans *p, search;
 
 				assert(st != NULL);
 
 				/* Skip transitions we've already got */
 				search.c = e->symbol;
-				if ((p = set_contains(trans, &search))) {
+				if ((p = trans_set_contains(trans, &search))) {
 					continue;
 				}
 
@@ -357,7 +488,7 @@ listnonepsilonstates(const struct fsm *fsm ,struct set *trans, struct set *set)
 				p->c = e->symbol;
 				p->state = st;
 
-				if (!set_add(&trans, p)) {
+				if (!trans_set_add(trans, p)) {
 					f_free(fsm, p);
 					clear_trans(fsm, trans);
 					return 0;
@@ -373,24 +504,24 @@ listnonepsilonstates(const struct fsm *fsm ,struct set *trans, struct set *set)
  * Return a list of all states reachable from set via the given transition.
  */
 static int
-allstatesreachableby(struct set *set, char c, struct set **sl)
+allstatesreachableby(struct state_set *set, char c, struct state_set *sl)
 {
 	struct fsm_state *s;
-	struct set_iter it;
+	struct state_iter it;
 
 	assert(set != NULL);
 
-	for (s = set_first(set, &it); s != NULL; s = set_next(&it)) {
+	for (s = state_set_first(set, &it); s != NULL; s = state_set_next(&it)) {
 		struct fsm_state *es;
 		struct fsm_edge *to;
 
 		if ((to = fsm_hasedge(s, (unsigned char) c)) != NULL) {
-			struct set_iter jt;
+			struct state_iter jt;
 
-			for (es = set_first(to->sl, &jt); es != NULL; es = set_next(&jt)) {
+			for (es = state_set_first(to->sl, &jt); es != NULL; es = state_set_next(&jt)) {
 				assert(es != NULL);
 
-				if (!set_add(sl, es)) {
+				if (!state_set_add(sl, es)) {
 					return 0;
 				}
 			}
@@ -401,16 +532,16 @@ allstatesreachableby(struct set *set, char c, struct set **sl)
 }
 
 static void
-carryend(struct set *set, struct fsm *fsm, struct fsm_state *state)
+carryend(struct state_set *set, struct fsm *fsm, struct fsm_state *state)
 {
-	struct set_iter it;
+	struct state_iter it;
 	struct fsm_state *s;
 
 	assert(set != NULL); /* TODO: right? */
 	assert(fsm != NULL);
 	assert(state != NULL);
 
-	for (s = set_first(set, &it); s != NULL; s = set_next(&it)) {
+	for (s = state_set_first(set, &it); s != NULL; s = state_set_next(&it)) {
 		if (fsm_isend(fsm, s)) {
 			fsm_setend(fsm, state, 1);
 		}
@@ -437,15 +568,15 @@ static struct fsm *
 determinise(struct fsm *nfa,
 	struct fsm_determinise_cache *dcache)
 {
-	const static struct set_iter_save sv_init;
+	const static struct mapping_iter_save sv_init;
 
 	struct mapping *curr;
-	struct set *mappings;
-	struct set_iter it;
-	struct set *trans;
+	struct mapping_set *mappings;
+	struct mapping_iter it;
+	struct trans_set *trans;
 	struct fsm *dfa;
 
-	struct set_iter_save sv;
+	struct mapping_iter_save sv;
 
 	assert(nfa != NULL);
 	assert(nfa->opt != NULL);
@@ -471,13 +602,13 @@ determinise(struct fsm *nfa,
 	}
 
 	if (dcache->mappings == NULL) {
-		dcache->mappings = set_create(cmp_mapping);
+		dcache->mappings = mapping_set_create(nfa);
 	}
 	mappings = dcache->mappings;
 	assert(mappings != NULL);
 
 	if (dcache->trans == NULL) {
-		dcache->trans = set_create(cmp_trans);
+		dcache->trans = trans_set_create(nfa);
 	}
 	trans = dcache->trans;
 	assert(trans != NULL);
@@ -527,8 +658,8 @@ determinise(struct fsm *nfa,
 	 * While there are still DFA states remaining to be "done", process each.
 	 */
 	sv = sv_init;
-	for (curr = set_first(mappings, &it); (curr = nextnotdone(mappings, &sv)) != NULL; curr->done = 1) {
-		struct set_iter jt;
+	for (curr = mapping_set_first(mappings, &it); (curr = nextnotdone(mappings, &sv)) != NULL; curr->done = 1) {
+		struct trans_iter jt;
 		struct trans *t;
 
 		/*
@@ -544,27 +675,27 @@ determinise(struct fsm *nfa,
 			goto error;
 		}
 
-		for (t = set_first(trans, &jt); t != NULL; t = set_next(&jt)) {
+		for (t = trans_set_first(trans, &jt); t != NULL; t = trans_set_next(&jt)) {
 			struct fsm_state *new;
 			struct fsm_edge *e;
-			struct set *reachable;
+			struct state_set *reachable;
 
 			assert(t->state != NULL);
 
-			reachable = NULL;
+			reachable = state_set_create();
 
 			/*
 			 * Find the closure of the set of all NFA states which are reachable
 			 * through this label, starting from the set of states forming curr's
 			 * closure.
 			 */
-			if (!allstatesreachableby(curr->closure, t->c, &reachable)) {
-				set_free(reachable);
+			if (!allstatesreachableby(curr->closure, t->c, reachable)) {
+				state_set_free(reachable);
 				goto error;
 			}
 
 			new = set_closure(mappings, dfa, reachable);
-			set_free(reachable);
+			state_set_free(reachable);
 			if (new == NULL) {
 				clear_trans(dfa, trans);
 				goto error;
@@ -581,9 +712,9 @@ determinise(struct fsm *nfa,
 
 #ifdef DEBUG_TODFA
 		{
-			struct set *q;
+			struct state_set *q;
 
-			for (q = set_first(curr->closure, &jt); q != NULL; q = set_next(&jt)) {
+			for (q = state_set_first(curr->closure, &jt); q != NULL; q = state_set_next(&jt)) {
 				if (!set_add(&curr->dfastate->nfasl, q)) {
 					goto error;
 				}
@@ -635,8 +766,8 @@ fsm_determinise_cache(struct fsm *fsm,
 			return 0;
 		}
 
-		(*dcache)->mappings = NULL;
-		(*dcache)->trans    = NULL;
+		(*dcache)->mappings = mapping_set_create(fsm);
+		(*dcache)->trans    = trans_set_create(fsm);
 	}
 
 	dfa = determinise(fsm, *dcache);
@@ -680,11 +811,11 @@ fsm_determinise_freecache(struct fsm *fsm, struct fsm_determinise_cache *dcache)
 	clear_trans(fsm, dcache->trans);
 
 	if (dcache->mappings != NULL) {
-		set_free(dcache->mappings);
+		mapping_set_free(fsm,dcache->mappings);
 	}
 
 	if (dcache->trans != NULL) {
-		set_free(dcache->trans);
+		trans_set_free(fsm,dcache->trans);
 	}
 
 	f_free(fsm, dcache);

--- a/src/libfsm/edge.c
+++ b/src/libfsm/edge.c
@@ -25,7 +25,7 @@ fsm_addedge(struct fsm_state *from, struct fsm_state *to, enum fsm_edge_type typ
 	assert(to != NULL);
 
 	new.symbol = type;
-	e = set_contains(from->edges, &new);
+	e = edge_set_contains(from->edges, &new);
 	if (e == NULL) {
 		e = malloc(sizeof *e);
 		if (e == NULL) {
@@ -33,14 +33,14 @@ fsm_addedge(struct fsm_state *from, struct fsm_state *to, enum fsm_edge_type typ
 		}
 
 		e->symbol = type;
-		e->sl = NULL;
+		e->sl = state_set_create();
 
-		if (!set_add(&from->edges, e)) {
+		if (!edge_set_add(from->edges, e)) {
 			return NULL;
 		}
 	}
 
-	if (set_add(&e->sl, to) == NULL) {
+	if (state_set_add(e->sl, to) == NULL) {
 		return NULL;
 	}
 
@@ -102,8 +102,8 @@ fsm_hasedge(const struct fsm_state *s, int c)
 	struct fsm_edge *e, search;
 
 	search.symbol = c;
-	e = set_contains(s->edges, &search);
-	if (e == NULL || set_empty(e->sl)) {
+	e = edge_set_contains(s->edges, &search);
+	if (e == NULL || state_set_empty(e->sl)) {
 		return NULL;
 	}
 

--- a/src/libfsm/exec.c
+++ b/src/libfsm/exec.c
@@ -28,7 +28,7 @@ nextstate(const struct fsm_state *state, int c)
 		return NULL;
 	}
 
-	return set_only(e->sl);
+	return state_set_only(e->sl);
 }
 
 struct fsm_state *

--- a/src/libfsm/fsm.c
+++ b/src/libfsm/fsm.c
@@ -78,16 +78,16 @@ free_contents(struct fsm *fsm)
 	assert(fsm != NULL);
 
 	for (s = fsm->sl; s != NULL; s = next) {
-		struct set_iter it;
+		struct edge_iter it;
 		struct fsm_edge *e;
 		next = s->next;
 
-		for (e = set_first(s->edges, &it); e != NULL; e = set_next(&it)) {
-			set_free(e->sl);
+		for (e = edge_set_first(s->edges, &it); e != NULL; e = edge_set_next(&it)) {
+			state_set_free(e->sl);
 			f_free(fsm, e);
 		}
 
-		set_free(s->edges);
+		edge_set_free(s->edges);
 		f_free(fsm, s);
 	}
 }
@@ -168,7 +168,7 @@ fsm_move(struct fsm *dst, struct fsm *src)
 }
 
 void
-fsm_carryopaque(struct fsm *fsm, const struct set *set,
+fsm_carryopaque(struct fsm *fsm, const struct state_set *set,
 	struct fsm *new, struct fsm_state *state)
 {
 	ctassert(sizeof (void *) == sizeof (struct fsm_state *));
@@ -189,7 +189,7 @@ fsm_carryopaque(struct fsm *fsm, const struct set *set,
 	 * and the cast here.
 	 */
 
-	fsm->opt->carryopaque((void *) set_array(set), set_count(set),
+	fsm->opt->carryopaque((void *) state_set_array(set), state_set_count(set),
 		new, state);
 }
 
@@ -221,12 +221,12 @@ fsm_countedges(const struct fsm *fsm)
 	 * should be replaced with something better when possible
 	 */
 	for (src = fsm->sl; src != NULL; src = src->next) {
-		struct set_iter ei;
+		struct edge_iter ei;
 		const struct fsm_edge *e;
 
-		for (e = set_first(src->edges, &ei); e != NULL; e=set_next(&ei)) {
-			assert(n + set_count(e->sl) > n); /* handle overflow with more grace? */
-			n += set_count(e->sl);
+		for (e = edge_set_first(src->edges, &ei); e != NULL; e=edge_set_next(&ei)) {
+			assert(n + state_set_count(e->sl) > n); /* handle overflow with more grace? */
+			n += state_set_count(e->sl);
 		}
 	}
 

--- a/src/libfsm/internal.c
+++ b/src/libfsm/internal.c
@@ -1,0 +1,178 @@
+#include <stddef.h>
+#include <stdlib.h>
+
+#include "internal.h"
+
+/* edge set */
+
+void
+edge_set_free(struct edge_set *set)
+{
+	if (set == NULL) {
+		return;
+	}
+
+	if (set->set != NULL) {
+		set_free(set->set);
+		set->set = NULL;
+	}
+
+	free(set);
+}
+
+struct fsm_edge *
+edge_set_add(struct edge_set *set, struct fsm_edge *e)
+{
+	return set_add(&set->set, e);
+}
+
+struct fsm_edge *
+edge_set_contains(const struct edge_set *set, const struct fsm_edge *e)
+{
+	return set_contains(set->set, e);
+}
+
+size_t
+edge_set_count(const struct edge_set *set)
+{
+	return set_count(set->set);
+}
+
+void
+edge_set_remove(struct edge_set *set, const struct fsm_edge *e)
+{
+	set_remove(&set->set, (void *)e);
+}
+
+struct fsm_edge *
+edge_set_first(struct edge_set *set, struct edge_iter *it)
+{
+	return set_first(set->set, &it->iter);
+}
+
+struct fsm_edge *
+edge_set_firstafter(struct edge_set *set, struct edge_iter *it, const struct fsm_edge *e)
+{
+	return set_firstafter(set->set, &it->iter, (void *)e);
+}
+
+struct fsm_edge *
+edge_set_next(struct edge_iter *it)
+{
+	return set_next(&it->iter);
+}
+
+int
+edge_set_hasnext(struct edge_iter *it)
+{
+	return set_hasnext(&it->iter);
+}
+
+struct fsm_edge *
+edge_set_only(const struct edge_set *s)
+{
+	return set_only(s->set);
+}
+
+
+/* state set */
+
+struct state_set *
+state_set_create(void)
+{
+	static const struct state_set init;
+	struct state_set *set;
+
+	set = malloc(sizeof *set);
+	if (!set) {
+		return NULL;
+	}
+
+	*set = init;
+	set->set = NULL;
+
+	return set;
+}
+
+void
+state_set_free(struct state_set *set)
+{
+	if (set == NULL) {
+		return;
+	}
+
+	if (set->set != NULL) {
+		set_free(set->set);
+		set->set = NULL;
+	}
+
+	free(set);
+}
+
+struct fsm_state *
+state_set_add(struct state_set *set, struct fsm_state *st)
+{
+	return set_add(&set->set, st);
+}
+
+void
+state_set_remove(struct state_set *set, const struct fsm_state *st)
+{
+	set_remove(&set->set, (void *)st);
+}
+
+int
+state_set_empty(const struct state_set *s)
+{
+	return set_empty(s->set);
+}
+
+struct fsm_state *
+state_set_only(const struct state_set *s)
+{
+	return set_only(s->set);
+}
+
+struct fsm_state *
+state_set_contains(const struct state_set *set, const struct fsm_state *st)
+{
+	return set_contains(set->set, st);
+}
+
+size_t
+state_set_count(const struct state_set *set)
+{
+	return set_count(set->set);
+}
+
+struct fsm_state *
+state_set_first(struct state_set *set, struct state_iter *it)
+{
+	return set_first(set->set, &it->iter);
+}
+
+struct fsm_state *
+state_set_next(struct state_iter *it)
+{
+	return set_next(&it->iter);
+}
+
+int
+state_set_hasnext(struct state_iter *it)
+{
+	return set_hasnext(&it->iter);
+}
+
+const struct fsm_state **
+state_set_array(const struct state_set *set)
+{
+	return (const struct fsm_state **)set_array(set->set);
+}
+
+int
+state_set_cmp(const struct state_set *a, const struct state_set *b)
+{
+	return set_cmp(a->set, b->set);
+}
+
+

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -13,9 +13,11 @@
 #include <fsm/fsm.h>
 #include <fsm/options.h>
 
+#include <adt/set.h>
+
 #define FSM_ENDCOUNT_MAX ULONG_MAX
 
-struct set;
+/* struct set; */
 
 /*
  * The alphabet (Sigma) for libfsm's FSM is arbitrary octets.
@@ -35,15 +37,104 @@ enum fsm_edge_type {
 
 #define FSM_EDGE_MAX FSM_EDGE_EPSILON
 
+struct fsm_edge;
+struct fsm_state;
+
+struct edge_set {
+	struct set *set;
+};
+
+struct edge_iter {
+	struct set_iter iter;
+};
+
+void
+edge_set_free(struct edge_set *set);
+
+struct fsm_edge *
+edge_set_add(struct edge_set *set, struct fsm_edge *e);
+
+struct fsm_edge *
+edge_set_contains(const struct edge_set *set, const struct fsm_edge *e);
+
+size_t
+edge_set_count(const struct edge_set *set);
+
+void
+edge_set_remove(struct edge_set *set, const struct fsm_edge *e);
+
+struct fsm_edge *
+edge_set_first(struct edge_set *set, struct edge_iter *it);
+
+struct fsm_edge *
+edge_set_firstafter(struct edge_set *set, struct edge_iter *it, const struct fsm_edge *e);
+
+struct fsm_edge *
+edge_set_next(struct edge_iter *it);
+
+int
+edge_set_hasnext(struct edge_iter *it);
+
+struct fsm_edge *
+edge_set_only(const struct edge_set *s);
+
+struct state_set {
+	struct set *set;
+};
+
+struct state_set *
+state_set_create(void);
+
+void
+state_set_free(struct state_set *set);
+
+struct fsm_state *
+state_set_add(struct state_set *set, struct fsm_state *st);
+
+void
+state_set_remove(struct state_set *set, const struct fsm_state *st);
+
+int
+state_set_empty(const struct state_set *s);
+
+struct fsm_state *
+state_set_only(const struct state_set *s);
+
+struct state_iter {
+	struct set_iter iter;
+};
+
+struct fsm_state *
+state_set_contains(const struct state_set *set, const struct fsm_state *st);
+
+size_t
+state_set_count(const struct state_set *set);
+
+struct fsm_state *
+state_set_first(struct state_set *set, struct state_iter *it);
+
+struct fsm_state *
+state_set_next(struct state_iter *it);
+
+int
+state_set_hasnext(struct state_iter *it);
+
+/* uses set_cmp */
+int
+state_set_cmp(const struct state_set *a, const struct state_set *b);
+
+const struct fsm_state **
+state_set_array(const struct state_set *set);
+
 struct fsm_edge {
-	struct set *sl;
+	struct state_set *sl;
 	enum fsm_edge_type symbol;
 };
 
 struct fsm_state {
 	unsigned int end:1;
 
-	struct set *edges; /* containing `struct fsm_edge *` */
+	struct edge_set *edges; /* containing `struct fsm_edge *` */
 
 	void *opaque;
 
@@ -79,7 +170,7 @@ struct fsm_edge *
 fsm_addedge(struct fsm_state *from, struct fsm_state *to, enum fsm_edge_type type);
 
 void
-fsm_carryopaque(struct fsm *fsm, const struct set *set,
+fsm_carryopaque(struct fsm *fsm, const struct state_set *set,
 	struct fsm *new, struct fsm_state *state);
 
 #endif

--- a/src/libfsm/mergestates.c
+++ b/src/libfsm/mergestates.c
@@ -18,12 +18,12 @@ fsm_mergestates(struct fsm *fsm, struct fsm_state *a, struct fsm_state *b)
 {
 	struct fsm_edge *e, *f;
 	struct fsm_state *s;
-	struct set_iter it;
+	struct edge_iter it;
 
 	/* edges from b */
-	for (e = set_first(b->edges, &it); e != NULL; e = set_next(&it)) {
-		struct set_iter jt;
-		for (s = set_first(e->sl, &jt); s != NULL; s = set_next(&jt)) {
+	for (e = edge_set_first(b->edges, &it); e != NULL; e = edge_set_next(&it)) {
+		struct state_iter jt;
+		for (s = state_set_first(e->sl, &jt); s != NULL; s = state_set_next(&jt)) {
 			f = fsm_addedge(a, s, e->symbol);
 			if (f == NULL) {
 				return NULL;
@@ -33,13 +33,13 @@ fsm_mergestates(struct fsm *fsm, struct fsm_state *a, struct fsm_state *b)
 
 	/* edges to b */
 	for (s = fsm->sl; s != NULL; s = s->next) {
-		for (e = set_first(s->edges, &it); e != NULL; e = set_next(&it)) {
-			if (set_contains(e->sl, b)) {
+		for (e = edge_set_first(s->edges, &it); e != NULL; e = edge_set_next(&it)) {
+			if (state_set_contains(e->sl, b)) {
 				f = fsm_addedge(s, a, e->symbol);
 				if (f == NULL) {
 					return NULL;
 				}
-				set_remove(&e->sl, b);
+				state_set_remove(e->sl, b);
 			}
 		}
 	}

--- a/src/libfsm/mode.c
+++ b/src/libfsm/mode.c
@@ -17,7 +17,7 @@ struct fsm_state *
 fsm_findmode(const struct fsm_state *state, unsigned int *freq)
 {
 	struct fsm_edge *e;
-	struct set_iter it;
+	struct edge_iter it;
 	struct fsm_state *s;
 
 	struct {
@@ -30,15 +30,15 @@ fsm_findmode(const struct fsm_state *state, unsigned int *freq)
 
 	assert(state != NULL);
 
-	for (e = set_first(state->edges, &it); e != NULL; e = set_next(&it)) {
-		struct set_iter jt;
+	for (e = edge_set_first(state->edges, &it); e != NULL; e = edge_set_next(&it)) {
+		struct state_iter jt;
 
 		if (e->symbol > UCHAR_MAX) {
 			break;
 		}
 
-		for (s = set_first(e->sl, &jt); s != NULL; s = set_next(&jt)) {
-			struct set_iter kt = it;
+		for (s = state_set_first(e->sl, &jt); s != NULL; s = state_set_next(&jt)) {
+			struct edge_iter kt = it;
 			struct fsm_edge *c;
 			unsigned int curr;
 
@@ -48,8 +48,8 @@ fsm_findmode(const struct fsm_state *state, unsigned int *freq)
 			 * This works because the edges are still sorted by
 			 * symbol, so we don't have to walk the whole thing.
 			 */
-			for (c = set_next(&kt); c != NULL; c = set_next(&kt)) {
-				if (set_contains(c->sl, s)) {
+			for (c = edge_set_next(&kt); c != NULL; c = edge_set_next(&kt)) {
+				if (state_set_contains(c->sl, s)) {
 					curr++;
 				}
 			}

--- a/src/libfsm/pred/epsilonsonly.c
+++ b/src/libfsm/pred/epsilonsonly.c
@@ -17,7 +17,7 @@ int
 fsm_epsilonsonly(const struct fsm *fsm, const struct fsm_state *state)
 {
 	struct fsm_edge *e, s;
-	struct set_iter it;
+	struct edge_iter it;
 
 	assert(fsm != NULL);
 	assert(state != NULL);
@@ -25,17 +25,17 @@ fsm_epsilonsonly(const struct fsm *fsm, const struct fsm_state *state)
 	(void) fsm;
 
 	s.symbol = FSM_EDGE_EPSILON;
-	e = set_contains(state->edges, &s);
-	if (e == NULL || set_empty(e->sl)) {
+	e = edge_set_contains(state->edges, &s);
+	if (e == NULL || state_set_empty(e->sl)) {
 		return 0;
 	}
 
-	for (e = set_first(state->edges, &it); e != NULL; e = set_next(&it)) {
+	for (e = edge_set_first(state->edges, &it); e != NULL; e = edge_set_next(&it)) {
 		if (e->symbol == FSM_EDGE_EPSILON) {
 			continue;
 		}
 
-		if (!set_empty(e->sl)) {
+		if (!state_set_empty(e->sl)) {
 			return 0;
 		}
 	}

--- a/src/libfsm/pred/hasincoming.c
+++ b/src/libfsm/pred/hasincoming.c
@@ -23,10 +23,10 @@ fsm_hasincoming(const struct fsm *fsm, const struct fsm_state *state)
 
 	for (s = fsm->sl; s != NULL; s = s->next) {
 		struct fsm_edge *e;
-		struct set_iter it;
+		struct edge_iter it;
 
-		for (e = set_first(s->edges, &it); e != NULL; e = set_next(&it)) {
-			if (set_contains(e->sl, state)) {
+		for (e = edge_set_first(s->edges, &it); e != NULL; e = edge_set_next(&it)) {
+			if (state_set_contains(e->sl, state)) {
 				return 1;
 			}
 		}

--- a/src/libfsm/pred/hasoutgoing.c
+++ b/src/libfsm/pred/hasoutgoing.c
@@ -17,14 +17,14 @@ int
 fsm_hasoutgoing(const struct fsm *fsm, const struct fsm_state *state)
 {
 	struct fsm_edge *e;
-	struct set_iter it;
+	struct edge_iter it;
 
 	assert(fsm != NULL);
 	assert(state != NULL);
 
 	(void) fsm;
-	for (e = set_first(state->edges, &it); e != NULL; e = set_next(&it)) {
-		if (!set_empty(e->sl)) {
+	for (e = edge_set_first(state->edges, &it); e != NULL; e = edge_set_next(&it)) {
+		if (!state_set_empty(e->sl)) {
 			return 1;
 		}
 	}

--- a/src/libfsm/pred/iscomplete.c
+++ b/src/libfsm/pred/iscomplete.c
@@ -18,7 +18,7 @@ int
 fsm_iscomplete(const struct fsm *fsm, const struct fsm_state *state)
 {
 	struct fsm_edge *e;
-	struct set_iter it;
+	struct edge_iter it;
 	unsigned n;
 
 	assert(fsm != NULL);
@@ -27,13 +27,13 @@ fsm_iscomplete(const struct fsm *fsm, const struct fsm_state *state)
 	n = 0;
 
 	/* TODO: assert state is in fsm->sl */
-	for (e = set_first(state->edges, &it); e != NULL; e = set_next(&it)) {
+	for (e = edge_set_first(state->edges, &it); e != NULL; e = edge_set_next(&it)) {
 		/* epsilon transitions have no effect on completeness */
 		if (e->symbol > UCHAR_MAX) {
 			continue;
 		}
 
-		if (set_empty(e->sl)) {
+		if (state_set_empty(e->sl)) {
 			continue;
 		}
 

--- a/src/libfsm/pred/isdfa.c
+++ b/src/libfsm/pred/isdfa.c
@@ -18,7 +18,7 @@ int
 fsm_isdfa(const struct fsm *fsm, const struct fsm_state *state)
 {
 	struct fsm_edge *e, s;
-	struct set_iter it;
+	struct edge_iter it;
 
 	assert(fsm != NULL);
 
@@ -33,27 +33,27 @@ fsm_isdfa(const struct fsm *fsm, const struct fsm_state *state)
 	 * DFA may not have epsilon edges.
 	 */
 	s.symbol = FSM_EDGE_EPSILON;
-	e = set_contains(state->edges, &s);
-	if (e != NULL && !set_empty(e->sl)) {
+	e = edge_set_contains(state->edges, &s);
+	if (e != NULL && !state_set_empty(e->sl)) {
 		return 0;
 	}
 
 	/*
 	 * DFA may not have duplicate edges.
 	 */
-	for (e = set_first(state->edges, &it); e != NULL; e = set_next(&it)) {
-		struct set_iter jt;
+	for (e = edge_set_first(state->edges, &it); e != NULL; e = edge_set_next(&it)) {
+		struct state_iter jt;
 
 		if (e->symbol > UCHAR_MAX) {
 			break;
 		}
 
-		if (set_empty(e->sl)) {
+		if (state_set_empty(e->sl)) {
 			continue;
 		}
 
-		(void) set_first(e->sl, &jt);
-		if (set_hasnext(&jt)) {
+		(void) state_set_first(e->sl, &jt);
+		if (state_set_hasnext(&jt)) {
 			return 0;
 		}
 	}

--- a/src/libfsm/print/api.c
+++ b/src/libfsm/print/api.c
@@ -124,7 +124,8 @@ fsm_print_api(FILE *f, const struct fsm *fsm)
 	for (s = fsm->sl; s != NULL; s = s->next) {
 		struct fsm_edge *e;
 		struct fsm_state *st;
-		struct set_iter it, jt;
+		struct edge_iter it;
+		struct state_iter jt;
 		unsigned int from, to;
 		unsigned int i;
 
@@ -134,8 +135,8 @@ fsm_print_api(FILE *f, const struct fsm *fsm)
 			bm_clear(&a[i]);
 		}
 
-		for (e = set_first(s->edges, &it); e != NULL; e = set_next(&it)) {
-			for (st = set_first(e->sl, &jt); st != NULL; st = set_next(&jt)) {
+		for (e = edge_set_first(s->edges, &it); e != NULL; e = edge_set_next(&it)) {
+			for (st = state_set_first(e->sl, &jt); st != NULL; st = state_set_next(&jt)) {
 				assert(st != NULL);
 
 				to = indexof(fsm, st);

--- a/src/libfsm/print/dot.c
+++ b/src/libfsm/print/dot.c
@@ -44,21 +44,21 @@ indexof(const struct fsm *fsm, const struct fsm_state *state)
 /* Return true if the edges after o contains state */
 /* TODO: centralise */
 static int
-contains(struct set *edges, int o, struct fsm_state *state)
+contains(struct edge_set *edges, int o, struct fsm_state *state)
 {
 	struct fsm_edge *e, search;
-	struct set_iter it;
+	struct edge_iter it;
 
 	assert(edges != NULL);
 	assert(state != NULL);
 
 	search.symbol = o;
-	for (e = set_firstafter(edges, &it, &search); e != NULL; e = set_next(&it)) {
+	for (e = edge_set_firstafter(edges, &it, &search); e != NULL; e = edge_set_next(&it)) {
 		if (e->symbol > UCHAR_MAX) {
 			return 0;
 		}
 
-		if (set_contains(e->sl, state)) {
+		if (state_set_contains(e->sl, state)) {
 			return 1;
 		}
 	}
@@ -70,7 +70,7 @@ static void
 singlestate(FILE *f, const struct fsm *fsm, struct fsm_state *s)
 {
 	struct fsm_edge *e, search;
-	struct set_iter it;
+	struct edge_iter it;
 
 	assert(f != NULL);
 	assert(fsm != NULL);
@@ -94,10 +94,10 @@ singlestate(FILE *f, const struct fsm *fsm, struct fsm_state *s)
 
 			fprintf(f, "{");
 
-			for (q = set_first(s->nfasl, &it); q != NULL; q = set_next(&it)) {
+			for (q = edge_set_first(s->nfasl, &it); q != NULL; q = edge_set_next(&it)) {
 				fprintf(f, "%u", indexof(fsm->nfa, q));
 
-				if (set_hasnext(&it)) {
+				if (edge_set_hasnext(&it)) {
 					fprintf(f, ",");
 				}
 			}
@@ -110,11 +110,11 @@ singlestate(FILE *f, const struct fsm *fsm, struct fsm_state *s)
 	}
 
 	if (!fsm->opt->consolidate_edges) {
-		for (e = set_first(s->edges, &it); e != NULL; e = set_next(&it)) {
+		for (e = edge_set_first(s->edges, &it); e != NULL; e = edge_set_next(&it)) {
 			struct fsm_state *st;
-			struct set_iter jt;
+			struct state_iter jt;
 
-			for (st = set_first(e->sl, &jt); st != NULL; st = set_next(&jt)) {
+			for (st = state_set_first(e->sl, &jt); st != NULL; st = state_set_next(&jt)) {
 				assert(st != NULL);
 
 				fprintf(f, "\t%sS%-2u -> %sS%-2u [ label = <",
@@ -149,17 +149,17 @@ singlestate(FILE *f, const struct fsm *fsm, struct fsm_state *s)
 	 * looping through each edge.
 	 */
 	/* TODO: handle special edges upto FSM_EDGE_MAX separately */
-	for (e = set_first(s->edges, &it); e != NULL; e = set_next(&it)) {
+	for (e = edge_set_first(s->edges, &it); e != NULL; e = edge_set_next(&it)) {
 		struct fsm_state *st;
-		struct set_iter jt;
+		struct state_iter jt;
 
 		if (e->symbol > UCHAR_MAX) {
 			break;
 		}
 
-		for (st = set_first(e->sl, &jt); st != NULL; st = set_next(&jt)) {
+		for (st = state_set_first(e->sl, &jt); st != NULL; st = state_set_next(&jt)) {
 			struct fsm_edge *ne;
-			struct set_iter kt;
+			struct edge_iter kt;
 			struct bm bm;
 
 			assert(st != NULL);
@@ -172,12 +172,12 @@ singlestate(FILE *f, const struct fsm *fsm, struct fsm_state *s)
 			bm_clear(&bm);
 
 			/* find all edges which go from this state to the same target state */
-			for (ne = set_first(s->edges, &kt); ne != NULL; ne = set_next(&kt)) {
+			for (ne = edge_set_first(s->edges, &kt); ne != NULL; ne = edge_set_next(&kt)) {
 				if (ne->symbol > UCHAR_MAX) {
 					break;
 				}
 
-				if (set_contains(ne->sl, st)) {
+				if (state_set_contains(ne->sl, st)) {
 					bm_set(&bm, ne->symbol);
 				}
 			}
@@ -204,11 +204,11 @@ singlestate(FILE *f, const struct fsm *fsm, struct fsm_state *s)
 	 * Special edges are not consolidated above
 	 */
 	search.symbol = UCHAR_MAX;
-	for (e = set_firstafter(s->edges, &it, &search); e != NULL; e = set_next(&it)) {
+	for (e = edge_set_firstafter(s->edges, &it, &search); e != NULL; e = edge_set_next(&it)) {
 		struct fsm_state *st;
-		struct set_iter jt;
+		struct state_iter jt;
 
-		for (st = set_first(e->sl, &jt); st != NULL; st = set_next(&jt)) {
+		for (st = state_set_first(e->sl, &jt); st != NULL; st = state_set_next(&jt)) {
 			fprintf(f, "\t%sS%-2u -> %sS%-2u [ weight = 1, label = <",
 				fsm->opt->prefix != NULL ? fsm->opt->prefix : "",
 				indexof(fsm, s),

--- a/src/libfsm/print/fsm.c
+++ b/src/libfsm/print/fsm.c
@@ -45,14 +45,15 @@ findany(const struct fsm_state *state)
 {
 	struct fsm_state *f, *s;
 	struct fsm_edge *e;
-	struct set_iter it;
+	struct edge_iter it;
+	struct state_iter jt;
 	struct bm bm;
 
 	assert(state != NULL);
 
 	bm_clear(&bm);
 
-	e = set_first(state->edges, &it);
+	e = edge_set_first(state->edges, &it);
 	if (e == NULL) {
 		return NULL;
 	}
@@ -63,21 +64,21 @@ findany(const struct fsm_state *state)
 		return NULL;
 	}
 
-	f = set_first(e->sl, &it);
+	f = state_set_first(e->sl, &jt);
 	if (f == NULL) {
 		return NULL;
 	}
 
-	for (e = set_first(state->edges, &it); e != NULL; e = set_next(&it)) {
+	for (e = edge_set_first(state->edges, &it); e != NULL; e = edge_set_next(&it)) {
 		if (e->symbol > UCHAR_MAX) {
 			return NULL;
 		}
 
-		if (set_count(e->sl) != 1) {
+		if (state_set_count(e->sl) != 1) {
 			return NULL;
 		}
 
-		s = set_only(e->sl);
+		s = state_set_only(e->sl);
 		if (f != s) {
 			return NULL;
 		}
@@ -105,7 +106,7 @@ fsm_print_fsm(FILE *f, const struct fsm *fsm)
 
 	for (s = fsm->sl; s != NULL; s = s->next) {
 		struct fsm_edge *e;
-		struct set_iter it;
+		struct edge_iter it;
 
 		{
 			const struct fsm_state *a;
@@ -117,11 +118,11 @@ fsm_print_fsm(FILE *f, const struct fsm *fsm)
 			}
 		}
 
-		for (e = set_first(s->edges, &it); e != NULL; e = set_next(&it)) {
+		for (e = edge_set_first(s->edges, &it); e != NULL; e = edge_set_next(&it)) {
 			struct fsm_state *st;
-			struct set_iter jt;
+			struct state_iter jt;
 
-			for (st = set_first(e->sl, &jt); st != NULL; st = set_next(&jt)) {
+			for (st = state_set_first(e->sl, &jt); st != NULL; st = state_set_next(&jt)) {
 				assert(st != NULL);
 
 				fprintf(f, "%-2u -> %2u", indexof(fsm, s), indexof(fsm, st));

--- a/src/libfsm/print/ir.c
+++ b/src/libfsm/print/ir.c
@@ -84,7 +84,7 @@ make_groups(const struct fsm *fsm, const struct fsm_state *state, const struct f
 	struct range ranges[UCHAR_MAX]; /* worst case */
 	struct ir_group *groups;
 	struct fsm_edge *e;
-	struct set_iter it;
+	struct edge_iter it;
 	size_t i, j, k;
 	size_t n;
 
@@ -102,18 +102,18 @@ make_groups(const struct fsm *fsm, const struct fsm_state *state, const struct f
 
 	n = 0;
 
-	for (e = set_first(state->edges, &it); e != NULL; e = set_next(&it)) {
+	for (e = edge_set_first(state->edges, &it); e != NULL; e = edge_set_next(&it)) {
 		struct fsm_state *s;
 
 		if (e->symbol > UCHAR_MAX) {
 			break;
 		}
 
-		if (set_empty(e->sl)) {
+		if (state_set_empty(e->sl)) {
 			continue;
 		}
 
-		s = set_only(e->sl);
+		s = state_set_only(e->sl);
 		if (s == mode) {
 			continue;
 		}
@@ -126,25 +126,25 @@ make_groups(const struct fsm *fsm, const struct fsm_state *state, const struct f
 			do {
 				const struct fsm_edge *ne;
 				const struct fsm_state *ns;
-				struct set_iter jt;
+				struct edge_iter jt;
 
-				ne = set_firstafter(state->edges, &jt, e);
+				ne = edge_set_firstafter(state->edges, &jt, e);
 				if (ne == NULL || ne->symbol != e->symbol + 1) {
 					break;
 				}
 
-				if (set_empty(ne->sl)) {
+				if (state_set_empty(ne->sl)) {
 					break;
 				}
 
-				ns = set_only(ne->sl);
+				ns = state_set_only(ne->sl);
 				if (ns == mode || ns != s) {
 					break;
 				}
 
 				ranges[n].end = ne->symbol;
 
-				e = set_next(&it);
+				e = edge_set_next(&it);
 			} while (e != NULL);
 		}
 
@@ -378,9 +378,9 @@ make_state(const struct fsm *fsm,
 	/* no edges */
 	{
 		struct fsm_edge *e;
-		struct set_iter it;
+		struct edge_iter it;
 
-		e = set_first(state->edges, &it);
+		e = edge_set_first(state->edges, &it);
 		if (!e || e->symbol > UCHAR_MAX) {
 			cs->strategy = IR_NONE;
 			return 0;

--- a/src/libfsm/print/json.c
+++ b/src/libfsm/print/json.c
@@ -42,14 +42,14 @@ static int
 hasmore(const struct fsm_state *s, int i)
 {
 	struct fsm_edge *e, search;
-	struct set_iter it;
+	struct edge_iter it;
 
 	assert(s != NULL);
 
 	i++;
 	search.symbol = i;
-	for (e = set_firstafter(s->edges, &it, &search); e != NULL; e = set_next(&it)) {
-		if (!set_empty(e->sl)) {
+	for (e = edge_set_firstafter(s->edges, &it, &search); e != NULL; e = edge_set_next(&it)) {
+		if (!state_set_empty(e->sl)) {
 			return 1;
 		}
 	}
@@ -72,7 +72,7 @@ fsm_print_json(FILE *f, const struct fsm *fsm)
 
 		for (s = fsm->sl; s != NULL; s = s->next) {
 			struct fsm_edge *e;
-			struct set_iter it;
+			struct edge_iter it;
 
 			fprintf(f, "\t\t{\n");
 
@@ -81,11 +81,11 @@ fsm_print_json(FILE *f, const struct fsm *fsm)
 
 			fprintf(f, "\t\t\t\"edges\": [\n");
 
-			for (e = set_first(s->edges, &it); e != NULL; e = set_next(&it)) {
+			for (e = edge_set_first(s->edges, &it); e != NULL; e = edge_set_next(&it)) {
 				struct fsm_state *st;
-				struct set_iter jt;
+				struct state_iter jt;
 
-				for (st = set_first(e->sl, &jt); st != NULL; st = set_next(&jt)) {
+				for (st = state_set_first(e->sl, &jt); st != NULL; st = state_set_next(&jt)) {
 					assert(st != NULL);
 
 					fprintf(f, "\t\t\t\t{ ");
@@ -108,7 +108,7 @@ fsm_print_json(FILE *f, const struct fsm *fsm)
 					fprintf(f, "\"to\": %u",
 						indexof(fsm, st));
 
-					fprintf(f, "}%s\n", set_hasnext(&it) && hasmore(s, e->symbol) ? "," : "");
+					fprintf(f, "}%s\n", edge_set_hasnext(&it) && hasmore(s, e->symbol) ? "," : "");
 				}
 			}
 

--- a/src/libfsm/shortest.c
+++ b/src/libfsm/shortest.c
@@ -70,7 +70,7 @@ fsm_shortest(const struct fsm *fsm,
 	while (u = priq_pop(&todo), u != NULL) {
 		const struct fsm_state *s;
 		struct fsm_edge *e;
-		struct set_iter it;
+		struct edge_iter it;
 
 		priq_move(&done, u);
 
@@ -83,10 +83,10 @@ fsm_shortest(const struct fsm *fsm,
 			goto done;
 		}
 
-		for (e = set_first(u->state->edges, &it); e != NULL; e = set_next(&it)) {
-			struct set_iter jt;
+		for (e = edge_set_first(u->state->edges, &it); e != NULL; e = edge_set_next(&it)) {
+			struct state_iter jt;
 
-			for (s = set_first(e->sl, &jt); s != NULL; s = set_next(&jt)) {
+			for (s = state_set_first(e->sl, &jt); s != NULL; s = state_set_next(&jt)) {
 				struct priq *v;
 				unsigned c;
 

--- a/src/libfsm/subgraph.c
+++ b/src/libfsm/subgraph.c
@@ -128,7 +128,8 @@ fsm_state_duplicatesubgraphx(struct fsm *fsm, struct fsm_state *state,
 	/* TODO: errors leave fsm in a questionable state */
 
 	while (m = getnextnotdone(mappings), m != NULL) {
-		struct set_iter it, jt;
+		struct edge_iter it;
+		struct state_iter jt;
 		struct fsm_state *s;
 		struct fsm_edge *e;
 
@@ -136,8 +137,8 @@ fsm_state_duplicatesubgraphx(struct fsm *fsm, struct fsm_state *state,
 			*x = m->new;
 		}
 
-		for (e = set_first(m->old->edges, &it); e != NULL; e = set_next(&it)) {
-			for (s = set_first(e->sl, &jt); s != NULL; s = set_next(&jt)) {
+		for (e = edge_set_first(m->old->edges, &it); e != NULL; e = edge_set_next(&it)) {
+			for (s = state_set_first(e->sl, &jt); s != NULL; s = state_set_next(&jt)) {
 				struct mapping *to;
 
 				assert(s != NULL);

--- a/src/libfsm/trim.c
+++ b/src/libfsm/trim.c
@@ -40,13 +40,13 @@ fsm_trim(struct fsm *fsm)
 
 	while (p = dlist_nextnotdone(list), p != NULL) {
 		struct fsm_edge *e;
-		struct set_iter it;
+		struct edge_iter it;
 
-		for (e = set_first(p->state->edges, &it); e != NULL; e = set_next(&it)) {
+		for (e = edge_set_first(p->state->edges, &it); e != NULL; e = edge_set_next(&it)) {
 			struct fsm_state *st;
-			struct set_iter jt;
+			struct state_iter jt;
 
-			for (st = set_first(e->sl, &jt); st != NULL; st = set_next(&jt)) {
+			for (st = state_set_first(e->sl, &jt); st != NULL; st = state_set_next(&jt)) {
 				/* not a list operation... */
 				if (dlist_contains(list, st)) {
 					continue;

--- a/src/libfsm/walk/iter.c
+++ b/src/libfsm/walk/iter.c
@@ -52,13 +52,13 @@ fsm_walk_edges(const struct fsm *fsm, void *opaque,
 	assert(callback != NULL);
 
 	for (src = fsm->sl; src != NULL; src = src->next) {
-		struct set_iter ei;
+		struct edge_iter ei;
 		const struct fsm_edge *e;
 
-		for (e = set_first(src->edges, &ei); e != NULL; e=set_next(&ei)) {
-			struct set_iter di;
+		for (e = edge_set_first(src->edges, &ei); e != NULL; e=edge_set_next(&ei)) {
+			struct state_iter di;
 			const struct fsm_state *dst;
-			for (dst = set_first(e->sl, &di); dst != NULL; dst=set_next(&di)) {
+			for (dst = state_set_first(e->sl, &di); dst != NULL; dst=state_set_next(&di)) {
 				if (!callback(fsm, src, (unsigned int)e->symbol, dst, opaque)) {
 					return 0;
 				}

--- a/src/libfsm/walk/reachable.c
+++ b/src/libfsm/walk/reachable.c
@@ -38,7 +38,7 @@ fsm_reachable(const struct fsm *fsm, const struct fsm_state *state,
 
 	while (p = dlist_nextnotdone(list), p != NULL) {
 		struct fsm_edge *e;
-		struct set_iter it;
+		struct edge_iter it;
 
 		if (any) {
 			if (predicate(fsm, p->state)) {
@@ -52,11 +52,11 @@ fsm_reachable(const struct fsm *fsm, const struct fsm_state *state,
 			}
 		}
 
-		for (e = set_first(p->state->edges, &it); e != NULL; e = set_next(&it)) {
+		for (e = edge_set_first(p->state->edges, &it); e != NULL; e = edge_set_next(&it)) {
 			struct fsm_state *st;
-			struct set_iter jt;
+			struct state_iter jt;
 
-			for (st = set_first(e->sl, &jt); st != NULL; st = set_next(&jt)) {
+			for (st = state_set_first(e->sl, &jt); st != NULL; st = state_set_next(&jt)) {
 				/* not a list operation... */
 				if (dlist_contains(list, st)) {
 					continue;

--- a/src/libfsm/walk2.c
+++ b/src/libfsm/walk2.c
@@ -32,12 +32,84 @@ struct fsm_walk2_tuple {
 	struct fsm_state *comb;
 };
 
+struct tuple_set {
+	struct set *set;
+};
+
+/* comparison of fsm_walk2_tuples for the (ordered) set */
+static int
+cmp_walk2_tuple(const void *a, const void *b)
+{
+	const struct fsm_walk2_tuple *pa = a, *pb = b;
+	ptrdiff_t delta;
+
+	/* XXX: do we need to specially handle NULLs? */
+
+	delta = (pa->a > pb->a) - (pa->a < pb->a);
+	if (delta == 0) {
+		delta = (pa->b > pb->b) - (pa->b < pb->b);
+	}
+
+	return delta;
+}
+
+struct tuple_set *
+tuple_set_create(const struct fsm *fsm)
+{
+	static const struct tuple_set init;
+	struct tuple_set *set;
+
+	set = f_malloc(fsm, sizeof *set);
+	if (!set) {
+		return NULL;
+	}
+	*set = init;
+	set->set = set_create(cmp_walk2_tuple);
+	if (set->set == NULL) {
+		free(set);
+		return NULL;
+	}
+
+	return set;
+}
+
+void
+tuple_set_free(const struct fsm *fsm, struct tuple_set *set)
+{
+	if (set == NULL) {
+		return;
+	}
+
+	if (set->set != NULL) {
+		set_free(set->set);
+		set->set = NULL;
+	}
+
+	f_free(fsm, set);
+}
+
+static struct fsm_walk2_tuple *
+tuple_set_contains(struct tuple_set *set, const struct fsm_walk2_tuple *item)
+{
+	return set_contains(set->set, (const void *)item);
+}
+
+static struct fsm_walk2_tuple *
+tuple_set_add(struct tuple_set *set, const struct fsm_walk2_tuple *item)
+{
+	return set_add(&set->set, (void *)item);
+}
+
+struct tuple_iter {
+	struct set_iter iter;
+};
+
 struct fsm_walk2_data {
 	struct fsm_walk2_tuple_pool *head;
 	size_t top;
 
 	struct fsm *new;
-	struct set *states;
+	struct tuple_set *states;
 
 	/*
 	 * Table for which combinations are valid bits.
@@ -60,23 +132,6 @@ struct fsm_walk2_data {
 	unsigned endmask :4; /* bit table for what states are end states in the combined graph */
 	unsigned edgemask:4; /* bit table for which edges should be followed */
 };
-
-/* comparison of fsm_walk2_tuples for the (ordered) set */
-static int
-cmp_walk2_tuple(const void *a, const void *b)
-{
-	const struct fsm_walk2_tuple *pa = a, *pb = b;
-	ptrdiff_t delta;
-
-	/* XXX: do we need to specially handle NULLs? */
-
-	delta = (pa->a > pb->a) - (pa->a < pb->a);
-	if (delta == 0) {
-		delta = (pa->b > pb->b) - (pa->b < pb->b);
-	}
-
-	return delta;
-}
 
 /*
  * Size of the tuple pool (see comment in struct fsm_walk2_tuple_pool below).
@@ -104,7 +159,7 @@ fsm_walk2_data_free(const struct fsm *fsm, struct fsm_walk2_data *data)
 	struct fsm_walk2_tuple_pool *p, *next;
 
 	if (data->states) {
-		set_free(data->states);
+		tuple_set_free(fsm,data->states);
 	}
 
 	for (p = data->head; p != NULL; p = next) {
@@ -179,7 +234,7 @@ fsm_walk2_tuple_new(struct fsm_walk2_data *data,
 
 	assert(data->states);
 
-	p = set_contains(data->states, &lkup);
+	p = tuple_set_contains(data->states, &lkup);
 	if (p != NULL) {
 		return p;
 	}
@@ -198,7 +253,7 @@ fsm_walk2_tuple_new(struct fsm_walk2_data *data,
 	p->a = a;
 	p->b = b;
 	p->comb = comb;
-	if (!set_add(&data->states, p)) {
+	if (!tuple_set_add(data->states, p)) {
 		return NULL;
 	}
 
@@ -252,7 +307,7 @@ fsm_walk2_edges(struct fsm_walk2_data *data,
 	const struct fsm *a, const struct fsm *b, struct fsm_walk2_tuple *start)
 {
 	struct fsm_state *qa, *qb, *qc;
-	struct set_iter ei, ej;
+	struct edge_iter ei, ej;
 	const struct fsm_edge *ea, *eb;
 
 	assert(a != NULL);
@@ -324,8 +379,8 @@ fsm_walk2_edges(struct fsm_walk2_data *data,
 	}
 
 	/* take care of only A and both A&B edges */
-	for (ea = set_first(qa->edges, &ei); ea != NULL; ea=set_next(&ei)) {
-		struct set_iter dia, dib;
+	for (ea = edge_set_first(qa->edges, &ei); ea != NULL; ea = edge_set_next(&ei)) {
+		struct state_iter dia, dib;
 		const struct fsm_state *da, *db;
 
 		eb = qb ? fsm_hasedge(qb, ea->symbol) : NULL;
@@ -338,8 +393,8 @@ fsm_walk2_edges(struct fsm_walk2_data *data,
 			continue;
 		}
 
-		for (da = set_first(ea->sl, &dia); da != NULL; da=set_next(&dia)) {
-			db = eb ? set_first(eb->sl, &dib) : NULL;
+		for (da = state_set_first(ea->sl, &dia); da != NULL; da = state_set_next(&dia)) {
+			db = eb ? state_set_first(eb->sl, &dib) : NULL;
 
 			/*
 			 * for loop with break to handle the situation where there is no
@@ -372,7 +427,7 @@ fsm_walk2_edges(struct fsm_walk2_data *data,
 
 				/* if db != NULL, fetch the next edge in B */
 				if (db != NULL) {
-					db = set_next(&dib);
+					db = state_set_next(&dib);
 				}
 
 				/* if db == NULL, stop iterating over edges in B */
@@ -391,8 +446,8 @@ only_b:
 	}
 
 	/* take care of only B edges */
-	for (eb = set_first(qb->edges, &ej); eb != NULL; eb=set_next(&ej)) {
-		struct set_iter dib;
+	for (eb = edge_set_first(qb->edges, &ej); eb != NULL; eb=edge_set_next(&ej)) {
+		struct state_iter dib;
 		const struct fsm_state *db;
 
 		ea = qa ? fsm_hasedge(qa, eb->symbol) : NULL;
@@ -406,7 +461,7 @@ only_b:
 		 * ONLYB loop is simpler because we only deal with
 		 * states in the B graph (the A state is always NULL)
 		 */
-		for (db = set_first(eb->sl, &dib); db != NULL; db=set_next(&dib)) {
+		for (db = state_set_first(eb->sl, &dib); db != NULL; db=state_set_next(&dib)) {
 			for (;;) {
 				struct fsm_walk2_tuple *dst;
 
@@ -498,7 +553,7 @@ fsm_walk2(const struct fsm *a, const struct fsm *b,
 		goto error;
 	}
 
-	data.states = set_create(cmp_walk2_tuple);
+	data.states = tuple_set_create(data.new);
 	if (data.states == NULL) {
 		goto error;
 	}


### PR DESCRIPTION
Adds specific set types (state_set, edge_set, etc.) to libfsm.  This makes it easier to see which specific sets hold what values and allows the implementation of specific sets to vary.

This stacks on #124 