### PR TITLE
A quick attempt at comparative benchmarking

### DIFF
--- a/examples/bm/Makefile
+++ b/examples/bm/Makefile
@@ -1,0 +1,8 @@
+all: pcre libfsm
+
+pcre: pcre.c
+	gcc -o pcre -O3 -Wall -std=c89 pcre.c -lpcre
+
+libfsm: libfsm.c
+	gcc -o libfsm -O3 -Wall -std=c89 libfsm.c -I ../../include ../../build/lib/libre.a ../../build/lib/libfsm.a
+

--- a/examples/bm/Makefile
+++ b/examples/bm/Makefile
@@ -1,8 +1,12 @@
 all: pcre libfsm
 
+# repetition to smooth out contextual noise
+BM_MAX ?= 100
+BM_CFLAGS += -DBM_MAX=${BM_MAX}
+
 pcre: pcre.c
-	gcc -o pcre -O3 -Wall -std=c89 pcre.c -lpcre
+	gcc -o pcre -O3 -Wall -std=c89 ${BM_CFLAGS} pcre.c -lpcre
 
 libfsm: libfsm.c
-	gcc -o libfsm -O3 -Wall -std=c89 libfsm.c -I ../../include ../../build/lib/libre.a ../../build/lib/libfsm.a
+	gcc -o libfsm -O3 -Wall -std=c89 ${BM_CFLAGS} libfsm.c -I ../../include ../../build/lib/libre.a ../../build/lib/libfsm.a
 

--- a/examples/bm/bm.sh
+++ b/examples/bm/bm.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# $1 ./pcre
+# $2 /usr/share/dict/words
+# $3 re.blab
+# $4 1000
+
+for i in `seq 1 $(($4 / 100)) $4`; do
+	for j in `seq 1 10`; do
+		re="`./nblab.sh $3 $i`"
+		($1 "$re" < $2 2> /dev/null || echo 0) | tr -d '\n'
+		echo -n ' '
+	done
+	echo
+done
+

--- a/examples/bm/bm.sh
+++ b/examples/bm/bm.sh
@@ -6,11 +6,7 @@
 # $4 1000
 
 for i in `seq 1 $(($4 / 100)) $4`; do
-	for j in `seq 1 10`; do
-		re="`./nblab.sh $3 $i`"
-		($1 "$re" < $2 2> /dev/null || echo 0) | tr -d '\n'
-		echo -n ' '
-	done
-	echo
+	re="`./nblab.sh $3 $i`"
+	$1 "$re" < $2 2> /dev/null || echo 0
 done
 

--- a/examples/bm/libfsm.c
+++ b/examples/bm/libfsm.c
@@ -30,7 +30,7 @@ main(int argc, char *argv[])
 	opt.comments = 0;
 	opt.io = FSM_IO_STR;
 
-	p = s;
+	p = argv[1];
 	fsm = re_comp(RE_PCRE, fsm_sgetc, &p, &opt, 0, &e);
 	if (fsm == NULL) {
 		re_perror(RE_LITERAL, &e, NULL, s);

--- a/examples/bm/libfsm.c
+++ b/examples/bm/libfsm.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2019 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <fsm/fsm.h>
+#include <fsm/options.h>
+#include <fsm/print.h>
+#include <re/re.h>
+
+int
+main(int argc, char *argv[])
+{
+	struct fsm *fsm;
+	const static struct fsm_options opt_defaults;
+	struct fsm_options opt = opt_defaults;
+	char s[4096];
+	const char *p;
+	struct re_err e;
+
+	opt.tidy = 0;
+	opt.anonymous_states  = 1;
+	opt.consolidate_edges = 1;
+	opt.case_ranges = 1;
+	opt.comments = 0;
+	opt.io = FSM_IO_STR;
+
+	p = s;
+	fsm = re_comp(RE_PCRE, fsm_sgetc, &p, &opt, 0, &e);
+	if (fsm == NULL) {
+		re_perror(RE_LITERAL, &e, NULL, s);
+		return 1;
+	}
+
+	if (-1 == fsm_minimise(fsm)) {
+		perror("fsm_minimise");
+		return 1;
+	}
+
+	printf("#define _POSIX_C_SOURCE 200112L\n");
+	printf("#define TOK_UNKNOWN EOF\n");
+	printf("\n");
+	printf("#include <unistd.h>\n");
+	printf("#include <stdlib.h>\n");
+	printf("#include <time.h>\n");
+	printf("\n");
+
+	fsm_print_c(stdout, fsm);
+
+	printf("int main(void) {\n");
+	printf("\tchar s[4096];\n");
+	printf("\tunsigned n;\n");
+	printf("struct timespec pre, post;\n");
+	printf("\n");
+
+	printf("if (-1 == clock_gettime(CLOCK_MONOTONIC, &pre)) {\n");
+	printf("	perror(\"clock_gettime\");\n");
+	printf("	exit(EXIT_FAILURE);\n");
+	printf("}\n");
+	printf("\n");
+
+	printf("\tn = 0;\n");
+	printf("\twhile (fgets(s, sizeof s, stdin) != NULL) {\n");
+	printf("\t\tn += fsm_main(s) != EOF;\n");
+	printf("\t}\n");
+	printf("\n");
+
+	printf("if (-1 == clock_gettime(CLOCK_MONOTONIC, &post)) {\n");
+	printf("	perror(\"clock_gettime\");\n");
+	printf("	exit(EXIT_FAILURE);\n");
+	printf("}\n");
+	printf("\n");
+
+/*
+	printf("\tprintf(\"%%u %%s\\n\", n, n == 1 ? \"match\" : \"matches\");\n");
+*/
+
+	printf("{\n");
+	printf("	double ms;\n");
+	printf("\n");
+	printf("	ms = 1000.0 * (post.tv_sec  - pre.tv_sec)\n");
+	printf("				+ (post.tv_nsec - pre.tv_nsec) / 1e6;\n");
+	printf("\n");
+	printf("	printf(\"%%f\\n\", ms);\n");
+	printf("}\n");
+	printf("\n");
+
+	printf("\treturn 0;\n");
+	printf("}\n");
+
+	fsm_free(fsm);
+
+	return 0;
+}
+

--- a/examples/bm/libfsm.c
+++ b/examples/bm/libfsm.c
@@ -89,8 +89,10 @@ main(int argc, char *argv[])
 	printf("\tchar s[4096];\n");
 	printf("\tunsigned n;\n");
 	printf("\tdouble ms;\n");
+	printf("\tint i, max;\n");
 	printf("\n");
 
+	printf("\tmax = %d;\n", BM_MAX);
 	printf("\tms = 0;\n");
 	printf("\tn = 0;\n");
 	printf("\n");
@@ -105,7 +107,9 @@ main(int argc, char *argv[])
 	printf("\t\t}\n");
 	printf("\n");
 
-	printf("\t\tn += fsm_main(s) != EOF;\n");
+	printf("\t\tfor (i = 0; i < max; i++) {\n");
+	printf("\t\t\tn += fsm_main(s) != EOF;\n");
+	printf("\t\t}\n");
 	printf("\n");
 
 	printf("\t\tif (-1 == clock_gettime(CLOCK_MONOTONIC, &post)) {\n");
@@ -119,7 +123,7 @@ main(int argc, char *argv[])
 */
 
 	printf("\t\tms = 1000.0 * (post.tv_sec  - pre.tv_sec)\n");
-	printf("\t\t            + (post.tv_nsec - pre.tv_nsec) / 1e6;\n");
+	printf("\t\t            + (post.tv_nsec - pre.tv_nsec) / 1e6 / (double) %d;\n", BM_MAX);
 	printf("\n");
 
 	printf("\t}\n");

--- a/examples/bm/libfsm.c
+++ b/examples/bm/libfsm.c
@@ -83,42 +83,49 @@ main(int argc, char *argv[])
 
 	fsm_print_c(stdout, fsm);
 
-	printf("int main(void) {\n");
+	printf("int\n");
+	printf("main(void)\n");
+	printf("{\n");
 	printf("\tchar s[4096];\n");
 	printf("\tunsigned n;\n");
-	printf("struct timespec pre, post;\n");
+	printf("\tdouble ms;\n");
 	printf("\n");
 
-	printf("if (-1 == clock_gettime(CLOCK_MONOTONIC, &pre)) {\n");
-	printf("	perror(\"clock_gettime\");\n");
-	printf("	exit(EXIT_FAILURE);\n");
-	printf("}\n");
-	printf("\n");
-
+	printf("\tms = 0;\n");
 	printf("\tn = 0;\n");
-	printf("\twhile (fgets(s, sizeof s, stdin) != NULL) {\n");
-	printf("\t\tn += fsm_main(s) != EOF;\n");
-	printf("\t}\n");
 	printf("\n");
 
-	printf("if (-1 == clock_gettime(CLOCK_MONOTONIC, &post)) {\n");
-	printf("	perror(\"clock_gettime\");\n");
-	printf("	exit(EXIT_FAILURE);\n");
-	printf("}\n");
+	printf("\twhile (fgets(s, sizeof s, stdin) != NULL) {\n");
+	printf("\t\tstruct timespec pre, post;\n");
+	printf("\n");
+
+	printf("\t\tif (-1 == clock_gettime(CLOCK_MONOTONIC, &pre)) {\n");
+	printf("\t\t	perror(\"clock_gettime\");\n");
+	printf("\t\t	exit(EXIT_FAILURE);\n");
+	printf("\t\t}\n");
+	printf("\n");
+
+	printf("\t\tn += fsm_main(s) != EOF;\n");
+	printf("\n");
+
+	printf("\t\tif (-1 == clock_gettime(CLOCK_MONOTONIC, &post)) {\n");
+	printf("\t\t	perror(\"clock_gettime\");\n");
+	printf("\t\t	exit(EXIT_FAILURE);\n");
+	printf("\t\t}\n");
 	printf("\n");
 
 /*
-	printf("\tprintf(\"%%u %%s\\n\", n, n == 1 ? \"match\" : \"matches\");\n");
+	printf("\t\tprintf(\"%%u %%s\\n\", n, n == 1 ? \"match\" : \"matches\");\n");
 */
 
-	printf("{\n");
-	printf("	double ms;\n");
+	printf("\t\tms = 1000.0 * (post.tv_sec  - pre.tv_sec)\n");
+	printf("\t\t            + (post.tv_nsec - pre.tv_nsec) / 1e6;\n");
 	printf("\n");
-	printf("	ms = 1000.0 * (post.tv_sec  - pre.tv_sec)\n");
-	printf("				+ (post.tv_nsec - pre.tv_nsec) / 1e6;\n");
+
+	printf("\t}\n");
 	printf("\n");
-	printf("	printf(\"%%f\\n\", ms);\n");
-	printf("}\n");
+
+	printf("\tprintf(\"%%f\\n\", ms);\n");
 	printf("\n");
 
 	printf("\treturn 0;\n");

--- a/examples/bm/libfsm.sh
+++ b/examples/bm/libfsm.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+./libfsm | gcc -o /tmp/bm-$$ -xc -Wall -std=c89 -O3 -
+/tmp/bm-$$ "$1"
+

--- a/examples/bm/libfsm.sh
+++ b/examples/bm/libfsm.sh
@@ -1,5 +1,5 @@
 #!/bin/sh -e
 
-./libfsm | gcc -o /tmp/bm-$$ -xc -Wall -std=c89 -O3 -
+./libfsm $* | gcc -o /tmp/bm-$$ -xc -Wall -std=c89 -O3 -
 /tmp/bm-$$ "$1"
 

--- a/examples/bm/literal.blab
+++ b/examples/bm/literal.blab
@@ -1,0 +1,5 @@
+
+# literal strings
+
+literal = [A-Za-z0-9]+
+

--- a/examples/bm/nblab.sh
+++ b/examples/bm/nblab.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# generate text approximately however many characters long
+# $1 - a.blab
+# $2 - 5
+
+t=''
+while [ ${#t} -lt $(($2 / 2)) -o ${#t} -gt $(($2 * 2))  ]; do
+	t="`blab -f $(($2 * 2)) $1`"
+done
+
+echo -n "$t"
+

--- a/examples/bm/pcre.c
+++ b/examples/bm/pcre.c
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#define _POSIX_C_SOURCE 200112L
+
+#include <unistd.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include <pcre.h>
+
+int
+main(int argc, char *argv[])
+{
+	pcre *re;
+	pcre_extra *e;
+	int r;
+	char s[4096];
+	const char *err;
+	int o;
+	unsigned n;
+	struct timespec pre, post;
+
+	re = pcre_compile(argv[1], 0, &err, &o, NULL);
+	if (re == NULL) {
+		fprintf(stderr, "pcre_compile: %s\n", err);
+		abort();
+	}
+
+	e = pcre_study(re, 0, &err);
+	if (e == NULL && err != NULL) {
+		fprintf(stderr, "pcre_study: %s\n", err);
+		abort();
+	}
+
+	n = 0;
+
+
+	if (-1 == clock_gettime(CLOCK_MONOTONIC, &pre)) {
+		perror("clock_gettime");
+		exit(EXIT_FAILURE);
+	}
+
+	while (fgets(s, sizeof s, stdin) != NULL) {
+		r = pcre_exec(re, e, s, strlen(s) - 1, 0, 0, NULL, 0);
+		if (r == PCRE_ERROR_NOMATCH) {
+			continue;
+		}
+
+		if (r == 0) {
+			n++;
+			continue;
+		}
+
+		fprintf(stderr, "%d\n", r);
+		abort();
+	}
+
+	if (-1 == clock_gettime(CLOCK_MONOTONIC, &post)) {
+		perror("clock_gettime");
+		exit(EXIT_FAILURE);
+	}
+
+	pcre_free(re);
+
+/*
+	printf("%u %s\n", n, n == 1 ? "match" : "matches");
+*/
+
+	{
+		double ms;
+
+		ms = 1000.0 * (post.tv_sec  - pre.tv_sec)
+					+ (post.tv_nsec - pre.tv_nsec) / 1e6;
+
+		printf("%f\n", ms);
+	}
+
+	return 0;
+}
+

--- a/examples/bm/pcre.c
+++ b/examples/bm/pcre.c
@@ -26,7 +26,9 @@ main(int argc, char *argv[])
 	unsigned n;
 	int flags;
 	double ms;
+	int i, max;
 
+	max = BM_MAX;
 	flags = 0;
 
 	{
@@ -79,7 +81,13 @@ main(int argc, char *argv[])
 			exit(EXIT_FAILURE);
 		}
 
-		r = pcre_exec(re, e, s, z - 1, 0, 0, NULL, 0);
+		for (i = 0; i < max; i++) {
+			r = pcre_exec(re, e, s, z - 1, 0, 0, NULL, 0);
+			if (r != 0 && r != PCRE_ERROR_NOMATCH) {
+				fprintf(stderr, "%d\n", r);
+				abort();
+			}
+		}
 
 		if (-1 == clock_gettime(CLOCK_MONOTONIC, &post)) {
 			perror("clock_gettime");
@@ -87,7 +95,7 @@ main(int argc, char *argv[])
 		}
 
 		ms += 1000.0 * (post.tv_sec  - pre.tv_sec)
-		             + (post.tv_nsec - pre.tv_nsec) / 1e6;
+		             + (post.tv_nsec - pre.tv_nsec) / 1e6 / (double) max;
 
 		if (r == PCRE_ERROR_NOMATCH) {
 			continue;
@@ -95,11 +103,7 @@ main(int argc, char *argv[])
 
 		if (r == 0) {
 			n++;
-			continue;
 		}
-
-		fprintf(stderr, "%d\n", r);
-		abort();
 	}
 
 	pcre_free(re);

--- a/examples/bm/pcre.c
+++ b/examples/bm/pcre.c
@@ -25,8 +25,35 @@ main(int argc, char *argv[])
 	int o;
 	unsigned n;
 	struct timespec pre, post;
+	int flags;
 
-	re = pcre_compile(argv[1], 0, &err, &o, NULL);
+	flags = 0;
+
+	{
+		int c;
+
+		while (c = getopt(argc, argv, "h" "b"), c != -1) {
+			switch (c) {
+			case 'b':
+				flags |= PCRE_ANCHORED;
+				break;
+
+			case 'h':
+			case '?':
+			default:
+				goto usage;
+			}
+		}
+
+		argc -= optind;
+		argv += optind;
+	}
+
+	if (argc < 1) {
+		goto usage;
+	}
+
+	re = pcre_compile(argv[0], PCRE_ANCHORED, &err, &o, NULL);
 	if (re == NULL) {
 		fprintf(stderr, "pcre_compile: %s\n", err);
 		abort();
@@ -82,5 +109,12 @@ main(int argc, char *argv[])
 	}
 
 	return 0;
+
+usage:
+
+	fprintf(stderr, "usage: pcre [-b] <regexp>\n");
+	fprintf(stderr, "       pcre -h\n");
+
+	return 1;
 }
 

--- a/examples/bm/re-norep.blab
+++ b/examples/bm/re-norep.blab
@@ -1,0 +1,8 @@
+
+# simple regexps with no repetition
+
+re = re "|" re
+	| re "?"
+	| "(" re ")"
+	| [A-Za-z0-9]+
+

--- a/examples/bm/re.blab
+++ b/examples/bm/re.blab
@@ -1,0 +1,9 @@
+
+re = re "|" re
+	| re re
+	| atomic ( "?" | "*" | "+" )
+	| atomic "{" [0-9]{1,3} "}"
+	| atomic
+
+atomic = "(" re ")" | [A-Za-z0-9]+
+


### PR DESCRIPTION
These programs time execution for regexps using libpcre vs. libfsm's generated code. Just the execution time is counted, not compilation time. bm.sh is the top-level entry point. Run it like so:
```
; ./bm.sh ./pcre /usr/share/dict/words re-norep.blab 10000 | guff -b
    x: [0 - 99]    y: [0 - 3426.65]
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠐⠀⠀⠀⠀⠀⠀⠀
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠁⠀⠀⠀⠀
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⡀⠀⠀⠀⠀⠀⠈⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠄⠀
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠐⠀⢀⠀⠀⠀⢈⢀⡀⠀⠀⠁⠀⠀⠀⠁⠂⠁⠀⠀
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠠⠀⠀⢀⢀⠀⣀⠀⠀⠁⠌⠀⠅⠨⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⡇⠀⠀⠀⠀⠀⠀⠄⠀⠂⠄⠤⠀⠐⠀⠀⠐⠈⢀⠀⠀⠀⠀⠀⠀⠠⠀⠀⠀⠀⠀⠀⠀⡀⠀⠀
⣇⣀⣀⣂⣀⣘⣭⣀⣂⣀⣀⣄⣀⣠⣂⣀⣒⣀⣠⣁⣐⣀⣂⣈⣴⣀⣠⣄⣀⣰⣀⣀⣁⣠⣄⣀
```