### PR TITLE
Fix incorrect end-of-input check for `pair` io mode

### DIFF
--- a/src/libfsm/print/c.c
+++ b/src/libfsm/print/c.c
@@ -369,7 +369,7 @@ fsm_print_c_complete(FILE *f, const struct ir *ir, const struct fsm_options *opt
 		break;
 
 	case FSM_IO_PAIR:
-		fprintf(f, "\tfor (p = b; *p != e; p++) {\n");
+		fprintf(f, "\tfor (p = b; p != e; p++) {\n");
 		break;
 	}
 


### PR DESCRIPTION
Find a bug, fix a bug:
```
In function 'fsm_main':
warning: comparison between pointer and integer
  for (p = b; *p != e; p++) {
                 ^~
```

I haven't ever used the `pair` mode myself so my criteria here is "the generated C _looks_ correct and I don't see warnings..." :)

edit: for reference the above is reproducible via something like `./build/bin/re -l c -k pair 'asdf' | gcc -c -x -`