### PR TITLE
trim: Avoid stale start pointer when trimming the first state.

### DIFF
--- a/src/libfsm/trim.c
+++ b/src/libfsm/trim.c
@@ -139,6 +139,9 @@ sweep_states(struct fsm *fsm)
 			if (prev != NULL) {
 				prev->next = next;
 			}
+			if (fsm->sl == s) {
+				fsm->sl = next;
+			}
 
 			edge_set_free(s->edges);
 			free(s);


### PR DESCRIPTION
This was uncovered by the use-after-free in `tests/trim/in0.fsm`.
After the stale pointer is fixed, the test passes.

Fixes #152.