### PR TITLE
determinise: Check for NULL return before dereferencing.

### DIFF
--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -210,6 +210,11 @@ set_closure(struct mapping_set *mappings, struct fsm *dfa, struct state_set *set
 	}
 
 	m = addtomappings(mappings, dfa, ec);
+	if (m == NULL) {
+		state_set_free(ec);
+		return NULL;
+	}
+
 	/* TODO: test ec */
 
 	return m->dfastate;


### PR DESCRIPTION
While unlikely, this prevents an allocation failure in addtomappings
leading to a NULL pointer dereference.

I don't think this is what the `TODO: test ec` comment refers to, but should that be removed?