### PR TITLE
Handling for empty example strings

### DIFF
--- a/src/libfsm/example.c
+++ b/src/libfsm/example.c
@@ -46,6 +46,12 @@ fsm_example(const struct fsm *fsm, const struct fsm_state *goal,
 		return -1;
 	}
 
+	if (path != NULL && path->state != start) {
+		/* no known path to goal */
+		n = 0;
+		goto done;
+	}
+
 	n = 0;
 
 	for (p = path; p != NULL; p = p->next) {
@@ -60,6 +66,8 @@ fsm_example(const struct fsm *fsm, const struct fsm_state *goal,
 
 		n++;
 	}
+
+done:
 
 	if (bufsz > 0) {
 		*buf++ = '\0';

--- a/src/libfsm/example.c
+++ b/src/libfsm/example.c
@@ -46,7 +46,9 @@ fsm_example(const struct fsm *fsm, const struct fsm_state *goal,
 		return -1;
 	}
 
-	for (p = path, n = 0; p != NULL; p = p->next, n++) {
+	n = 0;
+
+	for (p = path; p != NULL; p = p->next) {
 		if (p->type == FSM_EDGE_EPSILON) {
 			continue;
 		}
@@ -55,6 +57,8 @@ fsm_example(const struct fsm *fsm, const struct fsm_state *goal,
 			*buf++ = p->type;
 			bufsz--;
 		}
+
+		n++;
 	}
 
 	if (bufsz > 0) {

--- a/src/libfsm/print/fsm.c
+++ b/src/libfsm/print/fsm.c
@@ -157,10 +157,12 @@ fsm_print_fsm(FILE *f, const struct fsm *fsm)
 							return;
 						}
 
-						fprintf(f, " # e.g. \"");
-						escputs(f, fsm->opt, fsm_escputc, buf);
-						fprintf(f, "%s\"",
-							n >= (int) sizeof buf - 1 ? "..." : "");
+						if (n > 0) {
+							fprintf(f, " # e.g. \"");
+							escputs(f, fsm->opt, fsm_escputc, buf);
+							fprintf(f, "%s\"",
+								n >= (int) sizeof buf - 1 ? "..." : "");
+						}
 					}
 				}
 

--- a/src/libfsm/print/ir.c
+++ b/src/libfsm/print/ir.c
@@ -539,7 +539,14 @@ make_ir(const struct fsm *fsm)
 				goto error_example;
 			}
 
-			if ((size_t) n < ir->n + 1) {
+			/*
+			 * The goal state is always reachable for a DFA with
+			 * no "stray" states, but the caller may not trim an FSM.
+			 */
+			if (n == 0) {
+				f_free(fsm, p);
+				p = NULL;
+			} else if ((size_t) n < ir->n + 1) {
 				char *tmp;
 
 				n = strlen(p);

--- a/src/libre/re_char_class.c
+++ b/src/libre/re_char_class.c
@@ -356,6 +356,7 @@ link_char_class_into_fsm(struct re_char_class *cc, struct fsm *fsm,
 	
 	if (!is_empty) {
 		const struct fsm_state *end;
+		int n;
 
 		if (err == NULL) {
 			return 0;
@@ -368,10 +369,14 @@ link_char_class_into_fsm(struct re_char_class *cc, struct fsm *fsm,
 		assert(end != NULL);
 		assert(end != fsm_getstart(cc->dup)); /* due to the structure */
 		
-		if (-1 == fsm_example(cc->dup, end, err->dup, sizeof err->dup)) {
+		n = fsm_example(cc->dup, end, err->dup, sizeof err->dup);
+		if (n == -1) {
 			err->e = RE_EERRNO;
 			return 0;
 		}
+		
+		/* due to the structure */
+		assert(n > 0);
 		
 		/* XXX: to return when we can show minimal coverage again */
 		strcpy(err->set, err->dup);

--- a/src/lx/main.c
+++ b/src/lx/main.c
@@ -938,33 +938,41 @@ main(int argc, char *argv[])
 						return EXIT_FAILURE;
 					}
 
-					fprintf(stderr, "ambiguous mappings to ");
+					/*
+					 * When n == 0, we have two patterns which match the empty string.
+					 * Here we defer to the error about the start state accepting,
+					 * and it seems redundant to also show an error about both patterns
+					 * matching the same input, even if there's a non-empty part.
+					 */
+					if (n > 0) {
+						fprintf(stderr, "ambiguous mappings to ");
 
-					for (p = m->conflict; p != NULL; p = p->next) {
-						if (p->m->token != NULL) {
-							fprintf(stderr, "$%s", p->m->token->s);
-						} else if (p->m->to == NULL) {
-							fprintf(stderr, "skip");
-						}
-						if (p->m->token != NULL && p->m->to != NULL) {
-							fprintf(stderr, "/");
-						}
-						if (p->m->to == ast->global) {
-							fprintf(stderr, "global zone");
-						} else if (p->m->to != NULL) {
-							fprintf(stderr, "z%p", (void *) p->m->to); /* TODO: zindexof(n->to) */
+						for (p = m->conflict; p != NULL; p = p->next) {
+							if (p->m->token != NULL) {
+								fprintf(stderr, "$%s", p->m->token->s);
+							} else if (p->m->to == NULL) {
+								fprintf(stderr, "skip");
+							}
+							if (p->m->token != NULL && p->m->to != NULL) {
+								fprintf(stderr, "/");
+							}
+							if (p->m->to == ast->global) {
+								fprintf(stderr, "global zone");
+							} else if (p->m->to != NULL) {
+								fprintf(stderr, "z%p", (void *) p->m->to); /* TODO: zindexof(n->to) */
+							}
+
+							if (p->next != NULL) {
+								fprintf(stderr, ", ");
+							}
 						}
 
-						if (p->next != NULL) {
-							fprintf(stderr, ", ");
-						}
+						/* TODO: escape hex etc */
+						fprintf(stderr, "; for example on input '%s%s'\n", buf,
+							n >= (int) sizeof buf - 1 ? "..." : "");
+
+						e = 1;
 					}
-
-					/* TODO: escape hex etc */
-					fprintf(stderr, "; for example on input '%s%s'\n", buf,
-						n >= (int) sizeof buf - 1 ? "..." : "");
-
-					e = 1;
 				}
 			}
 		}


### PR DESCRIPTION
This is just tidying up cases for 0-length strings in preparation for removing epsilon edges from the paths used for finding examples.