### PR TITLE
Separate storage for epsilon edges

### DIFF
--- a/examples/glob/main.c
+++ b/examples/glob/main.c
@@ -107,7 +107,7 @@ compile(const char *glob)
 	for (p = glob; *p; p++) {
 		struct fsm_state *new;
 
-		/* TODO: we could omit this; see fsm_addedge() accepting NULL */
+		/* TODO: we could omit this */
 		new = fsm_addstate(fsm);
 		if (!new) {
 			perror("fsm_addstate");

--- a/include/adt/edgeset.h
+++ b/include/adt/edgeset.h
@@ -45,6 +45,9 @@ edge_set_next(struct edge_iter *it);
 int
 edge_set_hasnext(struct edge_iter *it);
 
+int
+edge_set_empty(const struct edge_set *s);
+
 struct fsm_edge *
 edge_set_only(const struct edge_set *s);
 

--- a/include/adt/path.h
+++ b/include/adt/path.h
@@ -12,11 +12,11 @@ struct fsm_state;
 struct path {
 	struct fsm_state *state;
 	struct path *next;
-	int type; /* XXX: fsm_edge_type is private */
+	char c;
 };
 
 struct path *
-path_push(struct path **head, struct fsm_state *state, int type);
+path_push(struct path **head, struct fsm_state *state, char c);
 
 void
 path_free(struct path *path);

--- a/include/adt/priq.h
+++ b/include/adt/priq.h
@@ -16,7 +16,7 @@ struct priq {
 	/* XXX: specific to shortest.c */
 	struct fsm_state *state;
 	struct priq *prev; /* previous node in shortest path */
-	int type; /* XXX: should really be fsm_edge_type */
+	char c;
 };
 
 /*

--- a/include/fsm/cost.h
+++ b/include/fsm/cost.h
@@ -11,9 +11,8 @@ struct fsm_state;
 
 #define FSM_COST_INFINITY UINT_MAX
 
-/* XXX: fsm_edge_type is private */
 unsigned
-fsm_cost_legible(const struct fsm_state *from, const struct fsm_state *to, int c);
+fsm_cost_legible(const struct fsm_state *from, const struct fsm_state *to, char c);
 
 #endif
 

--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -17,7 +17,6 @@
 
 struct fsm;
 struct fsm_state;
-struct fsm_edge;
 struct fsm_determinise_cache;
 struct fsm_options;
 struct path; /* XXX */
@@ -117,7 +116,7 @@ fsm_removestate(struct fsm *fsm, struct fsm_state *state);
 /*
  * Add an edge from a given state to a given state, labelled with the given
  * label. If an edge to that state of the same label already exists, the
- * existing edge is returned.
+ * existing edge is used instead, and a new edge is not added.
  *
  * Edges may be one of the following types:
  *
@@ -125,15 +124,15 @@ fsm_removestate(struct fsm *fsm, struct fsm_state *state);
  * - Any character
  * - A literal character. The character '\0' is permitted.
  *
- * Returns false on error; see errno.
+ * Returns 1 on success, or 0 on error; see errno.
  */
-struct fsm_edge *
+int
 fsm_addedge_epsilon(struct fsm *fsm, struct fsm_state *from, struct fsm_state *to);
 
-struct fsm_edge *
+int
 fsm_addedge_any(struct fsm *fsm, struct fsm_state *from, struct fsm_state *to);
 
-struct fsm_edge *
+int
 fsm_addedge_literal(struct fsm *fsm, struct fsm_state *from, struct fsm_state *to,
 	char c);
 

--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -260,6 +260,11 @@ fsm_mergestates(struct fsm *fsm, struct fsm_state *a, struct fsm_state *b);
 int
 fsm_trim(struct fsm *fsm);
 
+/*
+ * Produce a short legible string that matches up to a goal state.
+ *
+ * The given FSM is expected to be a Glushkov NFA.
+ */
 int
 fsm_example(const struct fsm *fsm, const struct fsm_state *goal,
 	char *buf, size_t bufsz);
@@ -340,11 +345,13 @@ fsm_equal(const struct fsm *a, const struct fsm *b);
  * A discovered path is returned, or NULL on error. If the goal is not
  * reachable, then the path returned will be non-NULL but will not contain
  * the goal state.
+ *
+ * The given FSM is expected to be a Glushkov NFA.
  */
 struct path *
 fsm_shortest(const struct fsm *fsm,
 	const struct fsm_state *start, const struct fsm_state *goal,
-	unsigned (*cost)(const struct fsm_state *from, const struct fsm_state *to, int c));
+	unsigned (*cost)(const struct fsm_state *from, const struct fsm_state *to, char c));
 
 /*
  * Execute an FSM reading input from the user-specified callback fsm_getc().

--- a/src/adt/edgeset.c
+++ b/src/adt/edgeset.c
@@ -88,6 +88,12 @@ edge_set_hasnext(struct edge_iter *it)
 	return set_hasnext(&it->iter);
 }
 
+int
+edge_set_empty(const struct edge_set *set)
+{
+	return set_empty((const struct set *) set);
+}
+
 struct fsm_edge *
 edge_set_only(const struct edge_set *set)
 {

--- a/src/adt/edgeset.c
+++ b/src/adt/edgeset.c
@@ -19,7 +19,9 @@ edge_set_create(int (*cmp)(const void *a, const void *b))
 void
 edge_set_free(struct edge_set *set)
 {
-	assert(set != NULL);
+	if (set == NULL) {
+		return;
+	}
 
 	set_free((struct set *) set);
 }
@@ -28,6 +30,7 @@ struct fsm_edge *
 edge_set_add(struct edge_set *set, struct fsm_edge *e)
 {
 	assert(set != NULL);
+	assert(e != NULL);
 
 	return set_add((struct set *) set, e);
 }
@@ -36,6 +39,7 @@ struct fsm_edge *
 edge_set_contains(const struct edge_set *set, const struct fsm_edge *e)
 {
 	assert(set != NULL);
+	assert(e != NULL);
 
 	return set_contains((const struct set *) set, e);
 }
@@ -43,7 +47,9 @@ edge_set_contains(const struct edge_set *set, const struct fsm_edge *e)
 size_t
 edge_set_count(const struct edge_set *set)
 {
-	assert(set != NULL);
+	if (set == NULL) {
+		return 0;
+	}
 
 	return set_count((const struct set *) set);
 }
@@ -51,7 +57,11 @@ edge_set_count(const struct edge_set *set)
 void
 edge_set_remove(struct edge_set *set, const struct fsm_edge *e)
 {
-	assert(set != NULL);
+	assert(e != NULL);
+
+	if (set == NULL) {
+		return;
+	}
 
 	set_remove((struct set *) set, e);
 }
@@ -59,7 +69,11 @@ edge_set_remove(struct edge_set *set, const struct fsm_edge *e)
 struct fsm_edge *
 edge_set_first(struct edge_set *set, struct edge_iter *it)
 {
-	assert(set != NULL);
+	assert(it != NULL);
+
+	if (set == NULL) {
+		return NULL;
+	}
 
 	return set_first((struct set *) set, &it->iter);
 }
@@ -68,6 +82,8 @@ struct fsm_edge *
 edge_set_firstafter(const struct edge_set *set, struct edge_iter *it, const struct fsm_edge *e)
 {
 	assert(set != NULL);
+	assert(it != NULL);
+	assert(e != NULL);
 
 	return set_firstafter((const struct set *) set, &it->iter, e);
 }
@@ -91,6 +107,10 @@ edge_set_hasnext(struct edge_iter *it)
 int
 edge_set_empty(const struct edge_set *set)
 {
+	if (set == NULL) {
+		return 1;
+	}
+
 	return set_empty((const struct set *) set);
 }
 

--- a/src/adt/path.c
+++ b/src/adt/path.c
@@ -10,7 +10,7 @@
 #include <adt/path.h>
 
 struct path *
-path_push(struct path **head, struct fsm_state *state, int type)
+path_push(struct path **head, struct fsm_state *state, char c)
 {
 	struct path *new;
 
@@ -23,7 +23,7 @@ path_push(struct path **head, struct fsm_state *state, int type)
 	}
 
 	new->state = state;
-	new->type  = type;
+	new->c     = c;
 
 	new->next  = *head;
 	*head      = new;

--- a/src/adt/priq.c
+++ b/src/adt/priq.c
@@ -110,7 +110,7 @@ priq_push(struct priq **priq,
 	new->cost  = cost;
 	new->state = state;
 	new->prev  = NULL;
-	new->type  = -1; /* XXX: nothing meaningful to set here */
+	new->c     = '\0'; /* XXX: nothing meaningful to set here */
 
 	new->next = *p;
 	*p = new;

--- a/src/adt/stateset.c
+++ b/src/adt/stateset.c
@@ -19,7 +19,9 @@ state_set_create(void)
 void
 state_set_free(struct state_set *set)
 {
-	assert(set != NULL);
+	if (set == NULL) {
+		return;
+	}
 
 	set_free((struct set *) set);
 }
@@ -28,6 +30,7 @@ struct fsm_state *
 state_set_add(struct state_set *set, struct fsm_state *st)
 {
 	assert(set != NULL);
+	assert(st != NULL);
 
 	return set_add((struct set *) set, st);
 }
@@ -35,7 +38,11 @@ state_set_add(struct state_set *set, struct fsm_state *st)
 void
 state_set_remove(struct state_set *set, const struct fsm_state *st)
 {
-	assert(set != NULL);
+	assert(st != NULL);
+
+	if (set == NULL) {
+		return;
+	}
 
 	set_remove((struct set *) set, st);
 }
@@ -43,7 +50,9 @@ state_set_remove(struct state_set *set, const struct fsm_state *st)
 int
 state_set_empty(const struct state_set *set)
 {
-	assert(set != NULL);
+	if (set == NULL) {
+		return 1;
+	}
 
 	return set_empty((const struct set *) set);
 }
@@ -59,7 +68,11 @@ state_set_only(const struct state_set *set)
 struct fsm_state *
 state_set_contains(const struct state_set *set, const struct fsm_state *st)
 {
-	assert(set != NULL);
+	assert(st != NULL);
+
+	if (set == NULL) {
+		return NULL;
+	}
 
 	return set_contains((const struct set *) set, st);
 }
@@ -67,7 +80,9 @@ state_set_contains(const struct state_set *set, const struct fsm_state *st)
 size_t
 state_set_count(const struct state_set *set)
 {
-	assert(set != NULL);
+	if (set == NULL) {
+		return 0;
+	}
 
 	return set_count((const struct set *) set);
 }
@@ -75,7 +90,11 @@ state_set_count(const struct state_set *set)
 struct fsm_state *
 state_set_first(struct state_set *set, struct state_iter *it)
 {
-	assert(set != NULL);
+	assert(it != NULL);
+
+	if (set == NULL) {
+		return NULL;
+	}
 
 	return set_first((struct set *) set, &it->iter);
 }

--- a/src/libfsm/clone.c
+++ b/src/libfsm/clone.c
@@ -78,9 +78,17 @@ fsm_clone(const struct fsm *fsm)
 					newfrom = equiv;
 					newto   = to->tmp.equiv;
 
-					if (!fsm_addedge(newfrom, newto, e->symbol)) {
-						fsm_free(new);
-						return NULL;
+					if (e->symbol > UCHAR_MAX) {
+						assert(e->symbol == FSM_EDGE_EPSILON);
+						if (!fsm_addedge_epsilon(new, newfrom, newto)) {
+							fsm_free(new);
+							return NULL;
+						}
+					} else {
+						if (!fsm_addedge_literal(new, newfrom, newto, e->symbol)) {
+							fsm_free(new);
+							return NULL;
+						}
 					}
 				}
 			}

--- a/src/libfsm/collect.c
+++ b/src/libfsm/collect.c
@@ -43,6 +43,19 @@ mark_states(struct fsm *fsm)
 		if (!queue_pop(q, (void *)&s)) { break; }
 
 		/* enqueue all directly reachable and unmarked, and mark them */
+		{
+			struct state_iter state_iter;
+			struct fsm_state *es;
+			for (es = state_set_first(s->epsilons, &state_iter);
+			     es != NULL;
+			     es = state_set_next(&state_iter)) {
+				if (es->reachable) { continue; }
+				if (!queue_push(q, es)) {
+					goto cleanup;
+				}
+				es->reachable = 1;
+			}
+		}
 		for (e = edge_set_first(s->edges, &edge_iter);
 		     e != NULL;
 		     e = edge_set_next(&edge_iter)) {

--- a/src/libfsm/complete.c
+++ b/src/libfsm/complete.c
@@ -22,7 +22,6 @@ fsm_complete(struct fsm *fsm,
 {
 	struct fsm_state *new;
 	struct fsm_state *s;
-	size_t i;
 
 	assert(fsm != NULL);
 	assert(predicate != NULL);
@@ -50,16 +49,14 @@ fsm_complete(struct fsm *fsm,
 		return 0;
 	}
 
-	for (i = 0; i <= UCHAR_MAX; i++) {
-		struct fsm_edge *e;
-		e = fsm_addedge(new, new, i);
-		if (e == NULL) {
-			/* TODO: free stuff */
-			return 0;
-		}
+	if (!fsm_addedge_any(fsm, new, new)) {
+		/* TODO: free stuff */
+		return 0;
 	}
 
 	for (s = fsm->sl; s != NULL; s = s->next) {
+		size_t i;
+
 		if (!predicate(fsm, s)) {
 			continue;
 		}
@@ -69,7 +66,7 @@ fsm_complete(struct fsm *fsm,
 				continue;
 			}
 
-			if (!fsm_addedge(s, new, i)) {
+			if (!fsm_addedge_literal(fsm, s, new, i)) {
 				/* TODO: free stuff */
 				return 0;
 			}

--- a/src/libfsm/complete.c
+++ b/src/libfsm/complete.c
@@ -55,14 +55,14 @@ fsm_complete(struct fsm *fsm,
 	}
 
 	for (s = fsm->sl; s != NULL; s = s->next) {
-		size_t i;
+		unsigned i;
 
 		if (!predicate(fsm, s)) {
 			continue;
 		}
 
 		for (i = 0; i <= UCHAR_MAX; i++) {
-			if (fsm_hasedge(s, i)) {
+			if (fsm_hasedge_literal(s, i)) {
 				continue;
 			}
 

--- a/src/libfsm/cost/legible.c
+++ b/src/libfsm/cost/legible.c
@@ -23,9 +23,8 @@ isother(int c)
 }
 
 unsigned
-fsm_cost_legible(const struct fsm_state *from, const struct fsm_state *to, int c)
+fsm_cost_legible(const struct fsm_state *from, const struct fsm_state *to, char c)
 {
-	enum fsm_edge_type type;
 	size_t i;
 
 	/*
@@ -33,7 +32,7 @@ fsm_cost_legible(const struct fsm_state *from, const struct fsm_state *to, int c
 	 * sequence is seen as worth avoiding where possible.
  	 *
 	 * Note that although not explicitly encoded here, for the same cost
-	 * (and assuming a suitable character set), lower characater values
+	 * (and assuming a suitable character set), lower character values
 	 * have precedence over higher (e.g. 'a' is preferable to 'z')
 	 * because of the traversal order for edges when searching the graph.
 	 */
@@ -58,14 +57,8 @@ fsm_cost_legible(const struct fsm_state *from, const struct fsm_state *to, int c
 	(void) from;
 	(void) to;
 
-	type = c;
-
-	if (type == FSM_EDGE_EPSILON) {
-		return 0;
-	}
-
 	for (i = 0; i < sizeof a / sizeof *a; i++) {
-		if (a[i].is(type)) {
+		if (a[i].is(c)) {
 			return a[i].cost;
 		}
 	}

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -524,7 +524,6 @@ determinise(struct fsm *nfa,
 
 		for (t = trans_set_first(trans, &jt); t != NULL; t = trans_set_next(&jt)) {
 			struct fsm_state *new;
-			struct fsm_edge *e;
 			struct state_set *reachable;
 
 			assert(t->state != NULL);
@@ -551,8 +550,7 @@ determinise(struct fsm *nfa,
 				goto error;
 			}
 
-			e = fsm_addedge_literal(dfa, curr->dfastate, new, t->c);
-			if (e == NULL) {
+			if (!fsm_addedge_literal(dfa, curr->dfastate, new, t->c)) {
 				clear_trans(dfa, trans);
 				goto error;
 			}

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -358,7 +358,7 @@ allstatesreachableby(struct state_set *set, char c, struct state_set *sl)
 		struct fsm_state *es;
 		struct fsm_edge *to;
 
-		if ((to = fsm_hasedge(s, (unsigned char) c)) != NULL) {
+		if ((to = fsm_hasedge_literal(s, c)) != NULL) {
 			struct state_iter jt;
 
 			for (es = state_set_first(to->sl, &jt); es != NULL; es = state_set_next(&jt)) {

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -307,10 +307,6 @@ listnonepsilonstates(const struct fsm *fsm, struct trans_set *trans, struct stat
 			struct fsm_state *st;
 			struct state_iter kt;
 
-			if (e->symbol > UCHAR_MAX) {
-				break;
-			}
-
 			for (st = state_set_first(e->sl, &kt); st != NULL; st = state_set_next(&kt)) {
 				struct trans *p, search;
 

--- a/src/libfsm/eclosure.c
+++ b/src/libfsm/eclosure.c
@@ -20,7 +20,7 @@
 #include "internal.h"
 
 /*
- * Return a list of each state in the epsilon closure of the given state.
+ * Return a set of each state in the epsilon closure of the given state.
  * These are all the states reachable through epsilon transitions (that is,
  * without consuming any input by traversing a labelled edge), including the
  * given state itself.
@@ -34,7 +34,6 @@ struct state_set *
 epsilon_closure(const struct fsm_state *state, struct state_set *closure)
 {
 	struct fsm_state *s;
-	struct fsm_edge *e;
 	struct state_iter it;
 
 	assert(state != NULL);
@@ -50,14 +49,11 @@ epsilon_closure(const struct fsm_state *state, struct state_set *closure)
 	}
 
 	/* Follow each epsilon transition */
-	e = fsm_hasedge_epsilon(state);
-	if (e != NULL) {
-		for (s = state_set_first(e->sl, &it); s != NULL; s = state_set_next(&it)) {
-			assert(s != NULL);
+	for (s = state_set_first(state->epsilons, &it); s != NULL; s = state_set_next(&it)) {
+		assert(s != NULL);
 
-			if (epsilon_closure(s, closure) == NULL) {
-				return NULL;
-			}
+		if (epsilon_closure(s, closure) == NULL) {
+			return NULL;
 		}
 	}
 

--- a/src/libfsm/eclosure.c
+++ b/src/libfsm/eclosure.c
@@ -50,7 +50,8 @@ epsilon_closure(const struct fsm_state *state, struct state_set *closure)
 	}
 
 	/* Follow each epsilon transition */
-	if ((e = fsm_hasedge(state, FSM_EDGE_EPSILON)) != NULL) {
+	e = fsm_hasedge_epsilon(state);
+	if (e != NULL) {
 		for (s = state_set_first(e->sl, &it); s != NULL; s = state_set_next(&it)) {
 			assert(s != NULL);
 

--- a/src/libfsm/edge.c
+++ b/src/libfsm/edge.c
@@ -18,7 +18,7 @@
 
 #include "internal.h"
 
-int
+static int
 fsm_addedge(struct fsm_state *from, struct fsm_state *to, enum fsm_edge_type type)
 {
 	struct fsm_edge *e, new;

--- a/src/libfsm/edge.c
+++ b/src/libfsm/edge.c
@@ -98,11 +98,29 @@ fsm_addedge_literal(struct fsm *fsm,
 }
 
 struct fsm_edge *
-fsm_hasedge(const struct fsm_state *s, int c)
+fsm_hasedge_epsilon(const struct fsm_state *s)
 {
 	struct fsm_edge *e, search;
 
-	search.symbol = c;
+	assert(s != NULL);
+
+	search.symbol = FSM_EDGE_EPSILON;
+	e = edge_set_contains(s->edges, &search);
+	if (e == NULL || state_set_empty(e->sl)) {
+		return NULL;
+	}
+
+	return e;
+}
+
+struct fsm_edge *
+fsm_hasedge_literal(const struct fsm_state *s, char c)
+{
+	struct fsm_edge *e, search;
+
+	assert(s != NULL);
+
+	search.symbol = (unsigned char) c;
 	e = edge_set_contains(s->edges, &search);
 	if (e == NULL || state_set_empty(e->sl)) {
 		return NULL;

--- a/src/libfsm/edge.c
+++ b/src/libfsm/edge.c
@@ -18,7 +18,7 @@
 
 #include "internal.h"
 
-struct fsm_edge *
+int
 fsm_addedge(struct fsm_state *from, struct fsm_state *to, enum fsm_edge_type type)
 {
 	struct fsm_edge *e, new;
@@ -31,25 +31,25 @@ fsm_addedge(struct fsm_state *from, struct fsm_state *to, enum fsm_edge_type typ
 	if (e == NULL) {
 		e = malloc(sizeof *e);
 		if (e == NULL) {
-			return NULL;
+			return 0;
 		}
 
 		e->symbol = type;
 		e->sl = state_set_create();
 
 		if (!edge_set_add(from->edges, e)) {
-			return NULL;
+			return 0;
 		}
 	}
 
 	if (state_set_add(e->sl, to) == NULL) {
-		return NULL;
+		return 0;
 	}
 
-	return e;
+	return 1;
 }
 
-struct fsm_edge *
+int
 fsm_addedge_epsilon(struct fsm *fsm,
 	struct fsm_state *from, struct fsm_state *to)
 {
@@ -62,11 +62,10 @@ fsm_addedge_epsilon(struct fsm *fsm,
 	return fsm_addedge(from, to, FSM_EDGE_EPSILON);
 }
 
-struct fsm_edge *
+int
 fsm_addedge_any(struct fsm *fsm,
 	struct fsm_state *from, struct fsm_state *to)
 {
-	struct fsm_edge *e;
 	int i;
 
 	assert(fsm != NULL);
@@ -76,15 +75,15 @@ fsm_addedge_any(struct fsm *fsm,
 	(void) fsm;
 
 	for (i = 0; i <= UCHAR_MAX; i++) {
-		if (!(e = fsm_addedge(from, to, i))) {
-			return NULL;
+		if (!fsm_addedge(from, to, i)) {
+			return 0;
 		}
 	}
 
-	return e;
+	return 1;
 }
 
-struct fsm_edge *
+int
 fsm_addedge_literal(struct fsm *fsm,
 	struct fsm_state *from, struct fsm_state *to,
 	char c)

--- a/src/libfsm/example.c
+++ b/src/libfsm/example.c
@@ -13,6 +13,8 @@
 
 #include <fsm/fsm.h>
 #include <fsm/cost.h>
+#include <fsm/pred.h>
+#include <fsm/walk.h>
 
 #include "internal.h"
 
@@ -26,6 +28,7 @@ fsm_example(const struct fsm *fsm, const struct fsm_state *goal,
 	size_t n;
 
 	assert(fsm != NULL);
+	assert(!fsm_has(fsm, fsm_hasepsilons));
 	assert(buf != NULL || bufsz == 0);
 	assert(goal != NULL);
 	/* TODO: assert goal is in fsm */
@@ -46,21 +49,18 @@ fsm_example(const struct fsm *fsm, const struct fsm_state *goal,
 		return -1;
 	}
 
-	if (path != NULL && path->state != start) {
+	n = 0;
+
+	if (path->state != start) {
 		/* no known path to goal */
-		n = 0;
 		goto done;
 	}
 
-	n = 0;
+	assert(path->c == '\0');
 
-	for (p = path; p != NULL; p = p->next) {
-		if (p->type == FSM_EDGE_EPSILON) {
-			continue;
-		}
-
+	for (p = path->next; p != NULL; p = p->next) {
 		if (bufsz > 1) {
-			*buf++ = p->type;
+			*buf++ = p->c;
 			bufsz--;
 		}
 

--- a/src/libfsm/exec.c
+++ b/src/libfsm/exec.c
@@ -25,7 +25,7 @@ nextstate(const struct fsm_state *state, int c)
 
 	assert(state != NULL);
 
-	if (!(e = fsm_hasedge(state, c))) {
+	if (!(e = fsm_hasedge_literal(state, c))) {
 		return NULL;
 	}
 

--- a/src/libfsm/fsm.c
+++ b/src/libfsm/fsm.c
@@ -89,6 +89,7 @@ free_contents(struct fsm *fsm)
 			f_free(fsm, e);
 		}
 
+		state_set_free(s->epsilons);
 		edge_set_free(s->edges);
 		f_free(fsm, s);
 	}

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -84,9 +84,6 @@ struct fsm {
 struct fsm_edge *
 fsm_hasedge(const struct fsm_state *s, int c);
 
-int
-fsm_addedge(struct fsm_state *from, struct fsm_state *to, enum fsm_edge_type type);
-
 void
 fsm_carryopaque(struct fsm *fsm, const struct state_set *set,
 	struct fsm *new, struct fsm_state *state);

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -82,7 +82,10 @@ struct fsm {
 };
 
 struct fsm_edge *
-fsm_hasedge(const struct fsm_state *s, int c);
+fsm_hasedge_epsilon(const struct fsm_state *s);
+
+struct fsm_edge *
+fsm_hasedge_literal(const struct fsm_state *s, char c);
 
 void
 fsm_carryopaque(struct fsm *fsm, const struct state_set *set,

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -21,41 +21,34 @@ struct state_set;
  * These octets may or may not spell out UTF-8 sequences,
  * depending on the context in which the FSM is used.
  *
- * Octets are implemented here as (unsigned char) values in C.
- * As an implementation detail, we extend this range from 0..UCHAR_MAX
- * to include "special" edge types after the last valid octet.
- *
- * Currently the only special edge type is the epsilon transition,
- * for Thompson NFA.
+ * Octets are stored as unsigned char for orderability
+ * independent of the signedness of char.
  */
+
+/*
+ * The highest value of an symbol, the maximum value in Sigma.
+ */
+#define FSM_SIGMA_MAX UCHAR_MAX
 
 /*
  * The number of non-special symbols in the alphabet.
  * This is the number of symbols with the value <= UCHAR_MAX.
  */
-#define FSM_SIGMA_COUNT (UCHAR_MAX + 1)
-
-enum fsm_edge_type {
-	FSM_EDGE_EPSILON = UCHAR_MAX + 1
-};
-
-/*
- * The highest value of an symbol, including special symbols.
- */
-#define FSM_EDGE_MAX FSM_EDGE_EPSILON
+#define FSM_SIGMA_COUNT (FSM_SIGMA_MAX + 1)
 
 #define FSM_ENDCOUNT_MAX ULONG_MAX
 
 struct fsm_edge {
 	struct state_set *sl;
-	enum fsm_edge_type symbol;
+	unsigned char symbol;
 };
 
 struct fsm_state {
 	unsigned int end:1;
 	unsigned int reachable:1;
 
-	struct edge_set *edges; /* containing `struct fsm_edge *` */
+	struct edge_set *edges;
+	struct state_set *epsilons;
 
 	void *opaque;
 
@@ -80,9 +73,6 @@ struct fsm {
 
 	const struct fsm_options *opt;
 };
-
-struct fsm_edge *
-fsm_hasedge_epsilon(const struct fsm_state *s);
 
 struct fsm_edge *
 fsm_hasedge_literal(const struct fsm_state *s, char c);

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -84,7 +84,7 @@ struct fsm {
 struct fsm_edge *
 fsm_hasedge(const struct fsm_state *s, int c);
 
-struct fsm_edge *
+int
 fsm_addedge(struct fsm_state *from, struct fsm_state *to, enum fsm_edge_type type);
 
 void

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -21,7 +21,6 @@ fsm_isany
 fsm_iscomplete
 fsm_isdfa
 fsm_isend
-fsm_hasedge
 fsm_hasincoming
 fsm_hasoutgoing
 fsm_hasepsilons

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -47,7 +47,6 @@ fsm_merge
 fsm_addstate
 fsm_removestate
 
-fsm_addedge
 fsm_addedge_any
 fsm_addedge_epsilon
 fsm_addedge_literal

--- a/src/libfsm/mergestates.c
+++ b/src/libfsm/mergestates.c
@@ -23,42 +23,43 @@ fsm_mergestates(struct fsm *fsm, struct fsm_state *a, struct fsm_state *b)
 	struct edge_iter it;
 
 	/* edges from b */
+	{
+		struct state_iter jt;
+
+		for (s = state_set_first(b->epsilons, &jt); s != NULL; s = state_set_next(&jt)) {
+			if (!fsm_addedge_epsilon(fsm, a, s)) {
+				return NULL;
+			}
+		}
+	}
 	for (e = edge_set_first(b->edges, &it); e != NULL; e = edge_set_next(&it)) {
 		struct state_iter jt;
 
 		for (s = state_set_first(e->sl, &jt); s != NULL; s = state_set_next(&jt)) {
-			if (e->symbol > UCHAR_MAX) {
-				assert(e->symbol == FSM_EDGE_EPSILON);
-				if (!fsm_addedge_epsilon(fsm, a, s)) {
-					return NULL;
-				}
-			} else {
-				if (!fsm_addedge_literal(fsm, a, s, e->symbol)) {
-					return NULL;
-				}
+			if (!fsm_addedge_literal(fsm, a, s, e->symbol)) {
+				return NULL;
 			}
 		}
 	}
 
 	/* edges to b */
 	for (s = fsm->sl; s != NULL; s = s->next) {
-		for (e = edge_set_first(s->edges, &it); e != NULL; e = edge_set_next(&it)) {
-			if (!state_set_contains(e->sl, b)) {
-				continue;
-			}
+		if (state_set_contains(s->epsilons, b)) {
+			state_set_remove(s->epsilons, b);
 
-			if (e->symbol > UCHAR_MAX) {
-				assert(e->symbol == FSM_EDGE_EPSILON);
-				if (!fsm_addedge_epsilon(fsm, s, a)) {
-					return NULL;
-				}
-			} else {
+			if (!fsm_addedge_epsilon(fsm, s, a)) {
+				return NULL;
+			}
+		}
+
+		for (e = edge_set_first(s->edges, &it); e != NULL; e = edge_set_next(&it)) {
+			state_set_remove(e->sl, b);
+
+			if (state_set_contains(e->sl, b)) {
 				if (!fsm_addedge_literal(fsm, s, a, e->symbol)) {
 					return NULL;
 				}
 			}
-
-			state_set_remove(e->sl, b);
 		}
 	}
 

--- a/src/libfsm/mergestates.c
+++ b/src/libfsm/mergestates.c
@@ -18,7 +18,7 @@
 struct fsm_state *
 fsm_mergestates(struct fsm *fsm, struct fsm_state *a, struct fsm_state *b)
 {
-	struct fsm_edge *e, *f;
+	struct fsm_edge *e;
 	struct fsm_state *s;
 	struct edge_iter it;
 
@@ -26,8 +26,7 @@ fsm_mergestates(struct fsm *fsm, struct fsm_state *a, struct fsm_state *b)
 	for (e = edge_set_first(b->edges, &it); e != NULL; e = edge_set_next(&it)) {
 		struct state_iter jt;
 		for (s = state_set_first(e->sl, &jt); s != NULL; s = state_set_next(&jt)) {
-			f = fsm_addedge(a, s, e->symbol);
-			if (f == NULL) {
+			if (!fsm_addedge(a, s, e->symbol)) {
 				return NULL;
 			}
 		}
@@ -37,8 +36,7 @@ fsm_mergestates(struct fsm *fsm, struct fsm_state *a, struct fsm_state *b)
 	for (s = fsm->sl; s != NULL; s = s->next) {
 		for (e = edge_set_first(s->edges, &it); e != NULL; e = edge_set_next(&it)) {
 			if (state_set_contains(e->sl, b)) {
-				f = fsm_addedge(s, a, e->symbol);
-				if (f == NULL) {
+				if (!fsm_addedge(s, a, e->symbol)) {
 					return NULL;
 				}
 				state_set_remove(e->sl, b);

--- a/src/libfsm/mode.c
+++ b/src/libfsm/mode.c
@@ -35,10 +35,6 @@ fsm_findmode(const struct fsm_state *state, unsigned int *freq)
 	for (e = edge_set_first(state->edges, &it); e != NULL; e = edge_set_next(&it)) {
 		struct state_iter jt;
 
-		if (e->symbol > UCHAR_MAX) {
-			break;
-		}
-
 		for (s = state_set_first(e->sl, &jt); s != NULL; s = state_set_next(&jt)) {
 			struct edge_iter kt = it;
 			struct fsm_edge *c;

--- a/src/libfsm/pred/epsilonsonly.c
+++ b/src/libfsm/pred/epsilonsonly.c
@@ -18,7 +18,7 @@
 int
 fsm_epsilonsonly(const struct fsm *fsm, const struct fsm_state *state)
 {
-	struct fsm_edge *e, s;
+	struct fsm_edge *e;
 	struct edge_iter it;
 
 	assert(fsm != NULL);
@@ -26,17 +26,11 @@ fsm_epsilonsonly(const struct fsm *fsm, const struct fsm_state *state)
 
 	(void) fsm;
 
-	s.symbol = FSM_EDGE_EPSILON;
-	e = edge_set_contains(state->edges, &s);
-	if (e == NULL || state_set_empty(e->sl)) {
+	if (state_set_empty(state->epsilons)) {
 		return 0;
 	}
 
 	for (e = edge_set_first(state->edges, &it); e != NULL; e = edge_set_next(&it)) {
-		if (e->symbol == FSM_EDGE_EPSILON) {
-			continue;
-		}
-
 		if (!state_set_empty(e->sl)) {
 			return 0;
 		}

--- a/src/libfsm/pred/hasepsilons.c
+++ b/src/libfsm/pred/hasepsilons.c
@@ -18,19 +18,11 @@
 int
 fsm_hasepsilons(const struct fsm *fsm, const struct fsm_state *state)
 {
-	struct fsm_edge *e, s;
-
 	assert(fsm != NULL);
 	assert(state != NULL);
 
 	(void) fsm;
 
-	s.symbol = FSM_EDGE_EPSILON;
-	e = edge_set_contains(state->edges, &s);
-	if (e == NULL || state_set_empty(e->sl)) {
-		return 0;
-	}
-
-	return 1;
+	return !state_set_empty(state->epsilons);
 }
 

--- a/src/libfsm/pred/hasincoming.c
+++ b/src/libfsm/pred/hasincoming.c
@@ -27,8 +27,12 @@ fsm_hasincoming(const struct fsm *fsm, const struct fsm_state *state)
 		struct fsm_edge *e;
 		struct edge_iter it;
 
+		if (state_set_contains(s->epsilons, state)) {
+			return 1;
+		}
+
 		for (e = edge_set_first(s->edges, &it); e != NULL; e = edge_set_next(&it)) {
-			if (state_set_contains(e->sl, state)) {
+			if (e->sl != NULL && state_set_contains(e->sl, state)) {
 				return 1;
 			}
 		}

--- a/src/libfsm/pred/hasnondeterminism.c
+++ b/src/libfsm/pred/hasnondeterminism.c
@@ -31,10 +31,6 @@ state_hasnondeterminism(const struct fsm_state *state, struct bm *bm)
 	for (e = edge_set_first(state->edges, &jt); e != NULL; e = edge_set_next(&jt)) {
 		size_t n;
 
-		if (e->symbol > UCHAR_MAX) {
-			continue;
-		}
-
 		n = state_set_count(e->sl);
 
 		if (n == 0) {

--- a/src/libfsm/pred/hasoutgoing.c
+++ b/src/libfsm/pred/hasoutgoing.c
@@ -25,6 +25,11 @@ fsm_hasoutgoing(const struct fsm *fsm, const struct fsm_state *state)
 	assert(state != NULL);
 
 	(void) fsm;
+
+	if (!state_set_empty(state->epsilons)) {
+		return 1;
+	}
+
 	for (e = edge_set_first(state->edges, &it); e != NULL; e = edge_set_next(&it)) {
 		if (!state_set_empty(e->sl)) {
 			return 1;

--- a/src/libfsm/pred/iscomplete.c
+++ b/src/libfsm/pred/iscomplete.c
@@ -28,13 +28,11 @@ fsm_iscomplete(const struct fsm *fsm, const struct fsm_state *state)
 
 	n = 0;
 
+	/* epsilon transitions have no effect on completeness */
+	(void) state->epsilons;
+
 	/* TODO: assert state is in fsm->sl */
 	for (e = edge_set_first(state->edges, &it); e != NULL; e = edge_set_next(&it)) {
-		/* epsilon transitions have no effect on completeness */
-		if (e->symbol > UCHAR_MAX) {
-			continue;
-		}
-
 		if (state_set_empty(e->sl)) {
 			continue;
 		}

--- a/src/libfsm/pred/isdfa.c
+++ b/src/libfsm/pred/isdfa.c
@@ -19,7 +19,7 @@
 int
 fsm_isdfa(const struct fsm *fsm, const struct fsm_state *state)
 {
-	struct fsm_edge *e, s;
+	struct fsm_edge *e;
 	struct edge_iter it;
 
 	assert(fsm != NULL);
@@ -34,9 +34,7 @@ fsm_isdfa(const struct fsm *fsm, const struct fsm_state *state)
 	/*
 	 * DFA may not have epsilon edges.
 	 */
-	s.symbol = FSM_EDGE_EPSILON;
-	e = edge_set_contains(state->edges, &s);
-	if (e != NULL && !state_set_empty(e->sl)) {
+	if (!state_set_empty(state->epsilons)) {
 		return 0;
 	}
 
@@ -45,10 +43,6 @@ fsm_isdfa(const struct fsm *fsm, const struct fsm_state *state)
 	 */
 	for (e = edge_set_first(state->edges, &it); e != NULL; e = edge_set_next(&it)) {
 		struct state_iter jt;
-
-		if (e->symbol > UCHAR_MAX) {
-			break;
-		}
 
 		if (state_set_empty(e->sl)) {
 			continue;

--- a/src/libfsm/print/api.c
+++ b/src/libfsm/print/api.c
@@ -137,17 +137,20 @@ fsm_print_api(FILE *f, const struct fsm *fsm)
 			bm_clear(&a[i]);
 		}
 
+		for (st = state_set_first(s->epsilons, &jt); st != NULL; st = state_set_next(&jt)) {
+			assert(st != NULL);
+
+			to = indexof(fsm, st);
+
+			fprintf(f, "\tif (!fsm_addedge_epsilon(fsm, s[%u], s[%u])) { goto error; }\n",
+				from, to);
+		}
+
 		for (e = edge_set_first(s->edges, &it); e != NULL; e = edge_set_next(&it)) {
 			for (st = state_set_first(e->sl, &jt); st != NULL; st = state_set_next(&jt)) {
 				assert(st != NULL);
 
 				to = indexof(fsm, st);
-
-				if (e->symbol == FSM_EDGE_EPSILON) {
-					fprintf(f, "\tif (!fsm_addedge_epsilon(fsm, s[%u], s[%u])) { goto error; }\n",
-						from, to);
-					continue;
-				}
 
 				bm_set(&a[indexof(fsm, st)], e->symbol);
 			}

--- a/src/libfsm/print/fsm.c
+++ b/src/libfsm/print/fsm.c
@@ -19,6 +19,7 @@
 
 #include <fsm/fsm.h>
 #include <fsm/pred.h>
+#include <fsm/walk.h>
 #include <fsm/print.h>
 #include <fsm/options.h>
 
@@ -147,7 +148,7 @@ fsm_print_fsm(FILE *f, const struct fsm *fsm)
 				if (fsm->opt->comments) {
 					if (st == fsm->start) {
 						fprintf(f, " # start");
-					} else if (fsm->start != NULL) {
+					} else if (fsm->start != NULL && !fsm_has(fsm, fsm_hasepsilons)) {
 						char buf[50];
 						int n;
 

--- a/src/libfsm/print/fsm.c
+++ b/src/libfsm/print/fsm.c
@@ -73,10 +73,6 @@ findany(const struct fsm_state *state)
 	}
 
 	for (e = edge_set_first(state->edges, &it); e != NULL; e = edge_set_next(&it)) {
-		if (e->symbol > UCHAR_MAX) {
-			return NULL;
-		}
-
 		if (state_set_count(e->sl) != 1) {
 			return NULL;
 		}
@@ -112,6 +108,17 @@ fsm_print_fsm(FILE *f, const struct fsm *fsm)
 		struct edge_iter it;
 
 		{
+			struct fsm_state *st;
+			struct state_iter jt;
+
+			for (st = state_set_first(s->epsilons, &jt); st != NULL; st = state_set_next(&jt)) {
+				assert(st != NULL);
+
+				fprintf(f, "%-2u -> %2u;\n", indexof(fsm, s), indexof(fsm, st));
+			}
+		}
+
+		{
 			const struct fsm_state *a;
 
 			a = findany(s);
@@ -130,18 +137,9 @@ fsm_print_fsm(FILE *f, const struct fsm *fsm)
 
 				fprintf(f, "%-2u -> %2u", indexof(fsm, s), indexof(fsm, st));
 
-				/* TODO: print " ?" if all edges are equal */
-
-				switch (e->symbol) {
-				case FSM_EDGE_EPSILON:
-					break;
-
-				default:
-					fputs(" \"", f);
-					fsm_escputc(f, fsm->opt, e->symbol);
-					putc('\"', f);
-					break;
-				}
+				fputs(" \"", f);
+				fsm_escputc(f, fsm->opt, e->symbol);
+				putc('\"', f);
 
 				fprintf(f, ";");
 

--- a/src/libfsm/print/ir.c
+++ b/src/libfsm/print/ir.c
@@ -107,10 +107,6 @@ make_groups(const struct fsm *fsm, const struct fsm_state *state, const struct f
 	for (e = edge_set_first(state->edges, &it); e != NULL; e = edge_set_next(&it)) {
 		struct fsm_state *s;
 
-		if (e->symbol > UCHAR_MAX) {
-			break;
-		}
-
 		if (state_set_empty(e->sl)) {
 			continue;
 		}
@@ -379,11 +375,7 @@ make_state(const struct fsm *fsm,
 
 	/* no edges */
 	{
-		struct fsm_edge *e;
-		struct edge_iter it;
-
-		e = edge_set_first(state->edges, &it);
-		if (!e || e->symbol > UCHAR_MAX) {
+		if (edge_set_empty(state->edges)) {
 			cs->strategy = IR_NONE;
 			return 0;
 		}

--- a/src/libfsm/print/json.c
+++ b/src/libfsm/print/json.c
@@ -83,6 +83,27 @@ fsm_print_json(FILE *f, const struct fsm *fsm)
 
 			fprintf(f, "\t\t\t\"edges\": [\n");
 
+			{
+				struct fsm_state *st;
+				struct state_iter jt;
+
+				for (st = state_set_first(s->epsilons, &jt); st != NULL; st = state_set_next(&jt)) {
+					assert(st != NULL);
+
+					fprintf(f, "\t\t\t\t{ ");
+
+					fprintf(f, "\"char\": ");
+					fputs(" false", f);
+					fprintf(f, ", ");
+
+					fprintf(f, "\"to\": %u",
+						indexof(fsm, st));
+
+					/* XXX: should count .sl inside an edge */
+					fprintf(f, "}%s\n", !edge_set_empty(s->edges) ? "," : "");
+				}
+			}
+
 			for (e = edge_set_first(s->edges, &it); e != NULL; e = edge_set_next(&it)) {
 				struct fsm_state *st;
 				struct state_iter jt;
@@ -93,17 +114,9 @@ fsm_print_json(FILE *f, const struct fsm *fsm)
 					fprintf(f, "\t\t\t\t{ ");
 
 					fprintf(f, "\"char\": ");
-					switch (e->symbol) {
-					case FSM_EDGE_EPSILON:
-						fputs(" false", f);
-						break;
-
-					default:
-						fputs(" \"", f);
-						json_escputc(f, fsm->opt, e->symbol);
-						putc('\"', f);
-						break;
-					}
+					fputs(" \"", f);
+					json_escputc(f, fsm->opt, e->symbol);
+					putc('\"', f);
 
 					fprintf(f, ", ");
 

--- a/src/libfsm/reverse.c
+++ b/src/libfsm/reverse.c
@@ -128,10 +128,19 @@ fsm_reverse(struct fsm *fsm)
 
 					assert(from != NULL);
 
-					if (!fsm_addedge(from, to, e->symbol)) {
-						state_set_free(endset);
-						fsm_free(new);
-						return 0;
+					if (e->symbol > UCHAR_MAX) {
+						assert(e->symbol == FSM_EDGE_EPSILON);
+						if (!fsm_addedge_epsilon(new, from, to)) {
+							state_set_free(endset);
+							fsm_free(new);
+							return 0;
+						}
+					} else {
+						if (!fsm_addedge_literal(new, from, to, e->symbol)) {
+							state_set_free(endset);
+							fsm_free(new);
+							return 0;
+						}
 					}
 				}
 			}

--- a/src/libfsm/reverse.c
+++ b/src/libfsm/reverse.c
@@ -121,7 +121,6 @@ fsm_reverse(struct fsm *fsm)
 
 				for (se = state_set_first(e->sl, &jt); se != NULL; se = state_set_next(&jt)) {
 					struct fsm_state *from;
-					struct fsm_edge *edge;
 
 					assert(se != NULL);
 
@@ -129,8 +128,7 @@ fsm_reverse(struct fsm *fsm)
 
 					assert(from != NULL);
 
-					edge = fsm_addedge(from, to, e->symbol);
-					if (edge == NULL) {
+					if (!fsm_addedge(from, to, e->symbol)) {
 						state_set_free(endset);
 						fsm_free(new);
 						return 0;

--- a/src/libfsm/reverse.c
+++ b/src/libfsm/reverse.c
@@ -116,31 +116,29 @@ fsm_reverse(struct fsm *fsm)
 
 			assert(to != NULL);
 
+			{
+				struct state_iter jt;
+
+				for (se = state_set_first(s->epsilons, &jt); se != NULL; se = state_set_next(&jt)) {
+					assert(se->tmp.equiv != NULL);
+
+					if (!fsm_addedge_epsilon(new, se->tmp.equiv, to)) {
+						state_set_free(endset);
+						fsm_free(new);
+						return 0;
+					}
+				}
+			}
 			for (e = edge_set_first(s->edges, &it); e != NULL; e = edge_set_next(&it)) {
 				struct state_iter jt;
 
 				for (se = state_set_first(e->sl, &jt); se != NULL; se = state_set_next(&jt)) {
-					struct fsm_state *from;
+					assert(se->tmp.equiv != NULL);
 
-					assert(se != NULL);
-
-					from = se->tmp.equiv;
-
-					assert(from != NULL);
-
-					if (e->symbol > UCHAR_MAX) {
-						assert(e->symbol == FSM_EDGE_EPSILON);
-						if (!fsm_addedge_epsilon(new, from, to)) {
-							state_set_free(endset);
-							fsm_free(new);
-							return 0;
-						}
-					} else {
-						if (!fsm_addedge_literal(new, from, to, e->symbol)) {
-							state_set_free(endset);
-							fsm_free(new);
-							return 0;
-						}
+					if (!fsm_addedge_literal(new, se->tmp.equiv, to, e->symbol)) {
+						state_set_free(endset);
+						fsm_free(new);
+						return 0;
 					}
 				}
 			}

--- a/src/libfsm/state.c
+++ b/src/libfsm/state.c
@@ -16,23 +16,6 @@
 
 #include "internal.h"
 
-static int
-fsm_state_cmpedges(const void *a, const void *b)
-{
-	const struct fsm_edge *ea, *eb;
-
-	assert(a != NULL);
-	assert(b != NULL);
-
-	ea = a;
-	eb = b;
-
-	/* N.B. various edge iterations rely on the ordering of edges to be in
-	 * ascending order.
-	 */
-	return (ea->symbol > eb->symbol) - (ea->symbol < eb->symbol);
-}
-
 struct fsm_state *
 fsm_addstate(struct fsm *fsm)
 {
@@ -46,14 +29,16 @@ fsm_addstate(struct fsm *fsm)
 	}
 
 	new->end = 0;
-	new->epsilons = state_set_create();
-	new->edges = edge_set_create(fsm_state_cmpedges);
 	new->opaque = NULL;
 
-	if (new->epsilons == NULL || new->edges == NULL) {
-		/* XXX */
-		return NULL;
-	}
+	/*
+	 * Sets for epsilon and labelled transitions are kept NULL
+	 * until populated; this suits the most nodes in the bodies of
+	 * typical FSM that do not have epsilons, and (less often)
+	 * nodes that have no edges.
+	 */
+	new->epsilons = NULL;
+	new->edges    = NULL;
 
 	fsm_state_clear_tmp(new);
 

--- a/src/libfsm/subgraph.c
+++ b/src/libfsm/subgraph.c
@@ -151,8 +151,15 @@ fsm_state_duplicatesubgraphx(struct fsm *fsm, struct fsm_state *state,
 					return NULL;
 				}
 
-				if (!fsm_addedge(m->new, to->new, e->symbol)) {
-					return NULL;
+				if (e->symbol > UCHAR_MAX) {
+					assert(e->symbol == FSM_EDGE_EPSILON);
+					if (!fsm_addedge_epsilon(fsm, m->new, to->new)) {
+						return NULL;
+					}
+				} else {
+					if (!fsm_addedge_literal(fsm, m->new, to->new, e->symbol)) {
+						return NULL;
+					}
 				}
 			}
 		}

--- a/src/libfsm/subgraph.c
+++ b/src/libfsm/subgraph.c
@@ -139,6 +139,23 @@ fsm_state_duplicatesubgraphx(struct fsm *fsm, struct fsm_state *state,
 			*x = m->new;
 		}
 
+		{
+			for (s = state_set_first(m->old->epsilons, &jt); s != NULL; s = state_set_next(&jt)) {
+				struct mapping *to;
+
+				assert(s != NULL);
+
+				to = mapping_ensure(fsm, &mappings, s);
+				if (to == NULL) {
+					mapping_free(fsm, mappings);
+					return NULL;
+				}
+
+				if (!fsm_addedge_epsilon(fsm, m->new, to->new)) {
+					return NULL;
+				}
+			}
+		}
 		for (e = edge_set_first(m->old->edges, &it); e != NULL; e = edge_set_next(&it)) {
 			for (s = state_set_first(e->sl, &jt); s != NULL; s = state_set_next(&jt)) {
 				struct mapping *to;
@@ -151,15 +168,8 @@ fsm_state_duplicatesubgraphx(struct fsm *fsm, struct fsm_state *state,
 					return NULL;
 				}
 
-				if (e->symbol > UCHAR_MAX) {
-					assert(e->symbol == FSM_EDGE_EPSILON);
-					if (!fsm_addedge_epsilon(fsm, m->new, to->new)) {
-						return NULL;
-					}
-				} else {
-					if (!fsm_addedge_literal(fsm, m->new, to->new, e->symbol)) {
-						return NULL;
-					}
+				if (!fsm_addedge_literal(fsm, m->new, to->new, e->symbol)) {
+					return NULL;
 				}
 			}
 		}

--- a/src/libfsm/trim.c
+++ b/src/libfsm/trim.c
@@ -44,6 +44,22 @@ fsm_trim(struct fsm *fsm)
 		struct fsm_edge *e;
 		struct edge_iter it;
 
+		{
+			struct fsm_state *st;
+			struct state_iter jt;
+
+			for (st = state_set_first(p->state->epsilons, &jt); st != NULL; st = state_set_next(&jt)) {
+				/* not a list operation... */
+				if (dlist_contains(list, st)) {
+					continue;
+				}
+
+				if (!dlist_push(&list, st)) {
+					return -1;
+				}
+			}
+		}
+
 		for (e = edge_set_first(p->state->edges, &it); e != NULL; e = edge_set_next(&it)) {
 			struct fsm_state *st;
 			struct state_iter jt;
@@ -81,6 +97,7 @@ fsm_trim(struct fsm *fsm)
 
 	dlist_free(list);
 
+#if 0
 	/*
 	 * Remove all states which have no reachable end state henceforth.
 	 * These are a trailing suffix which will never accept.
@@ -111,6 +128,7 @@ fsm_trim(struct fsm *fsm)
 			}
 		}
 	}
+#endif
 
 	return 1;
 }

--- a/src/libfsm/walk2.c
+++ b/src/libfsm/walk2.c
@@ -319,7 +319,12 @@ fsm_walk2_edges(struct fsm_walk2_data *data,
 		struct state_iter dia, dib;
 		const struct fsm_state *da, *db;
 
-		eb = qb ? fsm_hasedge(qb, ea->symbol) : NULL;
+		if (ea->symbol > UCHAR_MAX) {
+			assert(ea->symbol == FSM_EDGE_EPSILON);
+			eb = qb ? fsm_hasedge_epsilon(qb) : NULL;
+		} else {
+			eb = qb ? fsm_hasedge_literal(qb, ea->symbol) : NULL;
+		}
 
 		/*
 		 * If eb == NULL we can only follow this edge if ONLYA
@@ -393,7 +398,12 @@ only_b:
 		struct state_iter dib;
 		const struct fsm_state *db;
 
-		ea = qa ? fsm_hasedge(qa, eb->symbol) : NULL;
+		if (eb->symbol > UCHAR_MAX) {
+			assert(eb->symbol == FSM_EDGE_EPSILON);
+			ea = qa ? fsm_hasedge_epsilon(qa) : NULL;
+		} else {
+			ea = qa ? fsm_hasedge_literal(qa, eb->symbol) : NULL;
+		}
 
 		/* if A has the edge, it's not an only B edge */
 		if (ea != NULL) {

--- a/src/libfsm/walk2.c
+++ b/src/libfsm/walk2.c
@@ -347,8 +347,15 @@ fsm_walk2_edges(struct fsm_walk2_data *data,
 				assert(dst != NULL);
 				assert(dst->comb != NULL);
 
-				if (!fsm_addedge(qc, dst->comb, ea->symbol)) {
-					return 0;
+				if (ea->symbol > UCHAR_MAX) {
+					assert(ea->symbol == FSM_EDGE_EPSILON);
+					if (!fsm_addedge_epsilon(data->new, qc, dst->comb)) {
+						return 0;
+					}
+				} else {
+					if (!fsm_addedge_literal(data->new, qc, dst->comb, ea->symbol)) {
+						return 0;
+					}
 				}
 
 				/*
@@ -407,8 +414,15 @@ only_b:
 				assert(dst != NULL);
 				assert(dst->comb != NULL);
 
-				if (!fsm_addedge(qc, dst->comb, eb->symbol)) {
-					return 0;
+				if (eb->symbol > UCHAR_MAX) {
+					assert(eb->symbol == FSM_EDGE_EPSILON);
+					if (!fsm_addedge_epsilon(data->new, qc, dst->comb)) {
+						return 0;
+					}
+				} else {
+					if (!fsm_addedge_literal(data->new, qc, dst->comb, eb->symbol)) {
+						return 0;
+					}
 				}
 
 				/*

--- a/src/libfsm/walk2.c
+++ b/src/libfsm/walk2.c
@@ -319,12 +319,7 @@ fsm_walk2_edges(struct fsm_walk2_data *data,
 		struct state_iter dia, dib;
 		const struct fsm_state *da, *db;
 
-		if (ea->symbol > UCHAR_MAX) {
-			assert(ea->symbol == FSM_EDGE_EPSILON);
-			eb = qb ? fsm_hasedge_epsilon(qb) : NULL;
-		} else {
-			eb = qb ? fsm_hasedge_literal(qb, ea->symbol) : NULL;
-		}
+		eb = qb ? fsm_hasedge_literal(qb, ea->symbol) : NULL;
 
 		/*
 		 * If eb == NULL we can only follow this edge if ONLYA
@@ -352,15 +347,8 @@ fsm_walk2_edges(struct fsm_walk2_data *data,
 				assert(dst != NULL);
 				assert(dst->comb != NULL);
 
-				if (ea->symbol > UCHAR_MAX) {
-					assert(ea->symbol == FSM_EDGE_EPSILON);
-					if (!fsm_addedge_epsilon(data->new, qc, dst->comb)) {
-						return 0;
-					}
-				} else {
-					if (!fsm_addedge_literal(data->new, qc, dst->comb, ea->symbol)) {
-						return 0;
-					}
+				if (!fsm_addedge_literal(data->new, qc, dst->comb, ea->symbol)) {
+					return 0;
 				}
 
 				/*
@@ -398,12 +386,7 @@ only_b:
 		struct state_iter dib;
 		const struct fsm_state *db;
 
-		if (eb->symbol > UCHAR_MAX) {
-			assert(eb->symbol == FSM_EDGE_EPSILON);
-			ea = qa ? fsm_hasedge_epsilon(qa) : NULL;
-		} else {
-			ea = qa ? fsm_hasedge_literal(qa, eb->symbol) : NULL;
-		}
+		ea = qa ? fsm_hasedge_literal(qa, eb->symbol) : NULL;
 
 		/* if A has the edge, it's not an only B edge */
 		if (ea != NULL) {
@@ -424,15 +407,8 @@ only_b:
 				assert(dst != NULL);
 				assert(dst->comb != NULL);
 
-				if (eb->symbol > UCHAR_MAX) {
-					assert(eb->symbol == FSM_EDGE_EPSILON);
-					if (!fsm_addedge_epsilon(data->new, qc, dst->comb)) {
-						return 0;
-					}
-				} else {
-					if (!fsm_addedge_literal(data->new, qc, dst->comb, eb->symbol)) {
-						return 0;
-					}
+				if (!fsm_addedge_literal(data->new, qc, dst->comb, eb->symbol)) {
+					return 0;
 				}
 
 				/*

--- a/src/libre/re_char_class.c
+++ b/src/libre/re_char_class.c
@@ -364,6 +364,13 @@ link_char_class_into_fsm(struct re_char_class *cc, struct fsm *fsm,
 
 		/* TODO: would like to show the original spelling verbatim, too */
 		
+		/* fsm_example requires no epsilons;
+		 * TODO: would fsm_glushkovise() here, when we have it */
+		if (!fsm_determinise(cc->dup)) {
+			err->e = RE_EERRNO;
+			return 0;
+		}
+
 		/* XXX: this is just one example; really I want to show the entire set */
 		end = fsm_any(cc->dup, fsm_isend);
 		assert(end != NULL);


### PR DESCRIPTION
This PR splits the underlying `struct set` for epsilons from labelled edges.

The general idea is that we went to do different things with both, and rarely intermingle operations. In particular questions like "does this state have epsilons" should now be O(1), rather than searching to find that edge.

`FSM_EDGE_EPSILON` is now removed, and the labelled edges are keyed by a character rather than by a "type" enum.

While I'm here, I made these sets default to NULL until populated, just to save some mallocing.