### PR TITLE
libfsm: Fix `fsm->tail` update during GC sweep.

### DIFF
--- a/src/libfsm/collect.c
+++ b/src/libfsm/collect.c
@@ -86,6 +86,7 @@ sweep_states(struct fsm *fsm)
 	struct fsm_state *prev = NULL;
 	struct fsm_state *s = fsm->sl;
 	struct fsm_state *next;
+	struct fsm_state **new_tail = &fsm->sl;
 	int swept = 0;
 
 	/* This doesn't use fsm_removestate because it would be modifying the
@@ -106,15 +107,17 @@ sweep_states(struct fsm *fsm)
 
 			/* unlink */
 			if (prev != NULL) { prev->next = next; }
-			if (s == *fsm->tail) { *fsm->tail = prev; }
 			edge_set_free(s->edges);
 			free(s);
 			swept++;
 		} else {
+			new_tail = &s->next;
 			prev = s;
 		}
 		s = next;
 	}
+
+	fsm->tail = new_tail;
 	return swept;
 }
 


### PR DESCRIPTION
Since we're already walking the fsm states in order, we can update the candidate for the new tail in every reachable state (`&s->next`), and then save the candidate at the end.

This also accounts for when the fsm's state list is empty -- the candidate for the new tail starts as the start of the state list.

I'm suggesting this as an alternative to #140, because it's a much smaller change, and I find the logic clearer.