### PR TITLE
Fix for FLAGS node in re_ast_print_dot

### DIFF
--- a/src/libre/print/dot.c
+++ b/src/libre/print/dot.c
@@ -160,13 +160,12 @@ re_ast_print_dot(FILE *f, const struct fsm_options *opt,
 static void
 re_flags_print(FILE *f, enum re_flags fl)
 {
-	const char *sep = "";
-	if (fl & RE_ICASE) { fprintf(f, "%si", sep); sep = " "; }
-	if (fl & RE_TEXT) { fprintf(f, "%sg", sep); sep = " "; }
-	if (fl & RE_MULTI) { fprintf(f, "%sm", sep); sep = " "; }
-	if (fl & RE_REVERSE) { fprintf(f, "%sr", sep); sep = " "; }
-	if (fl & RE_SINGLE) { fprintf(f, "%ss", sep); sep = " "; }
-	if (fl & RE_ZONE) { fprintf(f, "%sz", sep); sep = " "; }
+	if (fl & RE_ICASE  ) { fprintf(f, "i"); }
+	if (fl & RE_TEXT   ) { fprintf(f, "g"); }
+	if (fl & RE_MULTI  ) { fprintf(f, "m"); }
+	if (fl & RE_REVERSE) { fprintf(f, "r"); }
+	if (fl & RE_SINGLE ) { fprintf(f, "s"); }
+	if (fl & RE_ZONE   ) { fprintf(f, "z"); }
 }
 
 static void

--- a/src/libre/print/dot.c
+++ b/src/libre/print/dot.c
@@ -125,11 +125,11 @@ pp_iter(FILE *f, const struct fsm_options *opt,
 		break;
 
 	case AST_EXPR_FLAGS:
-		fprintf(f, "\tn%p [ label = <{FLAGS|{+", (void *) n);
+		fprintf(f, "\tn%p [ label = <FLAGS|{+", (void *) n);
 		re_flags_print(f, n->u.flags.pos);
-		fprintf(f, "|-");
+		fprintf(f, "}|{-");
 		re_flags_print(f, n->u.flags.neg);
-		fprintf(f, "> ];\n");
+		fprintf(f, "}> ];\n");
 		break;
 
 	default:


### PR DESCRIPTION
When running:
```re -p -r pcre -l ast '(?i).{0,2}(Tom|Sawyer|Huckleberry|Finn)$' | dot -Tpng > ast1.png```

dot gives the error:
```Error: bad label format {FLAGS|{+i|-```

The error *seems* to be caused by unclosed braces.  This PR adjusts the braces so:

1. FLAGS doesn’t have a brace around it
2. pos-flags and neg-flags are enclosed in separate {} pairs