### PR TITLE
Changes mapping_set in determinise.c to use a hash set 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ SUBDIR += tests/reverse
 SUBDIR += tests/union
 SUBDIR += tests/set
 SUBDIR += tests/sql
+SUBDIR += tests/hashset
 SUBDIR += tests
 .if !empty(.TARGETS:Mfuzz)
 SUBDIR += theft

--- a/include/adt/hashset.h
+++ b/include/adt/hashset.h
@@ -1,0 +1,92 @@
+#ifndef HASHSET_H
+#define HASHSET_H
+
+#define DEFAULT_LOAD 0.66
+#define DEFAULT_NBUCKETS 4
+
+struct bucket;
+
+struct hashset {
+	size_t nbuckets;
+	size_t nitems;
+	struct bucket *buckets;
+	size_t maxload;
+	int (*cmp)(const void *,const void *);
+	unsigned long (*hash)(const void *);
+	float load;
+	uint32_t flags;
+};
+
+struct hashset_iter {
+	size_t i;
+	const struct hashset *set;
+};
+
+struct hashset *
+hashset_create(unsigned long (*hash)(const void *a),int (*cmp)(const void *a, const void *b));
+
+int
+hashset_initialize(struct hashset *s, size_t nb, float load,
+	unsigned long (*hash)(const void *a),int (*cmp)(const void *a, const void *b));
+
+void
+hashset_finalize(struct hashset *s);
+
+void *
+hashset_add(struct hashset *s, void *item);
+
+int
+hashset_remove(struct hashset *s, void *item);
+
+void
+hashset_free(struct hashset *s);
+
+size_t
+hashset_count(const struct hashset *s);
+
+void
+hashset_clear(struct hashset *s);
+
+/*
+ * Find if an item is in a set, and return it.
+ */
+void *
+hashset_contains(const struct hashset *s, const void *item);
+
+/*
+ * Compare two sets for equality.
+ */
+int
+hashset_equal(const struct hashset *a, const struct hashset *b);
+
+int
+hashset_empty(const struct hashset *s);
+
+void *
+hashset_first(const struct hashset *s, struct hashset_iter *it);
+
+void *
+hashset_next(struct hashset_iter *it);
+
+/*
+ * Return the sole item for a singleton set.
+ */
+void *
+hashset_only(const struct hashset *set);
+
+int
+hashset_hasnext(struct hashset_iter *it);
+
+/* Common hash functions */
+
+/* hashes pointer value */
+unsigned long
+hashptr(const void *p);
+
+/* hashes record pointed to by `p` with length n.
+ * this includes padding bytes, so treat with care. */
+unsigned long
+hashrec(const void *p, size_t n);
+
+#endif /* HASHSET_H */
+

--- a/include/adt/hashset.h
+++ b/include/adt/hashset.h
@@ -1,6 +1,8 @@
 #ifndef HASHSET_H
 #define HASHSET_H
 
+#include <stddef.h>
+
 #define DEFAULT_LOAD 0.66
 #define DEFAULT_NBUCKETS 4
 
@@ -14,7 +16,7 @@ struct hashset {
 	int (*cmp)(const void *,const void *);
 	unsigned long (*hash)(const void *);
 	float load;
-	uint32_t flags;
+	unsigned int flags;
 };
 
 struct hashset_iter {

--- a/src/adt/Makefile
+++ b/src/adt/Makefile
@@ -6,6 +6,8 @@ SRC += src/adt/priq.c
 SRC += src/adt/path.c
 SRC += src/adt/set.c
 SRC += src/adt/xalloc.c
+SRC += src/adt/hashset.c
+SRC += src/adt/siphash.c
 
 .for src in ${SRC:Msrc/adt/bitmap.c}
 CFLAGS.${src} += -I src # XXX: for internal.h

--- a/src/adt/Makefile
+++ b/src/adt/Makefile
@@ -14,6 +14,11 @@ CFLAGS.${src} += -I src # XXX: for internal.h
 DFLAGS.${src} += -I src # XXX: for internal.h
 .endfor
 
+.for src in ${SRC:Msrc/adt/siphash.c}
+CFLAGS.${src} += -std=c99 # XXX: for internal.h
+DFLAGS.${src} += -std=c99 # XXX: for internal.h
+.endfor
+
 PART += adt
 
 .for src in ${SRC:Msrc/adt/*.c}

--- a/src/adt/hashset.c
+++ b/src/adt/hashset.c
@@ -4,12 +4,12 @@
  * See LICENCE for the full copyright terms.
  */
 
+#include <adt/hashset.h>
+
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-
-#include <adt/hashset.h>
 
 /* XXX: explore whether we should split the bucket or not */
 
@@ -72,6 +72,7 @@ hashset_initialize(struct hashset *s, size_t nb, float load,
 
 	s->buckets = calloc(nb, sizeof s->buckets[0]);
 	s->maxload = load * nb;
+	s->nbuckets = nb;
 	return (s->buckets != NULL);
 }
 
@@ -185,7 +186,10 @@ hashset_remove(struct hashset *s, void *item)
 void
 hashset_finalize(struct hashset *s)
 {
+	const static struct hashset zero;
+
 	free(s->buckets);
+	*s = zero;
 }
 
 void

--- a/src/adt/hashset.c
+++ b/src/adt/hashset.c
@@ -1,0 +1,370 @@
+/*
+ * Copyright 2018- Shannon Stewman
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <adt/hashset.h>
+
+/* XXX: explore whether we should split the bucket or not */
+
+struct bucket {
+	unsigned long hash;
+	void *item;
+};
+
+#define TOMBSTONE_HASH (~(0UL))
+#define UNSET_HASH     (0UL)
+
+static int
+is_pow2(size_t n) {
+	return (n & (n-1)) == 0;
+}
+
+static int
+finditem(const struct hashset *s, unsigned long hash, const void *item, size_t *bp)
+{
+	size_t b,c,nb;
+
+	if (s->nbuckets == 0) {
+		return 0;
+	}
+
+	b = is_pow2(s->nbuckets) ? (hash & (s->nbuckets-1)) : (hash % s->nbuckets);
+	nb = s->nbuckets;
+	for (c=0; c < nb; c++) {
+		if (s->buckets[b].hash == hash) {
+			if (item == s->buckets[b].item || s->cmp(item, s->buckets[b].item) == 0) {
+				*bp = b;
+				return 1;
+			}
+		} else if (s->buckets[b].item == NULL && s->buckets[b].hash == UNSET_HASH) {
+			*bp = b;
+			return 0;
+		}
+
+		if (++b == nb) {
+			b = 0;
+		}
+	}
+
+	*bp = nb;
+	return 0;
+}
+
+int
+hashset_initialize(struct hashset *s, size_t nb, float load,
+	unsigned long (*hash)(const void *a),int (*cmp)(const void *a, const void *b))
+{
+	static const struct hashset init;
+	*s = init;
+	s->hash = hash;
+	s->cmp = cmp;
+	s->load = load;
+	if (nb == 0) {
+		return 1;
+	}
+
+	s->buckets = calloc(nb, sizeof s->buckets[0]);
+	s->maxload = load * nb;
+	return (s->buckets != NULL);
+}
+
+struct hashset *
+hashset_create(unsigned long (*hash)(const void *a),int (*cmp)(const void *a, const void *b))
+{
+	struct hashset *s = malloc(sizeof *s);
+	hashset_initialize(s, 0,DEFAULT_LOAD, hash,cmp);
+	return s;
+}
+
+static int
+rehash(struct hashset *s)
+{
+	const static struct hashset hs_init;
+
+	size_t i,nb,newsz;
+	struct hashset ns;
+	struct bucket *b;
+
+	ns = hs_init;
+
+	/* check resizing logic */
+	newsz = (s->nbuckets > 0) ? 2*s->nbuckets : DEFAULT_NBUCKETS;
+	ns.buckets = calloc(newsz, sizeof ns.buckets[0]);
+	if (ns.buckets == NULL) {
+		return 0;
+	}
+
+	ns.nbuckets = newsz;
+	ns.maxload = s->load * newsz;
+	ns.hash = s->hash;
+	ns.cmp  = s->cmp;
+
+	nb = s->nbuckets;
+	b = s->buckets;
+	for (i=0; i < nb; i++) {
+		size_t bi = 0;
+
+		if (b[i].item == NULL) {
+			continue;
+		}
+
+		/* XXX: replace finditem with something that doesn't
+		 * call cmp() since all items should be unique */
+		finditem(&ns, b[i].hash, b[i].item, &bi);
+		ns.buckets[bi] = b[i];
+	}
+
+	free(s->buckets);
+	s->nbuckets = ns.nbuckets;
+	s->buckets  = ns.buckets;
+	s->maxload  = ns.maxload;
+	return 1;
+}
+
+void *
+hashset_add(struct hashset *s, void *item)
+{
+	size_t b=0;
+	unsigned long hash = s->hash(item);
+
+	if (s->buckets == NULL) {
+		if (!rehash(s)) {
+			return NULL;
+		}
+	}
+
+	if (finditem(s,hash,item,&b)) {
+		/* found, return item */
+		return s->buckets[b].item;
+	}
+
+	/* not found, so add it */
+
+	/* check if we need a rehash */
+	if (s->nitems >= s->maxload) {
+		if (!rehash(s)) {
+			return NULL;
+		}
+
+		/* re-find the first available bucket */
+		finditem(s,hash,item,&b);
+	}
+
+	s->buckets[b].hash = hash;
+	s->buckets[b].item = item;
+
+	s->nitems++;
+
+	return item;
+}
+
+int
+hashset_remove(struct hashset *s, void *item)
+{
+	size_t b;
+	unsigned long h = s->hash(item);
+	b = 0;
+	if (s->nitems == 0 || !finditem(s,h,item,&b)) {
+		return 0;
+	}
+
+	s->buckets[b].item = NULL;
+	s->buckets[b].hash = TOMBSTONE_HASH;
+	s->nitems--;
+
+	return 1;
+}
+
+void
+hashset_finalize(struct hashset *s)
+{
+	free(s->buckets);
+}
+
+void
+hashset_free(struct hashset *s)
+{
+	if (s != NULL) {
+		hashset_finalize(s);
+		free(s);
+	}
+}
+
+size_t
+hashset_count(const struct hashset *s)
+{
+	return s->nitems;
+}
+
+void
+hashset_clear(struct hashset *s)
+{
+	s->nitems = 0;
+	if (s->buckets != NULL) {
+		memset(s->buckets, 0, s->nbuckets * sizeof s->buckets[0]);
+	}
+}
+
+/*
+ * Find if an item is in a set, and return it.
+ */
+void *
+hashset_contains(const struct hashset *s, const void *item)
+{
+	unsigned long h = s->hash(item);
+	size_t b = 0;
+	if (finditem(s,h,item,&b)) {
+		return s->buckets[b].item;
+	}
+
+	return NULL;
+}
+
+/*
+ * Compare two sets for equality.
+ */
+int
+hashset_equal(const struct hashset *a, const struct hashset *b)
+{
+	size_t i,n;
+	struct bucket *ab;
+
+	if (a->nitems != b->nitems) {
+		return 0;
+	}
+
+	n = a->nbuckets;
+	ab = a->buckets;
+	for (i=0; i < n; i++) {
+		if (ab[i].item != NULL && !hashset_contains(b,ab[i].item)) {
+			return 0;
+		}
+	}
+
+	return 1;
+}
+
+int
+hashset_empty(const struct hashset *s)
+{
+	return s->nitems == 0;
+}
+
+static void *
+hs_next(const struct hashset *s, size_t *ip)
+{
+	size_t i = *ip, nb = s->nbuckets;
+	for (; i < nb; i++) {
+		if (s->buckets[i].item != NULL) {
+			*ip = i+1;
+			return s->buckets[i].item;
+		}
+	}
+
+	*ip = nb;
+	return NULL;
+}
+
+void *
+hashset_first(const struct hashset *s, struct hashset_iter *it)
+{
+	it->set = s;
+	it->i = 0;
+	return hs_next(s, &it->i);
+}
+
+void *
+hashset_next(struct hashset_iter *it)
+{
+	return hs_next(it->set, &it->i);
+}
+
+/*
+ * Return the sole item for a singleton set.
+ */
+void *
+hashset_only(const struct hashset *s)
+{
+	size_t i,n;
+	struct bucket *b;
+
+	if (s->nitems == 0) {
+		return NULL;
+	}
+
+	n = s->nbuckets;
+	b=s->buckets;
+	for (i=0; i < n; i++) {
+		if (b[i].item != NULL) {
+			return b[i].item;
+		}
+	}
+
+	/* should not reach */
+	abort();
+}
+
+static int
+hs_hasnext(const struct hashset *s, size_t *ip)
+{
+	size_t i = *ip, nb = s->nbuckets;
+	for (; i < nb; i++) {
+		if (s->buckets[i].item != NULL) {
+			*ip = i;
+			return 1;
+		}
+	}
+
+	*ip = nb;
+	return 0;
+}
+
+int
+hashset_hasnext(struct hashset_iter *it)
+{
+	return hs_hasnext(it->set, &it->i);
+}
+
+extern int
+siphash(const uint8_t *in, const size_t inlen, const uint8_t *k,
+            uint8_t *out, const size_t outlen);
+
+/* random key read from /dev/random */
+/* XXX: replace with a seed read from /dev/random at startup... */
+static const unsigned char hashk[] = {
+	0x14, 0xa8, 0xff, 0x36, 0x15, 0x16, 0x2c, 0xf7, 0xf4, 0xce, 0xb8, 0x66, 0x74, 0xf4, 0x3d, 0x64,
+};
+
+unsigned long
+hashptr(const void *p) {
+	unsigned char v[sizeof p];
+	unsigned long h;
+	unsigned char ha[sizeof h];
+
+	memcpy(&v[0], &p, sizeof p);
+
+	siphash(v, sizeof v, hashk, &ha[0], sizeof ha);
+	memcpy(&h, &ha[0], sizeof h);
+
+	return h;
+}
+
+unsigned long
+hashrec(const void *p, size_t n) {
+	const unsigned char *s = p;
+	unsigned long h = 0;
+	unsigned char ha[sizeof h];
+
+	siphash(s, n, hashk, &ha[0], sizeof ha);
+	memcpy(&h, &ha[0], sizeof h);
+
+	return h;
+}
+

--- a/src/adt/siphash.c
+++ b/src/adt/siphash.c
@@ -1,0 +1,165 @@
+/*
+   SipHash reference C implementation
+
+   Copyright (c) 2012-2016 Jean-Philippe Aumasson
+   <jeanphilippe.aumasson@gmail.com>
+   Copyright (c) 2012-2014 Daniel J. Bernstein <djb@cr.yp.to>
+
+   To the extent possible under law, the author(s) have dedicated all copyright
+   and related and neighboring rights to this software to the public domain
+   worldwide. This software is distributed without any warranty.
+
+   You should have received a copy of the CC0 Public Domain Dedication along
+   with
+   this software. If not, see
+   <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+/* default: SipHash-2-4 */
+#define cROUNDS 2
+#define dROUNDS 4
+
+#define ROTL(x, b) (uint64_t)(((x) << (b)) | ((x) >> (64 - (b))))
+
+#define U32TO8_LE(p, v)                                                        \
+    (p)[0] = (uint8_t)((v));                                                   \
+    (p)[1] = (uint8_t)((v) >> 8);                                              \
+    (p)[2] = (uint8_t)((v) >> 16);                                             \
+    (p)[3] = (uint8_t)((v) >> 24);
+
+#define U64TO8_LE(p, v)                                                        \
+    U32TO8_LE((p), (uint32_t)((v)));                                           \
+    U32TO8_LE((p) + 4, (uint32_t)((v) >> 32));
+
+#define U8TO64_LE(p)                                                           \
+    (((uint64_t)((p)[0])) | ((uint64_t)((p)[1]) << 8) |                        \
+     ((uint64_t)((p)[2]) << 16) | ((uint64_t)((p)[3]) << 24) |                 \
+     ((uint64_t)((p)[4]) << 32) | ((uint64_t)((p)[5]) << 40) |                 \
+     ((uint64_t)((p)[6]) << 48) | ((uint64_t)((p)[7]) << 56))
+
+#define SIPROUND                                                               \
+    do {                                                                       \
+        v0 += v1;                                                              \
+        v1 = ROTL(v1, 13);                                                     \
+        v1 ^= v0;                                                              \
+        v0 = ROTL(v0, 32);                                                     \
+        v2 += v3;                                                              \
+        v3 = ROTL(v3, 16);                                                     \
+        v3 ^= v2;                                                              \
+        v0 += v3;                                                              \
+        v3 = ROTL(v3, 21);                                                     \
+        v3 ^= v0;                                                              \
+        v2 += v1;                                                              \
+        v1 = ROTL(v1, 17);                                                     \
+        v1 ^= v2;                                                              \
+        v2 = ROTL(v2, 32);                                                     \
+    } while (0)
+
+#ifdef DEBUG
+#define TRACE                                                                  \
+    do {                                                                       \
+        printf("(%3d) v0 %08x %08x\n", (int)inlen, (uint32_t)(v0 >> 32),       \
+               (uint32_t)v0);                                                  \
+        printf("(%3d) v1 %08x %08x\n", (int)inlen, (uint32_t)(v1 >> 32),       \
+               (uint32_t)v1);                                                  \
+        printf("(%3d) v2 %08x %08x\n", (int)inlen, (uint32_t)(v2 >> 32),       \
+               (uint32_t)v2);                                                  \
+        printf("(%3d) v3 %08x %08x\n", (int)inlen, (uint32_t)(v3 >> 32),       \
+               (uint32_t)v3);                                                  \
+    } while (0)
+#else
+#define TRACE
+#endif
+
+int siphash(const uint8_t *in, const size_t inlen, const uint8_t *k,
+            uint8_t *out, const size_t outlen) {
+
+    assert((outlen == 8) || (outlen == 16));
+    uint64_t v0 = 0x736f6d6570736575ULL;
+    uint64_t v1 = 0x646f72616e646f6dULL;
+    uint64_t v2 = 0x6c7967656e657261ULL;
+    uint64_t v3 = 0x7465646279746573ULL;
+    uint64_t k0 = U8TO64_LE(k);
+    uint64_t k1 = U8TO64_LE(k + 8);
+    uint64_t m;
+    int i;
+    const uint8_t *end = in + inlen - (inlen % sizeof(uint64_t));
+    const int left = inlen & 7;
+    uint64_t b = ((uint64_t)inlen) << 56;
+    v3 ^= k1;
+    v2 ^= k0;
+    v1 ^= k1;
+    v0 ^= k0;
+
+    if (outlen == 16)
+        v1 ^= 0xee;
+
+    for (; in != end; in += 8) {
+        m = U8TO64_LE(in);
+        v3 ^= m;
+
+        TRACE;
+        for (i = 0; i < cROUNDS; ++i)
+            SIPROUND;
+
+        v0 ^= m;
+    }
+
+    switch (left) {
+    case 7:
+        b |= ((uint64_t)in[6]) << 48;
+    case 6:
+        b |= ((uint64_t)in[5]) << 40;
+    case 5:
+        b |= ((uint64_t)in[4]) << 32;
+    case 4:
+        b |= ((uint64_t)in[3]) << 24;
+    case 3:
+        b |= ((uint64_t)in[2]) << 16;
+    case 2:
+        b |= ((uint64_t)in[1]) << 8;
+    case 1:
+        b |= ((uint64_t)in[0]);
+        break;
+    case 0:
+        break;
+    }
+
+    v3 ^= b;
+
+    TRACE;
+    for (i = 0; i < cROUNDS; ++i)
+        SIPROUND;
+
+    v0 ^= b;
+
+    if (outlen == 16)
+        v2 ^= 0xee;
+    else
+        v2 ^= 0xff;
+
+    TRACE;
+    for (i = 0; i < dROUNDS; ++i)
+        SIPROUND;
+
+    b = v0 ^ v1 ^ v2 ^ v3;
+    U64TO8_LE(out, b);
+
+    if (outlen == 8)
+        return 0;
+
+    v1 ^= 0xdd;
+
+    TRACE;
+    for (i = 0; i < dROUNDS; ++i)
+        SIPROUND;
+
+    b = v0 ^ v1 ^ v2 ^ v3;
+    U64TO8_LE(out + 8, b);
+
+    return 0;
+}

--- a/tests/hashset/Makefile
+++ b/tests/hashset/Makefile
@@ -1,0 +1,16 @@
+.include "../../share/mk/top.mk"
+
+TEST.tests/hashset != ls -1 tests/hashset/hashset*.c
+TEST_SRCDIR.tests/hashset = tests/hashset
+TEST_OUTDIR.tests/hashset = ${BUILD}/tests/hashset
+
+.for n in ${TEST.tests/hashset:T:R:C/^hashset//}
+test:: ${TEST_OUTDIR.tests/hashset}/res${n}
+
+SRC += ${TEST_SRCDIR.tests/hashset}/hashset${n}.c
+CFLAGS.${TEST_SRCDIR.tests/hashset}/hashset${n}.c = -UNDEBUG
+${TEST_OUTDIR.tests/hashset}/run${n}: ${TEST_OUTDIR.tests/hashset}/hashset${n}.o ${BUILD}/lib/adt.o
+	${CC} ${CFLAGS} -o ${TEST_OUTDIR.tests/hashset}/run${n} ${TEST_OUTDIR.tests/hashset}/hashset${n}.o ${BUILD}/lib/adt.o
+${TEST_OUTDIR.tests/hashset}/res${n}: ${TEST_OUTDIR.tests/hashset}/run${n}
+	( ${TEST_OUTDIR.tests/hashset}/run${n} 1>&2 && echo PASS || echo FAIL ) > ${TEST_OUTDIR.tests/hashset}/res${n}
+.endfor

--- a/tests/hashset/hashset0.c
+++ b/tests/hashset/hashset0.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Ed Kellett
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <adt/hashset.h>
+
+int cmp_int(const void *a_, const void *b_) {
+	int a = *(const int *)a_, b = *(const int *)b_;
+	if (a > b)      return 1;
+	else if (a < b) return -1;
+	else            return 0;
+}
+
+unsigned long hash_int(const void *a_)
+{
+	const int *a = a_;
+	return hashrec(a, sizeof *a);
+}
+
+int main(void) {
+	struct hashset *s = hashset_create(hash_int,cmp_int);
+	int a[3] = {1, 2, 3};
+	assert(hashset_add(s, &a[0]));
+	assert(hashset_add(s, &a[1]));
+	assert(hashset_add(s, &a[2]));
+	return 0;
+}

--- a/tests/hashset/hashset0.c
+++ b/tests/hashset/hashset0.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Ed Kellett
+ * Copyright 2018 Shannon Stewman
  *
  * See LICENCE for the full copyright terms.
  */

--- a/tests/hashset/hashset1.c
+++ b/tests/hashset/hashset1.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 Ed Kellett
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <adt/hashset.h>
+
+int cmp_int(const void *a_, const void *b_) {
+	int a = *(const int *)a_, b = *(const int *)b_;
+	if (a > b)      return 1;
+	else if (a < b) return -1;
+	else            return 0;
+}
+
+unsigned long hash_int(const void *a_)
+{
+	const int *a = a_;
+	return hashrec(a, sizeof *a);
+}
+
+int main(void) {
+	struct hashset *s = hashset_create(hash_int,cmp_int);
+	/* ensure that a has enough elements that the table has to be
+	 * rehashed a few times
+	 */
+	int a[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+
+	/* add 'em in */
+	assert(hashset_add(s, &a[0]));
+	assert(hashset_add(s, &a[1]));
+	assert(hashset_add(s, &a[2]));
+	assert(hashset_add(s, &a[3]));
+
+	assert(hashset_add(s, &a[4]));
+	assert(hashset_add(s, &a[5]));
+	assert(hashset_add(s, &a[6]));
+	assert(hashset_add(s, &a[7]));
+
+	assert(hashset_add(s, &a[8]));
+	assert(hashset_add(s, &a[9]));
+	assert(hashset_add(s, &a[10]));
+	assert(hashset_add(s, &a[11]));
+
+	assert(hashset_add(s, &a[12]));
+	assert(hashset_add(s, &a[13]));
+	assert(hashset_add(s, &a[14]));
+	assert(hashset_add(s, &a[15]));
+
+	/* check that they're in */
+	assert(hashset_contains(s, &a[0]));
+	assert(hashset_contains(s, &a[1]));
+	assert(hashset_contains(s, &a[2]));
+	assert(hashset_contains(s, &a[3]));
+
+	assert(hashset_contains(s, &a[4]));
+	assert(hashset_contains(s, &a[5]));
+	assert(hashset_contains(s, &a[6]));
+	assert(hashset_contains(s, &a[7]));
+
+	assert(hashset_contains(s, &a[8]));
+	assert(hashset_contains(s, &a[9]));
+	assert(hashset_contains(s, &a[10]));
+	assert(hashset_contains(s, &a[11]));
+
+	assert(hashset_contains(s, &a[12]));
+	assert(hashset_contains(s, &a[13]));
+	assert(hashset_contains(s, &a[14]));
+	assert(hashset_contains(s, &a[15]));
+
+	return 0;
+}

--- a/tests/hashset/hashset1.c
+++ b/tests/hashset/hashset1.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Ed Kellett
+ * Copyright 2018 Shannon Stewman
  *
  * See LICENCE for the full copyright terms.
  */

--- a/tests/hashset/hashset2.c
+++ b/tests/hashset/hashset2.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 Ed Kellett
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <adt/hashset.h>
+
+int cmp_int(const void *a_, const void *b_) {
+	int a = *(const int *)a_, b = *(const int *)b_;
+	if (a > b)      return 1;
+	else if (a < b) return -1;
+	else            return 0;
+}
+
+unsigned long hash_int(const void *a_)
+{
+	const int *a = a_;
+	return hashrec(a, sizeof *a);
+}
+
+int main(void) {
+	struct hashset *s = hashset_create(hash_int,cmp_int);
+	int a = 1;
+	assert(hashset_add(s, &a));
+	assert(hashset_add(s, &a));
+	assert(hashset_add(s, &a));
+
+	hashset_remove(s, &a);
+
+	assert(!hashset_contains(s, &a));
+
+	return 0;
+}
+

--- a/tests/hashset/hashset2.c
+++ b/tests/hashset/hashset2.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Ed Kellett
+ * Copyright 2018 Shannon Stewman
  *
  * See LICENCE for the full copyright terms.
  */

--- a/tests/hashset/hashset3.c
+++ b/tests/hashset/hashset3.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Ed Kellett
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <adt/hashset.h>
+
+int cmp_int(const void *a_, const void *b_) {
+	int a = *(const int *)a_, b = *(const int *)b_;
+	if (a > b)      return 1;
+	else if (a < b) return -1;
+	else            return 0;
+}
+
+unsigned long hash_int(const void *a_)
+{
+	const int *a = a_;
+	return hashrec(a, sizeof *a);
+}
+
+int main(void) {
+	struct hashset *s = hashset_create(hash_int,cmp_int);
+	struct hashset_iter iter;
+	int *p;
+	int a[3] = {1, 2, 3};
+	int seen[3] = {0, 0, 0};
+	int i;
+	assert(hashset_add(s, &a[0]));
+	assert(hashset_add(s, &a[1]));
+	assert(hashset_add(s, &a[2]));
+
+	for (p = hashset_first(s, &iter); p != NULL; p = hashset_next(&iter)) {
+		assert(*p == 1 || *p == 2 || *p == 3);
+		seen[*p - 1] = 1;
+	}
+
+	for (i = 0; i < 3; i++) {
+		assert(seen[i]);
+	}
+
+	return 0;
+}

--- a/tests/hashset/hashset3.c
+++ b/tests/hashset/hashset3.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Ed Kellett
+ * Copyright 2018 Shannon Stewman
  *
  * See LICENCE for the full copyright terms.
  */

--- a/tests/hashset/hashset4.c
+++ b/tests/hashset/hashset4.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 Ed Kellett
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <adt/hashset.h>
+
+int cmp_int(const void *a_, const void *b_) {
+	int a = *(const int *)a_, b = *(const int *)b_;
+	if (a > b)      return 1;
+	else if (a < b) return -1;
+	else            return 0;
+}
+
+unsigned long hash_int(const void *a_)
+{
+	const int *a = a_;
+	return hashrec(a, sizeof *a);
+}
+
+int *next_int(int reset) {
+	static int n = 0;
+	int *p;
+
+	if (reset) {
+		n = 0;
+		return NULL;
+	}
+
+	p = malloc(sizeof *p);
+	if (p == NULL) abort();
+	*p = n++;
+	return p;
+}
+
+int main(void) {
+	struct hashset *s = hashset_create(hash_int,cmp_int);
+	size_t i;
+	for (i = 0; i < 5000; i++) {
+		assert(hashset_add(s, next_int(0)));
+	}
+	assert(hashset_count(s) == 5000);
+
+	next_int(1);
+	for (i = 0; i < 5000; i++) {
+		assert(hashset_add(s, next_int(0)));
+	}
+	assert(hashset_count(s) == 5000);
+
+	return 0;
+}

--- a/tests/hashset/hashset4.c
+++ b/tests/hashset/hashset4.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Ed Kellett
+ * Copyright 2018 Shannon Stewman
  *
  * See LICENCE for the full copyright terms.
  */

--- a/tests/hashset/hashset5.c
+++ b/tests/hashset/hashset5.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Ed Kellett
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <adt/hashset.h>
+
+int cmp_int(const void *a_, const void *b_) {
+	int a = *(const int *)a_, b = *(const int *)b_;
+	if (a > b)      return 1;
+	else if (a < b) return -1;
+	else            return 0;
+}
+
+unsigned long hash_int(const void *a_)
+{
+	const int *a = a_;
+	return hashrec(a, sizeof *a);
+}
+
+int *next_int(void) {
+	static int n = 0;
+	int *p = malloc(sizeof *p);
+	if (p == NULL) abort();
+	*p = n++;
+	return p;
+}
+
+int main(void) {
+	struct hashset *s = hashset_create(hash_int,cmp_int);
+	int a[3] = {1200,2400,3600};
+	size_t i;
+	for (i = 0; i < 5000; i++) {
+		assert(hashset_add(s, next_int()));
+	}
+	for (i = 0; i < 3; i++) {
+		assert(hashset_contains(s, &a[i]));
+		hashset_remove(s, &a[i]);
+	}
+	assert(hashset_count(s) == 4997);
+	return 0;
+}

--- a/tests/hashset/hashset5.c
+++ b/tests/hashset/hashset5.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Ed Kellett
+ * Copyright 2018 Shannon Stewman
  *
  * See LICENCE for the full copyright terms.
  */

--- a/tests/hashset/hashset6.c
+++ b/tests/hashset/hashset6.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Ed Kellett
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <adt/hashset.h>
+
+int cmp_int(const void *a_, const void *b_) {
+	int a = *(const int *)a_, b = *(const int *)b_;
+	if (a > b)      return 1;
+	else if (a < b) return -1;
+	else            return 0;
+}
+
+unsigned long hash_int(const void *a_)
+{
+	const int *a = a_;
+	return hashrec(a, sizeof *a);
+}
+
+int *next_int(void) {
+	static int n = 0;
+	int *p = malloc(sizeof *p);
+	if (p == NULL) abort();
+	*p = n++;
+	return p;
+}
+
+int main(void) {
+	struct hashset *s = hashset_create(hash_int,cmp_int);
+	struct hashset_iter iter;
+	size_t i;
+	int *p;
+	for (i = 0; i < 5000; i++) {
+		assert(hashset_add(s, next_int()));
+	}
+	for (i = 0, p = hashset_first(s, &iter); i < 5000; i++, hashset_next(&iter)) {
+		assert(p);
+		if (i < 4999) {
+			assert(hashset_hasnext(&iter));
+		} else {
+			assert(!hashset_hasnext(&iter));
+		}
+	}
+	return 0;
+}

--- a/tests/hashset/hashset6.c
+++ b/tests/hashset/hashset6.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Ed Kellett
+ * Copyright 2018 Shannon Stewman
  *
  * See LICENCE for the full copyright terms.
  */


### PR DESCRIPTION
Changes the implementation of mapping_set, used by fsm_determinise, to use a hash set.  This eliminates the O(N^2) insertion sort that can bog down large power sets in NFA->DFA conversion, considerably speeding up determinisation for some graphs.

This stacks on #125 