### PR TITLE
Accelerates epsilon closures

### DIFF
--- a/include/fsm/options.h
+++ b/include/fsm/options.h
@@ -53,6 +53,13 @@ struct fsm_options {
 	 */
 	unsigned int always_hex:1;
 
+	/* use strongly-connected components names instead of state
+	 * names */
+	unsigned int scc_names:1;
+
+	/* use state index names for state names */
+	unsigned int index_names:1;
+
 	/* for generated code, what kind of I/O API to generate */
 	enum fsm_io io;
 

--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -324,7 +324,7 @@ main(int argc, char *argv[])
 	{
 		int c;
 
-		while (c = getopt(argc, argv, "h" "acwXe:k:i:" "xpq:l:dmrt:"), c != -1) {
+		while (c = getopt(argc, argv, "h" "aCcwXe:k:i:" "xpq:l:dmrt:"), c != -1) {
 			switch (c) {
 			case 'a': opt.anonymous_states  = 1;          break;
 			case 'c': opt.consolidate_edges = 1;          break;
@@ -333,6 +333,8 @@ main(int argc, char *argv[])
 			case 'e': opt.prefix            = optarg;     break;
 			case 'k': opt.io                = io(optarg); break;
 
+			case 'C': opt.anonymous_states  = 0;
+				  opt.scc_names         = 1;          break;
 			case 'i':
 				iterations = strtoul(optarg, NULL, 10);
 				/* XXX: error handling */
@@ -531,6 +533,14 @@ main(int argc, char *argv[])
 			}
 
 			/* TODO: option to print state number? */
+		}
+	}
+
+	if (opt.scc_names) {
+		extern int fsm_label_epsilon_scc(struct fsm *fsm);
+		if (fsm_label_epsilon_scc(fsm) < 0) {
+			perror("fsm_label_epsilon_scc");
+			return EXIT_FAILURE;
 		}
 	}
 

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -63,7 +63,7 @@ struct fsm_state {
 		struct fsm_state *visited;
 
 		/* epsilon closure */
-		struct state_set *eps_closure;
+		unsigned long eps_closure_id;
 	} tmp;
 
 	struct fsm_state *next;

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -47,6 +47,8 @@ struct fsm_state {
 	unsigned int end:1;
 	unsigned int reachable:1;
 
+	unsigned int index;     /* index used to label states.  labels are only valid until a state is added or removed */
+
 	struct edge_set *edges;
 	struct state_set *epsilons;
 
@@ -59,9 +61,14 @@ struct fsm_state {
 		struct fsm_state *equiv;
 		/* tracks which states have been visited in walk2 */
 		struct fsm_state *visited;
+
+		/* epsilon closure */
+		struct state_set *eps_closure;
 	} tmp;
 
 	struct fsm_state *next;
+
+	unsigned int eps_scc; /* epsilon closure strongly-connected components label */
 };
 
 struct fsm {

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -96,3 +96,4 @@ free_ir # XXX: workaround for lx
 fsm_collect_unreachable_states
 fsm_clear_tmp
 fsm_state_clear_tmp
+fsm_label_epsilon_scc

--- a/src/libfsm/print/dot.c
+++ b/src/libfsm/print/dot.c
@@ -80,7 +80,13 @@ singlestate(FILE *f, const struct fsm *fsm, struct fsm_state *s)
 			fsm->opt->prefix != NULL ? fsm->opt->prefix : "",
 			indexof(fsm, s));
 
-		fprintf(f, "%u", indexof(fsm, s));
+		if (fsm->opt->scc_names) {
+			fprintf(f, "%u", s->eps_scc);
+		} else if (fsm->opt->index_names) {
+			fprintf(f, "%u", s->index);
+		} else {
+			fprintf(f, "%u", indexof(fsm, s));
+		}
 
 		fprintf(f, "> ];\n");
 	}

--- a/src/libfsm/state.c
+++ b/src/libfsm/state.c
@@ -29,7 +29,10 @@ fsm_addstate(struct fsm *fsm)
 		return NULL;
 	}
 
-	new->end = 0;
+	new->end     = 0;
+	new->index   = 0;
+	new->eps_scc = 0;
+
 	new->opaque = NULL;
 
 	/*

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -466,9 +466,13 @@ main(int argc, char *argv[])
 	{
 		int c;
 
-		while (c = getopt(argc, argv, "h" "acwXe:k:" "bi" "sq:r:l:" "upmnxyz"), c != -1) {
+		while (c = getopt(argc, argv, "h" "aNCcwXe:k:" "bi" "sq:r:l:" "upmnxyz"), c != -1) {
 			switch (c) {
 			case 'a': opt.anonymous_states  = 0;          break;
+			case 'N': opt.anonymous_states  = 0;
+				  opt.index_names       = 1;          break;
+			case 'C': opt.anonymous_states  = 0;
+				  opt.scc_names         = 1;          break;
 			case 'c': opt.consolidate_edges = 0;          break;
 			case 'w': opt.fragment          = 1;          break;
 			case 'X': opt.always_hex        = 1;          break;
@@ -800,6 +804,14 @@ main(int argc, char *argv[])
 		}
 
 		opt.carryopaque = NULL;
+	}
+
+	if (keep_nfa && (opt.scc_names || opt.index_names)) {
+		extern int fsm_label_epsilon_scc(struct fsm *fsm);
+		if (fsm_label_epsilon_scc(fsm) < 0) {
+			perror("fsm_label_epsilon_scc");
+			return EXIT_FAILURE;
+		}
 	}
 
 	if (example) {


### PR DESCRIPTION
This PR has two techniques to accelerate generating epsilon closures for states and sets of states:

1) Uses Tarjan's strongly connected components to pre-generate epsilon closures for individual states
2) Uses pre-generated state epsilon closures to build epsilon closures for sets of states

I've mostly filed this PR because @katef asked me to.  I'm not sure it's worth merging in its current state.  It shows some performance regression for graphs with few epsilon transitions, and it's not clear what features of the graph (number of epsilon transitions, density of epsilon transitions, etc.) would make this a performance win.  We do know that it makes unanchored word determinization a lot faster, and it slightly slows down anchored word determinization.

A few notes:

1. The first step isn't always a performance win.  For graphs that have few epsilon closures, the SCC algorithm adds an extra iteration through the states.  However, for epsilon-heavy graphs, this can dramatically reduce the work of generating epsilon closures.
2. The second step should always improve performance, and could be combined with memoizing the epsilon closure of a state.