### PR TITLE
Fixes the return code handling of `fsm_trim()`

### DIFF
--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -93,6 +93,5 @@ fsm_print_cfrag # XXX: workaround for lx
 make_ir # XXX: workaround for lx
 free_ir # XXX: workaround for lx
 
-fsm_collect_unreachable_states
 fsm_clear_tmp
 fsm_state_clear_tmp

--- a/src/libfsm/trim.c
+++ b/src/libfsm/trim.c
@@ -104,12 +104,12 @@ cleanup:
 	return res;
 }
 
-int
+long
 sweep_states(struct fsm *fsm)
 {
 	struct fsm_state *prev, *s, *next;
 	struct fsm_state **new_tail;
-	int swept;
+	long swept;
 
 	prev = NULL;
 	s = fsm->sl;
@@ -161,7 +161,7 @@ sweep_states(struct fsm *fsm)
 int
 fsm_trim(struct fsm *fsm)
 {
-	int ret;
+	long ret;
 
 	clear_states(fsm->sl);
 

--- a/src/libfsm/trim.c
+++ b/src/libfsm/trim.c
@@ -161,6 +161,8 @@ sweep_states(struct fsm *fsm)
 int
 fsm_trim(struct fsm *fsm)
 {
+	int ret;
+
 	clear_states(fsm->sl);
 
 	if (!mark_states(fsm)) {
@@ -178,6 +180,13 @@ fsm_trim(struct fsm *fsm)
 	 * also removed.
 	 */
 
-	return sweep_states(fsm);
+	// sweep_states returns a negative value on error, otherwise it returns
+	// the number of states swept.
+	ret = sweep_states(fsm);
+	if (ret < 0) {
+		return ret;
+	}
+	
+	return 1;
 }
 


### PR DESCRIPTION
Noticed this trying to get the tests working.  PR does a few things:

* removes `fsm_collect_unreachable_states` from `libfsm.syms`.  This makes macOS willing to link `libfsm.so`

* Changes the return handing of `fsm_trim()` to return 1 on success and -1 on error.  Previously it passed the return of `sweep_states()` along undisturbed, which returned -1 on error and the number of trimmed states (which could be zero) on success.

* Changed the return type of `sweep_states()` from `int` to `long` in case someone tries to trim a graph with more than `INT_MAX` states that can't be reached from start.

Tests now pass again, except for `pcre/in5.re` which is very reliable in its failure.