### PR TITLE
Take the closure of a set of states directly from `struct state_array`

### DIFF
--- a/include/adt/set.h
+++ b/include/adt/set.h
@@ -24,12 +24,6 @@ set_create_singleton(const struct fsm_alloc *a,
 	int (*cmp)(const void *a, const void *b), void *item);
 
 struct set *
-set_create_from_array(const struct fsm_alloc *a,
-	void *items[], size_t n,
-	int (*cmp)(const void *a, const void *b),
-	int (*bulkcmp)(const void *, const void *));
-
-struct set *
 set_copy(const struct set *set);
 
 void *

--- a/include/adt/stateset.h
+++ b/include/adt/stateset.h
@@ -57,10 +57,6 @@ const struct fsm_state **
 state_set_array(const struct state_set *set);
 
 struct state_set *
-state_set_create_from_array(const struct fsm_alloc *a,
-	struct fsm_state **states, size_t n);
-
-struct state_set *
 state_set_create_singleton(const struct fsm_alloc *a,
 	struct fsm_state *state);
 

--- a/src/adt/set.c
+++ b/src/adt/set.c
@@ -122,38 +122,6 @@ set_create_singleton(const struct fsm_alloc *a,
 }
 
 struct set *
-set_create_from_array(const struct fsm_alloc *a,
-	void *items[], size_t n,
-	int (*cmp)(const void *a, const void *b),
-	int (*bulkcmp)(const void *, const void *))
-{
-	struct set *s;
-
-	if (n == 0) {
-		return set_create(a, cmp);
-	}
-
-	s = f_malloc(a, sizeof *s);
-	if (s == NULL) {
-		return NULL;
-	}
-
-	s->cmp = (cmp != NULL) ? cmp : set_cmpval;
-
-	if (n > 1) {
-		/* XXX - replace with something better? */
-		qsort((void *)(&items[0]), n, sizeof items[0], (bulkcmp != NULL) ? bulkcmp : set_bulkcmpval);
-	}
-
-	s->alloc = a;
-	s->i = n;
-	s->n = n;
-	s->a = items;
-
-	return s;
-}
-
-struct set *
 set_copy(const struct set *set)
 {
 	struct set *s;

--- a/src/adt/stateset.c
+++ b/src/adt/stateset.c
@@ -18,13 +18,6 @@ state_set_create(const struct fsm_alloc *a)
 }
 
 struct state_set *
-state_set_create_from_array(const struct fsm_alloc *a,
-	struct fsm_state **states, size_t n)
-{
-	return (struct state_set *) set_create_from_array(a, (void **) states, n, NULL, NULL);
-}
-
-struct state_set *
 state_set_create_singleton(const struct fsm_alloc *a,
 	struct fsm_state *state)
 {


### PR DESCRIPTION
Take the closure of a set of states directly from the constructed `struct state_array`, rather than first converting it to a `struct state_set`.

This avoids a `qsort()` in `set_create_from_array()` (and also a `memcpy` to zero out the array),
since we only construct the array of states in order to iterate over them as a set,
and the order does not matter for sake of finding the closure.

Benchmarking, I found negligible difference, which surprises me. I suppose these sets are relatively small for this data, but that there are lots of them.

before:
```
; ./words.sh 40000 100 | guff -b
    x: [0 - 19]    y: [0 - 17443]
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠂
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⠀⠁⠀⠀
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠐⠀⠀⠀⠀⠀⠀⠀⠀
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡀⠀⠂⠀⠀⠀⠀⠀⠀⠀⠀⠀
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⠀⠂⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⠀⠐⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠐⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⡇⠀⠀⠀⠀⠀⠀⠀⠀⡀⠀⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⠀⠀⠀⠀⠀⠀
⡇⠀⠀⠀⠀⢀⠀⠐⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⣇⣀⣄⣈⣀⣀⣀⣀⣀⣀⣀⣀⣀⣁⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀
```

after:
```
; ./words.sh 40000 100 | guff -b
    x: [0 - 19]    y: [0 - 17279]
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡀⠀⠂
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠐⠀⠀⠀⠀
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠐⠀⠀⠀⠀⠀⠀⠀⠀
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡀⠀⠂⠀⠀⠀⠀⠀⠀⠀⠀⠀
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⠀⠂⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⠀⠐⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠐⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⡇⠀⠀⠀⠀⠀⠀⠀⠀⡀⠀⠂⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⠀⠀⠀⠀⠀⠀
⡇⠀⠀⠀⠀⠠⠀⠐⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀
⣇⣀⣄⣈⣀⣀⣀⣀⣀⣀⣀⣀⣀⣁⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀⣀
```