### PR TITLE
Include alloc.h in fsm/Makefile

### DIFF
--- a/include/fsm/Makefile
+++ b/include/fsm/Makefile
@@ -1,5 +1,6 @@
 .include "../../share/mk/top.mk"
 
+STAGE_COPY += include/fsm/alloc.h
 STAGE_COPY += include/fsm/bool.h
 STAGE_COPY += include/fsm/cost.h
 STAGE_COPY += include/fsm/fsm.h


### PR DESCRIPTION
This PR includes the `alloc.h` header (introduced in https://github.com/katef/libfsm/pull/145) in fsm's Makefile. 