### PR TITLE
Missing character class error handling

### DIFF
--- a/src/libre/re.c
+++ b/src/libre/re.c
@@ -158,13 +158,12 @@ re_comp(enum re_dialect dialect, int (*getc)(void *opaque), void *opaque,
 		re_ast_expr_free(unsat);
 	}
 
-	new = re_comp_ast(ast, flags, opt);
+	new = re_comp_ast(ast, flags, opt, err);
 	re_ast_free(ast);
 	ast = NULL;
 
 	if (new == NULL) {
-		fprintf(stderr, "Compilation failed\n");
-		if (err->e == RE_ESUCCESS) {
+		if (err != NULL && err->e == RE_ESUCCESS) {
 			/* If we got here, we had a parse error
 			 * without error information set. */
 			assert(0);
@@ -188,9 +187,7 @@ error:
 
 	if (new != NULL) { fsm_free(new); }
 	if (ast != NULL) { re_ast_free(ast); }
-	if (err != NULL) {
-		err->e = RE_EERRNO;
-	}
+	if (err != NULL) { err->e = RE_EERRNO; }
 
 	return NULL;
 }

--- a/src/libre/re_char_class.c
+++ b/src/libre/re_char_class.c
@@ -292,7 +292,7 @@ fsm_any(const struct fsm *fsm,
 	assert(predicate != NULL);
 	
 	for (s = fsm->sl; s != NULL; s = s->next) {
-		if (!predicate(fsm, s)) {
+		if (predicate(fsm, s)) {
 			return s;
 		}
 	}
@@ -366,6 +366,7 @@ link_char_class_into_fsm(struct re_char_class *cc, struct fsm *fsm,
 		/* XXX: this is just one example; really I want to show the entire set */
 		end = fsm_any(cc->dup, fsm_isend);
 		assert(end != NULL);
+		assert(end != fsm_getstart(cc->dup)); /* due to the structure */
 		
 		if (-1 == fsm_example(cc->dup, end, err->dup, sizeof err->dup)) {
 			err->e = RE_EERRNO;

--- a/src/libre/re_comp.c
+++ b/src/libre/re_comp.c
@@ -309,6 +309,16 @@ comp_iter(struct comp_env *env,
 		break;
 
 	case AST_EXPR_CHAR_CLASS:
+		/*
+		 * XXX: this doesn't belong here; it's set as a fall-through.
+		 * Instead we should be populating .start/.end for each node
+		 * in the cca tree.
+		 */
+		if (env->err != NULL) {
+			env->err->start.byte = n->u.char_class.start.byte;
+			env->err->end.byte   = n->u.char_class.end.byte;
+		}
+
 		if (!re_char_class_ast_compile(n->u.char_class.cca,
 			env->fsm, env->flags, env->err, env->opt, x, y)) {
 			return 0;

--- a/src/libre/re_comp.c
+++ b/src/libre/re_comp.c
@@ -82,7 +82,8 @@ decide_linking(struct comp_env *env,
 struct fsm *
 re_comp_ast(struct ast_re *ast,
     enum re_flags flags,
-    const struct fsm_options *opt)
+    const struct fsm_options *opt,
+	struct re_err *err)
 {
 	struct fsm_state *x, *y;
 	struct comp_env env;
@@ -94,6 +95,7 @@ re_comp_ast(struct ast_re *ast,
 
 	env.opt = opt;
 	env.flags = flags;
+	env.err = err;
 	
 	x = fsm_getstart(env.fsm);
 	assert(x != NULL);

--- a/src/libre/re_comp.h
+++ b/src/libre/re_comp.h
@@ -17,6 +17,7 @@ re_parse(enum re_dialect dialect, int (*getc)(void *opaque), void *opaque,
 struct fsm *
 re_comp_ast(struct ast_re *ast,
     enum re_flags flags,
-    const struct fsm_options *opt);
+    const struct fsm_options *opt,
+	struct re_err *err);
 
 #endif


### PR DESCRIPTION
A couple of bugfixes for these error messages:
```
; ./build/bin/re 'abc[abca-z]xyz' 
/abc[abca-z]xyz/:4-12: Redundancy in group: overlap of [a]
```

Here the `struct re_err *` pointer was assumed to be present, where the `<re/re.h>` API allows `NULL`. The character class handling hadn't passed along this pointer where it was present, and the `.start/.end` byte offsets were missing.