### PR TITLE
Benchmarking for sets of words

### DIFF
--- a/examples/bm/libfsm.c
+++ b/examples/bm/libfsm.c
@@ -88,7 +88,7 @@ main(int argc, char *argv[])
 	printf("{\n");
 	printf("\tchar s[4096];\n");
 	printf("\tunsigned n;\n");
-	printf("\tdouble ms;\n");
+	printf("\tunsigned long ms;\n");
 	printf("\tint i, max;\n");
 	printf("\n");
 
@@ -122,14 +122,14 @@ main(int argc, char *argv[])
 	printf("\t\tprintf(\"%%u %%s\\n\", n, n == 1 ? \"match\" : \"matches\");\n");
 */
 
-	printf("\t\tms = 1000.0 * (post.tv_sec  - pre.tv_sec)\n");
-	printf("\t\t            + (post.tv_nsec - pre.tv_nsec) / 1e6 / (double) %d;\n", BM_MAX);
+	printf("\t\tms += 1000.0 * (post.tv_sec  - pre.tv_sec)\n");
+	printf("\t\t             + ((long) post.tv_nsec - (long) pre.tv_nsec) / 1000000 / %d;\n", BM_MAX);
 	printf("\n");
 
 	printf("\t}\n");
 	printf("\n");
 
-	printf("\tprintf(\"%%f\\n\", ms);\n");
+	printf("\tprintf(\"%%lu\\n\", ms);\n");
 	printf("\n");
 
 	printf("\treturn 0;\n");

--- a/examples/bm/pcre.c
+++ b/examples/bm/pcre.c
@@ -25,7 +25,7 @@ main(int argc, char *argv[])
 	int o;
 	unsigned n;
 	int flags;
-	double ms;
+	unsigned long ms;
 	int i, max;
 
 	max = BM_MAX;
@@ -94,8 +94,8 @@ main(int argc, char *argv[])
 			exit(EXIT_FAILURE);
 		}
 
-		ms += 1000.0 * (post.tv_sec  - pre.tv_sec)
-		             + (post.tv_nsec - pre.tv_nsec) / 1e6 / (double) max;
+		ms += 1000 * (long) (post.tv_sec - pre.tv_sec)
+		           + ((long) post.tv_nsec - (long) pre.tv_nsec) / 1000000 / max;
 
 		if (r == PCRE_ERROR_NOMATCH) {
 			continue;
@@ -112,7 +112,7 @@ main(int argc, char *argv[])
 	printf("%u %s\n", n, n == 1 ? "match" : "matches");
 */
 
-	printf("%f\n", ms);
+	printf("%lu\n", ms);
 
 	return 0;
 

--- a/examples/words/main.c
+++ b/examples/words/main.c
@@ -28,7 +28,7 @@ int main(int argc, char *argv[]) {
 	char s[BUFSIZ];
 	int (*dmf)(struct fsm *);
 	void (*print)(FILE *, const struct fsm *);
-	double ms, mt;
+	unsigned long ms, mt;
 	int timing;
 
 	opt.anonymous_states  = 1;
@@ -82,6 +82,8 @@ int main(int argc, char *argv[]) {
 	ms = 0;
 	mt = 0;
 
+	/* TODO: option to generate random strings instead */
+
 	while (fgets(s, sizeof s, stdin) != NULL) {
 		struct fsm *r;
 		struct re_err e;
@@ -120,8 +122,9 @@ int main(int argc, char *argv[]) {
 			exit(EXIT_FAILURE);
 		}
 
-		ms += 1000.0 * (post.tv_sec  - pre.tv_sec)
-					 + (post.tv_nsec - pre.tv_nsec) / 1e6;
+
+		ms += 1000 * (post.tv_sec - pre.tv_sec)
+		           + ((long) post.tv_nsec - (long) pre.tv_nsec) / 1000000;
 	}
 
 	fsm_setstart(fsm, start);
@@ -144,8 +147,8 @@ int main(int argc, char *argv[]) {
 			exit(EXIT_FAILURE);
 		}
 
-		mt += 1000.0 * (post.tv_sec  - pre.tv_sec)
-					 + (post.tv_nsec - pre.tv_nsec) / 1e6;
+		mt += 1000 * (post.tv_sec - pre.tv_sec)
+		           + ((long) post.tv_nsec - (long) pre.tv_nsec) / 1000000;
 	}
 
 	if (print != NULL) {
@@ -153,7 +156,7 @@ int main(int argc, char *argv[]) {
 	}
 
 	if (timing) {
-		printf("construction, reduction, total: %f, %f, %f\n", ms, mt, ms + mt);
+		printf("construction, reduction, total: %lu, %lu, %lu\n", ms, mt, ms + mt);
 	}
 
 	return 0;

--- a/examples/words/main.c
+++ b/examples/words/main.c
@@ -82,8 +82,6 @@ int main(int argc, char *argv[]) {
 	ms = 0;
 	mt = 0;
 
-	/* TODO: option to generate random strings instead */
-
 	while (fgets(s, sizeof s, stdin) != NULL) {
 		struct fsm *r;
 		struct re_err e;

--- a/examples/words/words.sh
+++ b/examples/words/words.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+# $1=5000 number of words
+# $2=1,100 for varying length words
+
+f() {
+	blab -s $1 -e "([a-zA-Z0-9]{$2} '\n'){$1}" \
+	| ./words -dt \
+	| cut -f2 -d: | cut -f2 -d,
+}
+
+for i in `seq 1 $(($1 / 20)) $1`; do
+	f $i $2
+done
+


### PR DESCRIPTION
I added timing for examples/words, outputting monotonic clock time in ms. It has a couple of CLI options, but nothing really remarkable. There's a shell script to run it.

For example, determinising 5000 words of between 40,50 characters in length:
```
; ./words.sh 5000 40,50 | guff -b
    x: [0 - 19]    y: [0 - 671]
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠂⠀⠂
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠐⠀⠀⠀⠀
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⠀⠐⠀⠀⠀⠀⠀⠀
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠂⠀⠀⠀⠀⠀⠀⠀⠀⠀
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⠀⠂⠀⠂⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠠⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡀⠀⠂⠈⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠁⠀⠀⠀⠀⠀⠀⠀⠀⢀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⣇⣀⣄⣈⣀⣠⣀⣠⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀
```