### PR TITLE
Alternative error handling for `fsm_print_c`

### DIFF
--- a/doc/tutorial/phase-code.c
+++ b/doc/tutorial/phase-code.c
@@ -1,12 +1,11 @@
-#include <assert.h>
-#include <stdio.h>
-
 int
 fsm_main(int (*fsm_getc)(void *opaque), void *opaque)
 {
 	int c;
 
-	assert(fsm_getc != NULL);
+	if (fsm_getc == NULL) {
+		return -1;
+	}
 
 	enum {
 		S0, S1, S2, S3, S4
@@ -54,7 +53,7 @@ fsm_main(int (*fsm_getc)(void *opaque), void *opaque)
 	case S2: return 0x1; /* "^ab+c?.?$" */
 	case S3: return 0x1; /* "^ab+c?.?$" */
 	case S4: return 0x1; /* "^ab+c?.?$" */
-	default: return EOF; /* unexpected EOF */
+	default: return -1; /* error */
 	}
 }
 

--- a/doc/tutorial/phase-code.c
+++ b/doc/tutorial/phase-code.c
@@ -49,7 +49,7 @@ fsm_main(int (*fsm_getc)(void *opaque), void *opaque)
 	case S2: return 0x1; /* "^ab+c?.?$" */
 	case S3: return 0x1; /* "^ab+c?.?$" */
 	case S4: return 0x1; /* "^ab+c?.?$" */
-	default: return -1; /* error */
+	default: return -1; /* unexpected EOT */
 	}
 }
 

--- a/doc/tutorial/phase-code.c
+++ b/doc/tutorial/phase-code.c
@@ -3,10 +3,6 @@ fsm_main(int (*fsm_getc)(void *opaque), void *opaque)
 {
 	int c;
 
-	if (fsm_getc == NULL) {
-		return -1;
-	}
-
 	enum {
 		S0, S1, S2, S3, S4
 	} state;

--- a/doc/tutorial/re.md
+++ b/doc/tutorial/re.md
@@ -92,7 +92,7 @@ This value is `1 << n` where _n_ is the `#0`, `#1` index we saw for `-z` earlier
     case S20: return 0x400; /* "finessing" */
     case S21: return 0x100; /* "finessed" */
     case S22: return 0x200; /* "finesses" */
-    default: return EOF; /* unexpected EOF */
+    default: return -1; /* error */
     }
 ```
 Input is read in one of several ways:

--- a/doc/tutorial/re.md
+++ b/doc/tutorial/re.md
@@ -92,7 +92,7 @@ This value is `1 << n` where _n_ is the `#0`, `#1` index we saw for `-z` earlier
     case S20: return 0x400; /* "finessing" */
     case S21: return 0x100; /* "finessed" */
     case S22: return 0x200; /* "finesses" */
-    default: return -1; /* error */
+    default: return -1; /* unexpected EOT */
     }
 ```
 Input is read in one of several ways:

--- a/doc/tutorial/trie.c
+++ b/doc/tutorial/trie.c
@@ -168,7 +168,7 @@ fsm_main(int (*fsm_getc)(void *opaque), void *opaque)
 	case S20: return 0x400; /* "finessing" */
 	case S21: return 0x100; /* "finessed" */
 	case S22: return 0x200; /* "finesses" */
-	default: return -1; /* error */
+	default: return -1; /* unexpected EOT */
 	}
 }
 

--- a/doc/tutorial/trie.c
+++ b/doc/tutorial/trie.c
@@ -1,12 +1,11 @@
-#include <assert.h>
-#include <stdio.h>
-
 int
 fsm_main(int (*fsm_getc)(void *opaque), void *opaque)
 {
 	int c;
 
-	assert(fsm_getc != NULL);
+	if (fsm_getc == NULL) {
+		return -1;
+	}
 
 	enum {
 		S0, S1, S2, S3, S4, S5, S6, S7, S8, S9, 
@@ -173,7 +172,7 @@ fsm_main(int (*fsm_getc)(void *opaque), void *opaque)
 	case S20: return 0x400; /* "finessing" */
 	case S21: return 0x100; /* "finessed" */
 	case S22: return 0x200; /* "finesses" */
-	default: return EOF; /* unexpected EOF */
+	default: return -1; /* error */
 	}
 }
 

--- a/doc/tutorial/trie.c
+++ b/doc/tutorial/trie.c
@@ -3,10 +3,6 @@ fsm_main(int (*fsm_getc)(void *opaque), void *opaque)
 {
 	int c;
 
-	if (fsm_getc == NULL) {
-		return -1;
-	}
-
 	enum {
 		S0, S1, S2, S3, S4, S5, S6, S7, S8, S9, 
 		S10, S11, S12, S13, S14, S15, S16, S17, S18, S19, 

--- a/src/libfsm/print/c.c
+++ b/src/libfsm/print/c.c
@@ -269,7 +269,7 @@ endstates(FILE *f, const struct fsm_options *opt, const struct ir *ir)
 
 	/* no end states */
 	if (!ir_hasend(ir)) {
-		printf("\treturn -1; /* error */\n");
+		printf("\treturn -1; /* unexpected EOT */\n");
 		return;
 	}
 
@@ -289,7 +289,7 @@ endstates(FILE *f, const struct fsm_options *opt, const struct ir *ir)
 		}
 		fprintf(f, "\n");
 	}
-	fprintf(f, "\tdefault: return -1; /* error */\n");
+	fprintf(f, "\tdefault: return -1; /* unexpected EOT */\n");
 	fprintf(f, "\t}\n");
 }
 

--- a/src/libfsm/print/c.c
+++ b/src/libfsm/print/c.c
@@ -411,8 +411,6 @@ fsm_print_c(FILE *f, const struct fsm *fsm)
 		return;
 	}
 
-	fprintf(f, "#include <assert.h>\n");
-	fprintf(f, "#include <stdio.h>\n");
 	fprintf(f, "\n");
 
 	fprintf(f, "int\n%smain", prefix);
@@ -423,7 +421,9 @@ fsm_print_c(FILE *f, const struct fsm *fsm)
 		fprintf(f, "{\n");
 		fprintf(f, "\tint c;\n");
 		fprintf(f, "\n");
-		fprintf(f, "\tassert(fsm_getc != NULL);\n");
+		fprintf(f, "\tif (fsm_getc == NULL) {\n");
+		fprintf(f, "\t\treturn -1;\n");
+		fprintf(f, "\t}\n");
 		fprintf(f, "\n");
 		break;
 
@@ -432,7 +432,9 @@ fsm_print_c(FILE *f, const struct fsm *fsm)
 		fprintf(f, "{\n");
 		fprintf(f, "\tconst char *p;\n");
 		fprintf(f, "\n");
-		fprintf(f, "\tassert(s != NULL);\n");
+		fprintf(f, "\tif (s == NULL) {\n");
+		fprintf(f, "\t\treturn -1;\n");
+		fprintf(f, "\t}\n");
 		fprintf(f, "\n");
 		break;
 
@@ -441,9 +443,9 @@ fsm_print_c(FILE *f, const struct fsm *fsm)
 		fprintf(f, "{\n");
 		fprintf(f, "\tconst char *p;\n");
 		fprintf(f, "\n");
-		fprintf(f, "\tassert(b != NULL);\n");
-		fprintf(f, "\tassert(e != NULL);\n");
-		fprintf(f, "\tassert(e > b);\n");
+		fprintf(f, "\tif (b == NULL || e == NULL || b >= e) {\n");
+		fprintf(f, "\t\treturn -1;\n");
+		fprintf(f, "\t}\n");
 		fprintf(f, "\n");
 		break;
 	}

--- a/src/libfsm/print/c.c
+++ b/src/libfsm/print/c.c
@@ -269,7 +269,7 @@ endstates(FILE *f, const struct fsm_options *opt, const struct ir *ir)
 
 	/* no end states */
 	if (!ir_hasend(ir)) {
-		printf("\treturn EOF; /* unexpected EOF */\n");
+		printf("\treturn -1; /* error */\n");
 		return;
 	}
 
@@ -289,7 +289,7 @@ endstates(FILE *f, const struct fsm_options *opt, const struct ir *ir)
 		}
 		fprintf(f, "\n");
 	}
-	fprintf(f, "\tdefault: return EOF; /* unexpected EOF */\n");
+	fprintf(f, "\tdefault: return -1; /* error */\n");
 	fprintf(f, "\t}\n");
 }
 

--- a/src/libfsm/print/c.c
+++ b/src/libfsm/print/c.c
@@ -421,9 +421,6 @@ fsm_print_c(FILE *f, const struct fsm *fsm)
 		fprintf(f, "{\n");
 		fprintf(f, "\tint c;\n");
 		fprintf(f, "\n");
-		fprintf(f, "\tif (fsm_getc == NULL) {\n");
-		fprintf(f, "\t\treturn -1;\n");
-		fprintf(f, "\t}\n");
 		fprintf(f, "\n");
 		break;
 
@@ -432,9 +429,6 @@ fsm_print_c(FILE *f, const struct fsm *fsm)
 		fprintf(f, "{\n");
 		fprintf(f, "\tconst char *p;\n");
 		fprintf(f, "\n");
-		fprintf(f, "\tif (s == NULL) {\n");
-		fprintf(f, "\t\treturn -1;\n");
-		fprintf(f, "\t}\n");
 		fprintf(f, "\n");
 		break;
 
@@ -443,9 +437,6 @@ fsm_print_c(FILE *f, const struct fsm *fsm)
 		fprintf(f, "{\n");
 		fprintf(f, "\tconst char *p;\n");
 		fprintf(f, "\n");
-		fprintf(f, "\tif (b == NULL || e == NULL || b >= e) {\n");
-		fprintf(f, "\t\treturn -1;\n");
-		fprintf(f, "\t}\n");
 		fprintf(f, "\n");
 		break;
 	}


### PR DESCRIPTION
This PR returns `-1` instead of asserting or returning `EOF` in error scenarios.  

The reasons for these changes are: 
- Make error handling more flexible for the caller of the fsm function; for example, handling a `-1` return value instead of dying on an `assert` 
- Making `-1` a more explicit error value instead of `EOF`; reducing the need for the context to handle or understand an `EOF` value.
- Eliminate the need to include libraries for `EOF`/`assert` in the generated code

Without these changes, a context that wants to handle `NULL` (or empty string) input differently would need to maintain that handling separately (and have it executed before the libfsm-generated code is called); additionally it would be confined to using `.fragment = true` if it wants this error handling in the same function as the state machine.