### PR TITLE
A callback to visit epsilon transitions as well as labelled edges

### DIFF
--- a/include/fsm/walk.h
+++ b/include/fsm/walk.h
@@ -49,21 +49,31 @@ int
 fsm_reachableany(const struct fsm *fsm, const struct fsm_state *state,
 	int (*predicate)(const struct fsm *, const struct fsm_state *));
 
-/* Allows iterating through the states of the graph with a callback
- * function.  Takes an opaque pointer that the callback can use for its
- * own purposes.
+/*
+ * Iterate through the states of an FSM with a callback function.
+ *
+ * Takes an opaque pointer that the callback can use for its own purposes.
+ *
+ * If the callback returns 0, will stop iterating and return 0.
+ * Otherwise will call the callback for each state and return 1.
  */
 int
 fsm_walk_states(const struct fsm *fsm, void *opaque,
 	int (*callback)(const struct fsm *, const struct fsm_state *, void *));
 
-/* Allows iterating through the states of the graph with a callback
- * function.  Takes an opaque pointer that the callback can use for its
- * own purposes.
+/*
+ * Iterate through the states of an FSM with callback functions for
+ * labelled and epsilon transitions respectively.
+ *
+ * Takes an opaque pointer that the callback can use for its own purposes.
+ *
+ * If these callbacks returns 0, will stop iterating and return 0.
+ * Otherwise will call the callback for each state and return 1.
  */
 int
 fsm_walk_edges(const struct fsm *fsm, void *opaque,
-	int (*callback)(const struct fsm *, const struct fsm_state *, unsigned int, const struct fsm_state *, void *));
+	int (*callback_literal)(const struct fsm *, const struct fsm_state *, const struct fsm_state *, char c, void *),
+	int (*callback_epsilon)(const struct fsm *, const struct fsm_state *, const struct fsm_state *, void *));
 
 #endif
 


### PR DESCRIPTION
This should've been done when I split `.epsilons` from the labelled transitions, but got missed.