### PR TITLE
NULL set reworking for ADT instances

### DIFF
--- a/include/adt/edgeset.h
+++ b/include/adt/edgeset.h
@@ -37,7 +37,7 @@ struct fsm_edge *
 edge_set_first(struct edge_set *set, struct edge_iter *it);
 
 struct fsm_edge *
-edge_set_firstafter(struct edge_set *set, struct edge_iter *it, const struct fsm_edge *e);
+edge_set_firstafter(const struct edge_set *set, struct edge_iter *it, const struct fsm_edge *e);
 
 struct fsm_edge *
 edge_set_next(struct edge_iter *it);

--- a/include/adt/hashset.h
+++ b/include/adt/hashset.h
@@ -34,7 +34,7 @@ void *
 hashset_add(struct hashset *s, void *item);
 
 int
-hashset_remove(struct hashset *s, void *item);
+hashset_remove(struct hashset *s, const void *item);
 
 void
 hashset_free(struct hashset *s);

--- a/include/adt/set.h
+++ b/include/adt/set.h
@@ -18,10 +18,10 @@ struct set *
 set_create(int (*cmp)(const void *a, const void *b));
 
 void *
-set_add(struct set **set, void *item);
+set_add(struct set *set, void *item);
 
 void
-set_remove(struct set **set, void *item);
+set_remove(struct set *set, void *item);
 
 void
 set_free(struct set *set);

--- a/include/adt/set.h
+++ b/include/adt/set.h
@@ -21,7 +21,7 @@ void *
 set_add(struct set *set, void *item);
 
 void
-set_remove(struct set *set, void *item);
+set_remove(struct set *set, const void *item);
 
 void
 set_free(struct set *set);
@@ -57,7 +57,7 @@ void *
 set_first(const struct set *set, struct set_iter *it);
 
 void *
-set_firstafter(const struct set *set, struct set_iter *it, void *item);
+set_firstafter(const struct set *set, struct set_iter *it, const void *item);
 
 void *
 set_next(struct set_iter *it);

--- a/include/adt/tupleset.h
+++ b/include/adt/tupleset.h
@@ -22,7 +22,7 @@ void
 tuple_set_free(struct tuple_set *set);
 
 struct fsm_walk2_tuple *
-tuple_set_contains(struct tuple_set *set, const struct fsm_walk2_tuple *item);
+tuple_set_contains(const struct tuple_set *set, const struct fsm_walk2_tuple *item);
 
 struct fsm_walk2_tuple *
 tuple_set_add(struct tuple_set *set, const struct fsm_walk2_tuple *item);

--- a/include/adt/tupleset.h
+++ b/include/adt/tupleset.h
@@ -25,7 +25,7 @@ struct fsm_walk2_tuple *
 tuple_set_contains(const struct tuple_set *set, const struct fsm_walk2_tuple *item);
 
 struct fsm_walk2_tuple *
-tuple_set_add(struct tuple_set *set, const struct fsm_walk2_tuple *item);
+tuple_set_add(struct tuple_set *set, struct fsm_walk2_tuple *item);
 
 #endif
 

--- a/include/adt/tupleset.h
+++ b/include/adt/tupleset.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Shannon F. Stewman
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#ifndef ADT_TUPLESET_H
+#define ADT_TUPLESET_H
+
+struct set;
+struct fsm_state;
+struct fsm_walk2_tuple;
+
+struct tuple_iter {
+	struct set_iter iter;
+};
+
+struct tuple_set *
+tuple_set_create(int (*cmp)(const void *, const void *));
+
+void
+tuple_set_free(struct tuple_set *set);
+
+struct fsm_walk2_tuple *
+tuple_set_contains(struct tuple_set *set, const struct fsm_walk2_tuple *item);
+
+struct fsm_walk2_tuple *
+tuple_set_add(struct tuple_set *set, const struct fsm_walk2_tuple *item);
+
+#endif
+

--- a/src/adt/Makefile
+++ b/src/adt/Makefile
@@ -14,6 +14,7 @@ SRC += src/adt/edgeset.c
 SRC += src/adt/stateset.c
 SRC += src/adt/mappingset.c
 SRC += src/adt/transset.c
+SRC += src/adt/tupleset.c
 
 .for src in ${SRC:Msrc/adt/bitmap.c}
 CFLAGS.${src} += -I src # XXX: for internal.h

--- a/src/adt/edgeset.c
+++ b/src/adt/edgeset.c
@@ -49,7 +49,7 @@ edge_set_free(struct edge_set *set)
 struct fsm_edge *
 edge_set_add(struct edge_set *set, struct fsm_edge *e)
 {
-	return set_add(&set->set, e);
+	return set_add(set->set, e);
 }
 
 struct fsm_edge *
@@ -67,7 +67,7 @@ edge_set_count(const struct edge_set *set)
 void
 edge_set_remove(struct edge_set *set, const struct fsm_edge *e)
 {
-	set_remove(&set->set, (void *)e);
+	set_remove(set->set, (void *)e);
 }
 
 struct fsm_edge *

--- a/src/adt/edgeset.c
+++ b/src/adt/edgeset.c
@@ -77,7 +77,7 @@ edge_set_first(struct edge_set *set, struct edge_iter *it)
 }
 
 struct fsm_edge *
-edge_set_firstafter(struct edge_set *set, struct edge_iter *it, const struct fsm_edge *e)
+edge_set_firstafter(const struct edge_set *set, struct edge_iter *it, const struct fsm_edge *e)
 {
 	return set_firstafter(set->set, &it->iter, (void *)e);
 }

--- a/src/adt/edgeset.c
+++ b/src/adt/edgeset.c
@@ -5,99 +5,94 @@
  */
 
 #include <assert.h>
-#include <stdlib.h>
+#include <stddef.h>
 
 #include <adt/set.h>
 #include <adt/edgeset.h>
 
-struct edge_set {
-	struct set *set;
-};
-
 struct edge_set *
 edge_set_create(int (*cmp)(const void *a, const void *b))
 {
-	struct edge_set *set;
-
-	set = malloc(sizeof *set);
-	if (set == NULL) {
-		return NULL;
-	}
-
-	set->set = set_create(cmp);
-	if (set->set == NULL) {
-		free(set);
-		return NULL;
-	}
-
-	return set;
+	return (struct edge_set *) set_create(cmp);
 }
 
 void
 edge_set_free(struct edge_set *set)
 {
-	if (set == NULL) {
-		return;
-	}
+	assert(set != NULL);
 
-	assert(set->set != NULL);
-	set_free(set->set);
-
-	free(set);
+	set_free((struct set *) set);
 }
 
 struct fsm_edge *
 edge_set_add(struct edge_set *set, struct fsm_edge *e)
 {
-	return set_add(set->set, e);
+	assert(set != NULL);
+
+	return set_add((struct set *) set, e);
 }
 
 struct fsm_edge *
 edge_set_contains(const struct edge_set *set, const struct fsm_edge *e)
 {
-	return set_contains(set->set, e);
+	assert(set != NULL);
+
+	return set_contains((const struct set *) set, e);
 }
 
 size_t
 edge_set_count(const struct edge_set *set)
 {
-	return set_count(set->set);
+	assert(set != NULL);
+
+	return set_count((const struct set *) set);
 }
 
 void
 edge_set_remove(struct edge_set *set, const struct fsm_edge *e)
 {
-	set_remove(set->set, (void *)e);
+	assert(set != NULL);
+
+	set_remove((struct set *) set, e);
 }
 
 struct fsm_edge *
 edge_set_first(struct edge_set *set, struct edge_iter *it)
 {
-	return set_first(set->set, &it->iter);
+	assert(set != NULL);
+
+	return set_first((struct set *) set, &it->iter);
 }
 
 struct fsm_edge *
 edge_set_firstafter(const struct edge_set *set, struct edge_iter *it, const struct fsm_edge *e)
 {
-	return set_firstafter(set->set, &it->iter, (void *)e);
+	assert(set != NULL);
+
+	return set_firstafter((const struct set *) set, &it->iter, e);
 }
 
 struct fsm_edge *
 edge_set_next(struct edge_iter *it)
 {
+	assert(it != NULL);
+
 	return set_next(&it->iter);
 }
 
 int
 edge_set_hasnext(struct edge_iter *it)
 {
+	assert(it != NULL);
+
 	return set_hasnext(&it->iter);
 }
 
 struct fsm_edge *
-edge_set_only(const struct edge_set *s)
+edge_set_only(const struct edge_set *set)
 {
-	return set_only(s->set);
-}
+	assert(set != NULL);
 
+	return set_only((const struct set *) set);
+}
 

--- a/src/adt/hashset.c
+++ b/src/adt/hashset.c
@@ -178,7 +178,7 @@ hashset_add(struct hashset *s, void *item)
 }
 
 int
-hashset_remove(struct hashset *s, void *item)
+hashset_remove(struct hashset *s, const void *item)
 {
 	size_t b;
 	unsigned long h = s->hash(item);

--- a/src/adt/mappingset.c
+++ b/src/adt/mappingset.c
@@ -5,85 +5,55 @@
  */
 
 #include <assert.h>
-#include <stdlib.h>
+#include <stddef.h>
 
 #include <adt/hashset.h>
 #include <adt/mappingset.h>
 
-/* Uses a hash set and a list to hold the items that are not yet done. */
-struct mapping_set {
-	struct hashset *set;
-};
-
 struct mapping_set *
-mapping_set_create(unsigned long (*hash)(const void *a), int (*cmp)(const void *a, const void *b))
+mapping_set_create(unsigned long (*hash)(const void *a),
+	int (*cmp)(const void *a, const void *b))
 {
-	struct mapping_set *set;
-
 	assert(hash != NULL);
 	assert(cmp != NULL);
 
-	set = malloc(sizeof *set);
-	if (set == NULL) {
-		return NULL;
-	}
-
-	set->set = hashset_create(hash, cmp);
-	if (set->set == NULL) {
-		free(set);
-		return NULL;
-	}
-
-	return set;
+	return (struct mapping_set *) hashset_create(hash, cmp);
 }
 
 void
 mapping_set_free(struct mapping_set *set)
 {
-	if (set == NULL) {
-		return;
-	}
-
-	assert(set->set != NULL);
-	hashset_free(set->set);
-	free(set);
+	hashset_free((struct hashset *) set);
 }
 
 struct mapping *
 mapping_set_add(struct mapping_set *set, struct mapping *item)
 {
 	assert(set != NULL);
-	assert(set->set != NULL);
 
-	if (hashset_add(set->set, item) == NULL) {
-		return NULL;
-	}
-
-	return item;
+	return hashset_add((struct hashset *) set, item);
 }
 
 struct mapping *
 mapping_set_contains(const struct mapping_set *set, const struct mapping *item)
 {
 	assert(set != NULL);
-	assert(set->set != NULL);
 
-	return hashset_contains(set->set, item);
+	return hashset_contains((const struct hashset *) set, item);
 }
 
 void
 mapping_set_clear(struct mapping_set *set)
 {
 	assert(set != NULL);
-	assert(set->set != NULL);
 
-	hashset_clear(set->set);
+	hashset_clear((struct hashset *) set);
 }
 
 struct mapping *
 mapping_set_first(const struct mapping_set *set, struct mapping_iter *it)
 {
-	return hashset_first(set->set, &it->iter);
+	return hashset_first((const struct hashset *) set, &it->iter);
 }
 
 struct mapping *

--- a/src/adt/set.c
+++ b/src/adt/set.c
@@ -137,7 +137,7 @@ set_add(struct set *set, void *item)
 }
 
 void
-set_remove(struct set *set, void *item)
+set_remove(struct set *set, const void *item)
 {
 	size_t i;
 
@@ -267,7 +267,7 @@ set_first(const struct set *set, struct set_iter *it)
 }
 
 void *
-set_firstafter(const struct set *set, struct set_iter *it, void *item)
+set_firstafter(const struct set *set, struct set_iter *it, const void *item)
 {
 	size_t i;
 	int r;

--- a/src/adt/set.c
+++ b/src/adt/set.c
@@ -61,111 +61,104 @@ set_cmpval(const void *a, const void *b)
 struct set *
 set_create(int (*cmp)(const void *a, const void *b))
 {
-	struct set *s;
+	struct set *set;
 
 	if (cmp == NULL) {
 		cmp = set_cmpval;
 	}
 
-	s = malloc(sizeof *s);
-	if (s == NULL) {
+	set = malloc(sizeof *set);
+	if (set == NULL) {
 		return NULL;
 	}
 
-	s->a = malloc(SET_INITIAL * sizeof *s->a);
-	if (s->a == NULL) {
+	set->a = malloc(SET_INITIAL * sizeof *set->a);
+	if (set->a == NULL) {
 		return NULL;
 	}
 
-	s->i = 0;
-	s->n = SET_INITIAL;
-	s->cmp = cmp;
+	set->i = 0;
+	set->n = SET_INITIAL;
+	set->cmp = cmp;
 
-	return s;
+	return set;
 }
 
 void *
-set_add(struct set **set, void *item)
+set_add(struct set *set, void *item)
 {
-	struct set *s;
 	size_t i;
 
 	assert(set != NULL);
-	assert(*set != NULL);
-	assert((*set)->cmp != NULL);
+	assert(set->cmp != NULL);
 	assert(item != NULL);
 
-	s = *set;
 	i = 0;
 
 	/*
 	 * If the item already exists in the set, return success.
 	 */
-	if (!set_empty(s)) {
-		i = set_search(s, item);
-		if (s->cmp(item, s->a[i]) == 0) {
+	if (!set_empty(set)) {
+		i = set_search(set, item);
+		if (set->cmp(item, set->a[i]) == 0) {
 			return item;
 		}
 	}
 
-	if (s->i) {
+	if (set->i) {
 		/* We're at capacity. Get more */
-		if (s->i == s->n) {
+		if (set->i == set->n) {
 			void **new;
 
-			new = realloc(s->a, (sizeof *s->a) * (s->n * 2));
+			new = realloc(set->a, (sizeof *set->a) * (set->n * 2));
 			if (new == NULL) {
 				return NULL;
 			}
 
-			s->a = new;
-			s->n *= 2;
+			set->a = new;
+			set->n *= 2;
 		}
 
-		if (s->cmp(item, s->a[i]) > 0) {
+		if (set->cmp(item, set->a[i]) > 0) {
 			i++;
 		}
 
-		memmove(&s->a[i + 1], &s->a[i], (s->i - i) * (sizeof *s->a));
-		s->a[i] = item;
-		s->i++;
+		memmove(&set->a[i + 1], &set->a[i], (set->i - i) * (sizeof *set->a));
+		set->a[i] = item;
+		set->i++;
 	} else {
-		s->a[0] = item;
-		s->i = 1;
+		set->a[0] = item;
+		set->i = 1;
 	}
 
-	assert(set_contains(s, item));
+	assert(set_contains(set, item));
 
 	return item;
 }
 
 void
-set_remove(struct set **set, void *item)
+set_remove(struct set *set, void *item)
 {
-	struct set *s;
 	size_t i;
 
 	assert(set != NULL);
-	assert(*set != NULL);
-	assert((*set)->cmp != NULL);
+	assert(set->cmp != NULL);
 	assert(item != NULL);
 
-	s = *set;
-
-	if (set_empty(s)) {
+	if (set_empty(set)) {
 		return;
 	}
 
-	i = set_search(s, item);
-	if (s->cmp(item, s->a[i]) == 0) {
-		if (i < s->i) {
-			memmove(&s->a[i], &s->a[i + 1], (s->i - i - 1) * (sizeof *s->a));
+	i = set_search(set, item);
+	if (set->cmp(item, set->a[i]) == 0) {
+		if (i < set->i) {
+			memmove(&set->a[i], &set->a[i + 1], (set->i - i - 1) * (sizeof *set->a));
 		}
 
-		s->i--;
+		set->i--;
 	}
 
-	assert(!set_contains(s, item));
+	assert(!set_contains(set, item));
 }
 
 void

--- a/src/adt/stateset.c
+++ b/src/adt/stateset.c
@@ -24,7 +24,11 @@ state_set_create(void)
 		return NULL;
 	}
 
-	set->set = NULL;
+	set->set = set_create(NULL);
+	if (set->set == NULL) {
+		free(set);
+		return NULL;
+	}
 
 	return set;
 }

--- a/src/adt/stateset.c
+++ b/src/adt/stateset.c
@@ -47,13 +47,13 @@ state_set_free(struct state_set *set)
 struct fsm_state *
 state_set_add(struct state_set *set, struct fsm_state *st)
 {
-	return set_add(&set->set, st);
+	return set_add(set->set, st);
 }
 
 void
 state_set_remove(struct state_set *set, const struct fsm_state *st)
 {
-	set_remove(&set->set, (void *)st);
+	set_remove(set->set, (void *)st);
 }
 
 int

--- a/src/adt/stateset.c
+++ b/src/adt/stateset.c
@@ -4,110 +4,113 @@
  * See LICENCE for the full copyright terms.
  */
 
+#include <assert.h>
 #include <stddef.h>
-#include <stdlib.h>
 
 #include <adt/set.h>
 #include <adt/stateset.h>
 
-struct state_set {
-	struct set *set;
-};
-
 struct state_set *
 state_set_create(void)
 {
-	struct state_set *set;
-
-	set = malloc(sizeof *set);
-	if (set == NULL) {
-		return NULL;
-	}
-
-	set->set = set_create(NULL);
-	if (set->set == NULL) {
-		free(set);
-		return NULL;
-	}
-
-	return set;
+	return (struct state_set *) set_create(NULL);
 }
 
 void
 state_set_free(struct state_set *set)
 {
-	if (set == NULL) {
-		return;
-	}
+	assert(set != NULL);
 
-	set_free(set->set);
-	free(set);
+	set_free((struct set *) set);
 }
 
 struct fsm_state *
 state_set_add(struct state_set *set, struct fsm_state *st)
 {
-	return set_add(set->set, st);
+	assert(set != NULL);
+
+	return set_add((struct set *) set, st);
 }
 
 void
 state_set_remove(struct state_set *set, const struct fsm_state *st)
 {
-	set_remove(set->set, (void *)st);
+	assert(set != NULL);
+
+	set_remove((struct set *) set, st);
 }
 
 int
-state_set_empty(const struct state_set *s)
+state_set_empty(const struct state_set *set)
 {
-	return set_empty(s->set);
+	assert(set != NULL);
+
+	return set_empty((const struct set *) set);
 }
 
 struct fsm_state *
-state_set_only(const struct state_set *s)
+state_set_only(const struct state_set *set)
 {
-	return set_only(s->set);
+	assert(set != NULL);
+
+	return set_only((const struct set *) set);
 }
 
 struct fsm_state *
 state_set_contains(const struct state_set *set, const struct fsm_state *st)
 {
-	return set_contains(set->set, st);
+	assert(set != NULL);
+
+	return set_contains((const struct set *) set, st);
 }
 
 size_t
 state_set_count(const struct state_set *set)
 {
-	return set_count(set->set);
+	assert(set != NULL);
+
+	return set_count((const struct set *) set);
 }
 
 struct fsm_state *
 state_set_first(struct state_set *set, struct state_iter *it)
 {
-	return set_first(set->set, &it->iter);
+	assert(set != NULL);
+
+	return set_first((struct set *) set, &it->iter);
 }
 
 struct fsm_state *
 state_set_next(struct state_iter *it)
 {
+	assert(it != NULL);
+
 	return set_next(&it->iter);
 }
 
 int
 state_set_hasnext(struct state_iter *it)
 {
+	assert(it != NULL);
+
 	return set_hasnext(&it->iter);
 }
 
 const struct fsm_state **
 state_set_array(const struct state_set *set)
 {
-	return (const struct fsm_state **)set_array(set->set);
+	assert(set != NULL);
+
+	return (const struct fsm_state **) set_array((const struct set *) set);
 }
 
 int
 state_set_cmp(const struct state_set *a, const struct state_set *b)
 {
-	return set_cmp(a->set, b->set);
+	assert(a != NULL);
+	assert(b != NULL);
+
+	return set_cmp((const struct set *) a, (const struct set *) b);
 }
 
 

--- a/src/adt/transset.c
+++ b/src/adt/transset.c
@@ -50,7 +50,7 @@ trans_set_free(struct trans_set *set)
 struct trans *
 trans_set_add(struct trans_set *set, struct trans *item)
 {
-	return set_add(&set->set, item);
+	return set_add(set->set, item);
 }
 
 struct trans *

--- a/src/adt/transset.c
+++ b/src/adt/transset.c
@@ -5,75 +5,65 @@
  */
 
 #include <assert.h>
-#include <stdlib.h>
+#include <stddef.h>
 
 #include <adt/set.h>
 #include <adt/hashset.h>
 #include <adt/transset.h>
 
-struct trans_set {
-	struct set *set;
-};
-
 struct trans_set *
 trans_set_create(int (*cmp)(const void *a, const void *b))
 {
-	struct trans_set *set;
-
 	assert(cmp != NULL);
 
-	set = malloc(sizeof *set);
-	if (set == NULL) {
-		return NULL;
-	}
-
-	set->set = set_create(cmp);
-	if (set->set == NULL) {
-		free(set);
-		return NULL;
-	}
-
-	return set;
+	return (struct trans_set *) set_create(cmp);
 }
 
 void
 trans_set_free(struct trans_set *set)
 {
-	if (set == NULL) {
-		return;
-	}
+	assert(set != NULL);
 
-	set_free(set->set);
-	free(set);
+	set_free((struct set *) set);
 }
 
 struct trans *
 trans_set_add(struct trans_set *set, struct trans *item)
 {
-	return set_add(set->set, item);
+	assert(set != NULL);
+
+	return set_add((struct set *) set, item);
 }
 
 struct trans *
 trans_set_contains(const struct trans_set *set, const struct trans *item)
 {
-	return set_contains(set->set, item);
+	assert(set != NULL);
+
+	return set_contains((const struct set *) set, item);
 }
 
 void
 trans_set_clear(struct trans_set *set)
 {
-	set_clear(set->set);
+	assert(set != NULL);
+
+	set_clear((struct set *) set);
 }
 
 struct trans *
 trans_set_first(const struct trans_set *set, struct trans_iter *it)
 {
-	return set_first(set->set, &it->iter);
+	assert(set != NULL);
+
+	return set_first((const struct set *) set, &it->iter);
 }
 
 struct trans *
 trans_set_next(struct trans_iter *it)
 {
+	assert(it != NULL);
+
 	return set_next(&it->iter);
 }
 

--- a/src/adt/tupleset.c
+++ b/src/adt/tupleset.c
@@ -62,6 +62,6 @@ tuple_set_contains(struct tuple_set *set, const struct fsm_walk2_tuple *item)
 struct fsm_walk2_tuple *
 tuple_set_add(struct tuple_set *set, const struct fsm_walk2_tuple *item)
 {
-	return set_add(&set->set, (void *)item);
+	return set_add(set->set, (void *)item);
 }
 

--- a/src/adt/tupleset.c
+++ b/src/adt/tupleset.c
@@ -6,62 +6,39 @@
 
 #include <assert.h>
 #include <stddef.h>
-#include <stdlib.h>
-#include <limits.h>
-#include <errno.h>
 
 #include <adt/set.h>
 #include <adt/tupleset.h>
 
-struct tuple_set {
-	struct set *set;
-};
-
 struct tuple_set *
 tuple_set_create(int (*cmp)(const void *, const void *))
 {
-	struct tuple_set *set;
-
 	assert(cmp != NULL);
 
-	set = malloc(sizeof *set);
-	if (!set) {
-		return NULL;
-	}
-
-	set->set = set_create(cmp);
-	if (set->set == NULL) {
-		free(set);
-		return NULL;
-	}
-
-	return set;
+	return (struct tuple_set *) set_create(cmp);
 }
 
 void
 tuple_set_free(struct tuple_set *set)
 {
-	if (set == NULL) {
-		return;
-	}
+	assert(set != NULL);
 
-	if (set->set != NULL) {
-		set_free(set->set);
-		set->set = NULL;
-	}
-
-	free(set);
+	set_free((struct set *) set);
 }
 
 struct fsm_walk2_tuple *
 tuple_set_contains(const struct tuple_set *set, const struct fsm_walk2_tuple *item)
 {
-	return set_contains(set->set, (const void *)item);
+	assert(set != NULL);
+
+	return set_contains((struct set *) set, item);
 }
 
 struct fsm_walk2_tuple *
-tuple_set_add(struct tuple_set *set, const struct fsm_walk2_tuple *item)
+tuple_set_add(struct tuple_set *set, struct fsm_walk2_tuple *item)
 {
-	return set_add(set->set, (void *)item);
+	assert(set != NULL);
+
+	return set_add((struct set *) set, item);
 }
 

--- a/src/adt/tupleset.c
+++ b/src/adt/tupleset.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Shannon F. Stewman
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <errno.h>
+
+#include <adt/set.h>
+#include <adt/tupleset.h>
+
+struct tuple_set {
+	struct set *set;
+};
+
+struct tuple_set *
+tuple_set_create(int (*cmp)(const void *, const void *))
+{
+	static const struct tuple_set init;
+	struct tuple_set *set;
+
+	assert(cmp != NULL);
+
+	set = malloc(sizeof *set);
+	if (!set) {
+		return NULL;
+	}
+	*set = init;
+	set->set = set_create(cmp);
+	if (set->set == NULL) {
+		free(set);
+		return NULL;
+	}
+
+	return set;
+}
+
+void
+tuple_set_free(struct tuple_set *set)
+{
+	if (set == NULL) {
+		return;
+	}
+
+	if (set->set != NULL) {
+		set_free(set->set);
+		set->set = NULL;
+	}
+
+	free(set);
+}
+
+struct fsm_walk2_tuple *
+tuple_set_contains(struct tuple_set *set, const struct fsm_walk2_tuple *item)
+{
+	return set_contains(set->set, (const void *)item);
+}
+
+struct fsm_walk2_tuple *
+tuple_set_add(struct tuple_set *set, const struct fsm_walk2_tuple *item)
+{
+	return set_add(&set->set, (void *)item);
+}
+

--- a/src/adt/tupleset.c
+++ b/src/adt/tupleset.c
@@ -54,7 +54,7 @@ tuple_set_free(struct tuple_set *set)
 }
 
 struct fsm_walk2_tuple *
-tuple_set_contains(struct tuple_set *set, const struct fsm_walk2_tuple *item)
+tuple_set_contains(const struct tuple_set *set, const struct fsm_walk2_tuple *item)
 {
 	return set_contains(set->set, (const void *)item);
 }

--- a/src/adt/tupleset.c
+++ b/src/adt/tupleset.c
@@ -20,7 +20,6 @@ struct tuple_set {
 struct tuple_set *
 tuple_set_create(int (*cmp)(const void *, const void *))
 {
-	static const struct tuple_set init;
 	struct tuple_set *set;
 
 	assert(cmp != NULL);
@@ -29,7 +28,7 @@ tuple_set_create(int (*cmp)(const void *, const void *))
 	if (!set) {
 		return NULL;
 	}
-	*set = init;
+
 	set->set = set_create(cmp);
 	if (set->set == NULL) {
 		free(set);

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -430,10 +430,6 @@ determinise(struct fsm *nfa,
 		return NULL;
 	}
 
-#ifdef DEBUG_TODFA
-	dfa->nfa = nfa;
-#endif
-
 	if (nfa->endcount == 0) {
 		dfa->start = fsm_addstate(dfa);
 		if (dfa->start == NULL) {
@@ -564,18 +560,6 @@ determinise(struct fsm *nfa,
 
 		clear_trans(dfa, trans);
 
-#ifdef DEBUG_TODFA
-		{
-			struct state_set *q;
-
-			for (q = state_set_first(curr->closure, &jt); q != NULL; q = state_set_next(&jt)) {
-				if (!set_add(&curr->dfastate->nfasl, q)) {
-					goto error;
-				}
-			}
-		}
-#endif
-
 		/*
 		 * The current DFA state is an end state if any of its associated NFA
 		 * states are end states.
@@ -638,24 +622,6 @@ fsm_determinise_cache(struct fsm *fsm,
 	if (dfa == NULL) {
 		return 0;
 	}
-
-#ifdef DEBUG_TODFA
-	fsm->nfa = fsm_new(fsm->opt);
-	if (fsm->nfa == NULL) {
-		return 0;
-	}
-
-	assert(dfa->nfa == fsm);
-
-	fsm->nfa->sl    = fsm->sl;
-	fsm->nfa->tail  = fsm->tail;
-	fsm->nfa->start = fsm->start;
-
-	/* for fsm_move's free contents */
-	fsm->sl    = NULL;
-	fsm->tail  = NULL;
-	fsm->start = NULL;
-#endif
 
 	fsm_move(fsm, dfa);
 

--- a/src/libfsm/fsm.c
+++ b/src/libfsm/fsm.c
@@ -119,10 +119,6 @@ fsm_new(const struct fsm_options *opt)
 
 	new->opt = opt;
 
-#ifdef DEBUG_TODFA
-	new->nfa   = NULL;
-#endif
-
 	return new;
 }
 

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -68,10 +68,6 @@ struct fsm_state {
 		struct fsm_state *visited;
 	} tmp;
 
-#ifdef DEBUG_TODFA
-	struct set *nfasl;
-#endif
-
 	struct fsm_state *next;
 };
 
@@ -83,10 +79,6 @@ struct fsm {
 	unsigned long endcount;
 
 	const struct fsm_options *opt;
-
-#ifdef DEBUG_TODFA
-	struct fsm *nfa;
-#endif
 };
 
 struct fsm_edge *

--- a/src/libfsm/print/dot.c
+++ b/src/libfsm/print/dot.c
@@ -86,28 +86,6 @@ singlestate(FILE *f, const struct fsm *fsm, struct fsm_state *s)
 
 		fprintf(f, "%u", indexof(fsm, s));
 
-#ifdef DEBUG_TODFA
-		if (s->nfasl != NULL) {
-			struct fsm_state *q;
-
-			assert(fsm->nfa != NULL);
-
-			fprintf(f, "<br/>");
-
-			fprintf(f, "{");
-
-			for (q = edge_set_first(s->nfasl, &it); q != NULL; q = edge_set_next(&it)) {
-				fprintf(f, "%u", indexof(fsm->nfa, q));
-
-				if (edge_set_hasnext(&it)) {
-					fprintf(f, ",");
-				}
-			}
-
-			fprintf(f, "}");
-		}
-#endif
-
 		fprintf(f, "> ];\n");
 	}
 

--- a/src/libfsm/state.c
+++ b/src/libfsm/state.c
@@ -49,10 +49,6 @@ fsm_addstate(struct fsm *fsm)
 	new->edges = edge_set_create(fsm_state_cmpedges);
 	new->opaque = NULL;
 
-#ifdef DEBUG_TODFA
-	new->nfasl = NULL;
-#endif
-
 	fsm_state_clear_tmp(new);
 
 	*fsm->tail = new;

--- a/tests/set/set0.c
+++ b/tests/set/set0.c
@@ -18,8 +18,8 @@ int cmp_int(const void *a_, const void *b_) {
 int main(void) {
 	struct set *s = set_create(cmp_int);
 	int a[3] = {1, 2, 3};
-	assert(set_add(&s, &a[0]));
-	assert(set_add(&s, &a[1]));
-	assert(set_add(&s, &a[2]));
+	assert(set_add(s, &a[0]));
+	assert(set_add(s, &a[1]));
+	assert(set_add(s, &a[2]));
 	return 0;
 }

--- a/tests/set/set1.c
+++ b/tests/set/set1.c
@@ -18,9 +18,9 @@ int cmp_int(const void *a_, const void *b_) {
 int main(void) {
 	struct set *s = set_create(cmp_int);
 	int a[3] = {1, 2, 3};
-	assert(set_add(&s, &a[0]));
-	assert(set_add(&s, &a[1]));
-	assert(set_add(&s, &a[2]));
+	assert(set_add(s, &a[0]));
+	assert(set_add(s, &a[1]));
+	assert(set_add(s, &a[2]));
 	assert(set_contains(s, &a[0]));
 	assert(set_contains(s, &a[1]));
 	assert(set_contains(s, &a[2]));

--- a/tests/set/set2.c
+++ b/tests/set/set2.c
@@ -18,10 +18,10 @@ int cmp_int(const void *a_, const void *b_) {
 int main(void) {
 	struct set *s = set_create(cmp_int);
 	int a = 1;
-	assert(set_add(&s, &a));
-	assert(set_add(&s, &a));
-	assert(set_add(&s, &a));
-	set_remove(&s, &a);
+	assert(set_add(s, &a));
+	assert(set_add(s, &a));
+	assert(set_add(s, &a));
+	set_remove(s, &a);
 	assert(!set_contains(s, &a));
 	return 0;
 }

--- a/tests/set/set3.c
+++ b/tests/set/set3.c
@@ -22,9 +22,9 @@ int main(void) {
 	int a[3] = {1, 2, 3};
 	int seen[3] = {0, 0, 0};
 	int i;
-	assert(set_add(&s, &a[0]));
-	assert(set_add(&s, &a[1]));
-	assert(set_add(&s, &a[2]));
+	assert(set_add(s, &a[0]));
+	assert(set_add(s, &a[1]));
+	assert(set_add(s, &a[2]));
 	for (p = set_first(s, &iter); p != NULL; p = set_next(&iter)) {
 		assert(*p == 1 || *p == 2 || *p == 3);
 		seen[*p - 1] = 1;

--- a/tests/set/set4.c
+++ b/tests/set/set4.c
@@ -27,7 +27,7 @@ int main(void) {
 	struct set *s = set_create(cmp_int);
 	size_t i;
 	for (i = 0; i < 5000; i++) {
-		assert(set_add(&s, next_int()));
+		assert(set_add(s, next_int()));
 	}
 	assert(set_count(s) == 5000);
 	return 0;

--- a/tests/set/set5.c
+++ b/tests/set/set5.c
@@ -28,11 +28,11 @@ int main(void) {
 	int a[3] = {1200,2400,3600};
 	size_t i;
 	for (i = 0; i < 5000; i++) {
-		assert(set_add(&s, next_int()));
+		assert(set_add(s, next_int()));
 	}
 	for (i = 0; i < 3; i++) {
 		assert(set_contains(s, &a[i]));
-		set_remove(&s, &a[i]);
+		set_remove(s, &a[i]);
 	}
 	assert(set_count(s) == 4997);
 	return 0;

--- a/tests/set/set6.c
+++ b/tests/set/set6.c
@@ -29,7 +29,7 @@ int main(void) {
 	size_t i;
 	int *p;
 	for (i = 0; i < 5000; i++) {
-		assert(set_add(&s, next_int()));
+		assert(set_add(s, next_int()));
 	}
 	for (i = 0, p = set_first(s, &iter); i < 5000; i++, set_next(&iter)) {
 		assert(p);

--- a/theft/fuzz_adt_set.c
+++ b/theft/fuzz_adt_set.c
@@ -19,8 +19,8 @@ struct model {
 
 static enum theft_trial_res prop_set_operations(struct theft *t, void *arg1);
 static enum theft_trial_res prop_set_equality(struct theft *t, void *arg1);
-static bool op_add(struct model *m, struct set_op *op, struct set **set);
-static bool op_remove(struct model *m, struct set_op *op, struct set **set);
+static bool op_add(struct model *m, struct set_op *op, struct set *set);
+static bool op_remove(struct model *m, struct set_op *op, struct set *set);
 static bool op_clear(struct model *m, struct set *set);
 static bool postcondition(struct model *m, struct set *set);
 
@@ -142,8 +142,8 @@ theft_trial_res prop_set_equality(struct theft *t, void *arg1)
 		assert(seq->values[i] != 0);
 		assert(permuted[i] != 0);
 
-		(void) set_add(&set_a, (void *) ((uintptr_t) seq->values[i])); /* XXX */
-		(void) set_add(&set_b, (void *) ((uintptr_t) permuted[i]));
+		(void) set_add(set_a, (void *) ((uintptr_t) seq->values[i])); /* XXX */
+		(void) set_add(set_b, (void *) ((uintptr_t) permuted[i]));
 	}
 
 	if (!set_equal(set_a, set_b)) {
@@ -176,13 +176,13 @@ get_pos(uintptr_t item, size_t *offset, uint64_t *bit)
 }
 
 static bool
-op_add(struct model *m, struct set_op *op, struct set **set)
+op_add(struct model *m, struct set_op *op, struct set *set)
 {
 	struct set *old_s;
 	size_t offset;
 	uint64_t bit;
 
-	old_s = *set;
+	old_s = set;
 
 	assert(op->u.add.item != 0);
 
@@ -202,13 +202,13 @@ op_add(struct model *m, struct set_op *op, struct set **set)
 }
 
 static bool
-op_remove(struct model *m, struct set_op *op, struct set **set)
+op_remove(struct model *m, struct set_op *op, struct set *set)
 {
 	struct set *old_s;
 	size_t offset;
 	uint64_t bit;
 
-	old_s = *set;
+	old_s = set;
 
 	assert(op->u.remove.item != 0);
 
@@ -341,9 +341,9 @@ prop_set_operations(struct theft *t, void *arg1)
 		op = &s->ops[i];
 
 		switch (op->t) {
-		case SET_OP_ADD:    r = op_add   (m, op, &set); break;
-		case SET_OP_REMOVE: r = op_remove(m, op, &set); break;
-		case SET_OP_CLEAR:  r = op_clear (m, set);      break;
+		case SET_OP_ADD:    r = op_add   (m, op, set); break;
+		case SET_OP_REMOVE: r = op_remove(m, op, set); break;
+		case SET_OP_CLEAR:  r = op_clear (m, set);     break;
 
 		default:
 			return THEFT_TRIAL_ERROR;


### PR DESCRIPTION
My motivation here was to disallow `NULL` being valid as an empty set, and to restrict instances to an allocated but empty struct, instead. This is just to reduce different possibilities. Unlike the original incarnations (where edge sets were in an array), these sets are only present when they're typically expected to contain items anyway.

Meanwhile I removed the structs for the strongly-typed wrappers, because they seem unnecessary now.