### PR TITLE
Pass through src and dst FSMs separately for `.carryopaque()` callbacks

### DIFF
--- a/examples/iprange/main.c
+++ b/examples/iprange/main.c
@@ -421,24 +421,38 @@ important(unsigned n)
 }
 
 static void
-carryopaque(const struct fsm_state **set, size_t n,
-	struct fsm *fsm, struct fsm_state *st)
+carryopaque(struct fsm *src_fsm, const struct fsm_state **src_set, size_t n,
+	struct fsm *dst_fsm, struct fsm_state *dst_state)
 {
 	void *o = NULL;
 	size_t i;
 
+	assert(src_fsm != NULL);
+	assert(src_set != NULL);
+	assert(n > 0);
+	assert(dst_state != NULL);
+	assert(dst_fsm != NULL);
+	assert(fsm_isend(dst_fsm, dst_state));
+	assert(fsm_getopaque(dst_fsm, dst_state) == NULL);
+
 	for (i = 0; i < n; i++) {
-		if (!fsm_isend(fsm, set[i])) {
+		/*
+		 * The opaque data is attached to end states only, so we skip
+		 * non-end states here.
+		 */
+		if (!fsm_isend(src_fsm, src_set[i])) {
 			continue;
 		}
+
+		assert(fsm_getopaque(src_fsm, src_set[i]) != NULL);
 
 		if (o == NULL) {
-			o = fsm_getopaque(fsm, set[i]);
-			fsm_setopaque(fsm, st, o);
+			o = fsm_getopaque(src_fsm, src_set[i]);
+			fsm_setopaque(dst_fsm, dst_state, o);
 			continue;
 		}
 
-		assert(o == fsm_getopaque(fsm, set[i]));
+		assert(o == fsm_getopaque(src_fsm, src_set[i]));
 	}
 }
 

--- a/include/fsm/options.h
+++ b/include/fsm/options.h
@@ -71,8 +71,8 @@ struct fsm_options {
 	void *endleaf_opaque;
 
 	/* TODO: explain */
-	void (*carryopaque)(const struct fsm_state **, size_t,
-		struct fsm *, struct fsm_state *);
+	void (*carryopaque)(struct fsm *src_fsm, const struct fsm_state **src_set, size_t n,
+		struct fsm *dst_fsm, struct fsm_state *dst_state);
 
 	/* custom allocation functions */
 	const struct fsm_alloc *alloc;

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -82,6 +82,10 @@ int
 fsm_addedge_bulk(struct fsm *fsm, struct fsm_state *from, struct fsm_state **to, size_t n, char c);
 
 void
+fsm_carryopaque_array(struct fsm *src_fsm, const struct fsm_state **src_set, size_t n,
+    struct fsm *dst_fsm, struct fsm_state *dst_state);
+
+void
 fsm_carryopaque(struct fsm *fsm, const struct state_set *set,
 	struct fsm *new, struct fsm_state *state);
 

--- a/src/libfsm/walk2.c
+++ b/src/libfsm/walk2.c
@@ -254,9 +254,7 @@ walk2_comb_state(struct fsm *dst_fsm, int is_end,
 	tmp.start = NULL;
 	tmp.opt = dst_fsm->opt;
 
-	/* TODO: call centralised fsm_carryopaque() instead, fake up a set */
-
-	tmp.opt->carryopaque(&tmp, states, count, dst_fsm, comb);
+	fsm_carryopaque_array(&tmp, states, count, dst_fsm, comb);
 
 	return comb;
 } 


### PR DESCRIPTION
This PR addresses some corner-cutting where I'd relied on the assumption that all states passed to the `.carryopaque()` callback would belong to the same FSM. That's not always the case, and so in this PR I pass a suitable FSM.

The walk2 facility doesn't have a suitable FSM, so I construct one.