### PR TITLE
Assumes macOS has clock_gettime unless -DMACOS_HAS_NO_CLOCK_GETTIME

### DIFF
--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -24,7 +24,7 @@
 
 #include "parser.h"
 
-#if defined(__APPLE__) && defined(__MACH__) && !defined(MACOS_HAS_CLOCK_GETTME)
+#if defined(__APPLE__) && defined(__MACH__) && defined(MACOS_HAS_NO_CLOCK_GETTME)
 #include <mach/clock.h>
 #include <mach/mach.h>
 


### PR DESCRIPTION
Newer versions have clock_gettime, so it’s better to assume it has the function than that it doesn’t.