### PR TITLE
libfsm/print/c: Fix output destination.

### DIFF
--- a/src/libfsm/print/c.c
+++ b/src/libfsm/print/c.c
@@ -269,7 +269,7 @@ endstates(FILE *f, const struct fsm_options *opt, const struct ir *ir)
 
 	/* no end states */
 	if (!ir_hasend(ir)) {
-		printf("\treturn -1; /* unexpected EOT */\n");
+		fprintf(f, "\treturn -1; /* unexpected EOT */\n");
 		return;
 	}
 


### PR DESCRIPTION
This has been causing that return to get lost from generated code.