### PR TITLE
Rework libre parsing to construct nary alt and concat AST nodes

### DIFF
--- a/src/libre/ast.c
+++ b/src/libre/ast.c
@@ -44,14 +44,14 @@ class_free_iter(struct ast_class *n)
 	assert(n != NULL);
 
 	switch (n->type) {
-	case AST_CLASS_CONCAT_N: {
+	case AST_CLASS_CONCAT: {
 		size_t i;
 
-		for (i = 0; i < n->u.concat_n.count; i++) {
-			class_free_iter(n->u.concat_n.n[i]);
+		for (i = 0; i < n->u.concat.count; i++) {
+			class_free_iter(n->u.concat.n[i]);
 		}
 
-		free(n->u.concat_n.n);
+		free(n->u.concat.n);
 		break;
 	}
 
@@ -89,22 +89,22 @@ free_iter(struct ast_expr *n)
 		/* these nodes have no subnodes or dynamic allocation */
 		break;
 
-	case AST_EXPR_CONCAT_N: {
+	case AST_EXPR_CONCAT: {
 		size_t i;
 
-		for (i = 0; i < n->u.concat_n.count; i++) {
-			free_iter(n->u.concat_n.n[i]);
+		for (i = 0; i < n->u.concat.count; i++) {
+			free_iter(n->u.concat.n[i]);
 		}
 
-		free(n->u.concat_n.n);
+		free(n->u.concat.n);
 		break;
 	}
 
-	case AST_EXPR_ALT_N: {
+	case AST_EXPR_ALT: {
 		size_t i;
 
-		for (i = 0; i < n->u.alt_n.count; i++) {
-			free_iter(n->u.alt_n.n[i]);
+		for (i = 0; i < n->u.alt.count; i++) {
+			free_iter(n->u.alt.n[i]);
 		}
 		break;
 	}
@@ -187,7 +187,7 @@ ast_make_expr_empty(void)
 }
 
 struct ast_expr *
-ast_make_expr_concat_n(void)
+ast_make_expr_concat(void)
 {
 	struct ast_expr *res;
 
@@ -196,12 +196,12 @@ ast_make_expr_concat_n(void)
 		return NULL;
 	}
 
-	res->type = AST_EXPR_CONCAT_N;
-	res->u.concat_n.alloc = 8; /* arbitrary initial value */
-	res->u.concat_n.count = 0;
+	res->type = AST_EXPR_CONCAT;
+	res->u.concat.alloc = 8; /* arbitrary initial value */
+	res->u.concat.count = 0;
 
-	res->u.concat_n.n = malloc(res->u.concat_n.alloc * sizeof *res->u.concat_n.n);
-	if (res->u.concat_n.n == NULL) {
+	res->u.concat.n = malloc(res->u.concat.alloc * sizeof *res->u.concat.n);
+	if (res->u.concat.n == NULL) {
 		free(res);
 		return NULL;
 	}
@@ -213,28 +213,28 @@ int
 ast_add_expr_concat(struct ast_expr *cat, struct ast_expr *node)
 {
 	assert(cat != NULL);
-	assert(cat->type == AST_EXPR_CONCAT_N);
+	assert(cat->type == AST_EXPR_CONCAT);
 
-	if (cat->u.concat_n.count == cat->u.concat_n.alloc) {
+	if (cat->u.concat.count == cat->u.concat.alloc) {
 		void *tmp;
 
-		tmp = realloc(cat->u.concat_n.n, cat->u.concat_n.alloc * 2 * sizeof *cat->u.concat_n.n);
+		tmp = realloc(cat->u.concat.n, cat->u.concat.alloc * 2 * sizeof *cat->u.concat.n);
 		if (tmp == NULL) {
 			return 0;
 		}
 
-		cat->u.concat_n.alloc *= 2;
-		cat->u.concat_n.n = tmp;
+		cat->u.concat.alloc *= 2;
+		cat->u.concat.n = tmp;
 	}
 
-	cat->u.concat_n.n[cat->u.concat_n.count] = node;
-	cat->u.concat_n.count++;
+	cat->u.concat.n[cat->u.concat.count] = node;
+	cat->u.concat.count++;
 
 	return 1;
 }
 
 struct ast_expr *
-ast_make_expr_alt_n(void)
+ast_make_expr_alt(void)
 {
 	struct ast_expr *res;
 
@@ -243,12 +243,12 @@ ast_make_expr_alt_n(void)
 		return NULL;
 	}
 
-	res->type = AST_EXPR_ALT_N;
-	res->u.alt_n.alloc = 8; /* arbitrary initial value */
-	res->u.alt_n.count = 0;
+	res->type = AST_EXPR_ALT;
+	res->u.alt.alloc = 8; /* arbitrary initial value */
+	res->u.alt.count = 0;
 
-	res->u.alt_n.n = malloc(res->u.alt_n.alloc * sizeof *res->u.alt_n.n);
-	if (res->u.alt_n.n == NULL) {
+	res->u.alt.n = malloc(res->u.alt.alloc * sizeof *res->u.alt.n);
+	if (res->u.alt.n == NULL) {
 		free(res);
 		return NULL;
 	}
@@ -260,22 +260,22 @@ int
 ast_add_expr_alt(struct ast_expr *cat, struct ast_expr *node)
 {
 	assert(cat != NULL);
-	assert(cat->type == AST_EXPR_ALT_N);
+	assert(cat->type == AST_EXPR_ALT);
 
-	if (cat->u.alt_n.count == cat->u.alt_n.alloc) {
+	if (cat->u.alt.count == cat->u.alt.alloc) {
 		void *tmp;
 
-		tmp = realloc(cat->u.alt_n.n, cat->u.alt_n.alloc * 2 * sizeof *cat->u.alt_n.n);
+		tmp = realloc(cat->u.alt.n, cat->u.alt.alloc * 2 * sizeof *cat->u.alt.n);
 		if (tmp == NULL) {
 			return 0;
 		}
 
-		cat->u.alt_n.alloc *= 2;
-		cat->u.alt_n.n = tmp;
+		cat->u.alt.alloc *= 2;
+		cat->u.alt.n = tmp;
 	}
 
-	cat->u.alt_n.n[cat->u.alt_n.count] = node;
-	cat->u.alt_n.count++;
+	cat->u.alt.n[cat->u.alt.count] = node;
+	cat->u.alt.count++;
 
 	return 1;
 }
@@ -415,7 +415,7 @@ ast_make_expr_anchor(enum ast_anchor_type type)
  */
 
 struct ast_class *
-ast_make_class_concat_n(void)
+ast_make_class_concat(void)
 {
 	struct ast_class *res;
 
@@ -424,12 +424,12 @@ ast_make_class_concat_n(void)
 		return NULL;
 	}
 
-	res->type = AST_CLASS_CONCAT_N;
-	res->u.concat_n.alloc = 8; /* arbitrary initial value */
-	res->u.concat_n.count = 0;
+	res->type = AST_CLASS_CONCAT;
+	res->u.concat.alloc = 8; /* arbitrary initial value */
+	res->u.concat.count = 0;
 
-	res->u.concat_n.n = malloc(res->u.concat_n.alloc * sizeof *res->u.concat_n.n);
-	if (res->u.concat_n.n == NULL) {
+	res->u.concat.n = malloc(res->u.concat.alloc * sizeof *res->u.concat.n);
+	if (res->u.concat.n == NULL) {
 		free(res);
 		return NULL;
 	}
@@ -441,22 +441,22 @@ int
 ast_add_class_concat(struct ast_class *cat, struct ast_class *node)
 {
 	assert(cat != NULL);
-	assert(cat->type == AST_CLASS_CONCAT_N);
+	assert(cat->type == AST_CLASS_CONCAT);
 
-	if (cat->u.concat_n.count == cat->u.concat_n.alloc) {
+	if (cat->u.concat.count == cat->u.concat.alloc) {
 		void *tmp;
 
-		tmp = realloc(cat->u.concat_n.n, cat->u.concat_n.alloc * 2 * sizeof *cat->u.concat_n.n);
+		tmp = realloc(cat->u.concat.n, cat->u.concat.alloc * 2 * sizeof *cat->u.concat.n);
 		if (tmp == NULL) {
 			return 0;
 		}
 
-		cat->u.concat_n.alloc *= 2;
-		cat->u.concat_n.n = tmp;
+		cat->u.concat.alloc *= 2;
+		cat->u.concat.n = tmp;
 	}
 
-	cat->u.concat_n.n[cat->u.concat_n.count] = node;
-	cat->u.concat_n.count++;
+	cat->u.concat.n[cat->u.concat.count] = node;
+	cat->u.concat.count++;
 
 	return 1;
 }

--- a/src/libre/ast.c
+++ b/src/libre/ast.c
@@ -181,7 +181,6 @@ ast_make_expr_empty(void)
 	}
 
 	res->type = AST_EXPR_EMPTY;
-	res->flags = AST_EXPR_FLAG_NULLABLE;
 
 	return res;
 }

--- a/src/libre/ast.c
+++ b/src/libre/ast.c
@@ -55,11 +55,6 @@ class_free_iter(struct ast_class *n)
 		break;
 	}
 
-	case AST_CLASS_CONCAT:
-		class_free_iter(n->u.concat.l);
-		class_free_iter(n->u.concat.r);
-		break;
-
 	case AST_CLASS_SUBTRACT:
 		class_free_iter(n->u.subtract.ast);
 		class_free_iter(n->u.subtract.mask);
@@ -94,11 +89,6 @@ free_iter(struct ast_expr *n)
 		/* these nodes have no subnodes or dynamic allocation */
 		break;
 
-	case AST_EXPR_CONCAT:
-		free_iter(n->u.concat.l);
-		free_iter(n->u.concat.r);
-		break;
-
 	case AST_EXPR_CONCAT_N: {
 		size_t i;
 
@@ -109,11 +99,6 @@ free_iter(struct ast_expr *n)
 		free(n->u.concat_n.n);
 		break;
 	}
-
-	case AST_EXPR_ALT:
-		free_iter(n->u.alt.l);
-		free_iter(n->u.alt.r);
-		break;
 
 	case AST_EXPR_ALT_N: {
 		size_t i;
@@ -202,51 +187,6 @@ ast_make_expr_empty(void)
 }
 
 struct ast_expr *
-ast_make_expr_concat(struct ast_expr *l, struct ast_expr *r)
-{
-	struct ast_expr *res;
-
-	assert(l != NULL);
-	assert(r != NULL);
-
-	res = calloc(1, sizeof *res);
-	if (res == NULL) {
-		return NULL;
-	}
-
-	res->type = AST_EXPR_CONCAT;
-	res->u.concat.l = l;
-	res->u.concat.r = r;
-
-	return res;
-}
-
-struct ast_expr *
-ast_make_expr_concat_count(size_t count)
-{
-	struct ast_expr *res;
-
-	assert(count > 0);
-
-	res = calloc(1, sizeof *res);
-	if (res == NULL) {
-		return NULL;
-	}
-
-	res->type = AST_EXPR_CONCAT_N;
-	res->u.concat_n.alloc = count;
-	res->u.concat_n.count = count;
-
-	res->u.concat_n.n = malloc(count * sizeof *res->u.concat_n.n);
-	if (res->u.concat_n.n == NULL) {
-		free(res);
-		return NULL;
-	}
-
-	return res;
-}
-
-struct ast_expr *
 ast_make_expr_concat_n(void)
 {
 	struct ast_expr *res;
@@ -291,45 +231,6 @@ ast_add_expr_concat(struct ast_expr *cat, struct ast_expr *node)
 	cat->u.concat_n.count++;
 
 	return 1;
-}
-
-struct ast_expr *
-ast_make_expr_alt(struct ast_expr *l, struct ast_expr *r)
-{
-	struct ast_expr *res;
-
-	assert(l != NULL);
-	assert(r != NULL);
-
-	res = calloc(1, sizeof *res);
-	if (res == NULL) {
-		return res;
-	}
-
-	res->type = AST_EXPR_ALT;
-	res->u.alt.l = l;
-	res->u.alt.r = r;
-
-	return res;
-}
-
-struct ast_expr *
-ast_make_expr_alt_count(size_t count)
-{
-	struct ast_expr *res;
-	size_t size = sizeof *res + (count - 1) * sizeof (struct ast_expr *);
-
-	res = calloc(1, size);
-	if (res == NULL) {
-		return NULL;
-	}
-
-	res->type = AST_EXPR_ALT_N;
-	res->u.alt_n.count = count;
-
-	/* cells are initialized by caller */
-
-	return res;
 }
 
 struct ast_expr *
@@ -512,23 +413,6 @@ ast_make_expr_anchor(enum ast_anchor_type type)
 /*
  * Character classes
  */
-
-struct ast_class *
-ast_make_class_concat(struct ast_class *l, struct ast_class *r)
-{
-	struct ast_class *res;
-
-	res = calloc(1, sizeof *res);
-	if (res == NULL) {
-		return NULL;
-	}
-
-	res->type = AST_CLASS_CONCAT;
-	res->u.concat.l = l;
-	res->u.concat.r = r;
-
-	return res;
-}
 
 struct ast_class *
 ast_make_class_concat_n(void)

--- a/src/libre/ast.h
+++ b/src/libre/ast.h
@@ -21,8 +21,8 @@ struct ast_pos {
 
 enum ast_expr_type {
 	AST_EXPR_EMPTY,
-	AST_EXPR_CONCAT_N,
-	AST_EXPR_ALT_N,
+	AST_EXPR_CONCAT,
+	AST_EXPR_ALT,
 	AST_EXPR_LITERAL,
 	AST_EXPR_ANY,
 	AST_EXPR_REPEATED,
@@ -94,7 +94,7 @@ enum ast_class_flags {
 };
 
 enum ast_class_type {
-	AST_CLASS_CONCAT_N,
+	AST_CLASS_CONCAT,
 	AST_CLASS_LITERAL,
 	AST_CLASS_RANGE,
 	AST_CLASS_NAMED,
@@ -130,7 +130,7 @@ struct ast_class {
 			size_t count; /* used */
 			size_t alloc; /* allocated */
 			struct ast_class **n;
-		} concat_n;
+		} concat;
 
 		struct {
 			unsigned char c;
@@ -179,14 +179,14 @@ struct ast_expr {
 			size_t count; /* used */
 			size_t alloc; /* allocated */
 			struct ast_expr **n;
-		} concat_n;
+		} concat;
 
 		/* unordered set */
 		struct {
 			size_t count; /* used */
 			size_t alloc; /* allocated */
 			struct ast_expr **n;
-		} alt_n;
+		} alt;
 
 		struct {
 			/*const*/ char c;
@@ -247,10 +247,10 @@ struct ast_expr *
 ast_make_expr_empty(void);
 
 struct ast_expr *
-ast_make_expr_concat_n(void);
+ast_make_expr_concat(void);
 
 struct ast_expr *
-ast_make_expr_alt_n(void);
+ast_make_expr_alt(void);
 
 int
 ast_add_expr_alt(struct ast_expr *cat, struct ast_expr *node);
@@ -285,7 +285,7 @@ ast_add_expr_concat(struct ast_expr *cat, struct ast_expr *node);
  */
 
 struct ast_class *
-ast_make_class_concat_n(void);
+ast_make_class_concat(void);
 
 struct ast_class *
 ast_make_class_literal(unsigned char c);

--- a/src/libre/ast.h
+++ b/src/libre/ast.h
@@ -193,8 +193,9 @@ struct ast_expr {
 
 		/* unordered set */
 		struct {
-			size_t count;
-			struct ast_expr *n[1];
+			size_t count; /* used */
+			size_t alloc; /* allocated */
+			struct ast_expr **n;
 		} alt_n;
 
 		struct {
@@ -268,7 +269,13 @@ struct ast_expr *
 ast_make_expr_alt(struct ast_expr *l, struct ast_expr *r);
 
 struct ast_expr *
-ast_make_expr_alt_n(size_t count);
+ast_make_expr_alt_count(size_t count);
+
+struct ast_expr *
+ast_make_expr_alt_n(void);
+
+int
+ast_add_expr_alt(struct ast_expr *cat, struct ast_expr *node);
 
 struct ast_expr *
 ast_make_expr_literal(char c);

--- a/src/libre/ast.h
+++ b/src/libre/ast.h
@@ -179,9 +179,11 @@ struct ast_expr {
 			struct ast_expr *r;
 		} concat;
 
+		/* ordered sequence */
 		struct {
-			size_t count;
-			struct ast_expr *n[1];
+			size_t count; /* used */
+			size_t alloc; /* allocated */
+			struct ast_expr **n;
 		} concat_n;
 
 		struct {
@@ -189,6 +191,7 @@ struct ast_expr {
 			struct ast_expr *r;
 		} alt;
 
+		/* unordered set */
 		struct {
 			size_t count;
 			struct ast_expr *n[1];
@@ -256,7 +259,10 @@ struct ast_expr *
 ast_make_expr_concat(struct ast_expr *l, struct ast_expr *r);
 
 struct ast_expr *
-ast_make_expr_concat_n(size_t count);
+ast_make_expr_concat_count(size_t count);
+
+struct ast_expr *
+ast_make_expr_concat_n(void);
 
 struct ast_expr *
 ast_make_expr_alt(struct ast_expr *l, struct ast_expr *r);
@@ -285,6 +291,9 @@ ast_make_expr_re_flags(enum re_flags pos, enum re_flags neg);
 
 struct ast_expr *
 ast_make_expr_anchor(enum ast_anchor_type type);
+
+int
+ast_add_expr_concat(struct ast_expr *cat, struct ast_expr *node);
 
 /*
  * Character classes

--- a/src/libre/ast.h
+++ b/src/libre/ast.h
@@ -97,6 +97,7 @@ enum ast_class_flags {
 
 enum ast_class_type {
 	AST_CLASS_CONCAT,
+	AST_CLASS_CONCAT_N,
 	AST_CLASS_LITERAL,
 	AST_CLASS_RANGE,
 	AST_CLASS_NAMED,
@@ -131,6 +132,13 @@ struct ast_class {
 			struct ast_class *l;
 			struct ast_class *r;
 		} concat;
+
+		/* unordered set */
+		struct {
+			size_t count; /* used */
+			size_t alloc; /* allocated */
+			struct ast_class **n;
+		} concat_n;
 
 		struct {
 			unsigned char c;
@@ -307,8 +315,10 @@ ast_add_expr_concat(struct ast_expr *cat, struct ast_expr *node);
  */
 
 struct ast_class *
-ast_make_class_concat(struct ast_class *l,
-	struct ast_class *r);
+ast_make_class_concat(struct ast_class *l, struct ast_class *r);
+
+struct ast_class *
+ast_make_class_concat_n(void);
 
 struct ast_class *
 ast_make_class_literal(unsigned char c);
@@ -322,6 +332,9 @@ ast_make_class_named(class_constructor *ctor);
 
 struct ast_class *
 ast_make_class_flags(enum ast_class_flags flags);
+
+int
+ast_add_class_concat(struct ast_class *cat, struct ast_class *node);
 
 struct ast_class *
 ast_make_class_subtract(struct ast_class *ast,

--- a/src/libre/ast.h
+++ b/src/libre/ast.h
@@ -21,9 +21,7 @@ struct ast_pos {
 
 enum ast_expr_type {
 	AST_EXPR_EMPTY,
-	AST_EXPR_CONCAT,
 	AST_EXPR_CONCAT_N,
-	AST_EXPR_ALT,
 	AST_EXPR_ALT_N,
 	AST_EXPR_LITERAL,
 	AST_EXPR_ANY,
@@ -96,7 +94,6 @@ enum ast_class_flags {
 };
 
 enum ast_class_type {
-	AST_CLASS_CONCAT,
 	AST_CLASS_CONCAT_N,
 	AST_CLASS_LITERAL,
 	AST_CLASS_RANGE,
@@ -128,11 +125,6 @@ struct ast_endpoint {
 struct ast_class {
 	enum ast_class_type type;
 	union {
-		struct {
-			struct ast_class *l;
-			struct ast_class *r;
-		} concat;
-
 		/* unordered set */
 		struct {
 			size_t count; /* used */
@@ -182,22 +174,12 @@ struct ast_expr {
 	enum ast_expr_flags flags;
 
 	union {
-		struct {
-			struct ast_expr *l;
-			struct ast_expr *r;
-		} concat;
-
 		/* ordered sequence */
 		struct {
 			size_t count; /* used */
 			size_t alloc; /* allocated */
 			struct ast_expr **n;
 		} concat_n;
-
-		struct {
-			struct ast_expr *l;
-			struct ast_expr *r;
-		} alt;
 
 		/* unordered set */
 		struct {
@@ -265,19 +247,7 @@ struct ast_expr *
 ast_make_expr_empty(void);
 
 struct ast_expr *
-ast_make_expr_concat(struct ast_expr *l, struct ast_expr *r);
-
-struct ast_expr *
-ast_make_expr_concat_count(size_t count);
-
-struct ast_expr *
 ast_make_expr_concat_n(void);
-
-struct ast_expr *
-ast_make_expr_alt(struct ast_expr *l, struct ast_expr *r);
-
-struct ast_expr *
-ast_make_expr_alt_count(size_t count);
 
 struct ast_expr *
 ast_make_expr_alt_n(void);
@@ -313,9 +283,6 @@ ast_add_expr_concat(struct ast_expr *cat, struct ast_expr *node);
 /*
  * Character classes
  */
-
-struct ast_class *
-ast_make_class_concat(struct ast_class *l, struct ast_class *r);
 
 struct ast_class *
 ast_make_class_concat_n(void);

--- a/src/libre/ast_analysis.c
+++ b/src/libre/ast_analysis.c
@@ -510,147 +510,10 @@ assign_lasts(struct ast_expr *n)
 	}
 }
 
-static unsigned
-count_chain(const struct ast_expr *n, enum ast_expr_type type)
-{
-	unsigned res;
-
-	res = 0;
-
-	for (;;) {
-		assert(n != NULL);
-
-		if (n->type == AST_EXPR_EMPTY) {
-			return res;
-		}
-
-		assert(n->type == type);
-		res++;
-
-		switch (type) {
-		case AST_EXPR_CONCAT:
-			n = n->u.concat.r;
-			break;
-
-		case AST_EXPR_ALT:
-			n = n->u.alt.r;
-			break;
-
-		default:
-			assert(!"unreached");
-			break;
-		}
-	}
-}
-
-static struct ast_expr *
-collect_chain(size_t count, struct ast_expr *doomed)
-{
-	size_t i;
-
-	switch (doomed->type) {
-	case AST_EXPR_CONCAT: {
-		struct ast_expr *dst;
-
-		if (count == 1) {
-			struct ast_expr *res = doomed->u.concat.l;
-			if (!flatten(&doomed->u.concat.l)) {
-				return 0;
-			}
-			res = doomed->u.concat.l;
-
-			assert(doomed->u.concat.r->type == AST_EXPR_EMPTY);
-			doomed->u.concat.l = ast_expr_tombstone;
-			ast_expr_free(doomed);
-			assert(res->type != AST_EXPR_CONCAT);
-
-			return res;
-		}
-
-		dst = ast_make_expr_concat_count(count);
-		if (dst == NULL) {
-			return NULL;
-		}
-
-		for (i = 0; i < count; i++) {
-			struct ast_expr *ndoomed;
-
-			ndoomed = doomed->u.concat.r;
-			if (!flatten(&doomed->u.concat.l)) {
-				return 0;
-			}
-
-			dst->u.concat_n.n[i] = doomed->u.concat.l;
-			doomed->u.concat.l = ast_expr_tombstone;
-			doomed->u.concat.r = ast_expr_tombstone;
-			ast_expr_free(doomed);
-			doomed = ndoomed;
-
-			if (i == count - 1) {
-				assert(doomed->type == AST_EXPR_EMPTY);
-			}
-		}
-		return dst;
-	}
-
-	case AST_EXPR_ALT: {
-		struct ast_expr *dst;
-
-		if (count == 1) {
-			/* If we get here, it's a parser bug. Right? */
-			assert(!"unreached");
-		}
-
-		dst = ast_make_expr_alt_count(count);
-		if (dst == NULL) {
-			return NULL;
-		}
-
-		for (i = 0; i < count; i++) {
-			struct ast_expr *ndoomed;
-
-			ndoomed = doomed->u.alt.r;
-			if (!flatten(&doomed->u.alt.l)) {
-				return 0;
-			}
-
-			dst->u.alt_n.n[i] = doomed->u.alt.l;
-			doomed->u.alt.l = ast_expr_tombstone;
-			doomed->u.alt.r = ast_expr_tombstone;
-			ast_expr_free(doomed);
-			doomed = ndoomed;
-
-			if (i == count - 1) {
-				assert(doomed->type == AST_EXPR_EMPTY);
-			}
-		}
-		return dst;
-	}
-
-	default:
-		assert(!"unreached");
-		return NULL;
-	}
-}
-
-/* TODO: do this directly in the parser. */
 static struct ast_expr *
 flatten_iter(struct ast_expr *n)
 {
 	switch (n->type) {
-	default:
-		return n;
-
-	case AST_EXPR_CONCAT: {
-		const unsigned count = count_chain(n, AST_EXPR_CONCAT);
-		return collect_chain(count, n);
-	}
-
-	case AST_EXPR_ALT: {
-		const unsigned count = count_chain(n, AST_EXPR_ALT);
-		return collect_chain(count, n);
-	}
-
 	case AST_EXPR_GROUP:
 		if (!flatten(&n->u.group.e)) {
 			return NULL;
@@ -663,6 +526,9 @@ flatten_iter(struct ast_expr *n)
 			return NULL;
 		}
 
+		return n;
+
+	default:
 		return n;
 	}
 }

--- a/src/libre/ast_analysis.c
+++ b/src/libre/ast_analysis.c
@@ -601,7 +601,7 @@ collect_chain(size_t count, struct ast_expr *doomed)
 			assert(!"unreached");
 		}
 
-		dst = ast_make_expr_alt_n(count);
+		dst = ast_make_expr_alt_count(count);
 		if (dst == NULL) {
 			return NULL;
 		}

--- a/src/libre/ast_analysis.c
+++ b/src/libre/ast_analysis.c
@@ -530,6 +530,37 @@ flatten(struct ast_expr *n)
 			}
 		}
 
+		/* remove empty children; these have no semantic effect */
+		for (i = 0; i < n->u.concat.count; ) {
+			if (n->u.concat.n[i]->type == AST_EXPR_EMPTY) {
+				ast_expr_free(n->u.concat.n[i]);
+
+				if (i + 1 < n->u.concat.count) {
+					memmove(&n->u.concat.n[i], &n->u.concat.n[i + 1],
+						(n->u.concat.count - i - 1) * sizeof n->u.concat.n[i]);
+				}
+
+				n->u.concat.count--;
+				continue;
+			}
+
+			i++;
+		}
+
+		if (n->u.concat.count == 0) {
+			free(n->u.concat.n);
+			n->type = AST_EXPR_EMPTY;
+			return 1;
+		}
+
+		if (n->u.concat.count == 1) {
+			void *p = n->u.concat.n, *q = n->u.concat.n[0];
+			*n = *n->u.concat.n[0];
+			free(p);
+			free(q);
+			return 1;
+		}
+
 		return 1;
 	}
 
@@ -540,6 +571,37 @@ flatten(struct ast_expr *n)
 			if (!flatten(n->u.alt.n[i])) {
 				return 0;
 			}
+		}
+
+		/* remove empty children; these have no semantic effect */
+		for (i = 0; i < n->u.alt.count; ) {
+			if (n->u.alt.n[i]->type == AST_EXPR_EMPTY) {
+				ast_expr_free(n->u.alt.n[i]);
+
+				if (i + 1 < n->u.alt.count) {
+					memmove(&n->u.alt.n[i], &n->u.alt.n[i + 1],
+						(n->u.alt.count - i - 1) * sizeof n->u.alt.n[i]);
+				}
+
+				n->u.alt.count--;
+				continue;
+			}
+
+			i++;
+		}
+
+		if (n->u.alt.count == 0) {
+			free(n->u.alt.n);
+			n->type = AST_EXPR_EMPTY;
+			return 1;
+		}
+
+		if (n->u.alt.count == 1) {
+			void *p = n->u.alt.n, *q = n->u.alt.n[0];
+			*n = *n->u.alt.n[0];
+			free(p);
+			free(q);
+			return 1;
 		}
 
 		return 1;

--- a/src/libre/ast_analysis.c
+++ b/src/libre/ast_analysis.c
@@ -567,11 +567,11 @@ collect_chain(size_t count, struct ast_expr *doomed)
 			return res;
 		}
 
-		dst = ast_make_expr_concat_n(count);
+		dst = ast_make_expr_concat_count(count);
 		if (dst == NULL) {
 			return NULL;
 		}
-		
+
 		for (i = 0; i < count; i++) {
 			struct ast_expr *ndoomed;
 

--- a/src/libre/ast_compile_class.c
+++ b/src/libre/ast_compile_class.c
@@ -417,11 +417,11 @@ comp_iter(struct cc *cc, const struct ast_class *n)
 	assert(n != NULL);
 
 	switch (n->type) {
-	case AST_CLASS_CONCAT_N: {
+	case AST_CLASS_CONCAT: {
 		size_t i;
 
-		for (i = 0; i < n->u.concat_n.count; i++) {
-			if (!comp_iter(cc, n->u.concat_n.n[i])) {
+		for (i = 0; i < n->u.concat.count; i++) {
+			if (!comp_iter(cc, n->u.concat.n[i])) {
 				return 0;
 			}
 		}

--- a/src/libre/ast_compile_class.c
+++ b/src/libre/ast_compile_class.c
@@ -417,15 +417,6 @@ comp_iter(struct cc *cc, const struct ast_class *n)
 	assert(n != NULL);
 
 	switch (n->type) {
-	case AST_CLASS_CONCAT:
-		if (!comp_iter(cc, n->u.concat.l)) {
-			return 0;
-		}
-		if (!comp_iter(cc, n->u.concat.r)) {
-			return 0;
-		}
-		break;
-
 	case AST_CLASS_CONCAT_N: {
 		size_t i;
 

--- a/src/libre/ast_compile_class.c
+++ b/src/libre/ast_compile_class.c
@@ -426,6 +426,17 @@ comp_iter(struct cc *cc, const struct ast_class *n)
 		}
 		break;
 
+	case AST_CLASS_CONCAT_N: {
+		size_t i;
+
+		for (i = 0; i < n->u.concat_n.count; i++) {
+			if (!comp_iter(cc, n->u.concat_n.n[i])) {
+				return 0;
+			}
+		}
+		break;
+	}
+
 	case AST_CLASS_LITERAL:
 		if (!cc_add_char(cc, n->u.literal.c)) {
 			return 0;

--- a/src/libre/ast_compile_expr.c
+++ b/src/libre/ast_compile_expr.c
@@ -621,7 +621,7 @@ comp_iter(struct comp_env *env,
 
 		const size_t count = n->u.alt_n.count;
 
-		assert(count > 1);
+		assert(count >= 1);
 
 		for (i = 0; i < count; i++) {
 			/*

--- a/src/libre/ast_compile_expr.c
+++ b/src/libre/ast_compile_expr.c
@@ -173,7 +173,7 @@ can_have_backward_epsilon_edge(const struct ast_expr *e)
 	case AST_EXPR_LITERAL:
 	case AST_EXPR_FLAGS:
 	case AST_EXPR_CLASS:
-	case AST_EXPR_ALT_N:
+	case AST_EXPR_ALT:
 	case AST_EXPR_ANCHOR:
 		/* These nodes cannot have a backward epsilon edge */
 		return 0;
@@ -267,8 +267,8 @@ decide_linking(struct comp_env *env,
 	case AST_EXPR_ANY:
 	case AST_EXPR_CLASS:
 
-	case AST_EXPR_CONCAT_N:
-	case AST_EXPR_ALT_N:
+	case AST_EXPR_CONCAT:
+	case AST_EXPR_ALT:
 	case AST_EXPR_REPEATED:
 	case AST_EXPR_FLAGS:
 	case AST_EXPR_TOMBSTONE:
@@ -550,14 +550,14 @@ comp_iter(struct comp_env *env,
 		EPSILON(x, y);
 		break;
 
-	case AST_EXPR_CONCAT_N:
+	case AST_EXPR_CONCAT:
 	{
 		struct fsm_state *z, *right;
 		struct fsm_state *curr_x;
 		enum re_flags saved;
 		size_t i;
 
-		const size_t count  = n->u.concat_n.count;
+		const size_t count  = n->u.concat.count;
 
 		curr_x = x;
 		saved  = env->flags;
@@ -567,10 +567,10 @@ comp_iter(struct comp_env *env,
 		NEWSTATE(z);
 
 		for (i = 0; i < count; i++) {
-			struct ast_expr *curr = n->u.concat_n.n[i];
+			struct ast_expr *curr = n->u.concat.n[i];
 			struct ast_expr *next = i == count - 1
 				? NULL
-				: n->u.concat_n.n[i + 1];
+				: n->u.concat.n[i + 1];
 
 			if (curr->type == AST_EXPR_FLAGS) {
 				/*
@@ -615,11 +615,11 @@ comp_iter(struct comp_env *env,
 		break;
 	}
 
-	case AST_EXPR_ALT_N:
+	case AST_EXPR_ALT:
 	{
 		size_t i;
 
-		const size_t count = n->u.alt_n.count;
+		const size_t count = n->u.alt.count;
 
 		assert(count >= 1);
 
@@ -629,7 +629,7 @@ comp_iter(struct comp_env *env,
 			 * epsilons when necessary, so there isn't much
 			 * more to do here.
 			 */
-			RECURSE(x, y, n->u.alt_n.n[i]);
+			RECURSE(x, y, n->u.alt.n[i]);
 		}		
 		break;
 	}

--- a/src/libre/dialect/glob/parser.c
+++ b/src/libre/dialect/glob/parser.c
@@ -220,7 +220,7 @@
 
 /* BEGINNING OF FUNCTION DECLARATIONS */
 
-static void p_list_Hof_Hnodes(flags, lex_state, act_state, err, t_ast__expr *);
+static void p_list_Hof_Hnodes(flags, lex_state, act_state, err, t_ast__expr);
 extern void p_re__glob(flags, lex_state, act_state, err, t_ast__expr *);
 
 /* BEGINNING OF STATIC VARIABLES */
@@ -229,17 +229,16 @@ extern void p_re__glob(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF FUNCTION DEFINITIONS */
 
 static void
-p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
+p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr ZIcat)
 {
-	t_ast__expr ZInode;
-
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 		return;
 	}
+ZL2_list_Hof_Hnodes:;
 	{
 		t_ast__expr ZIl;
 
-		/* BEGINNING OF INLINE: 99 */
+		/* BEGINNING OF INLINE: 102 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY):
@@ -266,7 +265,7 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 			goto ZL1;
 		}
 	
-#line 270 "src/libre/dialect/glob/parser.c"
+#line 269 "src/libre/dialect/glob/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-any */
 				}
@@ -278,8 +277,8 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 					/* BEGINNING OF INLINE: list-of-nodes::literal */
 					{
 						{
-							t_pos ZI93;
-							t_pos ZI94;
+							t_pos ZI96;
+							t_pos ZI97;
 
 							switch (CURRENT_TERMINAL) {
 							case (TOK_CHAR):
@@ -290,12 +289,12 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI93 = lex_state->lx.start;
-		ZI94   = lex_state->lx.end;
+		ZI96 = lex_state->lx.start;
+		ZI97   = lex_state->lx.end;
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 299 "src/libre/dialect/glob/parser.c"
+#line 298 "src/libre/dialect/glob/parser.c"
 								}
 								/* END OF EXTRACT: CHAR */
 								break;
@@ -315,7 +314,7 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 			goto ZL1;
 		}
 	
-#line 319 "src/libre/dialect/glob/parser.c"
+#line 318 "src/libre/dialect/glob/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-literal */
 				}
@@ -347,7 +346,7 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 			goto ZL1;
 		}
 	
-#line 351 "src/libre/dialect/glob/parser.c"
+#line 350 "src/libre/dialect/glob/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-any */
 					/* BEGINNING OF ACTION: atom-kleene */
@@ -356,7 +355,7 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 360 "src/libre/dialect/glob/parser.c"
+#line 359 "src/libre/dialect/glob/parser.c"
 					}
 					/* END OF ACTION: atom-kleene */
 					/* BEGINNING OF ACTION: ast-make-expr-atom */
@@ -369,7 +368,7 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 			goto ZL1;
 		}
 	
-#line 373 "src/libre/dialect/glob/parser.c"
+#line 372 "src/libre/dialect/glob/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-atom */
 				}
@@ -378,73 +377,38 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 99 */
-		/* BEGINNING OF INLINE: 102 */
+		/* END OF INLINE: 102 */
+		/* BEGINNING OF ACTION: ast-add-expr-concat */
+		{
+#line 725 "src/libre/parser.act"
+
+		if (!ast_add_expr_concat((ZIcat), (ZIl))) {
+			goto ZL1;
+		}
+	
+#line 390 "src/libre/dialect/glob/parser.c"
+		}
+		/* END OF ACTION: ast-add-expr-concat */
+		/* BEGINNING OF INLINE: 105 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_MANY): case (TOK_CHAR):
 				{
-					t_ast__expr ZIr;
-
-					p_list_Hof_Hnodes (flags, lex_state, act_state, err, &ZIr);
-					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-						RESTORE_LEXER;
-						goto ZL1;
-					}
-					/* BEGINNING OF ACTION: ast-make-expr-concat */
-					{
-#line 632 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_concat((ZIl), (ZIr));
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 404 "src/libre/dialect/glob/parser.c"
-					}
-					/* END OF ACTION: ast-make-expr-concat */
+					/* BEGINNING OF INLINE: list-of-nodes */
+					goto ZL2_list_Hof_Hnodes;
+					/* END OF INLINE: list-of-nodes */
 				}
-				break;
+				/*UNREACHED*/
 			default:
-				{
-					t_ast__expr ZIr;
-
-					/* BEGINNING OF ACTION: ast-make-expr-empty */
-					{
-#line 625 "src/libre/parser.act"
-
-		(ZIr) = ast_make_expr_empty();
-		if ((ZIr) == NULL) {
-			goto ZL1;
-		}
-	
-#line 422 "src/libre/dialect/glob/parser.c"
-					}
-					/* END OF ACTION: ast-make-expr-empty */
-					/* BEGINNING OF ACTION: ast-make-expr-concat */
-					{
-#line 632 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_concat((ZIl), (ZIr));
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 434 "src/libre/dialect/glob/parser.c"
-					}
-					/* END OF ACTION: ast-make-expr-concat */
-				}
 				break;
 			}
 		}
-		/* END OF INLINE: 102 */
+		/* END OF INLINE: 105 */
 	}
-	goto ZL0;
+	return;
 ZL1:;
 	SAVE_LEXER ((ERROR_TERMINAL));
 	return;
-ZL0:;
-	*ZOnode = ZInode;
 }
 
 void
@@ -456,12 +420,24 @@ p_re__glob(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 105 */
+		/* BEGINNING OF INLINE: 108 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_MANY): case (TOK_CHAR):
 				{
-					p_list_Hof_Hnodes (flags, lex_state, act_state, err, &ZInode);
+					/* BEGINNING OF ACTION: ast-make-expr-concat */
+					{
+#line 632 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_concat();
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 438 "src/libre/dialect/glob/parser.c"
+					}
+					/* END OF ACTION: ast-make-expr-concat */
+					p_list_Hof_Hnodes (flags, lex_state, act_state, err, ZInode);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL1;
@@ -479,15 +455,15 @@ p_re__glob(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 			goto ZL1;
 		}
 	
-#line 483 "src/libre/dialect/glob/parser.c"
+#line 459 "src/libre/dialect/glob/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-empty */
 				}
 				break;
 			}
 		}
-		/* END OF INLINE: 105 */
-		/* BEGINNING OF INLINE: 106 */
+		/* END OF INLINE: 108 */
+		/* BEGINNING OF INLINE: 109 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -510,13 +486,13 @@ p_re__glob(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 		}
 		goto ZL1;
 	
-#line 514 "src/libre/dialect/glob/parser.c"
+#line 490 "src/libre/dialect/glob/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 106 */
+		/* END OF INLINE: 109 */
 	}
 	goto ZL0;
 ZL1:;
@@ -528,7 +504,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 960 "src/libre/parser.act"
+#line 978 "src/libre/parser.act"
 
 
 	static int
@@ -672,6 +648,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 676 "src/libre/dialect/glob/parser.c"
+#line 652 "src/libre/dialect/glob/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/glob/parser.h
+++ b/src/libre/dialect/glob/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__glob(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 962 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/glob/parser.h"

--- a/src/libre/dialect/glob/parser.sid
+++ b/src/libre/dialect/glob/parser.sid
@@ -73,7 +73,7 @@
 
 	<ast-make-expr-empty>:         ()                       -> (:ast_expr);
 	<ast-make-expr-literal>:       (:char)                  -> (:ast_expr);
-	<ast-make-expr-concat>:        (:ast_expr, :ast_expr)   -> (:ast_expr);
+	<ast-make-expr-concat>:        ()                       -> (:ast_expr);
 	!<ast-make-expr-alt>:          (:ast_expr, :ast_expr)   -> (:ast_expr);
 	<ast-make-expr-any>:           ()                       -> (:ast_expr);
 	<ast-make-expr-atom>:          (:ast_expr, :ast_count)  -> (:ast_expr);
@@ -83,6 +83,8 @@
 	!<ast-make-expr-re-flags>:     (:re_flags, :re_flags)   -> (:ast_expr);
 	!<ast-make-expr-anchor-start>: ()                       -> (:ast_expr);
 	!<ast-make-expr-anchor-end>:   ()                       -> (:ast_expr);
+
+	<ast-add-expr-concat>: (:ast_expr, :ast_expr) -> ();
 
 	!<ast-make-class-concat>:      (:ast_class, :ast_class) -> (:ast_class);
 	!<ast-make-class-literal>:     (:char)                  -> (:ast_class);
@@ -111,7 +113,7 @@
 	!<mark-range>: (:pos, :pos) -> ();
 	!<mark-count>: (:pos, :pos) -> ();
 
-	list-of-nodes: () -> (node :ast_expr) [
+	list-of-nodes: (cat :ast_expr) -> () [
 		literal: () -> (c :char) = {
 			(c, !, !) = CHAR;
 		};
@@ -137,18 +139,19 @@
 			l = <ast-make-expr-atom>(e, c);
 		};
 
+		<ast-add-expr-concat>(cat, l);
+
 		{
-			r = list-of-nodes();
-			node = <ast-make-expr-concat>(l, r);
+			list-of-nodes(cat);
 		||
-			r = <ast-make-expr-empty>;
-			node = <ast-make-expr-concat>(l, r);
+			$;
 		};
 	};
 
 	re_glob: () -> (node :ast_expr) = {
 		{
-			node = list-of-nodes();
+			node = <ast-make-expr-concat>;
+			list-of-nodes(node);
 		||
 			node = <ast-make-expr-empty>();
 		};

--- a/src/libre/dialect/glob/parser.sid
+++ b/src/libre/dialect/glob/parser.sid
@@ -87,7 +87,7 @@
 	<ast-add-expr-concat>: (:ast_expr, :ast_expr) -> ();
 	!<ast-add-expr-alt>:   (:ast_expr, :ast_expr) -> ();
 
-	!<ast-make-class-concat>:      (:ast_class, :ast_class) -> (:ast_class);
+	!<ast-make-class-concat>:      ()                       -> (:ast_class);
 	!<ast-make-class-literal>:     (:char)                  -> (:ast_class);
 	!<ast-make-class-range>:       (:endpoint, :pos, :endpoint, :pos) -> (:ast_class);
 	!<ast-make-class-named>:       (:ast_class_id)          -> (:ast_class);
@@ -97,6 +97,8 @@
 	!<ast-make-class-flag-invert>: () -> (:ast_class);
 	!<ast-make-class-flag-minus>:  () -> (:ast_class);
 	!<ast-make-class-flag-invert-minus>: () -> (:ast_class);
+
+	!<ast-add-class-concat>: (:ast_class, :ast_class) -> ();
 
 	!<err-expected-term>;
 	!<err-expected-count>;

--- a/src/libre/dialect/glob/parser.sid
+++ b/src/libre/dialect/glob/parser.sid
@@ -74,7 +74,7 @@
 	<ast-make-expr-empty>:         ()                       -> (:ast_expr);
 	<ast-make-expr-literal>:       (:char)                  -> (:ast_expr);
 	<ast-make-expr-concat>:        ()                       -> (:ast_expr);
-	!<ast-make-expr-alt>:          (:ast_expr, :ast_expr)   -> (:ast_expr);
+	!<ast-make-expr-alt>:          ()                       -> (:ast_expr);
 	<ast-make-expr-any>:           ()                       -> (:ast_expr);
 	<ast-make-expr-atom>:          (:ast_expr, :ast_count)  -> (:ast_expr);
 	!<ast-make-expr-atom-any>:     (:ast_count)             -> (:ast_expr);
@@ -85,6 +85,7 @@
 	!<ast-make-expr-anchor-end>:   ()                       -> (:ast_expr);
 
 	<ast-add-expr-concat>: (:ast_expr, :ast_expr) -> ();
+	!<ast-add-expr-alt>:   (:ast_expr, :ast_expr) -> ();
 
 	!<ast-make-class-concat>:      (:ast_class, :ast_class) -> (:ast_class);
 	!<ast-make-class-literal>:     (:char)                  -> (:ast_class);

--- a/src/libre/dialect/like/parser.c
+++ b/src/libre/dialect/like/parser.c
@@ -220,7 +220,7 @@
 
 /* BEGINNING OF FUNCTION DECLARATIONS */
 
-static void p_list_Hof_Hnodes(flags, lex_state, act_state, err, t_ast__expr *);
+static void p_list_Hof_Hnodes(flags, lex_state, act_state, err, t_ast__expr);
 extern void p_re__like(flags, lex_state, act_state, err, t_ast__expr *);
 
 /* BEGINNING OF STATIC VARIABLES */
@@ -229,17 +229,16 @@ extern void p_re__like(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF FUNCTION DEFINITIONS */
 
 static void
-p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
+p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr ZIcat)
 {
-	t_ast__expr ZInode;
-
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 		return;
 	}
+ZL2_list_Hof_Hnodes:;
 	{
 		t_ast__expr ZIl;
 
-		/* BEGINNING OF INLINE: 99 */
+		/* BEGINNING OF INLINE: 102 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY):
@@ -266,7 +265,7 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 			goto ZL1;
 		}
 	
-#line 270 "src/libre/dialect/like/parser.c"
+#line 269 "src/libre/dialect/like/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-any */
 				}
@@ -278,8 +277,8 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 					/* BEGINNING OF INLINE: list-of-nodes::literal */
 					{
 						{
-							t_pos ZI93;
-							t_pos ZI94;
+							t_pos ZI96;
+							t_pos ZI97;
 
 							switch (CURRENT_TERMINAL) {
 							case (TOK_CHAR):
@@ -290,12 +289,12 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI93 = lex_state->lx.start;
-		ZI94   = lex_state->lx.end;
+		ZI96 = lex_state->lx.start;
+		ZI97   = lex_state->lx.end;
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 299 "src/libre/dialect/like/parser.c"
+#line 298 "src/libre/dialect/like/parser.c"
 								}
 								/* END OF EXTRACT: CHAR */
 								break;
@@ -315,7 +314,7 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 			goto ZL1;
 		}
 	
-#line 319 "src/libre/dialect/like/parser.c"
+#line 318 "src/libre/dialect/like/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-literal */
 				}
@@ -347,7 +346,7 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 			goto ZL1;
 		}
 	
-#line 351 "src/libre/dialect/like/parser.c"
+#line 350 "src/libre/dialect/like/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-any */
 					/* BEGINNING OF ACTION: atom-kleene */
@@ -356,7 +355,7 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 360 "src/libre/dialect/like/parser.c"
+#line 359 "src/libre/dialect/like/parser.c"
 					}
 					/* END OF ACTION: atom-kleene */
 					/* BEGINNING OF ACTION: ast-make-expr-atom */
@@ -369,7 +368,7 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 			goto ZL1;
 		}
 	
-#line 373 "src/libre/dialect/like/parser.c"
+#line 372 "src/libre/dialect/like/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-atom */
 				}
@@ -378,73 +377,38 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 99 */
-		/* BEGINNING OF INLINE: 102 */
+		/* END OF INLINE: 102 */
+		/* BEGINNING OF ACTION: ast-add-expr-concat */
+		{
+#line 725 "src/libre/parser.act"
+
+		if (!ast_add_expr_concat((ZIcat), (ZIl))) {
+			goto ZL1;
+		}
+	
+#line 390 "src/libre/dialect/like/parser.c"
+		}
+		/* END OF ACTION: ast-add-expr-concat */
+		/* BEGINNING OF INLINE: 105 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_MANY): case (TOK_CHAR):
 				{
-					t_ast__expr ZIr;
-
-					p_list_Hof_Hnodes (flags, lex_state, act_state, err, &ZIr);
-					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-						RESTORE_LEXER;
-						goto ZL1;
-					}
-					/* BEGINNING OF ACTION: ast-make-expr-concat */
-					{
-#line 632 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_concat((ZIl), (ZIr));
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 404 "src/libre/dialect/like/parser.c"
-					}
-					/* END OF ACTION: ast-make-expr-concat */
+					/* BEGINNING OF INLINE: list-of-nodes */
+					goto ZL2_list_Hof_Hnodes;
+					/* END OF INLINE: list-of-nodes */
 				}
-				break;
+				/*UNREACHED*/
 			default:
-				{
-					t_ast__expr ZIr;
-
-					/* BEGINNING OF ACTION: ast-make-expr-empty */
-					{
-#line 625 "src/libre/parser.act"
-
-		(ZIr) = ast_make_expr_empty();
-		if ((ZIr) == NULL) {
-			goto ZL1;
-		}
-	
-#line 422 "src/libre/dialect/like/parser.c"
-					}
-					/* END OF ACTION: ast-make-expr-empty */
-					/* BEGINNING OF ACTION: ast-make-expr-concat */
-					{
-#line 632 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_concat((ZIl), (ZIr));
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 434 "src/libre/dialect/like/parser.c"
-					}
-					/* END OF ACTION: ast-make-expr-concat */
-				}
 				break;
 			}
 		}
-		/* END OF INLINE: 102 */
+		/* END OF INLINE: 105 */
 	}
-	goto ZL0;
+	return;
 ZL1:;
 	SAVE_LEXER ((ERROR_TERMINAL));
 	return;
-ZL0:;
-	*ZOnode = ZInode;
 }
 
 void
@@ -456,12 +420,24 @@ p_re__like(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 105 */
+		/* BEGINNING OF INLINE: 108 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_MANY): case (TOK_CHAR):
 				{
-					p_list_Hof_Hnodes (flags, lex_state, act_state, err, &ZInode);
+					/* BEGINNING OF ACTION: ast-make-expr-concat */
+					{
+#line 632 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_concat();
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 438 "src/libre/dialect/like/parser.c"
+					}
+					/* END OF ACTION: ast-make-expr-concat */
+					p_list_Hof_Hnodes (flags, lex_state, act_state, err, ZInode);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL1;
@@ -479,15 +455,15 @@ p_re__like(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 			goto ZL1;
 		}
 	
-#line 483 "src/libre/dialect/like/parser.c"
+#line 459 "src/libre/dialect/like/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-empty */
 				}
 				break;
 			}
 		}
-		/* END OF INLINE: 105 */
-		/* BEGINNING OF INLINE: 106 */
+		/* END OF INLINE: 108 */
+		/* BEGINNING OF INLINE: 109 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -510,13 +486,13 @@ p_re__like(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 		}
 		goto ZL1;
 	
-#line 514 "src/libre/dialect/like/parser.c"
+#line 490 "src/libre/dialect/like/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 106 */
+		/* END OF INLINE: 109 */
 	}
 	goto ZL0;
 ZL1:;
@@ -528,7 +504,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 960 "src/libre/parser.act"
+#line 978 "src/libre/parser.act"
 
 
 	static int
@@ -672,6 +648,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 676 "src/libre/dialect/like/parser.c"
+#line 652 "src/libre/dialect/like/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/like/parser.h
+++ b/src/libre/dialect/like/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__like(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 962 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/like/parser.h"

--- a/src/libre/dialect/like/parser.sid
+++ b/src/libre/dialect/like/parser.sid
@@ -73,7 +73,7 @@
 
 	<ast-make-expr-empty>:         ()                       -> (:ast_expr);
 	<ast-make-expr-literal>:       (:char)                  -> (:ast_expr);
-	<ast-make-expr-concat>:        (:ast_expr, :ast_expr)   -> (:ast_expr);
+	<ast-make-expr-concat>:        ()                       -> (:ast_expr);
 	!<ast-make-expr-alt>:          (:ast_expr, :ast_expr)   -> (:ast_expr);
 	<ast-make-expr-any>:           ()                       -> (:ast_expr);
 	<ast-make-expr-atom>:          (:ast_expr, :ast_count)  -> (:ast_expr);
@@ -83,6 +83,8 @@
 	!<ast-make-expr-re-flags>:     (:re_flags, :re_flags)   -> (:ast_expr);
 	!<ast-make-expr-anchor-start>: ()                       -> (:ast_expr);
 	!<ast-make-expr-anchor-end>:   ()                       -> (:ast_expr);
+
+	<ast-add-expr-concat>: (:ast_expr, :ast_expr) -> ();
 
 	!<ast-make-class-concat>:      (:ast_class, :ast_class) -> (:ast_class);
 	!<ast-make-class-literal>:     (:char)                  -> (:ast_class);
@@ -111,7 +113,7 @@
 	!<mark-range>: (:pos, :pos) -> ();
 	!<mark-count>: (:pos, :pos) -> ();
 
-	list-of-nodes: () -> (node :ast_expr) [
+	list-of-nodes: (cat :ast_expr) -> () [
 		literal: () -> (c :char) = {
 			(c, !, !) = CHAR;
 		};
@@ -137,18 +139,19 @@
 			l = <ast-make-expr-atom>(e, c);
 		};
 
+		<ast-add-expr-concat>(cat, l);
+
 		{
-			r = list-of-nodes();
-			node = <ast-make-expr-concat>(l, r);
+			list-of-nodes(cat);
 		||
-			r = <ast-make-expr-empty>;
-			node = <ast-make-expr-concat>(l, r);
+			$;
 		};
 	};
 
 	re_like: () -> (node :ast_expr) = {
 		{
-			node = list-of-nodes();
+			node = <ast-make-expr-concat>;
+			list-of-nodes(node);
 		||
 			node = <ast-make-expr-empty>();
 		};

--- a/src/libre/dialect/like/parser.sid
+++ b/src/libre/dialect/like/parser.sid
@@ -87,7 +87,7 @@
 	<ast-add-expr-concat>: (:ast_expr, :ast_expr) -> ();
 	!<ast-add-expr-alt>:   (:ast_expr, :ast_expr) -> ();
 
-	!<ast-make-class-concat>:      (:ast_class, :ast_class) -> (:ast_class);
+	!<ast-make-class-concat>:      ()                       -> (:ast_class);
 	!<ast-make-class-literal>:     (:char)                  -> (:ast_class);
 	!<ast-make-class-range>:       (:endpoint, :pos, :endpoint, :pos) -> (:ast_class);
 	!<ast-make-class-named>:       (:ast_class_id) -> (:ast_class);
@@ -97,6 +97,8 @@
 	!<ast-make-class-flag-invert>:       () -> (:ast_class);
 	!<ast-make-class-flag-minus>:        () -> (:ast_class);
 	!<ast-make-class-flag-invert-minus>: () -> (:ast_class);
+
+	!<ast-add-class-concat>: (:ast_class, :ast_class) -> ();
 
 	!<err-expected-term>;
 	!<err-expected-count>;

--- a/src/libre/dialect/like/parser.sid
+++ b/src/libre/dialect/like/parser.sid
@@ -74,7 +74,7 @@
 	<ast-make-expr-empty>:         ()                       -> (:ast_expr);
 	<ast-make-expr-literal>:       (:char)                  -> (:ast_expr);
 	<ast-make-expr-concat>:        ()                       -> (:ast_expr);
-	!<ast-make-expr-alt>:          (:ast_expr, :ast_expr)   -> (:ast_expr);
+	!<ast-make-expr-alt>:          ()                       -> (:ast_expr);
 	<ast-make-expr-any>:           ()                       -> (:ast_expr);
 	<ast-make-expr-atom>:          (:ast_expr, :ast_count)  -> (:ast_expr);
 	!<ast-make-expr-atom-any>:     (:ast_count)             -> (:ast_expr);
@@ -85,6 +85,7 @@
 	!<ast-make-expr-anchor-end>:   ()                       -> (:ast_expr);
 
 	<ast-add-expr-concat>: (:ast_expr, :ast_expr) -> ();
+	!<ast-add-expr-alt>:   (:ast_expr, :ast_expr) -> ();
 
 	!<ast-make-class-concat>:      (:ast_class, :ast_class) -> (:ast_class);
 	!<ast-make-class-literal>:     (:char)                  -> (:ast_class);

--- a/src/libre/dialect/literal/parser.c
+++ b/src/libre/dialect/literal/parser.c
@@ -220,7 +220,7 @@
 
 /* BEGINNING OF FUNCTION DECLARATIONS */
 
-static void p_list_Hof_Hnodes(flags, lex_state, act_state, err, t_ast__expr *);
+static void p_list_Hof_Hnodes(flags, lex_state, act_state, err, t_ast__expr);
 extern void p_re__literal(flags, lex_state, act_state, err, t_ast__expr *);
 
 /* BEGINNING OF STATIC VARIABLES */
@@ -229,13 +229,12 @@ extern void p_re__literal(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF FUNCTION DEFINITIONS */
 
 static void
-p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
+p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr ZIcat)
 {
-	t_ast__expr ZInode;
-
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 		return;
 	}
+ZL2_list_Hof_Hnodes:;
 	{
 		t_char ZIc;
 		t_ast__expr ZIl;
@@ -243,8 +242,8 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 		/* BEGINNING OF INLINE: list-of-nodes::literal */
 		{
 			{
-				t_pos ZI93;
-				t_pos ZI94;
+				t_pos ZI96;
+				t_pos ZI97;
 
 				switch (CURRENT_TERMINAL) {
 				case (TOK_CHAR):
@@ -255,12 +254,12 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI93 = lex_state->lx.start;
-		ZI94   = lex_state->lx.end;
+		ZI96 = lex_state->lx.start;
+		ZI97   = lex_state->lx.end;
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 264 "src/libre/dialect/literal/parser.c"
+#line 263 "src/libre/dialect/literal/parser.c"
 					}
 					/* END OF EXTRACT: CHAR */
 					break;
@@ -280,75 +279,40 @@ p_list_Hof_Hnodes(flags flags, lex_state lex_state, act_state act_state, err err
 			goto ZL1;
 		}
 	
-#line 284 "src/libre/dialect/literal/parser.c"
+#line 283 "src/libre/dialect/literal/parser.c"
 		}
 		/* END OF ACTION: ast-make-expr-literal */
-		/* BEGINNING OF INLINE: 96 */
+		/* BEGINNING OF ACTION: ast-add-expr-concat */
+		{
+#line 725 "src/libre/parser.act"
+
+		if (!ast_add_expr_concat((ZIcat), (ZIl))) {
+			goto ZL1;
+		}
+	
+#line 294 "src/libre/dialect/literal/parser.c"
+		}
+		/* END OF ACTION: ast-add-expr-concat */
+		/* BEGINNING OF INLINE: 99 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CHAR):
 				{
-					t_ast__expr ZIr;
-
-					p_list_Hof_Hnodes (flags, lex_state, act_state, err, &ZIr);
-					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-						RESTORE_LEXER;
-						goto ZL1;
-					}
-					/* BEGINNING OF ACTION: ast-make-expr-concat */
-					{
-#line 632 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_concat((ZIl), (ZIr));
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 308 "src/libre/dialect/literal/parser.c"
-					}
-					/* END OF ACTION: ast-make-expr-concat */
+					/* BEGINNING OF INLINE: list-of-nodes */
+					goto ZL2_list_Hof_Hnodes;
+					/* END OF INLINE: list-of-nodes */
 				}
-				break;
+				/*UNREACHED*/
 			default:
-				{
-					t_ast__expr ZIr;
-
-					/* BEGINNING OF ACTION: ast-make-expr-empty */
-					{
-#line 625 "src/libre/parser.act"
-
-		(ZIr) = ast_make_expr_empty();
-		if ((ZIr) == NULL) {
-			goto ZL1;
-		}
-	
-#line 326 "src/libre/dialect/literal/parser.c"
-					}
-					/* END OF ACTION: ast-make-expr-empty */
-					/* BEGINNING OF ACTION: ast-make-expr-concat */
-					{
-#line 632 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_concat((ZIl), (ZIr));
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 338 "src/libre/dialect/literal/parser.c"
-					}
-					/* END OF ACTION: ast-make-expr-concat */
-				}
 				break;
 			}
 		}
-		/* END OF INLINE: 96 */
+		/* END OF INLINE: 99 */
 	}
-	goto ZL0;
+	return;
 ZL1:;
 	SAVE_LEXER ((ERROR_TERMINAL));
 	return;
-ZL0:;
-	*ZOnode = ZInode;
 }
 
 void
@@ -360,12 +324,24 @@ p_re__literal(flags flags, lex_state lex_state, act_state act_state, err err, t_
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 99 */
+		/* BEGINNING OF INLINE: 102 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CHAR):
 				{
-					p_list_Hof_Hnodes (flags, lex_state, act_state, err, &ZInode);
+					/* BEGINNING OF ACTION: ast-make-expr-concat */
+					{
+#line 632 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_concat();
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 342 "src/libre/dialect/literal/parser.c"
+					}
+					/* END OF ACTION: ast-make-expr-concat */
+					p_list_Hof_Hnodes (flags, lex_state, act_state, err, ZInode);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL1;
@@ -383,15 +359,15 @@ p_re__literal(flags flags, lex_state lex_state, act_state act_state, err err, t_
 			goto ZL1;
 		}
 	
-#line 387 "src/libre/dialect/literal/parser.c"
+#line 363 "src/libre/dialect/literal/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-empty */
 				}
 				break;
 			}
 		}
-		/* END OF INLINE: 99 */
-		/* BEGINNING OF INLINE: 100 */
+		/* END OF INLINE: 102 */
+		/* BEGINNING OF INLINE: 103 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -414,13 +390,13 @@ p_re__literal(flags flags, lex_state lex_state, act_state act_state, err err, t_
 		}
 		goto ZL1;
 	
-#line 418 "src/libre/dialect/literal/parser.c"
+#line 394 "src/libre/dialect/literal/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 100 */
+		/* END OF INLINE: 103 */
 	}
 	goto ZL0;
 ZL1:;
@@ -432,7 +408,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 960 "src/libre/parser.act"
+#line 978 "src/libre/parser.act"
 
 
 	static int
@@ -576,6 +552,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 580 "src/libre/dialect/literal/parser.c"
+#line 556 "src/libre/dialect/literal/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/literal/parser.h
+++ b/src/libre/dialect/literal/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__literal(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 962 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/literal/parser.h"

--- a/src/libre/dialect/literal/parser.sid
+++ b/src/libre/dialect/literal/parser.sid
@@ -74,7 +74,7 @@
 	<ast-make-expr-empty>:         ()                       -> (:ast_expr);
 	<ast-make-expr-literal>:       (:char)                  -> (:ast_expr);
 	<ast-make-expr-concat>:        ()                       -> (:ast_expr);
-	!<ast-make-expr-alt>:          (:ast_expr, :ast_expr)   -> (:ast_expr);
+	!<ast-make-expr-alt>:          ()                       -> (:ast_expr);
 	!<ast-make-expr-any>:          ()                       -> (:ast_expr);
 	!<ast-make-expr-atom>:         (:ast_expr, :ast_count)  -> (:ast_expr);
 	!<ast-make-expr-atom-any>:     (:ast_count)             -> (:ast_expr);
@@ -85,6 +85,7 @@
 	!<ast-make-expr-anchor-end>:   ()                       -> (:ast_expr);
 
 	<ast-add-expr-concat>: (:ast_expr, :ast_expr) -> ();
+	!<ast-add-expr-alt>:   (:ast_expr, :ast_expr) -> ();
 
 	!<ast-make-class-concat>:      (:ast_class, :ast_class) -> (:ast_class);
 	!<ast-make-class-literal>:     (:char)                  -> (:ast_class);

--- a/src/libre/dialect/literal/parser.sid
+++ b/src/libre/dialect/literal/parser.sid
@@ -87,7 +87,7 @@
 	<ast-add-expr-concat>: (:ast_expr, :ast_expr) -> ();
 	!<ast-add-expr-alt>:   (:ast_expr, :ast_expr) -> ();
 
-	!<ast-make-class-concat>:      (:ast_class, :ast_class) -> (:ast_class);
+	!<ast-make-class-concat>:      ()                       -> (:ast_class);
 	!<ast-make-class-literal>:     (:char)                  -> (:ast_class);
 	!<ast-make-class-range>:       (:endpoint, :pos, :endpoint, :pos) -> (:ast_class);
 	!<ast-make-class-named>:       (:ast_class_id)          -> (:ast_class);
@@ -97,6 +97,8 @@
 	!<ast-make-class-flag-invert>: () -> (:ast_class);
 	!<ast-make-class-flag-minus>:  () -> (:ast_class);
 	!<ast-make-class-flag-invert-minus>: () -> (:ast_class);
+
+	!<ast-add-class-concat>: (:ast_class, :ast_class) -> ();
 
 	!<err-expected-term>;
 	!<err-expected-count>;

--- a/src/libre/dialect/literal/parser.sid
+++ b/src/libre/dialect/literal/parser.sid
@@ -73,7 +73,7 @@
 
 	<ast-make-expr-empty>:         ()                       -> (:ast_expr);
 	<ast-make-expr-literal>:       (:char)                  -> (:ast_expr);
-	<ast-make-expr-concat>:        (:ast_expr, :ast_expr)   -> (:ast_expr);
+	<ast-make-expr-concat>:        ()                       -> (:ast_expr);
 	!<ast-make-expr-alt>:          (:ast_expr, :ast_expr)   -> (:ast_expr);
 	!<ast-make-expr-any>:          ()                       -> (:ast_expr);
 	!<ast-make-expr-atom>:         (:ast_expr, :ast_count)  -> (:ast_expr);
@@ -83,6 +83,8 @@
 	!<ast-make-expr-re-flags>:     (:re_flags, :re_flags)   -> (:ast_expr);
 	!<ast-make-expr-anchor-start>: ()                       -> (:ast_expr);
 	!<ast-make-expr-anchor-end>:   ()                       -> (:ast_expr);
+
+	<ast-add-expr-concat>: (:ast_expr, :ast_expr) -> ();
 
 	!<ast-make-class-concat>:      (:ast_class, :ast_class) -> (:ast_class);
 	!<ast-make-class-literal>:     (:char)                  -> (:ast_class);
@@ -111,7 +113,7 @@
 	!<mark-range>: (:pos, :pos) -> ();
 	!<mark-count>: (:pos, :pos) -> ();
 
-	list-of-nodes: () -> (node :ast_expr) [
+	list-of-nodes: (cat :ast_expr) -> () [
 		literal: () -> (c :char) = {
 			(c, !, !) = CHAR;
 		};
@@ -119,18 +121,19 @@
 		c = literal();
 		l = <ast-make-expr-literal>(c);
 
+		<ast-add-expr-concat>(cat, l);
+
 		{
-			r = list-of-nodes();
-			node = <ast-make-expr-concat>(l, r);
+			list-of-nodes(cat);
 		||
-			r = <ast-make-expr-empty>;
-			node = <ast-make-expr-concat>(l, r);
+			$;
 		};
 	};
 
 	re_literal: () -> (node :ast_expr) = {
 		{
-			node = list-of-nodes();
+			node = <ast-make-expr-concat>;
+			list-of-nodes(node);
 		||
 			node = <ast-make-expr-empty>();
 		};

--- a/src/libre/dialect/native/parser.c
+++ b/src/libre/dialect/native/parser.c
@@ -220,21 +220,19 @@
 
 /* BEGINNING OF FUNCTION DECLARATIONS */
 
-static void p_expr_C_Cclass_C_Cclass_Hhead(flags, lex_state, act_state, err, t_ast__class *);
+static void p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead(flags, lex_state, act_state, err, t_ast__class);
+static void p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms(flags, lex_state, act_state, err, t_ast__class);
 static void p_expr_C_Cliteral(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_expr_C_Cclass_C_Clist_Hof_Hclass_Hterms(flags, lex_state, act_state, err, t_ast__class *);
+static void p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags, lex_state, act_state, err, t_ast__class *);
+static void p_expr_C_Ccharacter_Hclass(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr(flags, lex_state, act_state, err, t_ast__expr *);
 extern void p_re__native(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_196(flags, lex_state, act_state, err, t_ast__expr *, t_ast__expr *);
-static void p_197(flags, lex_state, act_state, err, t_ast__expr *, t_ast__expr *);
-static void p_expr_C_Cclass_C_Cclass_Hterm(flags, lex_state, act_state, err, t_ast__class *);
-static void p_expr_C_Clist_Hof_Hatoms(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_expr_C_Cclass(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_213(flags, lex_state, act_state, err, t_char *, t_pos *, t_ast__class *);
-static void p_216(flags, lex_state, act_state, err, t_ast__expr *, t_pos *, t_unsigned *, t_ast__expr *);
-static void p_217(flags, lex_state, act_state, err, t_ast__expr *, t_ast__expr *);
-static void p_expr_C_Clist_Hof_Halts(flags, lex_state, act_state, err, t_ast__expr *);
+static void p_expr_C_Clist_Hof_Hatoms(flags, lex_state, act_state, err, t_ast__expr);
+static void p_214(flags, lex_state, act_state, err, t_char *, t_pos *, t_ast__class *);
+static void p_217(flags, lex_state, act_state, err, t_ast__expr *, t_pos *, t_unsigned *, t_ast__expr *);
+static void p_expr_C_Clist_Hof_Halts(flags, lex_state, act_state, err, t_ast__expr);
 static void p_expr_C_Catom(flags, lex_state, act_state, err, t_ast__expr *);
+static void p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed(flags, lex_state, act_state, err, t_ast__class *);
 static void p_expr_C_Calt(flags, lex_state, act_state, err, t_ast__expr *);
 
 /* BEGINNING OF STATIC VARIABLES */
@@ -243,64 +241,157 @@ static void p_expr_C_Calt(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF FUNCTION DEFINITIONS */
 
 static void
-p_expr_C_Cclass_C_Cclass_Hhead(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class *ZOf)
+p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class ZIclass)
 {
-	t_ast__class ZIf;
-
 	switch (CURRENT_TERMINAL) {
 	case (TOK_INVERT):
 		{
-			t_char ZI107;
+			t_char ZI110;
+			t_ast__class ZIf;
 
 			/* BEGINNING OF EXTRACT: INVERT */
 			{
 #line 239 "src/libre/parser.act"
 
-		ZI107 = '^';
+		ZI110 = '^';
 	
-#line 262 "src/libre/dialect/native/parser.c"
+#line 259 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: INVERT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-class-flag-invert */
 			{
-#line 797 "src/libre/parser.act"
+#line 809 "src/libre/parser.act"
 
 		(ZIf) = ast_make_class_flags(AST_CLASS_FLAG_INVERTED);
 		if ((ZIf) == NULL) {
 			goto ZL1;
 		}
 	
-#line 275 "src/libre/dialect/native/parser.c"
+#line 272 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-class-flag-invert */
+			/* BEGINNING OF ACTION: ast-add-class-concat */
+			{
+#line 830 "src/libre/parser.act"
+
+		if (!ast_add_class_concat((ZIclass), (ZIf))) {
+			goto ZL1;
+		}
+	
+#line 283 "src/libre/dialect/native/parser.c"
+			}
+			/* END OF ACTION: ast-add-class-concat */
 		}
 		break;
 	default:
 		{
+			t_ast__class ZIf;
+
 			/* BEGINNING OF ACTION: ast-make-class-flag-none */
 			{
-#line 790 "src/libre/parser.act"
+#line 802 "src/libre/parser.act"
 
 		(ZIf) = ast_make_class_flags(AST_CLASS_FLAG_NONE);
 		if ((ZIf) == NULL) {
 			goto ZL1;
 		}
 	
-#line 291 "src/libre/dialect/native/parser.c"
+#line 301 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-class-flag-none */
+			/* BEGINNING OF ACTION: ast-add-class-concat */
+			{
+#line 830 "src/libre/parser.act"
+
+		if (!ast_add_class_concat((ZIclass), (ZIf))) {
+			goto ZL1;
+		}
+	
+#line 312 "src/libre/dialect/native/parser.c"
+			}
+			/* END OF ACTION: ast-add-class-concat */
 		}
 		break;
 	case (ERROR_TERMINAL):
 		return;
 	}
-	goto ZL0;
+	return;
 ZL1:;
 	SAVE_LEXER ((ERROR_TERMINAL));
 	return;
-ZL0:;
-	*ZOf = ZIf;
+}
+
+static void
+p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class ZIclass)
+{
+	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+		return;
+	}
+ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
+	{
+		/* BEGINNING OF INLINE: 155 */
+		{
+			{
+				t_ast__class ZInode;
+
+				p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm (flags, lex_state, act_state, err, &ZInode);
+				if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+					RESTORE_LEXER;
+					goto ZL4;
+				}
+				/* BEGINNING OF ACTION: ast-add-class-concat */
+				{
+#line 830 "src/libre/parser.act"
+
+		if (!ast_add_class_concat((ZIclass), (ZInode))) {
+			goto ZL4;
+		}
+	
+#line 352 "src/libre/dialect/native/parser.c"
+				}
+				/* END OF ACTION: ast-add-class-concat */
+			}
+			goto ZL3;
+		ZL4:;
+			{
+				/* BEGINNING OF ACTION: err-expected-term */
+				{
+#line 456 "src/libre/parser.act"
+
+		if (err->e == RE_ESUCCESS) {
+			err->e = RE_EXTERM;
+		}
+		goto ZL1;
+	
+#line 368 "src/libre/dialect/native/parser.c"
+				}
+				/* END OF ACTION: err-expected-term */
+			}
+		ZL3:;
+		}
+		/* END OF INLINE: 155 */
+		/* BEGINNING OF INLINE: 156 */
+		{
+			switch (CURRENT_TERMINAL) {
+			case (TOK_NAMED__CLASS): case (TOK_ESC): case (TOK_OCT): case (TOK_HEX):
+			case (TOK_CHAR):
+				{
+					/* BEGINNING OF INLINE: expr::character-class::list-of-class-terms */
+					goto ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms;
+					/* END OF INLINE: expr::character-class::list-of-class-terms */
+				}
+				/*UNREACHED*/
+			default:
+				break;
+			}
+		}
+		/* END OF INLINE: 156 */
+	}
+	return;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
 }
 
 static void
@@ -314,13 +405,13 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 	{
 		t_char ZIc;
 
-		/* BEGINNING OF INLINE: 92 */
+		/* BEGINNING OF INLINE: 95 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CHAR):
 				{
-					t_pos ZI100;
-					t_pos ZI101;
+					t_pos ZI103;
+					t_pos ZI104;
 
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
@@ -329,12 +420,12 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI100 = lex_state->lx.start;
-		ZI101   = lex_state->lx.end;
+		ZI103 = lex_state->lx.start;
+		ZI104   = lex_state->lx.end;
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 338 "src/libre/dialect/native/parser.c"
+#line 429 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: CHAR */
 					ADVANCE_LEXER;
@@ -342,8 +433,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				break;
 			case (TOK_ESC):
 				{
-					t_pos ZI94;
-					t_pos ZI95;
+					t_pos ZI97;
+					t_pos ZI98;
 
 					/* BEGINNING OF EXTRACT: ESC */
 					{
@@ -365,10 +456,10 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		default:             break;
 		}
 
-		ZI94 = lex_state->lx.start;
-		ZI95   = lex_state->lx.end;
+		ZI97 = lex_state->lx.start;
+		ZI98   = lex_state->lx.end;
 	
-#line 372 "src/libre/dialect/native/parser.c"
+#line 463 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: ESC */
 					ADVANCE_LEXER;
@@ -376,8 +467,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				break;
 			case (TOK_HEX):
 				{
-					t_pos ZI98;
-					t_pos ZI99;
+					t_pos ZI101;
+					t_pos ZI102;
 
 					/* BEGINNING OF EXTRACT: HEX */
 					{
@@ -390,8 +481,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		assert(0 == strncmp(lex_state->buf.a, "\\x", 2));
 		assert(strlen(lex_state->buf.a) >= 3);
 
-		ZI98 = lex_state->lx.start;
-		ZI99   = lex_state->lx.end;
+		ZI101 = lex_state->lx.start;
+		ZI102   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -421,7 +512,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 425 "src/libre/dialect/native/parser.c"
+#line 516 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: HEX */
 					ADVANCE_LEXER;
@@ -429,8 +520,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				break;
 			case (TOK_OCT):
 				{
-					t_pos ZI96;
-					t_pos ZI97;
+					t_pos ZI99;
+					t_pos ZI100;
 
 					/* BEGINNING OF EXTRACT: OCT */
 					{
@@ -443,8 +534,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
 		assert(strlen(lex_state->buf.a) >= 2);
 
-		ZI96 = lex_state->lx.start;
-		ZI97   = lex_state->lx.end;
+		ZI99 = lex_state->lx.start;
+		ZI100   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -474,7 +565,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 478 "src/libre/dialect/native/parser.c"
+#line 569 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: OCT */
 					ADVANCE_LEXER;
@@ -484,7 +575,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 92 */
+		/* END OF INLINE: 95 */
 		/* BEGINNING OF ACTION: ast-make-expr-literal */
 		{
 #line 646 "src/libre/parser.act"
@@ -494,7 +585,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 			goto ZL1;
 		}
 	
-#line 498 "src/libre/dialect/native/parser.c"
+#line 589 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-make-expr-literal */
 	}
@@ -507,55 +598,344 @@ ZL0:;
 }
 
 static void
-p_expr_C_Cclass_C_Clist_Hof_Hclass_Hterms(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class *ZOnode)
+p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class *ZOnode)
 {
 	t_ast__class ZInode;
+
+	switch (CURRENT_TERMINAL) {
+	case (TOK_CHAR):
+		{
+			t_char ZI211;
+			t_pos ZI212;
+			t_pos ZI213;
+
+			/* BEGINNING OF EXTRACT: CHAR */
+			{
+#line 401 "src/libre/parser.act"
+
+		/* the first byte may be '\x00' */
+		assert(lex_state->buf.a[1] == '\0');
+
+		ZI212 = lex_state->lx.start;
+		ZI213   = lex_state->lx.end;
+
+		ZI211 = lex_state->buf.a[0];
+	
+#line 625 "src/libre/dialect/native/parser.c"
+			}
+			/* END OF EXTRACT: CHAR */
+			ADVANCE_LEXER;
+			p_214 (flags, lex_state, act_state, err, &ZI211, &ZI212, &ZInode);
+			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+				RESTORE_LEXER;
+				goto ZL1;
+			}
+		}
+		break;
+	case (TOK_ESC):
+		{
+			t_char ZI199;
+			t_pos ZI200;
+			t_pos ZI201;
+
+			/* BEGINNING OF EXTRACT: ESC */
+			{
+#line 274 "src/libre/parser.act"
+
+		assert(lex_state->buf.a[0] == '\\');
+		assert(lex_state->buf.a[1] != '\0');
+		assert(lex_state->buf.a[2] == '\0');
+
+		ZI199 = lex_state->buf.a[1];
+
+		switch (ZI199) {
+		case 'a': ZI199 = '\a'; break;
+		case 'f': ZI199 = '\f'; break;
+		case 'n': ZI199 = '\n'; break;
+		case 'r': ZI199 = '\r'; break;
+		case 't': ZI199 = '\t'; break;
+		case 'v': ZI199 = '\v'; break;
+		default:             break;
+		}
+
+		ZI200 = lex_state->lx.start;
+		ZI201   = lex_state->lx.end;
+	
+#line 665 "src/libre/dialect/native/parser.c"
+			}
+			/* END OF EXTRACT: ESC */
+			ADVANCE_LEXER;
+			p_214 (flags, lex_state, act_state, err, &ZI199, &ZI200, &ZInode);
+			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+				RESTORE_LEXER;
+				goto ZL1;
+			}
+		}
+		break;
+	case (TOK_HEX):
+		{
+			t_char ZI207;
+			t_pos ZI208;
+			t_pos ZI209;
+
+			/* BEGINNING OF EXTRACT: HEX */
+			{
+#line 365 "src/libre/parser.act"
+
+		unsigned long u;
+		char *s, *e;
+		int brace = 0;
+
+		assert(0 == strncmp(lex_state->buf.a, "\\x", 2));
+		assert(strlen(lex_state->buf.a) >= 3);
+
+		ZI208 = lex_state->lx.start;
+		ZI209   = lex_state->lx.end;
+
+		errno = 0;
+
+		s = lex_state->buf.a + 2;
+
+		if (*s == '{') {
+			s++;
+			brace = 1;
+		}
+
+		u = strtoul(s, &e, 16);
+
+		if ((u == ULONG_MAX && errno == ERANGE) || u > UCHAR_MAX) {
+			err->e = RE_EHEXRANGE;
+			snprintdots(err->esc, sizeof err->esc, lex_state->buf.a);
+			goto ZL1;
+		}
+
+		if (brace && *e == '}') {
+			e++;
+		}
+
+		if ((u == ULONG_MAX && errno != 0) || (*e != '\0')) {
+			err->e = RE_EXESC;
+			goto ZL1;
+		}
+
+		ZI207 = (char) (unsigned char) u;
+	
+#line 724 "src/libre/dialect/native/parser.c"
+			}
+			/* END OF EXTRACT: HEX */
+			ADVANCE_LEXER;
+			p_214 (flags, lex_state, act_state, err, &ZI207, &ZI208, &ZInode);
+			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+				RESTORE_LEXER;
+				goto ZL1;
+			}
+		}
+		break;
+	case (TOK_OCT):
+		{
+			t_char ZI203;
+			t_pos ZI204;
+			t_pos ZI205;
+
+			/* BEGINNING OF EXTRACT: OCT */
+			{
+#line 325 "src/libre/parser.act"
+
+		unsigned long u;
+		char *s, *e;
+		int brace = 0;
+
+		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
+		assert(strlen(lex_state->buf.a) >= 2);
+
+		ZI204 = lex_state->lx.start;
+		ZI205   = lex_state->lx.end;
+
+		errno = 0;
+
+		s = lex_state->buf.a + 1;
+
+		if (s[0] == 'o' && s[1] == '{') {
+			s += 2;
+			brace = 1;
+		}
+
+		u = strtoul(s, &e, 8);
+
+		if ((u == ULONG_MAX && errno == ERANGE) || u > UCHAR_MAX) {
+			err->e = RE_EOCTRANGE;
+			snprintdots(err->esc, sizeof err->esc, lex_state->buf.a);
+			goto ZL1;
+		}
+
+		if (brace && *e == '}') {
+			e++;
+		}
+
+		if ((u == ULONG_MAX && errno != 0) || *e != '\0') {
+			err->e = RE_EXESC;
+			goto ZL1;
+		}
+
+		ZI203 = (char) (unsigned char) u;
+	
+#line 783 "src/libre/dialect/native/parser.c"
+			}
+			/* END OF EXTRACT: OCT */
+			ADVANCE_LEXER;
+			p_214 (flags, lex_state, act_state, err, &ZI203, &ZI204, &ZInode);
+			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+				RESTORE_LEXER;
+				goto ZL1;
+			}
+		}
+		break;
+	case (TOK_NAMED__CLASS):
+		{
+			p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed (flags, lex_state, act_state, err, &ZInode);
+			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+				RESTORE_LEXER;
+				goto ZL1;
+			}
+		}
+		break;
+	case (ERROR_TERMINAL):
+		return;
+	default:
+		goto ZL1;
+	}
+	goto ZL0;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+ZL0:;
+	*ZOnode = ZInode;
+}
+
+static void
+p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
+{
+	t_ast__expr ZInode;
 
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 		return;
 	}
 	{
-		t_ast__class ZIl;
+		t_pos ZIstart;
+		t_pos ZI157;
+		t_ast__class ZIclass;
+		t_pos ZIend;
 
-		p_expr_C_Cclass_C_Cclass_Hterm (flags, lex_state, act_state, err, &ZIl);
-		/* BEGINNING OF INLINE: 152 */
+		switch (CURRENT_TERMINAL) {
+		case (TOK_OPENGROUP):
+			/* BEGINNING OF EXTRACT: OPENGROUP */
+			{
+#line 249 "src/libre/parser.act"
+
+		ZIstart = lex_state->lx.start;
+		ZI157   = lex_state->lx.end;
+	
+#line 839 "src/libre/dialect/native/parser.c"
+			}
+			/* END OF EXTRACT: OPENGROUP */
+			break;
+		default:
+			goto ZL1;
+		}
+		ADVANCE_LEXER;
+		/* BEGINNING OF ACTION: ast-make-class-concat */
 		{
-			switch (CURRENT_TERMINAL) {
-			case (TOK_NAMED__CLASS): case (TOK_ESC): case (TOK_OCT): case (TOK_HEX):
-			case (TOK_CHAR):
-				{
-					t_ast__class ZIr;
+#line 741 "src/libre/parser.act"
 
-					p_expr_C_Cclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, &ZIr);
-					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-						RESTORE_LEXER;
-						goto ZL1;
-					}
-					/* BEGINNING OF ACTION: ast-make-class-concat */
+		(ZIclass) = ast_make_class_concat();
+		if ((ZIclass) == NULL) {
+			goto ZL1;
+		}
+	
+#line 856 "src/libre/dialect/native/parser.c"
+		}
+		/* END OF ACTION: ast-make-class-concat */
+		p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead (flags, lex_state, act_state, err, ZIclass);
+		p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, ZIclass);
+		/* BEGINNING OF INLINE: 158 */
+		{
+			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+				RESTORE_LEXER;
+				goto ZL1;
+			}
+			{
+				t_char ZI159;
+				t_pos ZI160;
+
+				switch (CURRENT_TERMINAL) {
+				case (TOK_CLOSEGROUP):
+					/* BEGINNING OF EXTRACT: CLOSEGROUP */
 					{
-#line 729 "src/libre/parser.act"
+#line 254 "src/libre/parser.act"
 
-		(ZInode) = ast_make_class_concat((ZIl), (ZIr));
+		ZI159 = ']';
+		ZI160 = lex_state->lx.start;
+		ZIend   = lex_state->lx.end;
+	
+#line 881 "src/libre/dialect/native/parser.c"
+					}
+					/* END OF EXTRACT: CLOSEGROUP */
+					break;
+				default:
+					goto ZL3;
+				}
+				ADVANCE_LEXER;
+				/* BEGINNING OF ACTION: mark-group */
+				{
+#line 530 "src/libre/parser.act"
+
+		mark(&act_state->groupstart, &(ZIstart));
+		mark(&act_state->groupend,   &(ZIend));
+	
+#line 896 "src/libre/dialect/native/parser.c"
+				}
+				/* END OF ACTION: mark-group */
+			}
+			goto ZL2;
+		ZL3:;
+			{
+				/* BEGINNING OF ACTION: err-expected-closegroup */
+				{
+#line 491 "src/libre/parser.act"
+
+		if (err->e == RE_ESUCCESS) {
+			err->e = RE_EXCLOSEGROUP;
+		}
+		goto ZL1;
+	
+#line 912 "src/libre/dialect/native/parser.c"
+				}
+				/* END OF ACTION: err-expected-closegroup */
+				ZIend = ZIstart;
+			}
+		ZL2:;
+		}
+		/* END OF INLINE: 158 */
+		/* BEGINNING OF ACTION: ast-make-expr-class */
+		{
+#line 684 "src/libre/parser.act"
+
+		struct ast_pos ast_start, ast_end;
+
+		AST_POS_OF_LX_POS(ast_start, (ZIstart));
+		AST_POS_OF_LX_POS(ast_end, (ZIend));
+
+		mark(&act_state->groupstart, &(ZIstart));
+		mark(&act_state->groupend,   &(ZIend));
+
+		(ZInode) = ast_make_expr_class((ZIclass), &ast_start, &ast_end);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 544 "src/libre/dialect/native/parser.c"
-					}
-					/* END OF ACTION: ast-make-class-concat */
-				}
-				break;
-			default:
-				{
-					ZInode = ZIl;
-				}
-				break;
-			case (ERROR_TERMINAL):
-				RESTORE_LEXER;
-				goto ZL1;
-			}
+#line 937 "src/libre/dialect/native/parser.c"
 		}
-		/* END OF INLINE: 152 */
+		/* END OF ACTION: ast-make-expr-class */
 	}
 	goto ZL0;
 ZL1:;
@@ -570,18 +950,48 @@ p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__ex
 {
 	t_ast__expr ZInode;
 
-	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-		return;
-	}
-	{
-		t_ast__expr ZI194;
+	switch (CURRENT_TERMINAL) {
+	case (TOK_ANY): case (TOK_START): case (TOK_END): case (TOK_OPENSUB):
+	case (TOK_OPENGROUP): case (TOK_ESC): case (TOK_OCT): case (TOK_HEX):
+	case (TOK_CHAR):
+		{
+			/* BEGINNING OF ACTION: ast-make-expr-alt */
+			{
+#line 639 "src/libre/parser.act"
 
-		p_expr_C_Calt (flags, lex_state, act_state, err, &ZI194);
-		p_196 (flags, lex_state, act_state, err, &ZI194, &ZInode);
-		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-			RESTORE_LEXER;
+		(ZInode) = ast_make_expr_alt();
+		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
+	
+#line 968 "src/libre/dialect/native/parser.c"
+			}
+			/* END OF ACTION: ast-make-expr-alt */
+			p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, ZInode);
+			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+				RESTORE_LEXER;
+				goto ZL1;
+			}
+		}
+		break;
+	default:
+		{
+			/* BEGINNING OF ACTION: ast-make-expr-empty */
+			{
+#line 625 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_empty();
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 989 "src/libre/dialect/native/parser.c"
+			}
+			/* END OF ACTION: ast-make-expr-empty */
+		}
+		break;
+	case (ERROR_TERMINAL):
+		return;
 	}
 	goto ZL0;
 ZL1:;
@@ -595,7 +1005,7 @@ ZL1:;
 		}
 		goto ZL2;
 	
-#line 599 "src/libre/dialect/native/parser.c"
+#line 1009 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
 		/* BEGINNING OF ACTION: ast-make-expr-empty */
@@ -607,7 +1017,7 @@ ZL1:;
 			goto ZL2;
 		}
 	
-#line 611 "src/libre/dialect/native/parser.c"
+#line 1021 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-make-expr-empty */
 	}
@@ -628,40 +1038,18 @@ p_re__native(flags flags, lex_state lex_state, act_state act_state, err err, t_a
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 184 */
+		/* BEGINNING OF INLINE: 187 */
 		{
-			switch (CURRENT_TERMINAL) {
-			case (TOK_ANY): case (TOK_START): case (TOK_END): case (TOK_OPENSUB):
-			case (TOK_OPENGROUP): case (TOK_ESC): case (TOK_OCT): case (TOK_HEX):
-			case (TOK_CHAR):
-				{
-					p_expr (flags, lex_state, act_state, err, &ZInode);
-					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-						RESTORE_LEXER;
-						goto ZL1;
-					}
+			{
+				p_expr (flags, lex_state, act_state, err, &ZInode);
+				if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+					RESTORE_LEXER;
+					goto ZL1;
 				}
-				break;
-			default:
-				{
-					/* BEGINNING OF ACTION: ast-make-expr-empty */
-					{
-#line 625 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_empty();
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 657 "src/libre/dialect/native/parser.c"
-					}
-					/* END OF ACTION: ast-make-expr-empty */
-				}
-				break;
 			}
 		}
-		/* END OF INLINE: 184 */
-		/* BEGINNING OF INLINE: 185 */
+		/* END OF INLINE: 187 */
+		/* BEGINNING OF INLINE: 188 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -684,13 +1072,13 @@ p_re__native(flags flags, lex_state lex_state, act_state act_state, err err, t_a
 		}
 		goto ZL1;
 	
-#line 688 "src/libre/dialect/native/parser.c"
+#line 1076 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 185 */
+		/* END OF INLINE: 188 */
 	}
 	goto ZL0;
 ZL1:;
@@ -701,570 +1089,57 @@ ZL0:;
 }
 
 static void
-p_196(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZI194, t_ast__expr *ZOnode)
+p_expr_C_Clist_Hof_Hatoms(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr ZIcat)
 {
-	t_ast__expr ZInode;
-
-	switch (CURRENT_TERMINAL) {
-	case (TOK_ALT):
-		{
-			t_ast__expr ZIr;
-
-			ADVANCE_LEXER;
-			p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, &ZIr);
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-			/* BEGINNING OF ACTION: ast-make-expr-alt */
-			{
-#line 639 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_alt((*ZI194), (ZIr));
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 729 "src/libre/dialect/native/parser.c"
-			}
-			/* END OF ACTION: ast-make-expr-alt */
-		}
-		break;
-	default:
-		{
-			ZInode = *ZI194;
-		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOnode = ZInode;
-}
-
-static void
-p_197(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZIa, t_ast__expr *ZOnode)
-{
-	t_ast__expr ZInode;
-
-	switch (CURRENT_TERMINAL) {
-	case (TOK_ANY): case (TOK_START): case (TOK_END): case (TOK_OPENSUB):
-	case (TOK_OPENGROUP): case (TOK_ESC): case (TOK_OCT): case (TOK_HEX):
-	case (TOK_CHAR):
-		{
-			t_ast__expr ZIr;
-
-			p_expr_C_Clist_Hof_Hatoms (flags, lex_state, act_state, err, &ZIr);
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-			/* BEGINNING OF ACTION: ast-make-expr-concat */
-			{
-#line 632 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_concat((*ZIa), (ZIr));
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 776 "src/libre/dialect/native/parser.c"
-			}
-			/* END OF ACTION: ast-make-expr-concat */
-		}
-		break;
-	default:
-		{
-			t_ast__expr ZIr;
-
-			/* BEGINNING OF ACTION: ast-make-expr-empty */
-			{
-#line 625 "src/libre/parser.act"
-
-		(ZIr) = ast_make_expr_empty();
-		if ((ZIr) == NULL) {
-			goto ZL1;
-		}
-	
-#line 794 "src/libre/dialect/native/parser.c"
-			}
-			/* END OF ACTION: ast-make-expr-empty */
-			/* BEGINNING OF ACTION: ast-make-expr-concat */
-			{
-#line 632 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_concat((*ZIa), (ZIr));
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 806 "src/libre/dialect/native/parser.c"
-			}
-			/* END OF ACTION: ast-make-expr-concat */
-		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOnode = ZInode;
-}
-
-static void
-p_expr_C_Cclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class *ZOnode)
-{
-	t_ast__class ZInode;
-
-	switch (CURRENT_TERMINAL) {
-	case (TOK_CHAR):
-		{
-			t_char ZI210;
-			t_pos ZI211;
-			t_pos ZI212;
-
-			/* BEGINNING OF EXTRACT: CHAR */
-			{
-#line 401 "src/libre/parser.act"
-
-		/* the first byte may be '\x00' */
-		assert(lex_state->buf.a[1] == '\0');
-
-		ZI211 = lex_state->lx.start;
-		ZI212   = lex_state->lx.end;
-
-		ZI210 = lex_state->buf.a[0];
-	
-#line 846 "src/libre/dialect/native/parser.c"
-			}
-			/* END OF EXTRACT: CHAR */
-			ADVANCE_LEXER;
-			p_213 (flags, lex_state, act_state, err, &ZI210, &ZI211, &ZInode);
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-		}
-		break;
-	case (TOK_ESC):
-		{
-			t_char ZI198;
-			t_pos ZI199;
-			t_pos ZI200;
-
-			/* BEGINNING OF EXTRACT: ESC */
-			{
-#line 274 "src/libre/parser.act"
-
-		assert(lex_state->buf.a[0] == '\\');
-		assert(lex_state->buf.a[1] != '\0');
-		assert(lex_state->buf.a[2] == '\0');
-
-		ZI198 = lex_state->buf.a[1];
-
-		switch (ZI198) {
-		case 'a': ZI198 = '\a'; break;
-		case 'f': ZI198 = '\f'; break;
-		case 'n': ZI198 = '\n'; break;
-		case 'r': ZI198 = '\r'; break;
-		case 't': ZI198 = '\t'; break;
-		case 'v': ZI198 = '\v'; break;
-		default:             break;
-		}
-
-		ZI199 = lex_state->lx.start;
-		ZI200   = lex_state->lx.end;
-	
-#line 886 "src/libre/dialect/native/parser.c"
-			}
-			/* END OF EXTRACT: ESC */
-			ADVANCE_LEXER;
-			p_213 (flags, lex_state, act_state, err, &ZI198, &ZI199, &ZInode);
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-		}
-		break;
-	case (TOK_HEX):
-		{
-			t_char ZI206;
-			t_pos ZI207;
-			t_pos ZI208;
-
-			/* BEGINNING OF EXTRACT: HEX */
-			{
-#line 365 "src/libre/parser.act"
-
-		unsigned long u;
-		char *s, *e;
-		int brace = 0;
-
-		assert(0 == strncmp(lex_state->buf.a, "\\x", 2));
-		assert(strlen(lex_state->buf.a) >= 3);
-
-		ZI207 = lex_state->lx.start;
-		ZI208   = lex_state->lx.end;
-
-		errno = 0;
-
-		s = lex_state->buf.a + 2;
-
-		if (*s == '{') {
-			s++;
-			brace = 1;
-		}
-
-		u = strtoul(s, &e, 16);
-
-		if ((u == ULONG_MAX && errno == ERANGE) || u > UCHAR_MAX) {
-			err->e = RE_EHEXRANGE;
-			snprintdots(err->esc, sizeof err->esc, lex_state->buf.a);
-			goto ZL1;
-		}
-
-		if (brace && *e == '}') {
-			e++;
-		}
-
-		if ((u == ULONG_MAX && errno != 0) || (*e != '\0')) {
-			err->e = RE_EXESC;
-			goto ZL1;
-		}
-
-		ZI206 = (char) (unsigned char) u;
-	
-#line 945 "src/libre/dialect/native/parser.c"
-			}
-			/* END OF EXTRACT: HEX */
-			ADVANCE_LEXER;
-			p_213 (flags, lex_state, act_state, err, &ZI206, &ZI207, &ZInode);
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-		}
-		break;
-	case (TOK_OCT):
-		{
-			t_char ZI202;
-			t_pos ZI203;
-			t_pos ZI204;
-
-			/* BEGINNING OF EXTRACT: OCT */
-			{
-#line 325 "src/libre/parser.act"
-
-		unsigned long u;
-		char *s, *e;
-		int brace = 0;
-
-		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
-		assert(strlen(lex_state->buf.a) >= 2);
-
-		ZI203 = lex_state->lx.start;
-		ZI204   = lex_state->lx.end;
-
-		errno = 0;
-
-		s = lex_state->buf.a + 1;
-
-		if (s[0] == 'o' && s[1] == '{') {
-			s += 2;
-			brace = 1;
-		}
-
-		u = strtoul(s, &e, 8);
-
-		if ((u == ULONG_MAX && errno == ERANGE) || u > UCHAR_MAX) {
-			err->e = RE_EOCTRANGE;
-			snprintdots(err->esc, sizeof err->esc, lex_state->buf.a);
-			goto ZL1;
-		}
-
-		if (brace && *e == '}') {
-			e++;
-		}
-
-		if ((u == ULONG_MAX && errno != 0) || *e != '\0') {
-			err->e = RE_EXESC;
-			goto ZL1;
-		}
-
-		ZI202 = (char) (unsigned char) u;
-	
-#line 1004 "src/libre/dialect/native/parser.c"
-			}
-			/* END OF EXTRACT: OCT */
-			ADVANCE_LEXER;
-			p_213 (flags, lex_state, act_state, err, &ZI202, &ZI203, &ZInode);
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-		}
-		break;
-	case (TOK_NAMED__CLASS):
-		{
-			t_ast__class__id ZIid;
-
-			/* BEGINNING OF INLINE: expr::class::class-named */
-			{
-				{
-					t_pos ZI145;
-					t_pos ZI146;
-
-					switch (CURRENT_TERMINAL) {
-					case (TOK_NAMED__CLASS):
-						/* BEGINNING OF EXTRACT: NAMED_CLASS */
-						{
-#line 428 "src/libre/parser.act"
-
-		ZIid = DIALECT_CLASS(lex_state->buf.a);
-		if (ZIid == NULL) {
-			/* syntax error -- unrecognized class */
-			goto ZL1;
-		}
-
-		ZI145 = lex_state->lx.start;
-		ZI146   = lex_state->lx.end;
-	
-#line 1040 "src/libre/dialect/native/parser.c"
-						}
-						/* END OF EXTRACT: NAMED_CLASS */
-						break;
-					default:
-						goto ZL1;
-					}
-					ADVANCE_LEXER;
-				}
-			}
-			/* END OF INLINE: expr::class::class-named */
-			/* BEGINNING OF ACTION: ast-make-class-named */
-			{
-#line 776 "src/libre/parser.act"
-
-		(ZInode) = ast_make_class_named((ZIid));
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 1060 "src/libre/dialect/native/parser.c"
-			}
-			/* END OF ACTION: ast-make-class-named */
-		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
-	default:
-		goto ZL1;
-	}
-	goto ZL0;
-ZL1:;
-	{
-		/* BEGINNING OF ACTION: err-expected-term */
-		{
-#line 456 "src/libre/parser.act"
-
-		if (err->e == RE_ESUCCESS) {
-			err->e = RE_EXTERM;
-		}
-		goto ZL3;
-	
-#line 1082 "src/libre/dialect/native/parser.c"
-		}
-		/* END OF ACTION: err-expected-term */
-		/* BEGINNING OF ACTION: ast-make-class-flag-none */
-		{
-#line 790 "src/libre/parser.act"
-
-		(ZInode) = ast_make_class_flags(AST_CLASS_FLAG_NONE);
-		if ((ZInode) == NULL) {
-			goto ZL3;
-		}
-	
-#line 1094 "src/libre/dialect/native/parser.c"
-		}
-		/* END OF ACTION: ast-make-class-flag-none */
-	}
-	goto ZL0;
-ZL3:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOnode = ZInode;
-}
-
-static void
-p_expr_C_Clist_Hof_Hatoms(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
-{
-	t_ast__expr ZInode;
-
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 		return;
 	}
+ZL2_expr_C_Clist_Hof_Hatoms:;
 	{
 		t_ast__expr ZIa;
 
 		p_expr_C_Catom (flags, lex_state, act_state, err, &ZIa);
-		p_197 (flags, lex_state, act_state, err, &ZIa, &ZInode);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
 		}
+		/* BEGINNING OF ACTION: ast-add-expr-concat */
+		{
+#line 725 "src/libre/parser.act"
+
+		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
+			goto ZL1;
+		}
+	
+#line 1115 "src/libre/dialect/native/parser.c"
+		}
+		/* END OF ACTION: ast-add-expr-concat */
+		/* BEGINNING OF INLINE: 179 */
+		{
+			switch (CURRENT_TERMINAL) {
+			case (TOK_ANY): case (TOK_START): case (TOK_END): case (TOK_OPENSUB):
+			case (TOK_OPENGROUP): case (TOK_ESC): case (TOK_OCT): case (TOK_HEX):
+			case (TOK_CHAR):
+				{
+					/* BEGINNING OF INLINE: expr::list-of-atoms */
+					goto ZL2_expr_C_Clist_Hof_Hatoms;
+					/* END OF INLINE: expr::list-of-atoms */
+				}
+				/*UNREACHED*/
+			default:
+				break;
+			}
+		}
+		/* END OF INLINE: 179 */
 	}
-	goto ZL0;
+	return;
 ZL1:;
 	SAVE_LEXER ((ERROR_TERMINAL));
 	return;
-ZL0:;
-	*ZOnode = ZInode;
 }
 
 static void
-p_expr_C_Cclass(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
-{
-	t_ast__expr ZInode;
-
-	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-		return;
-	}
-	{
-		t_pos ZIstart;
-		t_pos ZI155;
-		t_ast__class ZIhead;
-		t_ast__class ZIbody;
-		t_pos ZIend;
-		t_ast__class ZIhb;
-
-		switch (CURRENT_TERMINAL) {
-		case (TOK_OPENGROUP):
-			/* BEGINNING OF EXTRACT: OPENGROUP */
-			{
-#line 249 "src/libre/parser.act"
-
-		ZIstart = lex_state->lx.start;
-		ZI155   = lex_state->lx.end;
-	
-#line 1157 "src/libre/dialect/native/parser.c"
-			}
-			/* END OF EXTRACT: OPENGROUP */
-			break;
-		default:
-			goto ZL1;
-		}
-		ADVANCE_LEXER;
-		p_expr_C_Cclass_C_Cclass_Hhead (flags, lex_state, act_state, err, &ZIhead);
-		p_expr_C_Cclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, &ZIbody);
-		/* BEGINNING OF INLINE: 158 */
-		{
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-			{
-				t_char ZI159;
-				t_pos ZI160;
-
-				switch (CURRENT_TERMINAL) {
-				case (TOK_CLOSEGROUP):
-					/* BEGINNING OF EXTRACT: CLOSEGROUP */
-					{
-#line 254 "src/libre/parser.act"
-
-		ZI159 = ']';
-		ZI160 = lex_state->lx.start;
-		ZIend   = lex_state->lx.end;
-	
-#line 1187 "src/libre/dialect/native/parser.c"
-					}
-					/* END OF EXTRACT: CLOSEGROUP */
-					break;
-				default:
-					goto ZL3;
-				}
-				ADVANCE_LEXER;
-				/* BEGINNING OF ACTION: mark-group */
-				{
-#line 530 "src/libre/parser.act"
-
-		mark(&act_state->groupstart, &(ZIstart));
-		mark(&act_state->groupend,   &(ZIend));
-	
-#line 1202 "src/libre/dialect/native/parser.c"
-				}
-				/* END OF ACTION: mark-group */
-			}
-			goto ZL2;
-		ZL3:;
-			{
-				/* BEGINNING OF ACTION: err-expected-closegroup */
-				{
-#line 491 "src/libre/parser.act"
-
-		if (err->e == RE_ESUCCESS) {
-			err->e = RE_EXCLOSEGROUP;
-		}
-		goto ZL1;
-	
-#line 1218 "src/libre/dialect/native/parser.c"
-				}
-				/* END OF ACTION: err-expected-closegroup */
-				ZIend = ZIstart;
-			}
-		ZL2:;
-		}
-		/* END OF INLINE: 158 */
-		/* BEGINNING OF ACTION: ast-make-class-concat */
-		{
-#line 729 "src/libre/parser.act"
-
-		(ZIhb) = ast_make_class_concat((ZIhead), (ZIbody));
-		if ((ZIhb) == NULL) {
-			goto ZL1;
-		}
-	
-#line 1235 "src/libre/dialect/native/parser.c"
-		}
-		/* END OF ACTION: ast-make-class-concat */
-		/* BEGINNING OF ACTION: ast-make-expr-class */
-		{
-#line 684 "src/libre/parser.act"
-
-		struct ast_pos ast_start, ast_end;
-
-		AST_POS_OF_LX_POS(ast_start, (ZIstart));
-		AST_POS_OF_LX_POS(ast_end, (ZIend));
-
-		mark(&act_state->groupstart, &(ZIstart));
-		mark(&act_state->groupend,   &(ZIend));
-
-		(ZInode) = ast_make_expr_class((ZIhb), &ast_start, &ast_end);
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 1255 "src/libre/dialect/native/parser.c"
-		}
-		/* END OF ACTION: ast-make-expr-class */
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOnode = ZInode;
-}
-
-static void
-p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI210, t_pos *ZI211, t_ast__class *ZOnode)
+p_214(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI211, t_pos *ZI212, t_ast__class *ZOnode)
 {
 	t_ast__class ZInode;
 
@@ -1273,14 +1148,14 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		{
 			/* BEGINNING OF ACTION: ast-make-class-literal */
 			{
-#line 736 "src/libre/parser.act"
+#line 748 "src/libre/parser.act"
 
-		(ZInode) = ast_make_class_literal((*ZI210));
+		(ZInode) = ast_make_class_literal((*ZI211));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1284 "src/libre/dialect/native/parser.c"
+#line 1159 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-class-literal */
 		}
@@ -1297,17 +1172,17 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 #line 594 "src/libre/parser.act"
 
 		(ZIa).type = AST_ENDPOINT_LITERAL;
-		(ZIa).u.literal.c = (*ZI210);
+		(ZIa).u.literal.c = (*ZI211);
 	
-#line 1303 "src/libre/dialect/native/parser.c"
+#line 1178 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
-			/* BEGINNING OF INLINE: 129 */
+			/* BEGINNING OF INLINE: 133 */
 			{
 				{
-					t_char ZI130;
-					t_pos ZI131;
-					t_pos ZI132;
+					t_char ZI134;
+					t_pos ZI135;
+					t_pos ZI136;
 
 					switch (CURRENT_TERMINAL) {
 					case (TOK_RANGE):
@@ -1315,11 +1190,11 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 						{
 #line 243 "src/libre/parser.act"
 
-		ZI130 = '-';
-		ZI131 = lex_state->lx.start;
-		ZI132   = lex_state->lx.end;
+		ZI134 = '-';
+		ZI135 = lex_state->lx.start;
+		ZI136   = lex_state->lx.end;
 	
-#line 1323 "src/libre/dialect/native/parser.c"
+#line 1198 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF EXTRACT: RANGE */
 						break;
@@ -1340,19 +1215,19 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		}
 		goto ZL1;
 	
-#line 1344 "src/libre/dialect/native/parser.c"
+#line 1219 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: err-expected-range */
 				}
 			ZL2:;
 			}
-			/* END OF INLINE: 129 */
-			/* BEGINNING OF INLINE: 133 */
+			/* END OF INLINE: 133 */
+			/* BEGINNING OF INLINE: 137 */
 			{
 				switch (CURRENT_TERMINAL) {
 				case (TOK_CHAR):
 					{
-						t_pos ZI139;
+						t_pos ZI143;
 
 						/* BEGINNING OF EXTRACT: CHAR */
 						{
@@ -1361,12 +1236,12 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI139 = lex_state->lx.start;
+		ZI143 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 
 		ZIcz = lex_state->buf.a[0];
 	
-#line 1370 "src/libre/dialect/native/parser.c"
+#line 1245 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF EXTRACT: CHAR */
 						ADVANCE_LEXER;
@@ -1374,7 +1249,7 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 					break;
 				case (TOK_ESC):
 					{
-						t_pos ZI135;
+						t_pos ZI139;
 
 						/* BEGINNING OF EXTRACT: ESC */
 						{
@@ -1396,10 +1271,10 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		default:             break;
 		}
 
-		ZI135 = lex_state->lx.start;
+		ZI139 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1403 "src/libre/dialect/native/parser.c"
+#line 1278 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF EXTRACT: ESC */
 						ADVANCE_LEXER;
@@ -1407,7 +1282,7 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 					break;
 				case (TOK_HEX):
 					{
-						t_pos ZI138;
+						t_pos ZI142;
 
 						/* BEGINNING OF EXTRACT: HEX */
 						{
@@ -1420,7 +1295,7 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		assert(0 == strncmp(lex_state->buf.a, "\\x", 2));
 		assert(strlen(lex_state->buf.a) >= 3);
 
-		ZI138 = lex_state->lx.start;
+		ZI142 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 
 		errno = 0;
@@ -1451,7 +1326,7 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 		ZIcz = (char) (unsigned char) u;
 	
-#line 1455 "src/libre/dialect/native/parser.c"
+#line 1330 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF EXTRACT: HEX */
 						ADVANCE_LEXER;
@@ -1459,7 +1334,7 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 					break;
 				case (TOK_OCT):
 					{
-						t_pos ZI137;
+						t_pos ZI141;
 
 						/* BEGINNING OF EXTRACT: OCT */
 						{
@@ -1472,7 +1347,7 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
 		assert(strlen(lex_state->buf.a) >= 2);
 
-		ZI137 = lex_state->lx.start;
+		ZI141 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 
 		errno = 0;
@@ -1503,7 +1378,7 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 		ZIcz = (char) (unsigned char) u;
 	
-#line 1507 "src/libre/dialect/native/parser.c"
+#line 1382 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF EXTRACT: OCT */
 						ADVANCE_LEXER;
@@ -1511,17 +1386,17 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 					break;
 				case (TOK_RANGE):
 					{
-						t_pos ZI140;
+						t_pos ZI144;
 
 						/* BEGINNING OF EXTRACT: RANGE */
 						{
 #line 243 "src/libre/parser.act"
 
 		ZIcz = '-';
-		ZI140 = lex_state->lx.start;
+		ZI144 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1525 "src/libre/dialect/native/parser.c"
+#line 1400 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF EXTRACT: RANGE */
 						ADVANCE_LEXER;
@@ -1531,7 +1406,7 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 					goto ZL1;
 				}
 			}
-			/* END OF INLINE: 133 */
+			/* END OF INLINE: 137 */
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
 #line 594 "src/libre/parser.act"
@@ -1539,17 +1414,17 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		(ZIz).type = AST_ENDPOINT_LITERAL;
 		(ZIz).u.literal.c = (ZIcz);
 	
-#line 1543 "src/libre/dialect/native/parser.c"
+#line 1418 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF ACTION: mark-range */
 			{
 #line 535 "src/libre/parser.act"
 
-		mark(&act_state->rangestart, &(*ZI211));
+		mark(&act_state->rangestart, &(*ZI212));
 		mark(&act_state->rangeend,   &(ZIend));
 	
-#line 1553 "src/libre/dialect/native/parser.c"
+#line 1428 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-range-distinct */
@@ -1558,7 +1433,7 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 		struct ast_pos ast_start, ast_end;
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI211));
+		AST_POS_OF_LX_POS(ast_start, (*ZI212));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		if ((ZIa).type != AST_ENDPOINT_LITERAL || (ZIz).type != AST_ENDPOINT_LITERAL) {
@@ -1571,17 +1446,17 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			goto ZL1;
 		}
 	
-#line 1575 "src/libre/dialect/native/parser.c"
+#line 1450 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-range-distinct */
 			/* BEGINNING OF ACTION: ast-make-class-range */
 			{
-#line 746 "src/libre/parser.act"
+#line 758 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI211));
+		AST_POS_OF_LX_POS(ast_start, (*ZI212));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		if ((ZIa).type != AST_ENDPOINT_LITERAL ||
@@ -1609,7 +1484,7 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			goto ZL1;
 		}
 	
-#line 1613 "src/libre/dialect/native/parser.c"
+#line 1488 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-class-range */
 		}
@@ -1626,14 +1501,14 @@ ZL0:;
 }
 
 static void
-p_216(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZIe, t_pos *ZI214, t_unsigned *ZIm, t_ast__expr *ZOnode)
+p_217(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZIe, t_pos *ZI215, t_unsigned *ZIm, t_ast__expr *ZOnode)
 {
 	t_ast__expr ZInode;
 
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CLOSECOUNT):
 		{
-			t_pos ZI172;
+			t_pos ZI171;
 			t_pos ZIend;
 			t_ast__count ZIc;
 
@@ -1641,10 +1516,10 @@ p_216(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			{
 #line 265 "src/libre/parser.act"
 
-		ZI172 = lex_state->lx.start;
+		ZI171 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1648 "src/libre/dialect/native/parser.c"
+#line 1523 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: CLOSECOUNT */
 			ADVANCE_LEXER;
@@ -1652,10 +1527,10 @@ p_216(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			{
 #line 540 "src/libre/parser.act"
 
-		mark(&act_state->countstart, &(*ZI214));
+		mark(&act_state->countstart, &(*ZI215));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 1659 "src/libre/dialect/native/parser.c"
+#line 1534 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: atom-count */
@@ -1669,18 +1544,18 @@ p_216(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			err->m = (*ZIm);
 			err->n = (*ZIm);
 
-			mark(&act_state->countstart, &(*ZI214));
+			mark(&act_state->countstart, &(*ZI215));
 			mark(&act_state->countend,   &(ZIend));
 
 			goto ZL1;
 		}
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI214));
+		AST_POS_OF_LX_POS(ast_start, (*ZI215));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (*ZIm), &ast_end);
 	
-#line 1684 "src/libre/dialect/native/parser.c"
+#line 1559 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: atom-count */
 			/* BEGINNING OF ACTION: ast-make-expr-atom */
@@ -1693,7 +1568,7 @@ p_216(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			goto ZL1;
 		}
 	
-#line 1697 "src/libre/dialect/native/parser.c"
+#line 1572 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-expr-atom */
 		}
@@ -1702,7 +1577,7 @@ p_216(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 		{
 			t_unsigned ZIn;
 			t_pos ZIend;
-			t_pos ZI175;
+			t_pos ZI174;
 			t_ast__count ZIc;
 
 			ADVANCE_LEXER;
@@ -1730,7 +1605,7 @@ p_216(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 
 		ZIn = (unsigned int) u;
 	
-#line 1734 "src/libre/dialect/native/parser.c"
+#line 1609 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -1745,9 +1620,9 @@ p_216(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 #line 265 "src/libre/parser.act"
 
 		ZIend = lex_state->lx.start;
-		ZI175   = lex_state->lx.end;
+		ZI174   = lex_state->lx.end;
 	
-#line 1751 "src/libre/dialect/native/parser.c"
+#line 1626 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF EXTRACT: CLOSECOUNT */
 				break;
@@ -1759,10 +1634,10 @@ p_216(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			{
 #line 540 "src/libre/parser.act"
 
-		mark(&act_state->countstart, &(*ZI214));
+		mark(&act_state->countstart, &(*ZI215));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 1766 "src/libre/dialect/native/parser.c"
+#line 1641 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: atom-count */
@@ -1776,18 +1651,18 @@ p_216(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			err->m = (*ZIm);
 			err->n = (ZIn);
 
-			mark(&act_state->countstart, &(*ZI214));
+			mark(&act_state->countstart, &(*ZI215));
 			mark(&act_state->countend,   &(ZIend));
 
 			goto ZL1;
 		}
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI214));
+		AST_POS_OF_LX_POS(ast_start, (*ZI215));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (ZIn), &ast_end);
 	
-#line 1791 "src/libre/dialect/native/parser.c"
+#line 1666 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: atom-count */
 			/* BEGINNING OF ACTION: ast-make-expr-atom */
@@ -1800,7 +1675,7 @@ p_216(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			goto ZL1;
 		}
 	
-#line 1804 "src/libre/dialect/native/parser.c"
+#line 1679 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-expr-atom */
 		}
@@ -1819,95 +1694,49 @@ ZL0:;
 }
 
 static void
-p_217(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZIa, t_ast__expr *ZOnode)
+p_expr_C_Clist_Hof_Halts(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr ZIalts)
 {
-	t_ast__expr ZInode;
-
-	switch (CURRENT_TERMINAL) {
-	case (TOK_ALT):
-		{
-			t_ast__expr ZIr;
-
-			ADVANCE_LEXER;
-			p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, &ZIr);
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-			/* BEGINNING OF ACTION: ast-make-expr-alt */
-			{
-#line 639 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_alt((*ZIa), (ZIr));
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 1847 "src/libre/dialect/native/parser.c"
-			}
-			/* END OF ACTION: ast-make-expr-alt */
-		}
-		break;
-	default:
-		{
-			t_ast__expr ZIr;
-
-			/* BEGINNING OF ACTION: ast-make-expr-empty */
-			{
-#line 625 "src/libre/parser.act"
-
-		(ZIr) = ast_make_expr_empty();
-		if ((ZIr) == NULL) {
-			goto ZL1;
-		}
-	
-#line 1865 "src/libre/dialect/native/parser.c"
-			}
-			/* END OF ACTION: ast-make-expr-empty */
-			/* BEGINNING OF ACTION: ast-make-expr-alt */
-			{
-#line 639 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_alt((*ZIa), (ZIr));
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 1877 "src/libre/dialect/native/parser.c"
-			}
-			/* END OF ACTION: ast-make-expr-alt */
-		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOnode = ZInode;
-}
-
-static void
-p_expr_C_Clist_Hof_Halts(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
-{
-	t_ast__expr ZInode;
-
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 		return;
 	}
+ZL2_expr_C_Clist_Hof_Halts:;
 	{
 		t_ast__expr ZIa;
 
 		p_expr_C_Calt (flags, lex_state, act_state, err, &ZIa);
-		p_217 (flags, lex_state, act_state, err, &ZIa, &ZInode);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
 		}
+		/* BEGINNING OF ACTION: ast-add-expr-alt */
+		{
+#line 731 "src/libre/parser.act"
+
+		if (!ast_add_expr_alt((ZIalts), (ZIa))) {
+			goto ZL1;
+		}
+	
+#line 1720 "src/libre/dialect/native/parser.c"
+		}
+		/* END OF ACTION: ast-add-expr-alt */
+		/* BEGINNING OF INLINE: 185 */
+		{
+			switch (CURRENT_TERMINAL) {
+			case (TOK_ALT):
+				{
+					ADVANCE_LEXER;
+					/* BEGINNING OF INLINE: expr::list-of-alts */
+					goto ZL2_expr_C_Clist_Hof_Halts;
+					/* END OF INLINE: expr::list-of-alts */
+				}
+				/*UNREACHED*/
+			default:
+				break;
+			}
+		}
+		/* END OF INLINE: 185 */
 	}
-	goto ZL0;
+	return;
 ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-alts */
@@ -1917,30 +1746,17 @@ ZL1:;
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXALTS;
 		}
-		goto ZL2;
+		goto ZL4;
 	
-#line 1923 "src/libre/dialect/native/parser.c"
+#line 1752 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
-		/* BEGINNING OF ACTION: ast-make-expr-empty */
-		{
-#line 625 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_empty();
-		if ((ZInode) == NULL) {
-			goto ZL2;
-		}
-	
-#line 1935 "src/libre/dialect/native/parser.c"
-		}
-		/* END OF ACTION: ast-make-expr-empty */
 	}
 	goto ZL0;
-ZL2:;
+ZL4:;
 	SAVE_LEXER ((ERROR_TERMINAL));
 	return;
 ZL0:;
-	*ZOnode = ZInode;
 }
 
 static void
@@ -1954,7 +1770,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 	{
 		t_ast__expr ZIe;
 
-		/* BEGINNING OF INLINE: 165 */
+		/* BEGINNING OF INLINE: 164 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY):
@@ -1969,7 +1785,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL1;
 		}
 	
-#line 1973 "src/libre/dialect/native/parser.c"
+#line 1789 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-any */
 				}
@@ -1986,7 +1802,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL1;
 		}
 	
-#line 1990 "src/libre/dialect/native/parser.c"
+#line 1806 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-anchor-end */
 				}
@@ -2010,10 +1826,10 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL1;
 		}
 	
-#line 2014 "src/libre/dialect/native/parser.c"
+#line 1830 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-group */
-					/* BEGINNING OF INLINE: 168 */
+					/* BEGINNING OF INLINE: 167 */
 					{
 						{
 							switch (CURRENT_TERMINAL) {
@@ -2036,13 +1852,13 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 		}
 		goto ZL1;
 	
-#line 2040 "src/libre/dialect/native/parser.c"
+#line 1856 "src/libre/dialect/native/parser.c"
 							}
 							/* END OF ACTION: err-expected-alts */
 						}
 					ZL3:;
 					}
-					/* END OF INLINE: 168 */
+					/* END OF INLINE: 167 */
 				}
 				break;
 			case (TOK_START):
@@ -2057,14 +1873,14 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL1;
 		}
 	
-#line 2061 "src/libre/dialect/native/parser.c"
+#line 1877 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-anchor-start */
 				}
 				break;
 			case (TOK_OPENGROUP):
 				{
-					p_expr_C_Cclass (flags, lex_state, act_state, err, &ZIe);
+					p_expr_C_Ccharacter_Hclass (flags, lex_state, act_state, err, &ZIe);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL1;
@@ -2084,24 +1900,24 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 165 */
-		/* BEGINNING OF INLINE: 169 */
+		/* END OF INLINE: 164 */
+		/* BEGINNING OF INLINE: 168 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_OPENCOUNT):
 				{
-					t_pos ZI214;
 					t_pos ZI215;
+					t_pos ZI216;
 					t_unsigned ZIm;
 
 					/* BEGINNING OF EXTRACT: OPENCOUNT */
 					{
 #line 260 "src/libre/parser.act"
 
-		ZI214 = lex_state->lx.start;
-		ZI215   = lex_state->lx.end;
+		ZI215 = lex_state->lx.start;
+		ZI216   = lex_state->lx.end;
 	
-#line 2105 "src/libre/dialect/native/parser.c"
+#line 1921 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: OPENCOUNT */
 					ADVANCE_LEXER;
@@ -2129,7 +1945,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 
 		ZIm = (unsigned int) u;
 	
-#line 2133 "src/libre/dialect/native/parser.c"
+#line 1949 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF EXTRACT: COUNT */
 						break;
@@ -2137,7 +1953,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 						goto ZL6;
 					}
 					ADVANCE_LEXER;
-					p_216 (flags, lex_state, act_state, err, &ZIe, &ZI214, &ZIm, &ZInode);
+					p_217 (flags, lex_state, act_state, err, &ZIe, &ZI215, &ZIm, &ZInode);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL6;
@@ -2155,7 +1971,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 
 		(ZIc) = ast_make_count(0, NULL, 1, NULL);
 	
-#line 2159 "src/libre/dialect/native/parser.c"
+#line 1975 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: atom-opt */
 					/* BEGINNING OF ACTION: ast-make-expr-atom */
@@ -2168,7 +1984,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL6;
 		}
 	
-#line 2172 "src/libre/dialect/native/parser.c"
+#line 1988 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-atom */
 				}
@@ -2184,7 +2000,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 
 		(ZIc) = ast_make_count(1, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 2188 "src/libre/dialect/native/parser.c"
+#line 2004 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: atom-plus */
 					/* BEGINNING OF ACTION: ast-make-expr-atom */
@@ -2197,7 +2013,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL6;
 		}
 	
-#line 2201 "src/libre/dialect/native/parser.c"
+#line 2017 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-atom */
 				}
@@ -2213,7 +2029,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 2217 "src/libre/dialect/native/parser.c"
+#line 2033 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: atom-kleene */
 					/* BEGINNING OF ACTION: ast-make-expr-atom */
@@ -2226,7 +2042,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL6;
 		}
 	
-#line 2230 "src/libre/dialect/native/parser.c"
+#line 2046 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-atom */
 				}
@@ -2241,7 +2057,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 2245 "src/libre/dialect/native/parser.c"
+#line 2061 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: atom-one */
 					/* BEGINNING OF ACTION: ast-make-expr-atom */
@@ -2254,7 +2070,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL6;
 		}
 	
-#line 2258 "src/libre/dialect/native/parser.c"
+#line 2074 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-atom */
 				}
@@ -2272,14 +2088,71 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 		}
 		goto ZL1;
 	
-#line 2276 "src/libre/dialect/native/parser.c"
+#line 2092 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF ACTION: err-expected-count */
 				ZInode = ZIe;
 			}
 		ZL5:;
 		}
-		/* END OF INLINE: 169 */
+		/* END OF INLINE: 168 */
+	}
+	goto ZL0;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+ZL0:;
+	*ZOnode = ZInode;
+}
+
+static void
+p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class *ZOnode)
+{
+	t_ast__class ZInode;
+
+	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+		return;
+	}
+	{
+		t_ast__class__id ZIid;
+		t_pos ZI149;
+		t_pos ZI150;
+
+		switch (CURRENT_TERMINAL) {
+		case (TOK_NAMED__CLASS):
+			/* BEGINNING OF EXTRACT: NAMED_CLASS */
+			{
+#line 428 "src/libre/parser.act"
+
+		ZIid = DIALECT_CLASS(lex_state->buf.a);
+		if (ZIid == NULL) {
+			/* syntax error -- unrecognized class */
+			goto ZL1;
+		}
+
+		ZI149 = lex_state->lx.start;
+		ZI150   = lex_state->lx.end;
+	
+#line 2137 "src/libre/dialect/native/parser.c"
+			}
+			/* END OF EXTRACT: NAMED_CLASS */
+			break;
+		default:
+			goto ZL1;
+		}
+		ADVANCE_LEXER;
+		/* BEGINNING OF ACTION: ast-make-class-named */
+		{
+#line 788 "src/libre/parser.act"
+
+		(ZInode) = ast_make_class_named((ZIid));
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 2154 "src/libre/dialect/native/parser.c"
+		}
+		/* END OF ACTION: ast-make-class-named */
 	}
 	goto ZL0;
 ZL1:;
@@ -2298,7 +2171,19 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 		return;
 	}
 	{
-		p_expr_C_Clist_Hof_Hatoms (flags, lex_state, act_state, err, &ZInode);
+		/* BEGINNING OF ACTION: ast-make-expr-concat */
+		{
+#line 632 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_concat();
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 2184 "src/libre/dialect/native/parser.c"
+		}
+		/* END OF ACTION: ast-make-expr-concat */
+		p_expr_C_Clist_Hof_Hatoms (flags, lex_state, act_state, err, ZInode);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -2314,7 +2199,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 960 "src/libre/parser.act"
+#line 978 "src/libre/parser.act"
 
 
 	static int
@@ -2458,6 +2343,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 2462 "src/libre/dialect/native/parser.c"
+#line 2347 "src/libre/dialect/native/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/native/parser.h
+++ b/src/libre/dialect/native/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__native(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 962 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/native/parser.h"

--- a/src/libre/dialect/native/parser.sid
+++ b/src/libre/dialect/native/parser.sid
@@ -78,7 +78,7 @@
 
 	<ast-make-expr-empty>:        ()                       -> (:ast_expr);
 	<ast-make-expr-literal>:      (:char)                  -> (:ast_expr);
-	<ast-make-expr-concat>:       (:ast_expr, :ast_expr)   -> (:ast_expr);
+	<ast-make-expr-concat>:       ()                       -> (:ast_expr);
 	<ast-make-expr-alt>:          (:ast_expr, :ast_expr)   -> (:ast_expr);
 	<ast-make-expr-any>:          ()                       -> (:ast_expr);
 	<ast-make-expr-atom>:         (:ast_expr, :ast_count)  -> (:ast_expr);
@@ -88,6 +88,8 @@
 	!<ast-make-expr-re-flags>:    (:re_flags, :re_flags)   -> (:ast_expr);
 	<ast-make-expr-anchor-start>: ()                       -> (:ast_expr);
 	<ast-make-expr-anchor-end>:   ()                       -> (:ast_expr);
+
+	<ast-add-expr-concat>: (:ast_expr, :ast_expr) -> ();
 
 	<ast-make-class-concat>:      (:ast_class, :ast_class) -> (:ast_class);
 	<ast-make-class-literal>:     (:char)                  -> (:ast_class);
@@ -295,26 +297,29 @@
 			};
 		};
 
-		list-of-atoms: () -> (node :ast_expr) = {
-		/* TODO: start/end anchors */
+		list-of-atoms: (cat :ast_expr) -> () = {
+			/* TODO: start/end anchors */
 			a = atom();
-			r = <ast-make-expr-empty>;
-			node = <ast-make-expr-concat>(a,r);
-		||
-			a = atom();
-			r = list-of-atoms();
-			node = <ast-make-expr-concat>(a,r);
+
+			<ast-add-expr-concat>(cat, a);
+
+			{
+				list-of-atoms(cat);
+			||
+				$;
+			};
 		};
 
 		alt: () -> (node :ast_expr) = {
-			node = list-of-atoms();
+			node = <ast-make-expr-concat>;
+			list-of-atoms(node);
 		};
 
 		list-of-alts: () -> (node :ast_expr) = {
 			a = alt();
 			r = <ast-make-expr-empty>;
 			node = <ast-make-expr-alt>(a,r);
-	  	||
+		||
 			a = alt();
 			ALT;
 			r = list-of-alts();

--- a/src/libre/dialect/native/parser.sid
+++ b/src/libre/dialect/native/parser.sid
@@ -79,7 +79,7 @@
 	<ast-make-expr-empty>:        ()                       -> (:ast_expr);
 	<ast-make-expr-literal>:      (:char)                  -> (:ast_expr);
 	<ast-make-expr-concat>:       ()                       -> (:ast_expr);
-	<ast-make-expr-alt>:          (:ast_expr, :ast_expr)   -> (:ast_expr);
+	<ast-make-expr-alt>:          ()                       -> (:ast_expr);
 	<ast-make-expr-any>:          ()                       -> (:ast_expr);
 	<ast-make-expr-atom>:         (:ast_expr, :ast_count)  -> (:ast_expr);
 	!<ast-make-expr-atom-any>:    (:ast_count)             -> (:ast_expr);
@@ -90,6 +90,7 @@
 	<ast-make-expr-anchor-end>:   ()                       -> (:ast_expr);
 
 	<ast-add-expr-concat>: (:ast_expr, :ast_expr) -> ();
+	<ast-add-expr-alt>:    (:ast_expr, :ast_expr) -> ();
 
 	<ast-make-class-concat>:      (:ast_class, :ast_class) -> (:ast_class);
 	<ast-make-class-literal>:     (:char)                  -> (:ast_class);
@@ -313,31 +314,32 @@
 		alt: () -> (node :ast_expr) = {
 			node = <ast-make-expr-concat>;
 			list-of-atoms(node);
+
+			/* we don't allow empty alts for this dialect */
 		};
 
-		list-of-alts: () -> (node :ast_expr) = {
+		list-of-alts: (alts :ast_expr) -> () = {
 			a = alt();
-			r = <ast-make-expr-empty>;
-			node = <ast-make-expr-alt>(a,r);
-		||
-			a = alt();
-			ALT;
-			r = list-of-alts();
-			node = <ast-make-expr-alt>(a, r);
+
+			<ast-add-expr-alt>(alts, a);
+
+			{
+				ALT;
+
+				list-of-alts(alts);
+			||
+				$;
+			};
 		##
 			<err-expected-alts>;
-			node = <ast-make-expr-empty>();
 		};
+
 	] = {
-		/* don't wrap a single alt in an alt chain */
-		node = alt();
+		node = <ast-make-expr-alt>;
+		list-of-alts(node);
 	||
-		/* keep alts into a linked list -- every right node
-		 * is either another alt or empty. */
-		a = alt();
-		ALT;
-		r = list-of-alts();
-		node = <ast-make-expr-alt>(a, r);
+		/* alts cannot be empty, but an entire expr can be empty */
+		node = <ast-make-expr-empty>;
 	##
 		<err-expected-alts>;
 		node = <ast-make-expr-empty>();
@@ -346,8 +348,6 @@
 	re_native: () -> (node :ast_expr) = {
 		{
 			node = expr();
-		||
-			node = <ast-make-expr-empty>();
 		};
 
 		{

--- a/src/libre/dialect/native/parser.sid
+++ b/src/libre/dialect/native/parser.sid
@@ -92,7 +92,7 @@
 	<ast-add-expr-concat>: (:ast_expr, :ast_expr) -> ();
 	<ast-add-expr-alt>:    (:ast_expr, :ast_expr) -> ();
 
-	<ast-make-class-concat>:      (:ast_class, :ast_class) -> (:ast_class);
+	<ast-make-class-concat>:      ()                       -> (:ast_class);
 	<ast-make-class-literal>:     (:char)                  -> (:ast_class);
 	<ast-make-class-range>:       (:endpoint, :pos, :endpoint, :pos) -> (:ast_class);
 	<ast-make-class-named>:       (:ast_class_id)          -> (:ast_class);
@@ -102,6 +102,8 @@
 	<ast-make-class-flag-invert>: () -> (:ast_class);
 	!<ast-make-class-flag-minus>: () -> (:ast_class);
 	!<ast-make-class-flag-invert-minus>: () -> (:ast_class);
+
+	<ast-add-class-concat>: (:ast_class, :ast_class) -> ();
 
 	<err-expected-term>;
 	<err-expected-count>;
@@ -122,6 +124,7 @@
 	<mark-count>: (:pos, :pos) -> ();
 
 	expr: () -> (node :ast_expr) [
+
 		literal: () -> (node :ast_expr) = {
 			{
 				(c, !, !) = ESC;
@@ -135,13 +138,17 @@
 			node = <ast-make-expr-literal>(c);
   		};
 
-		class: () -> (node :ast_expr) [
+		character-class: () -> (node :ast_expr) [
+
 			/* TODO: []] [-]] etc.? though they can be escaped. */
-			class-head: () -> (f :ast_class) = {
+			class-head: (class :ast_class) -> () = {
 				(!) = INVERT;
-				f = <ast-make-class-flag-invert>();
+				f = <ast-make-class-flag-invert>;
+				<ast-add-class-concat>(class, f);
 			||
+				/* XXX: why add a node at all? */
 				f = <ast-make-class-flag-none>();
+				<ast-add-class-concat>(class, f);
 			};
 
 			class-literal: () -> (node :ast_class) = {
@@ -168,13 +175,13 @@
 					(ca, start, !) = CHAR;
 				};
 				a = <ast-range-endpoint-literal>(ca);
-				
+
 				{
 					(!, !, !) = RANGE;
 				##
 					<err-expected-range>;
 				};
-	
+
 				{
 					(cz, !, end) = ESC;
 				||
@@ -187,14 +194,16 @@
 					(cz, !, end) = RANGE;
 				};
 				z = <ast-range-endpoint-literal>(cz);
-	
+
 				<mark-range>(start, end);
 				<ast-range-distinct>(a, start, z, end);
+
 				node = <ast-make-class-range>(a, start, z, end);
 			};
 
-			class-named: () -> (id :ast_class_id) = {
-                        	(id, !, !) = NAMED_CLASS;
+			class-named: () -> (node :ast_class) = {
+				(id, !, !) = NAMED_CLASS;
+				node = <ast-make-class-named>(id);
 			};
 
 			class-term: () -> (node :ast_class) = {
@@ -202,27 +211,31 @@
 			||
 				node = class-range();
 			||
-				id = class-named();
-				node = <ast-make-class-named>(id);
-			##
-				<err-expected-term>();
-				/* workaround sid warning */
-				node = <ast-make-class-flag-none>();
+				node = class-named();
 			};
-			    
-			list-of-class-terms: () -> (node :ast_class) = {
-				l = class-term();
+
+			list-of-class-terms: (class :ast_class) -> () = {
 				{
-					r = list-of-class-terms();
-					node = <ast-make-class-concat>(l, r);
+					node = class-term;
+					<ast-add-class-concat>(class, node);
+				##
+					<err-expected-term>;
+				};
+
+				{
+					list-of-class-terms(class);
 				||
-					node = l;
+					$;
 				};
 			};
+
 		] = {
 			(start, !) = OPENGROUP;
-			head = class-head();
-			body = list-of-class-terms();
+
+			class = <ast-make-class-concat>;
+
+			class-head(class);
+			list-of-class-terms(class);
 
 			{
 				(!, !, end) = CLOSEGROUP;
@@ -232,8 +245,7 @@
 				end = start; /* appease sid */
 			};
 
-			hb = <ast-make-class-concat>(head, body);
-			node = <ast-make-expr-class>(hb, start, end);
+			node = <ast-make-expr-class>(class, start, end);
 		};
 
 		atom: () -> (node :ast_expr) = {
@@ -247,7 +259,7 @@
 					<err-expected-alts>;
 				};
 			||
-				e = class();
+				e = character-class();
 			||
 				e = literal();
 			||

--- a/src/libre/dialect/pcre/parser.c
+++ b/src/libre/dialect/pcre/parser.c
@@ -220,31 +220,28 @@
 
 /* BEGINNING OF FUNCTION DECLARATIONS */
 
-static void p_254(flags, lex_state, act_state, err, t_ast__expr *, t_ast__expr *);
-static void p_expr_C_Cclass_C_Cclass_Hrange_C_Crange_Hendpoint_Hclass(flags, lex_state, act_state, err, t_endpoint *, t_pos *, t_pos *);
+static void p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead(flags, lex_state, act_state, err, t_ast__class);
 static void p_expr_C_Cflags_C_Cflag__set(flags, lex_state, act_state, err, t_re__flags, t_re__flags *);
-static void p_141(flags, lex_state, act_state, err);
-static void p_145(flags, lex_state, act_state, err, t_endpoint *, t_pos *);
-static void p_expr_C_Cclass_C_Cclass_Hhead(flags, lex_state, act_state, err, t_ast__class *);
+static void p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms(flags, lex_state, act_state, err, t_ast__class);
+static void p_146(flags, lex_state, act_state, err);
+static void p_150(flags, lex_state, act_state, err, t_endpoint *, t_pos *);
 static void p_expr_C_Cliteral(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_expr_C_Cclass_C_Clist_Hof_Hclass_Hterms(flags, lex_state, act_state, err, t_ast__class *);
+static void p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags, lex_state, act_state, err, t_ast__class *);
+static void p_expr_C_Ccharacter_Hclass(flags, lex_state, act_state, err, t_ast__expr *);
+static void p_expr_C_Ccharacter_Hclass_C_Cclass_Hrange_C_Crange_Hendpoint_Hliteral(flags, lex_state, act_state, err, t_endpoint *, t_pos *, t_pos *);
+static void p_190(flags, lex_state, act_state, err);
 static void p_expr(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_194(flags, lex_state, act_state, err);
 static void p_expr_C_Cflags(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_expr_C_Cclass_C_Cclass_Hterm(flags, lex_state, act_state, err, t_ast__class *);
-static void p_expr_C_Clist_Hof_Hatoms(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_expr_C_Cclass(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_expr_C_Cclass_C_Cclass_Hrange_C_Crange_Hendpoint_Hliteral(flags, lex_state, act_state, err, t_endpoint *, t_pos *, t_pos *);
-static void p_expr_C_Clist_Hof_Halts(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_225(flags, lex_state, act_state, err, t_ast__expr *, t_ast__expr *);
-static void p_226(flags, lex_state, act_state, err, t_ast__expr *, t_ast__expr *);
+static void p_expr_C_Clist_Hof_Hatoms(flags, lex_state, act_state, err, t_ast__expr);
+static void p_expr_C_Clist_Hof_Halts(flags, lex_state, act_state, err, t_ast__expr);
+static void p_expr_C_Ccharacter_Hclass_C_Cclass_Hrange_C_Crange_Hendpoint_Hclass(flags, lex_state, act_state, err, t_endpoint *, t_pos *, t_pos *);
+static void p_227(flags, lex_state, act_state, err, t_ast__class__id *, t_pos *, t_ast__class *);
 extern void p_re__pcre(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_230(flags, lex_state, act_state, err, t_ast__class__id *, t_pos *, t_ast__class *);
 static void p_expr_C_Catom(flags, lex_state, act_state, err, t_ast__expr *);
+static void p_247(flags, lex_state, act_state, err, t_char *, t_pos *, t_ast__class *);
 static void p_expr_C_Calt(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_250(flags, lex_state, act_state, err, t_char *, t_pos *, t_ast__class *);
+static void p_250(flags, lex_state, act_state, err, t_ast__expr *, t_pos *, t_unsigned *, t_ast__expr *);
 static void p_expr_C_Ctype(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_253(flags, lex_state, act_state, err, t_ast__expr *, t_pos *, t_unsigned *, t_ast__expr *);
 
 /* BEGINNING OF STATIC VARIABLES */
 
@@ -252,137 +249,85 @@ static void p_253(flags, lex_state, act_state, err, t_ast__expr *, t_pos *, t_un
 /* BEGINNING OF FUNCTION DEFINITIONS */
 
 static void
-p_254(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZIa, t_ast__expr *ZOnode)
+p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class ZIclass)
 {
-	t_ast__expr ZInode;
-
 	switch (CURRENT_TERMINAL) {
-	case (TOK_ALT):
+	case (TOK_INVERT):
 		{
-			t_ast__expr ZIr;
+			t_char ZI112;
+			t_ast__class ZIf;
 
-			ADVANCE_LEXER;
-			p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, &ZIr);
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-			/* BEGINNING OF ACTION: ast-make-expr-alt */
+			/* BEGINNING OF EXTRACT: INVERT */
 			{
-#line 639 "src/libre/parser.act"
+#line 239 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_alt((*ZIa), (ZIr));
-		if ((ZInode) == NULL) {
+		ZI112 = '^';
+	
+#line 267 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF EXTRACT: INVERT */
+			ADVANCE_LEXER;
+			/* BEGINNING OF ACTION: ast-make-class-flag-invert */
+			{
+#line 809 "src/libre/parser.act"
+
+		(ZIf) = ast_make_class_flags(AST_CLASS_FLAG_INVERTED);
+		if ((ZIf) == NULL) {
 			goto ZL1;
 		}
 	
 #line 280 "src/libre/dialect/pcre/parser.c"
 			}
-			/* END OF ACTION: ast-make-expr-alt */
+			/* END OF ACTION: ast-make-class-flag-invert */
+			/* BEGINNING OF ACTION: ast-add-class-concat */
+			{
+#line 830 "src/libre/parser.act"
+
+		if (!ast_add_class_concat((ZIclass), (ZIf))) {
+			goto ZL1;
+		}
+	
+#line 291 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: ast-add-class-concat */
 		}
 		break;
 	default:
 		{
-			t_ast__expr ZIr;
+			t_ast__class ZIf;
 
-			/* BEGINNING OF ACTION: ast-make-expr-empty */
+			/* BEGINNING OF ACTION: ast-make-class-flag-none */
 			{
-#line 625 "src/libre/parser.act"
+#line 802 "src/libre/parser.act"
 
-		(ZIr) = ast_make_expr_empty();
-		if ((ZIr) == NULL) {
+		(ZIf) = ast_make_class_flags(AST_CLASS_FLAG_NONE);
+		if ((ZIf) == NULL) {
 			goto ZL1;
 		}
 	
-#line 298 "src/libre/dialect/pcre/parser.c"
+#line 309 "src/libre/dialect/pcre/parser.c"
 			}
-			/* END OF ACTION: ast-make-expr-empty */
-			/* BEGINNING OF ACTION: ast-make-expr-alt */
+			/* END OF ACTION: ast-make-class-flag-none */
+			/* BEGINNING OF ACTION: ast-add-class-concat */
 			{
-#line 639 "src/libre/parser.act"
+#line 830 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_alt((*ZIa), (ZIr));
-		if ((ZInode) == NULL) {
+		if (!ast_add_class_concat((ZIclass), (ZIf))) {
 			goto ZL1;
 		}
 	
-#line 310 "src/libre/dialect/pcre/parser.c"
+#line 320 "src/libre/dialect/pcre/parser.c"
 			}
-			/* END OF ACTION: ast-make-expr-alt */
+			/* END OF ACTION: ast-add-class-concat */
 		}
 		break;
 	case (ERROR_TERMINAL):
 		return;
 	}
-	goto ZL0;
+	return;
 ZL1:;
 	SAVE_LEXER ((ERROR_TERMINAL));
 	return;
-ZL0:;
-	*ZOnode = ZInode;
-}
-
-static void
-p_expr_C_Cclass_C_Cclass_Hrange_C_Crange_Hendpoint_Hclass(flags flags, lex_state lex_state, act_state act_state, err err, t_endpoint *ZOr, t_pos *ZOstart, t_pos *ZOend)
-{
-	t_endpoint ZIr;
-	t_pos ZIstart;
-	t_pos ZIend;
-
-	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-		return;
-	}
-	{
-		t_ast__class__id ZIid;
-
-		/* BEGINNING OF INLINE: expr::class::class-named */
-		{
-			{
-				switch (CURRENT_TERMINAL) {
-				case (TOK_NAMED__CLASS):
-					/* BEGINNING OF EXTRACT: NAMED_CLASS */
-					{
-#line 428 "src/libre/parser.act"
-
-		ZIid = DIALECT_CLASS(lex_state->buf.a);
-		if (ZIid == NULL) {
-			/* syntax error -- unrecognized class */
-			goto ZL1;
-		}
-
-		ZIstart = lex_state->lx.start;
-		ZIend   = lex_state->lx.end;
-	
-#line 357 "src/libre/dialect/pcre/parser.c"
-					}
-					/* END OF EXTRACT: NAMED_CLASS */
-					break;
-				default:
-					goto ZL1;
-				}
-				ADVANCE_LEXER;
-			}
-		}
-		/* END OF INLINE: expr::class::class-named */
-		/* BEGINNING OF ACTION: ast-range-endpoint-class */
-		{
-#line 599 "src/libre/parser.act"
-
-		(ZIr).type = AST_ENDPOINT_CLASS;
-		(ZIr).u.class.ctor = (ZIid);
-	
-#line 375 "src/libre/dialect/pcre/parser.c"
-		}
-		/* END OF ACTION: ast-range-endpoint-class */
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOr = ZIr;
-	*ZOstart = ZIstart;
-	*ZOend = ZIend;
 }
 
 static void
@@ -401,7 +346,7 @@ p_expr_C_Cflags_C_Cflag__set(flags flags, lex_state lex_state, act_state act_sta
 
 		ZIc = RE_ICASE;
 	
-#line 405 "src/libre/dialect/pcre/parser.c"
+#line 350 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: FLAG_INSENSITIVE */
 			ADVANCE_LEXER;
@@ -411,7 +356,7 @@ p_expr_C_Cflags_C_Cflag__set(flags flags, lex_state lex_state, act_state act_sta
 
 		(ZIo) = (ZIi) | (ZIc);
 	
-#line 415 "src/libre/dialect/pcre/parser.c"
+#line 360 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: re-flag-union */
 		}
@@ -429,7 +374,7 @@ p_expr_C_Cflags_C_Cflag__set(flags flags, lex_state lex_state, act_state act_sta
 		}
 		goto ZL1;
 	
-#line 433 "src/libre/dialect/pcre/parser.c"
+#line 378 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: err-unknown-flag */
 		}
@@ -448,15 +393,87 @@ ZL0:;
 }
 
 static void
-p_141(flags flags, lex_state lex_state, act_state act_state, err err)
+p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class ZIclass)
+{
+	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+		return;
+	}
+ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
+	{
+		/* BEGINNING OF INLINE: 159 */
+		{
+			{
+				t_ast__class ZInode;
+
+				p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm (flags, lex_state, act_state, err, &ZInode);
+				if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+					RESTORE_LEXER;
+					goto ZL4;
+				}
+				/* BEGINNING OF ACTION: ast-add-class-concat */
+				{
+#line 830 "src/libre/parser.act"
+
+		if (!ast_add_class_concat((ZIclass), (ZInode))) {
+			goto ZL4;
+		}
+	
+#line 422 "src/libre/dialect/pcre/parser.c"
+				}
+				/* END OF ACTION: ast-add-class-concat */
+			}
+			goto ZL3;
+		ZL4:;
+			{
+				/* BEGINNING OF ACTION: err-expected-term */
+				{
+#line 456 "src/libre/parser.act"
+
+		if (err->e == RE_ESUCCESS) {
+			err->e = RE_EXTERM;
+		}
+		goto ZL1;
+	
+#line 438 "src/libre/dialect/pcre/parser.c"
+				}
+				/* END OF ACTION: err-expected-term */
+			}
+		ZL3:;
+		}
+		/* END OF INLINE: 159 */
+		/* BEGINNING OF INLINE: 160 */
+		{
+			switch (CURRENT_TERMINAL) {
+			case (TOK_NAMED__CLASS): case (TOK_ESC): case (TOK_CONTROL): case (TOK_OCT):
+			case (TOK_HEX): case (TOK_CHAR):
+				{
+					/* BEGINNING OF INLINE: expr::character-class::list-of-class-terms */
+					goto ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms;
+					/* END OF INLINE: expr::character-class::list-of-class-terms */
+				}
+				/*UNREACHED*/
+			default:
+				break;
+			}
+		}
+		/* END OF INLINE: 160 */
+	}
+	return;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+}
+
+static void
+p_146(flags flags, lex_state lex_state, act_state act_state, err err)
 {
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 		return;
 	}
 	{
-		t_char ZI142;
-		t_pos ZI143;
-		t_pos ZI144;
+		t_char ZI147;
+		t_pos ZI148;
+		t_pos ZI149;
 
 		switch (CURRENT_TERMINAL) {
 		case (TOK_RANGE):
@@ -464,11 +481,11 @@ p_141(flags flags, lex_state lex_state, act_state act_state, err err)
 			{
 #line 243 "src/libre/parser.act"
 
-		ZI142 = '-';
-		ZI143 = lex_state->lx.start;
-		ZI144   = lex_state->lx.end;
+		ZI147 = '-';
+		ZI148 = lex_state->lx.start;
+		ZI149   = lex_state->lx.end;
 	
-#line 472 "src/libre/dialect/pcre/parser.c"
+#line 489 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			break;
@@ -489,7 +506,7 @@ ZL1:;
 		}
 		goto ZL2;
 	
-#line 493 "src/libre/dialect/pcre/parser.c"
+#line 510 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-expected-range */
 	}
@@ -501,26 +518,26 @@ ZL0:;
 }
 
 static void
-p_145(flags flags, lex_state lex_state, act_state act_state, err err, t_endpoint *ZOupper, t_pos *ZOu__end)
+p_150(flags flags, lex_state lex_state, act_state act_state, err err, t_endpoint *ZOupper, t_pos *ZOend)
 {
 	t_endpoint ZIupper;
-	t_pos ZIu__end;
+	t_pos ZIend;
 
 	switch (CURRENT_TERMINAL) {
 	case (TOK_RANGE):
 		{
 			t_char ZIc;
-			t_pos ZIu__start;
+			t_pos ZI154;
 
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
 #line 243 "src/libre/parser.act"
 
 		ZIc = '-';
-		ZIu__start = lex_state->lx.start;
-		ZIu__end   = lex_state->lx.end;
+		ZI154 = lex_state->lx.start;
+		ZIend   = lex_state->lx.end;
 	
-#line 524 "src/libre/dialect/pcre/parser.c"
+#line 541 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
@@ -531,16 +548,16 @@ p_145(flags flags, lex_state lex_state, act_state act_state, err err, t_endpoint
 		(ZIupper).type = AST_ENDPOINT_LITERAL;
 		(ZIupper).u.literal.c = (ZIc);
 	
-#line 535 "src/libre/dialect/pcre/parser.c"
+#line 552 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 		}
 		break;
 	case (TOK_NAMED__CLASS):
 		{
-			t_pos ZIu__start;
+			t_pos ZI153;
 
-			p_expr_C_Cclass_C_Cclass_Hrange_C_Crange_Hendpoint_Hclass (flags, lex_state, act_state, err, &ZIupper, &ZIu__start, &ZIu__end);
+			p_expr_C_Ccharacter_Hclass_C_Cclass_Hrange_C_Crange_Hendpoint_Hclass (flags, lex_state, act_state, err, &ZIupper, &ZI153, &ZIend);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -550,9 +567,9 @@ p_145(flags flags, lex_state lex_state, act_state act_state, err err, t_endpoint
 	case (TOK_ESC): case (TOK_CONTROL): case (TOK_OCT): case (TOK_HEX):
 	case (TOK_CHAR):
 		{
-			t_pos ZIu__start;
+			t_pos ZI152;
 
-			p_expr_C_Cclass_C_Cclass_Hrange_C_Crange_Hendpoint_Hliteral (flags, lex_state, act_state, err, &ZIupper, &ZIu__start, &ZIu__end);
+			p_expr_C_Ccharacter_Hclass_C_Cclass_Hrange_C_Crange_Hendpoint_Hliteral (flags, lex_state, act_state, err, &ZIupper, &ZI152, &ZIend);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -570,68 +587,7 @@ ZL1:;
 	return;
 ZL0:;
 	*ZOupper = ZIupper;
-	*ZOu__end = ZIu__end;
-}
-
-static void
-p_expr_C_Cclass_C_Cclass_Hhead(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class *ZOf)
-{
-	t_ast__class ZIf;
-
-	switch (CURRENT_TERMINAL) {
-	case (TOK_INVERT):
-		{
-			t_char ZI109;
-
-			/* BEGINNING OF EXTRACT: INVERT */
-			{
-#line 239 "src/libre/parser.act"
-
-		ZI109 = '^';
-	
-#line 593 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF EXTRACT: INVERT */
-			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: ast-make-class-flag-invert */
-			{
-#line 797 "src/libre/parser.act"
-
-		(ZIf) = ast_make_class_flags(AST_CLASS_FLAG_INVERTED);
-		if ((ZIf) == NULL) {
-			goto ZL1;
-		}
-	
-#line 606 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: ast-make-class-flag-invert */
-		}
-		break;
-	default:
-		{
-			/* BEGINNING OF ACTION: ast-make-class-flag-none */
-			{
-#line 790 "src/libre/parser.act"
-
-		(ZIf) = ast_make_class_flags(AST_CLASS_FLAG_NONE);
-		if ((ZIf) == NULL) {
-			goto ZL1;
-		}
-	
-#line 622 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: ast-make-class-flag-none */
-		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOf = ZIf;
+	*ZOend = ZIend;
 }
 
 static void
@@ -645,13 +601,13 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 	{
 		t_char ZIc;
 
-		/* BEGINNING OF INLINE: 94 */
+		/* BEGINNING OF INLINE: 97 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CHAR):
 				{
-					t_pos ZI102;
-					t_pos ZI103;
+					t_pos ZI105;
+					t_pos ZI106;
 
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
@@ -660,12 +616,12 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI102 = lex_state->lx.start;
-		ZI103   = lex_state->lx.end;
+		ZI105 = lex_state->lx.start;
+		ZI106   = lex_state->lx.end;
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 669 "src/libre/dialect/pcre/parser.c"
+#line 625 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CHAR */
 					ADVANCE_LEXER;
@@ -673,8 +629,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				break;
 			case (TOK_ESC):
 				{
-					t_pos ZI96;
-					t_pos ZI97;
+					t_pos ZI99;
+					t_pos ZI100;
 
 					/* BEGINNING OF EXTRACT: ESC */
 					{
@@ -696,10 +652,10 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		default:             break;
 		}
 
-		ZI96 = lex_state->lx.start;
-		ZI97   = lex_state->lx.end;
+		ZI99 = lex_state->lx.start;
+		ZI100   = lex_state->lx.end;
 	
-#line 703 "src/libre/dialect/pcre/parser.c"
+#line 659 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: ESC */
 					ADVANCE_LEXER;
@@ -707,8 +663,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				break;
 			case (TOK_HEX):
 				{
-					t_pos ZI100;
-					t_pos ZI101;
+					t_pos ZI103;
+					t_pos ZI104;
 
 					/* BEGINNING OF EXTRACT: HEX */
 					{
@@ -721,8 +677,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		assert(0 == strncmp(lex_state->buf.a, "\\x", 2));
 		assert(strlen(lex_state->buf.a) >= 3);
 
-		ZI100 = lex_state->lx.start;
-		ZI101   = lex_state->lx.end;
+		ZI103 = lex_state->lx.start;
+		ZI104   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -752,7 +708,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 756 "src/libre/dialect/pcre/parser.c"
+#line 712 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: HEX */
 					ADVANCE_LEXER;
@@ -760,8 +716,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				break;
 			case (TOK_OCT):
 				{
-					t_pos ZI98;
-					t_pos ZI99;
+					t_pos ZI101;
+					t_pos ZI102;
 
 					/* BEGINNING OF EXTRACT: OCT */
 					{
@@ -774,8 +730,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
 		assert(strlen(lex_state->buf.a) >= 2);
 
-		ZI98 = lex_state->lx.start;
-		ZI99   = lex_state->lx.end;
+		ZI101 = lex_state->lx.start;
+		ZI102   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -805,7 +761,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 809 "src/libre/dialect/pcre/parser.c"
+#line 765 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OCT */
 					ADVANCE_LEXER;
@@ -815,7 +771,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 94 */
+		/* END OF INLINE: 97 */
 		/* BEGINNING OF ACTION: ast-make-expr-literal */
 		{
 #line 646 "src/libre/parser.act"
@@ -825,7 +781,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 			goto ZL1;
 		}
 	
-#line 829 "src/libre/dialect/pcre/parser.c"
+#line 785 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-expr-literal */
 	}
@@ -838,310 +794,16 @@ ZL0:;
 }
 
 static void
-p_expr_C_Cclass_C_Clist_Hof_Hclass_Hterms(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class *ZOnode)
-{
-	t_ast__class ZInode;
-
-	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-		return;
-	}
-	{
-		t_ast__class ZIl;
-
-		p_expr_C_Cclass_C_Cclass_Hterm (flags, lex_state, act_state, err, &ZIl);
-		/* BEGINNING OF INLINE: 160 */
-		{
-			switch (CURRENT_TERMINAL) {
-			case (TOK_NAMED__CLASS): case (TOK_ESC): case (TOK_CONTROL): case (TOK_OCT):
-			case (TOK_HEX): case (TOK_CHAR):
-				{
-					t_ast__class ZIr;
-
-					p_expr_C_Cclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, &ZIr);
-					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-						RESTORE_LEXER;
-						goto ZL1;
-					}
-					/* BEGINNING OF ACTION: ast-make-class-concat */
-					{
-#line 729 "src/libre/parser.act"
-
-		(ZInode) = ast_make_class_concat((ZIl), (ZIr));
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 875 "src/libre/dialect/pcre/parser.c"
-					}
-					/* END OF ACTION: ast-make-class-concat */
-				}
-				break;
-			default:
-				{
-					ZInode = ZIl;
-				}
-				break;
-			case (ERROR_TERMINAL):
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-		}
-		/* END OF INLINE: 160 */
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOnode = ZInode;
-}
-
-static void
-p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
-{
-	t_ast__expr ZInode;
-
-	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-		return;
-	}
-	{
-		t_ast__expr ZI223;
-
-		p_expr_C_Calt (flags, lex_state, act_state, err, &ZI223);
-		p_225 (flags, lex_state, act_state, err, &ZI223, &ZInode);
-		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-			RESTORE_LEXER;
-			goto ZL1;
-		}
-	}
-	goto ZL0;
-ZL1:;
-	{
-		/* BEGINNING OF ACTION: err-expected-alts */
-		{
-#line 477 "src/libre/parser.act"
-
-		if (err->e == RE_ESUCCESS) {
-			err->e = RE_EXALTS;
-		}
-		goto ZL2;
-	
-#line 930 "src/libre/dialect/pcre/parser.c"
-		}
-		/* END OF ACTION: err-expected-alts */
-		/* BEGINNING OF ACTION: ast-make-expr-empty */
-		{
-#line 625 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_empty();
-		if ((ZInode) == NULL) {
-			goto ZL2;
-		}
-	
-#line 942 "src/libre/dialect/pcre/parser.c"
-		}
-		/* END OF ACTION: ast-make-expr-empty */
-	}
-	goto ZL0;
-ZL2:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOnode = ZInode;
-}
-
-static void
-p_194(flags flags, lex_state lex_state, act_state act_state, err err)
-{
-	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-		return;
-	}
-	{
-		switch (CURRENT_TERMINAL) {
-		case (TOK_CLOSE):
-			break;
-		default:
-			goto ZL1;
-		}
-		ADVANCE_LEXER;
-	}
-	return;
-ZL1:;
-	{
-		/* BEGINNING OF ACTION: err-expected-alts */
-		{
-#line 477 "src/libre/parser.act"
-
-		if (err->e == RE_ESUCCESS) {
-			err->e = RE_EXALTS;
-		}
-		goto ZL2;
-	
-#line 981 "src/libre/dialect/pcre/parser.c"
-		}
-		/* END OF ACTION: err-expected-alts */
-	}
-	goto ZL0;
-ZL2:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-}
-
-static void
-p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
-{
-	t_ast__expr ZInode;
-
-	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-		return;
-	}
-	{
-		t_re__flags ZIempty__pos;
-		t_re__flags ZIempty__neg;
-		t_re__flags ZIpos;
-		t_re__flags ZIneg;
-
-		switch (CURRENT_TERMINAL) {
-		case (TOK_OPENFLAGS):
-			break;
-		default:
-			goto ZL1;
-		}
-		ADVANCE_LEXER;
-		/* BEGINNING OF ACTION: re-flag-none */
-		{
-#line 550 "src/libre/parser.act"
-
-		(ZIempty__pos) = RE_FLAGS_NONE;
-	
-#line 1019 "src/libre/dialect/pcre/parser.c"
-		}
-		/* END OF ACTION: re-flag-none */
-		/* BEGINNING OF ACTION: re-flag-none */
-		{
-#line 550 "src/libre/parser.act"
-
-		(ZIempty__neg) = RE_FLAGS_NONE;
-	
-#line 1028 "src/libre/dialect/pcre/parser.c"
-		}
-		/* END OF ACTION: re-flag-none */
-		/* BEGINNING OF INLINE: 182 */
-		{
-			switch (CURRENT_TERMINAL) {
-			case (TOK_FLAG__UNKNOWN): case (TOK_FLAG__INSENSITIVE):
-				{
-					p_expr_C_Cflags_C_Cflag__set (flags, lex_state, act_state, err, ZIempty__pos, &ZIpos);
-					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-						RESTORE_LEXER;
-						goto ZL1;
-					}
-				}
-				break;
-			default:
-				{
-					ZIpos = ZIempty__pos;
-				}
-				break;
-			}
-		}
-		/* END OF INLINE: 182 */
-		/* BEGINNING OF INLINE: 184 */
-		{
-			switch (CURRENT_TERMINAL) {
-			case (TOK_NEGATE):
-				{
-					ADVANCE_LEXER;
-					p_expr_C_Cflags_C_Cflag__set (flags, lex_state, act_state, err, ZIempty__neg, &ZIneg);
-					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-						RESTORE_LEXER;
-						goto ZL1;
-					}
-				}
-				break;
-			default:
-				{
-					ZIneg = ZIempty__neg;
-				}
-				break;
-			}
-		}
-		/* END OF INLINE: 184 */
-		/* BEGINNING OF INLINE: 187 */
-		{
-			{
-				switch (CURRENT_TERMINAL) {
-				case (TOK_CLOSEFLAGS):
-					break;
-				default:
-					goto ZL5;
-				}
-				ADVANCE_LEXER;
-				/* BEGINNING OF ACTION: ast-make-expr-re-flags */
-				{
-#line 704 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_re_flags((ZIpos), (ZIneg));
-		if ((ZInode) == NULL) {
-			goto ZL5;
-		}
-	
-#line 1091 "src/libre/dialect/pcre/parser.c"
-				}
-				/* END OF ACTION: ast-make-expr-re-flags */
-			}
-			goto ZL4;
-		ZL5:;
-			{
-				/* BEGINNING OF ACTION: err-expected-closeflags */
-				{
-#line 512 "src/libre/parser.act"
-
-		if (err->e == RE_ESUCCESS) {
-			err->e = RE_EXCLOSEFLAGS;
-		}
-		goto ZL1;
-	
-#line 1107 "src/libre/dialect/pcre/parser.c"
-				}
-				/* END OF ACTION: err-expected-closeflags */
-				/* BEGINNING OF ACTION: ast-make-expr-empty */
-				{
-#line 625 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_empty();
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 1119 "src/libre/dialect/pcre/parser.c"
-				}
-				/* END OF ACTION: ast-make-expr-empty */
-			}
-		ZL4:;
-		}
-		/* END OF INLINE: 187 */
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOnode = ZInode;
-}
-
-static void
-p_expr_C_Cclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class *ZOnode)
+p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class *ZOnode)
 {
 	t_ast__class ZInode;
 
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CHAR):
 		{
-			t_char ZI243;
-			t_pos ZI244;
-			t_pos ZI245;
+			t_char ZI240;
+			t_pos ZI241;
+			t_pos ZI242;
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
@@ -1150,16 +812,16 @@ p_expr_C_Cclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state act_s
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI244 = lex_state->lx.start;
-		ZI245   = lex_state->lx.end;
+		ZI241 = lex_state->lx.start;
+		ZI242   = lex_state->lx.end;
 
-		ZI243 = lex_state->buf.a[0];
+		ZI240 = lex_state->buf.a[0];
 	
-#line 1159 "src/libre/dialect/pcre/parser.c"
+#line 821 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
-			p_250 (flags, lex_state, act_state, err, &ZI243, &ZI244, &ZInode);
+			p_247 (flags, lex_state, act_state, err, &ZI240, &ZI241, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1168,9 +830,9 @@ p_expr_C_Cclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state act_s
 		break;
 	case (TOK_CONTROL):
 		{
-			t_char ZI247;
-			t_pos ZI248;
-			t_pos ZI249;
+			t_char ZI244;
+			t_pos ZI245;
+			t_pos ZI246;
 
 			/* BEGINNING OF EXTRACT: CONTROL */
 			{
@@ -1181,16 +843,16 @@ p_expr_C_Cclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state act_s
 		assert(lex_state->buf.a[2] != '\0');
 		assert(lex_state->buf.a[3] == '\0');
 
-		ZI247 = lex_state->buf.a[2];
-		if ((unsigned char) ZI247 > 127) {
+		ZI244 = lex_state->buf.a[2];
+		if ((unsigned char) ZI244 > 127) {
 			goto ZL1;
 		}
-		ZI247 = (((toupper((unsigned char)ZI247)) - 64) % 128 + 128) % 128;
+		ZI244 = (((toupper((unsigned char)ZI244)) - 64) % 128 + 128) % 128;
 
-		ZI248 = lex_state->lx.start;
-		ZI249   = lex_state->lx.end;
+		ZI245 = lex_state->lx.start;
+		ZI246   = lex_state->lx.end;
 	
-#line 1194 "src/libre/dialect/pcre/parser.c"
+#line 856 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: CONTROL */
 			ADVANCE_LEXER;
@@ -1203,10 +865,10 @@ p_expr_C_Cclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state act_s
 		}
 		goto ZL1;
 	
-#line 1207 "src/libre/dialect/pcre/parser.c"
+#line 869 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: err-unsupported */
-			p_250 (flags, lex_state, act_state, err, &ZI247, &ZI248, &ZInode);
+			p_247 (flags, lex_state, act_state, err, &ZI244, &ZI245, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1215,9 +877,9 @@ p_expr_C_Cclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state act_s
 		break;
 	case (TOK_ESC):
 		{
-			t_char ZI231;
-			t_pos ZI232;
-			t_pos ZI233;
+			t_char ZI228;
+			t_pos ZI229;
+			t_pos ZI230;
 
 			/* BEGINNING OF EXTRACT: ESC */
 			{
@@ -1227,26 +889,26 @@ p_expr_C_Cclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state act_s
 		assert(lex_state->buf.a[1] != '\0');
 		assert(lex_state->buf.a[2] == '\0');
 
-		ZI231 = lex_state->buf.a[1];
+		ZI228 = lex_state->buf.a[1];
 
-		switch (ZI231) {
-		case 'a': ZI231 = '\a'; break;
-		case 'f': ZI231 = '\f'; break;
-		case 'n': ZI231 = '\n'; break;
-		case 'r': ZI231 = '\r'; break;
-		case 't': ZI231 = '\t'; break;
-		case 'v': ZI231 = '\v'; break;
+		switch (ZI228) {
+		case 'a': ZI228 = '\a'; break;
+		case 'f': ZI228 = '\f'; break;
+		case 'n': ZI228 = '\n'; break;
+		case 'r': ZI228 = '\r'; break;
+		case 't': ZI228 = '\t'; break;
+		case 'v': ZI228 = '\v'; break;
 		default:             break;
 		}
 
-		ZI232 = lex_state->lx.start;
-		ZI233   = lex_state->lx.end;
+		ZI229 = lex_state->lx.start;
+		ZI230   = lex_state->lx.end;
 	
-#line 1246 "src/libre/dialect/pcre/parser.c"
+#line 908 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: ESC */
 			ADVANCE_LEXER;
-			p_250 (flags, lex_state, act_state, err, &ZI231, &ZI232, &ZInode);
+			p_247 (flags, lex_state, act_state, err, &ZI228, &ZI229, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1255,9 +917,9 @@ p_expr_C_Cclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state act_s
 		break;
 	case (TOK_HEX):
 		{
-			t_char ZI239;
-			t_pos ZI240;
-			t_pos ZI241;
+			t_char ZI236;
+			t_pos ZI237;
+			t_pos ZI238;
 
 			/* BEGINNING OF EXTRACT: HEX */
 			{
@@ -1270,8 +932,8 @@ p_expr_C_Cclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state act_s
 		assert(0 == strncmp(lex_state->buf.a, "\\x", 2));
 		assert(strlen(lex_state->buf.a) >= 3);
 
-		ZI240 = lex_state->lx.start;
-		ZI241   = lex_state->lx.end;
+		ZI237 = lex_state->lx.start;
+		ZI238   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -1299,13 +961,43 @@ p_expr_C_Cclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state act_s
 			goto ZL1;
 		}
 
-		ZI239 = (char) (unsigned char) u;
+		ZI236 = (char) (unsigned char) u;
 	
-#line 1305 "src/libre/dialect/pcre/parser.c"
+#line 967 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: HEX */
 			ADVANCE_LEXER;
-			p_250 (flags, lex_state, act_state, err, &ZI239, &ZI240, &ZInode);
+			p_247 (flags, lex_state, act_state, err, &ZI236, &ZI237, &ZInode);
+			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+				RESTORE_LEXER;
+				goto ZL1;
+			}
+		}
+		break;
+	case (TOK_NAMED__CLASS):
+		{
+			t_ast__class__id ZI224;
+			t_pos ZI225;
+			t_pos ZI226;
+
+			/* BEGINNING OF EXTRACT: NAMED_CLASS */
+			{
+#line 428 "src/libre/parser.act"
+
+		ZI224 = DIALECT_CLASS(lex_state->buf.a);
+		if (ZI224 == NULL) {
+			/* syntax error -- unrecognized class */
+			goto ZL1;
+		}
+
+		ZI225 = lex_state->lx.start;
+		ZI226   = lex_state->lx.end;
+	
+#line 997 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF EXTRACT: NAMED_CLASS */
+			ADVANCE_LEXER;
+			p_227 (flags, lex_state, act_state, err, &ZI224, &ZI225, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1314,9 +1006,9 @@ p_expr_C_Cclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state act_s
 		break;
 	case (TOK_OCT):
 		{
-			t_char ZI235;
-			t_pos ZI236;
-			t_pos ZI237;
+			t_char ZI232;
+			t_pos ZI233;
+			t_pos ZI234;
 
 			/* BEGINNING OF EXTRACT: OCT */
 			{
@@ -1329,8 +1021,8 @@ p_expr_C_Cclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state act_s
 		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
 		assert(strlen(lex_state->buf.a) >= 2);
 
-		ZI236 = lex_state->lx.start;
-		ZI237   = lex_state->lx.end;
+		ZI233 = lex_state->lx.start;
+		ZI234   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -1358,55 +1050,13 @@ p_expr_C_Cclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state act_s
 			goto ZL1;
 		}
 
-		ZI235 = (char) (unsigned char) u;
+		ZI232 = (char) (unsigned char) u;
 	
-#line 1364 "src/libre/dialect/pcre/parser.c"
+#line 1056 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: OCT */
 			ADVANCE_LEXER;
-			p_250 (flags, lex_state, act_state, err, &ZI235, &ZI236, &ZInode);
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-		}
-		break;
-	case (TOK_NAMED__CLASS):
-		{
-			t_ast__class__id ZI227;
-			t_pos ZI228;
-			t_pos ZI229;
-
-			/* BEGINNING OF INLINE: expr::class::class-named */
-			{
-				{
-					switch (CURRENT_TERMINAL) {
-					case (TOK_NAMED__CLASS):
-						/* BEGINNING OF EXTRACT: NAMED_CLASS */
-						{
-#line 428 "src/libre/parser.act"
-
-		ZI227 = DIALECT_CLASS(lex_state->buf.a);
-		if (ZI227 == NULL) {
-			/* syntax error -- unrecognized class */
-			goto ZL1;
-		}
-
-		ZI228 = lex_state->lx.start;
-		ZI229   = lex_state->lx.end;
-	
-#line 1399 "src/libre/dialect/pcre/parser.c"
-						}
-						/* END OF EXTRACT: NAMED_CLASS */
-						break;
-					default:
-						goto ZL1;
-					}
-					ADVANCE_LEXER;
-				}
-			}
-			/* END OF INLINE: expr::class::class-named */
-			p_230 (flags, lex_state, act_state, err, &ZI227, &ZI228, &ZInode);
+			p_247 (flags, lex_state, act_state, err, &ZI232, &ZI233, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1420,34 +1070,6 @@ p_expr_C_Cclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_state act_s
 	}
 	goto ZL0;
 ZL1:;
-	{
-		/* BEGINNING OF ACTION: err-expected-term */
-		{
-#line 456 "src/libre/parser.act"
-
-		if (err->e == RE_ESUCCESS) {
-			err->e = RE_EXTERM;
-		}
-		goto ZL3;
-	
-#line 1434 "src/libre/dialect/pcre/parser.c"
-		}
-		/* END OF ACTION: err-expected-term */
-		/* BEGINNING OF ACTION: ast-make-class-flag-none */
-		{
-#line 790 "src/libre/parser.act"
-
-		(ZInode) = ast_make_class_flags(AST_CLASS_FLAG_NONE);
-		if ((ZInode) == NULL) {
-			goto ZL3;
-		}
-	
-#line 1446 "src/libre/dialect/pcre/parser.c"
-		}
-		/* END OF ACTION: ast-make-class-flag-none */
-	}
-	goto ZL0;
-ZL3:;
 	SAVE_LEXER ((ERROR_TERMINAL));
 	return;
 ZL0:;
@@ -1455,33 +1077,7 @@ ZL0:;
 }
 
 static void
-p_expr_C_Clist_Hof_Hatoms(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
-{
-	t_ast__expr ZInode;
-
-	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-		return;
-	}
-	{
-		t_ast__expr ZIa;
-
-		p_expr_C_Catom (flags, lex_state, act_state, err, &ZIa);
-		p_226 (flags, lex_state, act_state, err, &ZIa, &ZInode);
-		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-			RESTORE_LEXER;
-			goto ZL1;
-		}
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOnode = ZInode;
-}
-
-static void
-p_expr_C_Cclass(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
+p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
 {
 	t_ast__expr ZInode;
 
@@ -1490,11 +1086,9 @@ p_expr_C_Cclass(flags flags, lex_state lex_state, act_state act_state, err err, 
 	}
 	{
 		t_pos ZIstart;
-		t_pos ZI162;
-		t_ast__class ZIhead;
-		t_ast__class ZIbody;
+		t_pos ZI161;
+		t_ast__class ZIclass;
 		t_pos ZIend;
-		t_ast__class ZIhb;
 
 		switch (CURRENT_TERMINAL) {
 		case (TOK_OPENGROUP):
@@ -1503,9 +1097,9 @@ p_expr_C_Cclass(flags flags, lex_state lex_state, act_state act_state, err err, 
 #line 249 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
-		ZI162   = lex_state->lx.end;
+		ZI161   = lex_state->lx.end;
 	
-#line 1509 "src/libre/dialect/pcre/parser.c"
+#line 1103 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: OPENGROUP */
 			break;
@@ -1513,17 +1107,29 @@ p_expr_C_Cclass(flags flags, lex_state lex_state, act_state act_state, err err, 
 			goto ZL1;
 		}
 		ADVANCE_LEXER;
-		p_expr_C_Cclass_C_Cclass_Hhead (flags, lex_state, act_state, err, &ZIhead);
-		p_expr_C_Cclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, &ZIbody);
-		/* BEGINNING OF INLINE: 165 */
+		/* BEGINNING OF ACTION: ast-make-class-concat */
+		{
+#line 741 "src/libre/parser.act"
+
+		(ZIclass) = ast_make_class_concat();
+		if ((ZIclass) == NULL) {
+			goto ZL1;
+		}
+	
+#line 1120 "src/libre/dialect/pcre/parser.c"
+		}
+		/* END OF ACTION: ast-make-class-concat */
+		p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead (flags, lex_state, act_state, err, ZIclass);
+		p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, ZIclass);
+		/* BEGINNING OF INLINE: 162 */
 		{
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
 			}
 			{
-				t_char ZI166;
-				t_pos ZI167;
+				t_char ZI163;
+				t_pos ZI164;
 
 				switch (CURRENT_TERMINAL) {
 				case (TOK_CLOSEGROUP):
@@ -1531,11 +1137,11 @@ p_expr_C_Cclass(flags flags, lex_state lex_state, act_state act_state, err err, 
 					{
 #line 254 "src/libre/parser.act"
 
-		ZI166 = ']';
-		ZI167 = lex_state->lx.start;
+		ZI163 = ']';
+		ZI164 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1539 "src/libre/dialect/pcre/parser.c"
+#line 1145 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CLOSEGROUP */
 					break;
@@ -1550,7 +1156,7 @@ p_expr_C_Cclass(flags flags, lex_state lex_state, act_state act_state, err err, 
 		mark(&act_state->groupstart, &(ZIstart));
 		mark(&act_state->groupend,   &(ZIend));
 	
-#line 1554 "src/libre/dialect/pcre/parser.c"
+#line 1160 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: mark-group */
 			}
@@ -1566,26 +1172,14 @@ p_expr_C_Cclass(flags flags, lex_state lex_state, act_state act_state, err err, 
 		}
 		goto ZL1;
 	
-#line 1570 "src/libre/dialect/pcre/parser.c"
+#line 1176 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: err-expected-closegroup */
 				ZIend = ZIstart;
 			}
 		ZL2:;
 		}
-		/* END OF INLINE: 165 */
-		/* BEGINNING OF ACTION: ast-make-class-concat */
-		{
-#line 729 "src/libre/parser.act"
-
-		(ZIhb) = ast_make_class_concat((ZIhead), (ZIbody));
-		if ((ZIhb) == NULL) {
-			goto ZL1;
-		}
-	
-#line 1587 "src/libre/dialect/pcre/parser.c"
-		}
-		/* END OF ACTION: ast-make-class-concat */
+		/* END OF INLINE: 162 */
 		/* BEGINNING OF ACTION: ast-make-expr-class */
 		{
 #line 684 "src/libre/parser.act"
@@ -1598,12 +1192,12 @@ p_expr_C_Cclass(flags flags, lex_state lex_state, act_state act_state, err err, 
 		mark(&act_state->groupstart, &(ZIstart));
 		mark(&act_state->groupend,   &(ZIend));
 
-		(ZInode) = ast_make_expr_class((ZIhb), &ast_start, &ast_end);
+		(ZInode) = ast_make_expr_class((ZIclass), &ast_start, &ast_end);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1607 "src/libre/dialect/pcre/parser.c"
+#line 1201 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-expr-class */
 	}
@@ -1616,7 +1210,7 @@ ZL0:;
 }
 
 static void
-p_expr_C_Cclass_C_Cclass_Hrange_C_Crange_Hendpoint_Hliteral(flags flags, lex_state lex_state, act_state act_state, err err, t_endpoint *ZOr, t_pos *ZOstart, t_pos *ZOend)
+p_expr_C_Ccharacter_Hclass_C_Cclass_Hrange_C_Crange_Hendpoint_Hliteral(flags flags, lex_state lex_state, act_state act_state, err err, t_endpoint *ZOr, t_pos *ZOstart, t_pos *ZOend)
 {
 	t_endpoint ZIr;
 	t_pos ZIstart;
@@ -1628,7 +1222,7 @@ p_expr_C_Cclass_C_Cclass_Hrange_C_Crange_Hendpoint_Hliteral(flags flags, lex_sta
 	{
 		t_char ZIc;
 
-		/* BEGINNING OF INLINE: 133 */
+		/* BEGINNING OF INLINE: 139 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CHAR):
@@ -1645,7 +1239,7 @@ p_expr_C_Cclass_C_Cclass_Hrange_C_Crange_Hendpoint_Hliteral(flags flags, lex_sta
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 1649 "src/libre/dialect/pcre/parser.c"
+#line 1243 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CHAR */
 					ADVANCE_LEXER;
@@ -1671,7 +1265,7 @@ p_expr_C_Cclass_C_Cclass_Hrange_C_Crange_Hendpoint_Hliteral(flags flags, lex_sta
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1675 "src/libre/dialect/pcre/parser.c"
+#line 1269 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CONTROL */
 					ADVANCE_LEXER;
@@ -1684,7 +1278,7 @@ p_expr_C_Cclass_C_Cclass_Hrange_C_Crange_Hendpoint_Hliteral(flags flags, lex_sta
 		}
 		goto ZL1;
 	
-#line 1688 "src/libre/dialect/pcre/parser.c"
+#line 1282 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: err-unsupported */
 				}
@@ -1714,7 +1308,7 @@ p_expr_C_Cclass_C_Cclass_Hrange_C_Crange_Hendpoint_Hliteral(flags flags, lex_sta
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1718 "src/libre/dialect/pcre/parser.c"
+#line 1312 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: ESC */
 					ADVANCE_LEXER;
@@ -1764,7 +1358,7 @@ p_expr_C_Cclass_C_Cclass_Hrange_C_Crange_Hendpoint_Hliteral(flags flags, lex_sta
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 1768 "src/libre/dialect/pcre/parser.c"
+#line 1362 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: HEX */
 					ADVANCE_LEXER;
@@ -1814,7 +1408,7 @@ p_expr_C_Cclass_C_Cclass_Hrange_C_Crange_Hendpoint_Hliteral(flags flags, lex_sta
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 1818 "src/libre/dialect/pcre/parser.c"
+#line 1412 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OCT */
 					ADVANCE_LEXER;
@@ -1824,7 +1418,7 @@ p_expr_C_Cclass_C_Cclass_Hrange_C_Crange_Hendpoint_Hliteral(flags flags, lex_sta
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 133 */
+		/* END OF INLINE: 139 */
 		/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 		{
 #line 594 "src/libre/parser.act"
@@ -1832,7 +1426,7 @@ p_expr_C_Cclass_C_Cclass_Hrange_C_Crange_Hendpoint_Hliteral(flags flags, lex_sta
 		(ZIr).type = AST_ENDPOINT_LITERAL;
 		(ZIr).u.literal.c = (ZIc);
 	
-#line 1836 "src/libre/dialect/pcre/parser.c"
+#line 1430 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-range-endpoint-literal */
 	}
@@ -1847,75 +1441,85 @@ ZL0:;
 }
 
 static void
-p_expr_C_Clist_Hof_Halts(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
+p_190(flags flags, lex_state lex_state, act_state act_state, err err)
+{
+	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+		return;
+	}
+	{
+		switch (CURRENT_TERMINAL) {
+		case (TOK_CLOSE):
+			break;
+		default:
+			goto ZL1;
+		}
+		ADVANCE_LEXER;
+	}
+	return;
+ZL1:;
+	{
+		/* BEGINNING OF ACTION: err-expected-alts */
+		{
+#line 477 "src/libre/parser.act"
+
+		if (err->e == RE_ESUCCESS) {
+			err->e = RE_EXALTS;
+		}
+		goto ZL2;
+	
+#line 1471 "src/libre/dialect/pcre/parser.c"
+		}
+		/* END OF ACTION: err-expected-alts */
+	}
+	goto ZL0;
+ZL2:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+ZL0:;
+}
+
+static void
+p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
 {
 	t_ast__expr ZInode;
 
-	switch (CURRENT_TERMINAL) {
-	case (TOK_ANY): case (TOK_START): case (TOK_END): case (TOK_OPENSUB):
-	case (TOK_OPENCAPTURE): case (TOK_OPENGROUP): case (TOK_NAMED__CLASS): case (TOK_OPENFLAGS):
-	case (TOK_ESC): case (TOK_CONTROL): case (TOK_OCT): case (TOK_HEX):
-	case (TOK_CHAR):
+	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+		return;
+	}
+	{
+		/* BEGINNING OF ACTION: ast-make-expr-alt */
 		{
-			t_ast__expr ZIa;
-
-			p_expr_C_Calt (flags, lex_state, act_state, err, &ZIa);
-			p_254 (flags, lex_state, act_state, err, &ZIa, &ZInode);
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-		}
-		break;
-	default:
-		{
-			t_ast__expr ZIa;
-			t_ast__expr ZIr;
-
-			/* BEGINNING OF ACTION: ast-make-expr-empty */
-			{
-#line 625 "src/libre/parser.act"
-
-		(ZIa) = ast_make_expr_empty();
-		if ((ZIa) == NULL) {
-			goto ZL1;
-		}
-	
-#line 1885 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: ast-make-expr-empty */
-			/* BEGINNING OF ACTION: ast-make-expr-empty */
-			{
-#line 625 "src/libre/parser.act"
-
-		(ZIr) = ast_make_expr_empty();
-		if ((ZIr) == NULL) {
-			goto ZL1;
-		}
-	
-#line 1897 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: ast-make-expr-empty */
-			/* BEGINNING OF ACTION: ast-make-expr-alt */
-			{
 #line 639 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_alt((ZIa), (ZIr));
+		(ZInode) = ast_make_expr_alt();
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1909 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: ast-make-expr-alt */
+#line 1500 "src/libre/dialect/pcre/parser.c"
 		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
+		/* END OF ACTION: ast-make-expr-alt */
+		p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, ZInode);
+		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+			RESTORE_LEXER;
+			goto ZL1;
+		}
 	}
 	goto ZL0;
 ZL1:;
 	{
+		/* BEGINNING OF ACTION: err-expected-alts */
+		{
+#line 477 "src/libre/parser.act"
+
+		if (err->e == RE_ESUCCESS) {
+			err->e = RE_EXALTS;
+		}
+		goto ZL2;
+	
+#line 1521 "src/libre/dialect/pcre/parser.c"
+		}
+		/* END OF ACTION: err-expected-alts */
 		/* BEGINNING OF ACTION: ast-make-expr-empty */
 		{
 #line 625 "src/libre/parser.act"
@@ -1925,7 +1529,7 @@ ZL1:;
 			goto ZL2;
 		}
 	
-#line 1929 "src/libre/dialect/pcre/parser.c"
+#line 1533 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-expr-empty */
 	}
@@ -1938,42 +1542,139 @@ ZL0:;
 }
 
 static void
-p_225(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZI223, t_ast__expr *ZOnode)
+p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
 {
 	t_ast__expr ZInode;
 
-	switch (CURRENT_TERMINAL) {
-	case (TOK_ALT):
+	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+		return;
+	}
+	{
+		t_re__flags ZIempty__pos;
+		t_re__flags ZIempty__neg;
+		t_re__flags ZIpos;
+		t_re__flags ZIneg;
+
+		switch (CURRENT_TERMINAL) {
+		case (TOK_OPENFLAGS):
+			break;
+		default:
+			goto ZL1;
+		}
+		ADVANCE_LEXER;
+		/* BEGINNING OF ACTION: re-flag-none */
 		{
-			t_ast__expr ZIr;
+#line 550 "src/libre/parser.act"
 
-			ADVANCE_LEXER;
-			p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, &ZIr);
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
+		(ZIempty__pos) = RE_FLAGS_NONE;
+	
+#line 1572 "src/libre/dialect/pcre/parser.c"
+		}
+		/* END OF ACTION: re-flag-none */
+		/* BEGINNING OF ACTION: re-flag-none */
+		{
+#line 550 "src/libre/parser.act"
+
+		(ZIempty__neg) = RE_FLAGS_NONE;
+	
+#line 1581 "src/libre/dialect/pcre/parser.c"
+		}
+		/* END OF ACTION: re-flag-none */
+		/* BEGINNING OF INLINE: 178 */
+		{
+			switch (CURRENT_TERMINAL) {
+			case (TOK_FLAG__UNKNOWN): case (TOK_FLAG__INSENSITIVE):
+				{
+					p_expr_C_Cflags_C_Cflag__set (flags, lex_state, act_state, err, ZIempty__pos, &ZIpos);
+					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+						RESTORE_LEXER;
+						goto ZL1;
+					}
+				}
+				break;
+			default:
+				{
+					ZIpos = ZIempty__pos;
+				}
+				break;
 			}
-			/* BEGINNING OF ACTION: ast-make-expr-alt */
+		}
+		/* END OF INLINE: 178 */
+		/* BEGINNING OF INLINE: 180 */
+		{
+			switch (CURRENT_TERMINAL) {
+			case (TOK_NEGATE):
+				{
+					ADVANCE_LEXER;
+					p_expr_C_Cflags_C_Cflag__set (flags, lex_state, act_state, err, ZIempty__neg, &ZIneg);
+					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+						RESTORE_LEXER;
+						goto ZL1;
+					}
+				}
+				break;
+			default:
+				{
+					ZIneg = ZIempty__neg;
+				}
+				break;
+			}
+		}
+		/* END OF INLINE: 180 */
+		/* BEGINNING OF INLINE: 183 */
+		{
 			{
-#line 639 "src/libre/parser.act"
+				switch (CURRENT_TERMINAL) {
+				case (TOK_CLOSEFLAGS):
+					break;
+				default:
+					goto ZL5;
+				}
+				ADVANCE_LEXER;
+				/* BEGINNING OF ACTION: ast-make-expr-re-flags */
+				{
+#line 704 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_alt((*ZI223), (ZIr));
+		(ZInode) = ast_make_expr_re_flags((ZIpos), (ZIneg));
+		if ((ZInode) == NULL) {
+			goto ZL5;
+		}
+	
+#line 1644 "src/libre/dialect/pcre/parser.c"
+				}
+				/* END OF ACTION: ast-make-expr-re-flags */
+			}
+			goto ZL4;
+		ZL5:;
+			{
+				/* BEGINNING OF ACTION: err-expected-closeflags */
+				{
+#line 512 "src/libre/parser.act"
+
+		if (err->e == RE_ESUCCESS) {
+			err->e = RE_EXCLOSEFLAGS;
+		}
+		goto ZL1;
+	
+#line 1660 "src/libre/dialect/pcre/parser.c"
+				}
+				/* END OF ACTION: err-expected-closeflags */
+				/* BEGINNING OF ACTION: ast-make-expr-empty */
+				{
+#line 625 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_empty();
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1966 "src/libre/dialect/pcre/parser.c"
+#line 1672 "src/libre/dialect/pcre/parser.c"
+				}
+				/* END OF ACTION: ast-make-expr-empty */
 			}
-			/* END OF ACTION: ast-make-expr-alt */
+		ZL4:;
 		}
-		break;
-	default:
-		{
-			ZInode = *ZI223;
-		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
+		/* END OF INLINE: 183 */
 	}
 	goto ZL0;
 ZL1:;
@@ -1984,65 +1685,271 @@ ZL0:;
 }
 
 static void
-p_226(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZIa, t_ast__expr *ZOnode)
+p_expr_C_Clist_Hof_Hatoms(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr ZIcat)
 {
-	t_ast__expr ZInode;
+	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+		return;
+	}
+ZL2_expr_C_Clist_Hof_Hatoms:;
+	{
+		t_ast__expr ZIa;
+
+		p_expr_C_Catom (flags, lex_state, act_state, err, &ZIa);
+		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+			RESTORE_LEXER;
+			goto ZL1;
+		}
+		/* BEGINNING OF ACTION: ast-add-expr-concat */
+		{
+#line 725 "src/libre/parser.act"
+
+		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
+			goto ZL1;
+		}
+	
+#line 1711 "src/libre/dialect/pcre/parser.c"
+		}
+		/* END OF ACTION: ast-add-expr-concat */
+		/* BEGINNING OF INLINE: 206 */
+		{
+			switch (CURRENT_TERMINAL) {
+			case (TOK_ANY): case (TOK_START): case (TOK_END): case (TOK_OPENSUB):
+			case (TOK_OPENCAPTURE): case (TOK_OPENGROUP): case (TOK_NAMED__CLASS): case (TOK_OPENFLAGS):
+			case (TOK_ESC): case (TOK_CONTROL): case (TOK_OCT): case (TOK_HEX):
+			case (TOK_CHAR):
+				{
+					/* BEGINNING OF INLINE: expr::list-of-atoms */
+					goto ZL2_expr_C_Clist_Hof_Hatoms;
+					/* END OF INLINE: expr::list-of-atoms */
+				}
+				/*UNREACHED*/
+			default:
+				break;
+			}
+		}
+		/* END OF INLINE: 206 */
+	}
+	return;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+}
+
+static void
+p_expr_C_Clist_Hof_Halts(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr ZIalts)
+{
+	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+		return;
+	}
+ZL2_expr_C_Clist_Hof_Halts:;
+	{
+		t_ast__expr ZIa;
+
+		p_expr_C_Calt (flags, lex_state, act_state, err, &ZIa);
+		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+			RESTORE_LEXER;
+			goto ZL1;
+		}
+		/* BEGINNING OF ACTION: ast-add-expr-alt */
+		{
+#line 731 "src/libre/parser.act"
+
+		if (!ast_add_expr_alt((ZIalts), (ZIa))) {
+			goto ZL1;
+		}
+	
+#line 1762 "src/libre/dialect/pcre/parser.c"
+		}
+		/* END OF ACTION: ast-add-expr-alt */
+		/* BEGINNING OF INLINE: 212 */
+		{
+			switch (CURRENT_TERMINAL) {
+			case (TOK_ALT):
+				{
+					ADVANCE_LEXER;
+					/* BEGINNING OF INLINE: expr::list-of-alts */
+					goto ZL2_expr_C_Clist_Hof_Halts;
+					/* END OF INLINE: expr::list-of-alts */
+				}
+				/*UNREACHED*/
+			default:
+				break;
+			}
+		}
+		/* END OF INLINE: 212 */
+	}
+	return;
+ZL1:;
+	{
+		/* BEGINNING OF ACTION: err-expected-alts */
+		{
+#line 477 "src/libre/parser.act"
+
+		if (err->e == RE_ESUCCESS) {
+			err->e = RE_EXALTS;
+		}
+		goto ZL4;
+	
+#line 1794 "src/libre/dialect/pcre/parser.c"
+		}
+		/* END OF ACTION: err-expected-alts */
+	}
+	goto ZL0;
+ZL4:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+ZL0:;
+}
+
+static void
+p_expr_C_Ccharacter_Hclass_C_Cclass_Hrange_C_Crange_Hendpoint_Hclass(flags flags, lex_state lex_state, act_state act_state, err err, t_endpoint *ZOr, t_pos *ZOstart, t_pos *ZOend)
+{
+	t_endpoint ZIr;
+	t_pos ZIstart;
+	t_pos ZIend;
+
+	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+		return;
+	}
+	{
+		t_ast__class__id ZIid;
+
+		switch (CURRENT_TERMINAL) {
+		case (TOK_NAMED__CLASS):
+			/* BEGINNING OF EXTRACT: NAMED_CLASS */
+			{
+#line 428 "src/libre/parser.act"
+
+		ZIid = DIALECT_CLASS(lex_state->buf.a);
+		if (ZIid == NULL) {
+			/* syntax error -- unrecognized class */
+			goto ZL1;
+		}
+
+		ZIstart = lex_state->lx.start;
+		ZIend   = lex_state->lx.end;
+	
+#line 1833 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF EXTRACT: NAMED_CLASS */
+			break;
+		default:
+			goto ZL1;
+		}
+		ADVANCE_LEXER;
+		/* BEGINNING OF ACTION: ast-range-endpoint-class */
+		{
+#line 599 "src/libre/parser.act"
+
+		(ZIr).type = AST_ENDPOINT_CLASS;
+		(ZIr).u.class.ctor = (ZIid);
+	
+#line 1848 "src/libre/dialect/pcre/parser.c"
+		}
+		/* END OF ACTION: ast-range-endpoint-class */
+	}
+	goto ZL0;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+ZL0:;
+	*ZOr = ZIr;
+	*ZOstart = ZIstart;
+	*ZOend = ZIend;
+}
+
+static void
+p_227(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class__id *ZI224, t_pos *ZI225, t_ast__class *ZOnode)
+{
+	t_ast__class ZInode;
 
 	switch (CURRENT_TERMINAL) {
-	case (TOK_ANY): case (TOK_START): case (TOK_END): case (TOK_OPENSUB):
-	case (TOK_OPENCAPTURE): case (TOK_OPENGROUP): case (TOK_NAMED__CLASS): case (TOK_OPENFLAGS):
-	case (TOK_ESC): case (TOK_CONTROL): case (TOK_OCT): case (TOK_HEX):
-	case (TOK_CHAR):
+	default:
 		{
-			t_ast__expr ZIr;
+			/* BEGINNING OF ACTION: ast-make-class-named */
+			{
+#line 788 "src/libre/parser.act"
 
-			p_expr_C_Clist_Hof_Hatoms (flags, lex_state, act_state, err, &ZIr);
+		(ZInode) = ast_make_class_named((*ZI224));
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 1879 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: ast-make-class-named */
+		}
+		break;
+	case (TOK_RANGE):
+		{
+			t_endpoint ZIlower;
+			t_endpoint ZIupper;
+			t_pos ZIend;
+
+			/* BEGINNING OF ACTION: ast-range-endpoint-class */
+			{
+#line 599 "src/libre/parser.act"
+
+		(ZIlower).type = AST_ENDPOINT_CLASS;
+		(ZIlower).u.class.ctor = (*ZI224);
+	
+#line 1897 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: ast-range-endpoint-class */
+			p_146 (flags, lex_state, act_state, err);
+			p_150 (flags, lex_state, act_state, err, &ZIupper, &ZIend);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
 			}
-			/* BEGINNING OF ACTION: ast-make-expr-concat */
+			/* BEGINNING OF ACTION: mark-range */
 			{
-#line 632 "src/libre/parser.act"
+#line 535 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_concat((*ZIa), (ZIr));
+		mark(&act_state->rangestart, &(*ZI225));
+		mark(&act_state->rangeend,   &(ZIend));
+	
+#line 1913 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: mark-range */
+			/* BEGINNING OF ACTION: ast-make-class-range */
+			{
+#line 758 "src/libre/parser.act"
+
+		struct ast_pos ast_start, ast_end;
+		unsigned char lower, upper;
+
+		AST_POS_OF_LX_POS(ast_start, (*ZI225));
+		AST_POS_OF_LX_POS(ast_end, (ZIend));
+
+		if ((ZIlower).type != AST_ENDPOINT_LITERAL ||
+			(ZIupper).type != AST_ENDPOINT_LITERAL) {
+			err->e = RE_EXUNSUPPORTD;
+			goto ZL1;
+		}
+
+		lower = (ZIlower).u.literal.c;
+		upper = (ZIupper).u.literal.c;
+
+		if (lower > upper) {
+			char a[5], b[5];
+			
+			assert(sizeof err->set >= 1 + sizeof a + 1 + sizeof b + 1 + 1);
+			
+			sprintf(err->set, "%s-%s",
+				escchar(a, sizeof a, lower), escchar(b, sizeof b, upper));
+			err->e = RE_ENEGRANGE;
+			goto ZL1;
+		}
+
+		(ZInode) = ast_make_class_range(&(ZIlower), ast_start, &(ZIupper), ast_end);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2014 "src/libre/dialect/pcre/parser.c"
+#line 1951 "src/libre/dialect/pcre/parser.c"
 			}
-			/* END OF ACTION: ast-make-expr-concat */
-		}
-		break;
-	default:
-		{
-			t_ast__expr ZIr;
-
-			/* BEGINNING OF ACTION: ast-make-expr-empty */
-			{
-#line 625 "src/libre/parser.act"
-
-		(ZIr) = ast_make_expr_empty();
-		if ((ZIr) == NULL) {
-			goto ZL1;
-		}
-	
-#line 2032 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: ast-make-expr-empty */
-			/* BEGINNING OF ACTION: ast-make-expr-concat */
-			{
-#line 632 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_concat((*ZIa), (ZIr));
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 2044 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: ast-make-expr-concat */
+			/* END OF ACTION: ast-make-class-range */
 		}
 		break;
 	case (ERROR_TERMINAL):
@@ -2099,122 +2006,13 @@ p_re__pcre(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 		}
 		goto ZL1;
 	
-#line 2103 "src/libre/dialect/pcre/parser.c"
+#line 2010 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
 		ZL3:;
 		}
 		/* END OF INLINE: 215 */
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOnode = ZInode;
-}
-
-static void
-p_230(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class__id *ZI227, t_pos *ZI228, t_ast__class *ZOnode)
-{
-	t_ast__class ZInode;
-
-	switch (CURRENT_TERMINAL) {
-	default:
-		{
-			/* BEGINNING OF ACTION: ast-make-class-named */
-			{
-#line 776 "src/libre/parser.act"
-
-		(ZInode) = ast_make_class_named((*ZI227));
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 2136 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: ast-make-class-named */
-		}
-		break;
-	case (TOK_RANGE):
-		{
-			t_endpoint ZIlower;
-			t_endpoint ZIupper;
-			t_pos ZIu__end;
-			t_pos ZI153;
-			t_pos ZI154;
-
-			/* BEGINNING OF ACTION: ast-range-endpoint-class */
-			{
-#line 599 "src/libre/parser.act"
-
-		(ZIlower).type = AST_ENDPOINT_CLASS;
-		(ZIlower).u.class.ctor = (*ZI227);
-	
-#line 2156 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: ast-range-endpoint-class */
-			p_141 (flags, lex_state, act_state, err);
-			p_145 (flags, lex_state, act_state, err, &ZIupper, &ZIu__end);
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-			/* BEGINNING OF ACTION: mark-range */
-			{
-#line 535 "src/libre/parser.act"
-
-		mark(&act_state->rangestart, &(*ZI228));
-		mark(&act_state->rangeend,   &(ZIu__end));
-	
-#line 2172 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: mark-range */
-			ZI153 = *ZI228;
-			ZI154 = ZIu__end;
-			/* BEGINNING OF ACTION: ast-make-class-range */
-			{
-#line 746 "src/libre/parser.act"
-
-		struct ast_pos ast_start, ast_end;
-		unsigned char lower, upper;
-
-		AST_POS_OF_LX_POS(ast_start, (*ZI228));
-		AST_POS_OF_LX_POS(ast_end, (ZIu__end));
-
-		if ((ZIlower).type != AST_ENDPOINT_LITERAL ||
-			(ZIupper).type != AST_ENDPOINT_LITERAL) {
-			err->e = RE_EXUNSUPPORTD;
-			goto ZL1;
-		}
-
-		lower = (ZIlower).u.literal.c;
-		upper = (ZIupper).u.literal.c;
-
-		if (lower > upper) {
-			char a[5], b[5];
-			
-			assert(sizeof err->set >= 1 + sizeof a + 1 + sizeof b + 1 + 1);
-			
-			sprintf(err->set, "%s-%s",
-				escchar(a, sizeof a, lower), escchar(b, sizeof b, upper));
-			err->e = RE_ENEGRANGE;
-			goto ZL1;
-		}
-
-		(ZInode) = ast_make_class_range(&(ZIlower), ast_start, &(ZIupper), ast_end);
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 2212 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: ast-make-class-range */
-		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
 	}
 	goto ZL0;
 ZL1:;
@@ -2235,7 +2033,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 	{
 		t_ast__expr ZIe;
 
-		/* BEGINNING OF INLINE: 190 */
+		/* BEGINNING OF INLINE: 186 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY):
@@ -2250,16 +2048,16 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL1;
 		}
 	
-#line 2254 "src/libre/dialect/pcre/parser.c"
+#line 2052 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-any */
 				}
 				break;
 			case (TOK_CONTROL):
 				{
-					t_char ZI195;
-					t_pos ZI196;
-					t_pos ZI197;
+					t_char ZI191;
+					t_pos ZI192;
+					t_pos ZI193;
 
 					/* BEGINNING OF EXTRACT: CONTROL */
 					{
@@ -2270,16 +2068,16 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 		assert(lex_state->buf.a[2] != '\0');
 		assert(lex_state->buf.a[3] == '\0');
 
-		ZI195 = lex_state->buf.a[2];
-		if ((unsigned char) ZI195 > 127) {
+		ZI191 = lex_state->buf.a[2];
+		if ((unsigned char) ZI191 > 127) {
 			goto ZL1;
 		}
-		ZI195 = (((toupper((unsigned char)ZI195)) - 64) % 128 + 128) % 128;
+		ZI191 = (((toupper((unsigned char)ZI191)) - 64) % 128 + 128) % 128;
 
-		ZI196 = lex_state->lx.start;
-		ZI197   = lex_state->lx.end;
+		ZI192 = lex_state->lx.start;
+		ZI193   = lex_state->lx.end;
 	
-#line 2283 "src/libre/dialect/pcre/parser.c"
+#line 2081 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CONTROL */
 					ADVANCE_LEXER;
@@ -2292,7 +2090,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 		}
 		goto ZL1;
 	
-#line 2296 "src/libre/dialect/pcre/parser.c"
+#line 2094 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: err-unsupported */
 					/* BEGINNING OF ACTION: ast-make-expr-empty */
@@ -2304,7 +2102,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL1;
 		}
 	
-#line 2308 "src/libre/dialect/pcre/parser.c"
+#line 2106 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-empty */
 				}
@@ -2321,7 +2119,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL1;
 		}
 	
-#line 2325 "src/libre/dialect/pcre/parser.c"
+#line 2123 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-anchor-end */
 				}
@@ -2345,10 +2143,10 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL1;
 		}
 	
-#line 2349 "src/libre/dialect/pcre/parser.c"
+#line 2147 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-group */
-					p_194 (flags, lex_state, act_state, err);
+					p_190 (flags, lex_state, act_state, err);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL1;
@@ -2359,7 +2157,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 				{
 					ADVANCE_LEXER;
 					p_expr (flags, lex_state, act_state, err, &ZIe);
-					p_194 (flags, lex_state, act_state, err);
+					p_190 (flags, lex_state, act_state, err);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL1;
@@ -2378,14 +2176,14 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL1;
 		}
 	
-#line 2382 "src/libre/dialect/pcre/parser.c"
+#line 2180 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-anchor-start */
 				}
 				break;
 			case (TOK_OPENGROUP):
 				{
-					p_expr_C_Cclass (flags, lex_state, act_state, err, &ZIe);
+					p_expr_C_Ccharacter_Hclass (flags, lex_state, act_state, err, &ZIe);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL1;
@@ -2423,24 +2221,24 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 190 */
-		/* BEGINNING OF INLINE: 198 */
+		/* END OF INLINE: 186 */
+		/* BEGINNING OF INLINE: 194 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_OPENCOUNT):
 				{
-					t_pos ZI251;
-					t_pos ZI252;
+					t_pos ZI248;
+					t_pos ZI249;
 					t_unsigned ZIm;
 
 					/* BEGINNING OF EXTRACT: OPENCOUNT */
 					{
 #line 260 "src/libre/parser.act"
 
-		ZI251 = lex_state->lx.start;
-		ZI252   = lex_state->lx.end;
+		ZI248 = lex_state->lx.start;
+		ZI249   = lex_state->lx.end;
 	
-#line 2444 "src/libre/dialect/pcre/parser.c"
+#line 2242 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OPENCOUNT */
 					ADVANCE_LEXER;
@@ -2468,7 +2266,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 
 		ZIm = (unsigned int) u;
 	
-#line 2472 "src/libre/dialect/pcre/parser.c"
+#line 2270 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF EXTRACT: COUNT */
 						break;
@@ -2476,7 +2274,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 						goto ZL4;
 					}
 					ADVANCE_LEXER;
-					p_253 (flags, lex_state, act_state, err, &ZIe, &ZI251, &ZIm, &ZInode);
+					p_250 (flags, lex_state, act_state, err, &ZIe, &ZI248, &ZIm, &ZInode);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL4;
@@ -2494,7 +2292,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 
 		(ZIc) = ast_make_count(0, NULL, 1, NULL);
 	
-#line 2498 "src/libre/dialect/pcre/parser.c"
+#line 2296 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: atom-opt */
 					/* BEGINNING OF ACTION: ast-make-expr-atom */
@@ -2507,7 +2305,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL4;
 		}
 	
-#line 2511 "src/libre/dialect/pcre/parser.c"
+#line 2309 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-atom */
 				}
@@ -2523,7 +2321,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 
 		(ZIc) = ast_make_count(1, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 2527 "src/libre/dialect/pcre/parser.c"
+#line 2325 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: atom-plus */
 					/* BEGINNING OF ACTION: ast-make-expr-atom */
@@ -2536,7 +2334,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL4;
 		}
 	
-#line 2540 "src/libre/dialect/pcre/parser.c"
+#line 2338 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-atom */
 				}
@@ -2552,7 +2350,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 2556 "src/libre/dialect/pcre/parser.c"
+#line 2354 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: atom-kleene */
 					/* BEGINNING OF ACTION: ast-make-expr-atom */
@@ -2565,7 +2363,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL4;
 		}
 	
-#line 2569 "src/libre/dialect/pcre/parser.c"
+#line 2367 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-atom */
 				}
@@ -2580,7 +2378,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 2584 "src/libre/dialect/pcre/parser.c"
+#line 2382 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: atom-one */
 					/* BEGINNING OF ACTION: ast-make-expr-atom */
@@ -2593,7 +2391,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL4;
 		}
 	
-#line 2597 "src/libre/dialect/pcre/parser.c"
+#line 2395 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-expr-atom */
 				}
@@ -2611,14 +2409,14 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 		}
 		goto ZL1;
 	
-#line 2615 "src/libre/dialect/pcre/parser.c"
+#line 2413 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: err-expected-count */
 				ZInode = ZIe;
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 198 */
+		/* END OF INLINE: 194 */
 	}
 	goto ZL0;
 ZL1:;
@@ -2629,30 +2427,7 @@ ZL0:;
 }
 
 static void
-p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
-{
-	t_ast__expr ZInode;
-
-	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-		return;
-	}
-	{
-		p_expr_C_Clist_Hof_Hatoms (flags, lex_state, act_state, err, &ZInode);
-		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-			RESTORE_LEXER;
-			goto ZL1;
-		}
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOnode = ZInode;
-}
-
-static void
-p_250(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI247, t_pos *ZI248, t_ast__class *ZOnode)
+p_247(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI244, t_pos *ZI245, t_ast__class *ZOnode)
 {
 	t_ast__class ZInode;
 
@@ -2661,14 +2436,14 @@ p_250(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		{
 			/* BEGINNING OF ACTION: ast-make-class-literal */
 			{
-#line 736 "src/libre/parser.act"
+#line 748 "src/libre/parser.act"
 
-		(ZInode) = ast_make_class_literal((*ZI247));
+		(ZInode) = ast_make_class_literal((*ZI244));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2672 "src/libre/dialect/pcre/parser.c"
+#line 2447 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-class-literal */
 		}
@@ -2677,22 +2452,20 @@ p_250(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		{
 			t_endpoint ZIlower;
 			t_endpoint ZIupper;
-			t_pos ZIu__end;
-			t_pos ZI153;
-			t_pos ZI154;
+			t_pos ZIend;
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
 #line 594 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_LITERAL;
-		(ZIlower).u.literal.c = (*ZI247);
+		(ZIlower).u.literal.c = (*ZI244);
 	
-#line 2692 "src/libre/dialect/pcre/parser.c"
+#line 2465 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
-			p_141 (flags, lex_state, act_state, err);
-			p_145 (flags, lex_state, act_state, err, &ZIupper, &ZIu__end);
+			p_146 (flags, lex_state, act_state, err);
+			p_150 (flags, lex_state, act_state, err, &ZIupper, &ZIend);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -2701,23 +2474,21 @@ p_250(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			{
 #line 535 "src/libre/parser.act"
 
-		mark(&act_state->rangestart, &(*ZI248));
-		mark(&act_state->rangeend,   &(ZIu__end));
+		mark(&act_state->rangestart, &(*ZI245));
+		mark(&act_state->rangeend,   &(ZIend));
 	
-#line 2708 "src/libre/dialect/pcre/parser.c"
+#line 2481 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: mark-range */
-			ZI153 = *ZI248;
-			ZI154 = ZIu__end;
 			/* BEGINNING OF ACTION: ast-make-class-range */
 			{
-#line 746 "src/libre/parser.act"
+#line 758 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI248));
-		AST_POS_OF_LX_POS(ast_end, (ZIu__end));
+		AST_POS_OF_LX_POS(ast_start, (*ZI245));
+		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		if ((ZIlower).type != AST_ENDPOINT_LITERAL ||
 			(ZIupper).type != AST_ENDPOINT_LITERAL) {
@@ -2744,13 +2515,263 @@ p_250(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			goto ZL1;
 		}
 	
-#line 2748 "src/libre/dialect/pcre/parser.c"
+#line 2519 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-class-range */
 		}
 		break;
 	case (ERROR_TERMINAL):
 		return;
+	}
+	goto ZL0;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+ZL0:;
+	*ZOnode = ZInode;
+}
+
+static void
+p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
+{
+	t_ast__expr ZInode;
+
+	switch (CURRENT_TERMINAL) {
+	case (TOK_ANY): case (TOK_START): case (TOK_END): case (TOK_OPENSUB):
+	case (TOK_OPENCAPTURE): case (TOK_OPENGROUP): case (TOK_NAMED__CLASS): case (TOK_OPENFLAGS):
+	case (TOK_ESC): case (TOK_CONTROL): case (TOK_OCT): case (TOK_HEX):
+	case (TOK_CHAR):
+		{
+			/* BEGINNING OF ACTION: ast-make-expr-concat */
+			{
+#line 632 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_concat();
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 2555 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: ast-make-expr-concat */
+			p_expr_C_Clist_Hof_Hatoms (flags, lex_state, act_state, err, ZInode);
+			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+				RESTORE_LEXER;
+				goto ZL1;
+			}
+		}
+		break;
+	default:
+		{
+			/* BEGINNING OF ACTION: ast-make-expr-empty */
+			{
+#line 625 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_empty();
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 2576 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: ast-make-expr-empty */
+		}
+		break;
+	case (ERROR_TERMINAL):
+		return;
+	}
+	goto ZL0;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+ZL0:;
+	*ZOnode = ZInode;
+}
+
+static void
+p_250(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZIe, t_pos *ZI248, t_unsigned *ZIm, t_ast__expr *ZOnode)
+{
+	t_ast__expr ZInode;
+
+	switch (CURRENT_TERMINAL) {
+	case (TOK_CLOSECOUNT):
+		{
+			t_pos ZI197;
+			t_pos ZIend;
+			t_ast__count ZIc;
+
+			/* BEGINNING OF EXTRACT: CLOSECOUNT */
+			{
+#line 265 "src/libre/parser.act"
+
+		ZI197 = lex_state->lx.start;
+		ZIend   = lex_state->lx.end;
+	
+#line 2611 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF EXTRACT: CLOSECOUNT */
+			ADVANCE_LEXER;
+			/* BEGINNING OF ACTION: mark-count */
+			{
+#line 540 "src/libre/parser.act"
+
+		mark(&act_state->countstart, &(*ZI248));
+		mark(&act_state->countend,   &(ZIend));
+	
+#line 2622 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: mark-count */
+			/* BEGINNING OF ACTION: atom-count */
+			{
+#line 576 "src/libre/parser.act"
+
+		struct ast_pos ast_start, ast_end;
+
+		if ((*ZIm) < (*ZIm)) {
+			err->e = RE_ENEGCOUNT;
+			err->m = (*ZIm);
+			err->n = (*ZIm);
+
+			mark(&act_state->countstart, &(*ZI248));
+			mark(&act_state->countend,   &(ZIend));
+
+			goto ZL1;
+		}
+
+		AST_POS_OF_LX_POS(ast_start, (*ZI248));
+		AST_POS_OF_LX_POS(ast_end, (ZIend));
+
+		(ZIc) = ast_make_count((*ZIm), &ast_start, (*ZIm), &ast_end);
+	
+#line 2647 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: atom-count */
+			/* BEGINNING OF ACTION: ast-make-expr-atom */
+			{
+#line 660 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_with_count((*ZIe), (ZIc));
+		if ((ZInode) == NULL) {
+			err->e = RE_EXEOF;
+			goto ZL1;
+		}
+	
+#line 2660 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: ast-make-expr-atom */
+		}
+		break;
+	case (TOK_SEP):
+		{
+			t_unsigned ZIn;
+			t_pos ZIend;
+			t_pos ZI200;
+			t_ast__count ZIc;
+
+			ADVANCE_LEXER;
+			switch (CURRENT_TERMINAL) {
+			case (TOK_COUNT):
+				/* BEGINNING OF EXTRACT: COUNT */
+				{
+#line 416 "src/libre/parser.act"
+
+		unsigned long u;
+		char *e;
+
+		u = strtoul(lex_state->buf.a, &e, 10);
+
+		if ((u == ULONG_MAX && errno == ERANGE) || u > UINT_MAX) {
+			err->e = RE_ECOUNTRANGE;
+			snprintdots(err->esc, sizeof err->esc, lex_state->buf.a);
+			goto ZL1;
+		}
+
+		if ((u == ULONG_MAX && errno != 0) || *e != '\0') {
+			err->e = RE_EXCOUNT;
+			goto ZL1;
+		}
+
+		ZIn = (unsigned int) u;
+	
+#line 2697 "src/libre/dialect/pcre/parser.c"
+				}
+				/* END OF EXTRACT: COUNT */
+				break;
+			default:
+				goto ZL1;
+			}
+			ADVANCE_LEXER;
+			switch (CURRENT_TERMINAL) {
+			case (TOK_CLOSECOUNT):
+				/* BEGINNING OF EXTRACT: CLOSECOUNT */
+				{
+#line 265 "src/libre/parser.act"
+
+		ZIend = lex_state->lx.start;
+		ZI200   = lex_state->lx.end;
+	
+#line 2714 "src/libre/dialect/pcre/parser.c"
+				}
+				/* END OF EXTRACT: CLOSECOUNT */
+				break;
+			default:
+				goto ZL1;
+			}
+			ADVANCE_LEXER;
+			/* BEGINNING OF ACTION: mark-count */
+			{
+#line 540 "src/libre/parser.act"
+
+		mark(&act_state->countstart, &(*ZI248));
+		mark(&act_state->countend,   &(ZIend));
+	
+#line 2729 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: mark-count */
+			/* BEGINNING OF ACTION: atom-count */
+			{
+#line 576 "src/libre/parser.act"
+
+		struct ast_pos ast_start, ast_end;
+
+		if ((ZIn) < (*ZIm)) {
+			err->e = RE_ENEGCOUNT;
+			err->m = (*ZIm);
+			err->n = (ZIn);
+
+			mark(&act_state->countstart, &(*ZI248));
+			mark(&act_state->countend,   &(ZIend));
+
+			goto ZL1;
+		}
+
+		AST_POS_OF_LX_POS(ast_start, (*ZI248));
+		AST_POS_OF_LX_POS(ast_end, (ZIend));
+
+		(ZIc) = ast_make_count((*ZIm), &ast_start, (ZIn), &ast_end);
+	
+#line 2754 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: atom-count */
+			/* BEGINNING OF ACTION: ast-make-expr-atom */
+			{
+#line 660 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_with_count((*ZIe), (ZIc));
+		if ((ZInode) == NULL) {
+			err->e = RE_EXEOF;
+			goto ZL1;
+		}
+	
+#line 2767 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: ast-make-expr-atom */
+		}
+		break;
+	case (ERROR_TERMINAL):
+		return;
+	default:
+		goto ZL1;
 	}
 	goto ZL0;
 ZL1:;
@@ -2789,7 +2810,7 @@ p_expr_C_Ctype(flags flags, lex_state lex_state, act_state act_state, err err, t
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 2793 "src/libre/dialect/pcre/parser.c"
+#line 2814 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			break;
@@ -2799,14 +2820,14 @@ p_expr_C_Ctype(flags flags, lex_state lex_state, act_state act_state, err err, t
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-make-class-named */
 		{
-#line 776 "src/libre/parser.act"
+#line 788 "src/libre/parser.act"
 
 		(ZInamed) = ast_make_class_named((ZIid));
 		if ((ZInamed) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2810 "src/libre/dialect/pcre/parser.c"
+#line 2831 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-class-named */
 		/* BEGINNING OF ACTION: ast-make-expr-class */
@@ -2826,7 +2847,7 @@ p_expr_C_Ctype(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL1;
 		}
 	
-#line 2830 "src/libre/dialect/pcre/parser.c"
+#line 2851 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-expr-class */
 	}
@@ -2838,202 +2859,9 @@ ZL0:;
 	*ZOnode = ZInode;
 }
 
-static void
-p_253(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZIe, t_pos *ZI251, t_unsigned *ZIm, t_ast__expr *ZOnode)
-{
-	t_ast__expr ZInode;
-
-	switch (CURRENT_TERMINAL) {
-	case (TOK_CLOSECOUNT):
-		{
-			t_pos ZI201;
-			t_pos ZIend;
-			t_ast__count ZIc;
-
-			/* BEGINNING OF EXTRACT: CLOSECOUNT */
-			{
-#line 265 "src/libre/parser.act"
-
-		ZI201 = lex_state->lx.start;
-		ZIend   = lex_state->lx.end;
-	
-#line 2861 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF EXTRACT: CLOSECOUNT */
-			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: mark-count */
-			{
-#line 540 "src/libre/parser.act"
-
-		mark(&act_state->countstart, &(*ZI251));
-		mark(&act_state->countend,   &(ZIend));
-	
-#line 2872 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: mark-count */
-			/* BEGINNING OF ACTION: atom-count */
-			{
-#line 576 "src/libre/parser.act"
-
-		struct ast_pos ast_start, ast_end;
-
-		if ((*ZIm) < (*ZIm)) {
-			err->e = RE_ENEGCOUNT;
-			err->m = (*ZIm);
-			err->n = (*ZIm);
-
-			mark(&act_state->countstart, &(*ZI251));
-			mark(&act_state->countend,   &(ZIend));
-
-			goto ZL1;
-		}
-
-		AST_POS_OF_LX_POS(ast_start, (*ZI251));
-		AST_POS_OF_LX_POS(ast_end, (ZIend));
-
-		(ZIc) = ast_make_count((*ZIm), &ast_start, (*ZIm), &ast_end);
-	
-#line 2897 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: atom-count */
-			/* BEGINNING OF ACTION: ast-make-expr-atom */
-			{
-#line 660 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_with_count((*ZIe), (ZIc));
-		if ((ZInode) == NULL) {
-			err->e = RE_EXEOF;
-			goto ZL1;
-		}
-	
-#line 2910 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: ast-make-expr-atom */
-		}
-		break;
-	case (TOK_SEP):
-		{
-			t_unsigned ZIn;
-			t_pos ZIend;
-			t_pos ZI204;
-			t_ast__count ZIc;
-
-			ADVANCE_LEXER;
-			switch (CURRENT_TERMINAL) {
-			case (TOK_COUNT):
-				/* BEGINNING OF EXTRACT: COUNT */
-				{
-#line 416 "src/libre/parser.act"
-
-		unsigned long u;
-		char *e;
-
-		u = strtoul(lex_state->buf.a, &e, 10);
-
-		if ((u == ULONG_MAX && errno == ERANGE) || u > UINT_MAX) {
-			err->e = RE_ECOUNTRANGE;
-			snprintdots(err->esc, sizeof err->esc, lex_state->buf.a);
-			goto ZL1;
-		}
-
-		if ((u == ULONG_MAX && errno != 0) || *e != '\0') {
-			err->e = RE_EXCOUNT;
-			goto ZL1;
-		}
-
-		ZIn = (unsigned int) u;
-	
-#line 2947 "src/libre/dialect/pcre/parser.c"
-				}
-				/* END OF EXTRACT: COUNT */
-				break;
-			default:
-				goto ZL1;
-			}
-			ADVANCE_LEXER;
-			switch (CURRENT_TERMINAL) {
-			case (TOK_CLOSECOUNT):
-				/* BEGINNING OF EXTRACT: CLOSECOUNT */
-				{
-#line 265 "src/libre/parser.act"
-
-		ZIend = lex_state->lx.start;
-		ZI204   = lex_state->lx.end;
-	
-#line 2964 "src/libre/dialect/pcre/parser.c"
-				}
-				/* END OF EXTRACT: CLOSECOUNT */
-				break;
-			default:
-				goto ZL1;
-			}
-			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: mark-count */
-			{
-#line 540 "src/libre/parser.act"
-
-		mark(&act_state->countstart, &(*ZI251));
-		mark(&act_state->countend,   &(ZIend));
-	
-#line 2979 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: mark-count */
-			/* BEGINNING OF ACTION: atom-count */
-			{
-#line 576 "src/libre/parser.act"
-
-		struct ast_pos ast_start, ast_end;
-
-		if ((ZIn) < (*ZIm)) {
-			err->e = RE_ENEGCOUNT;
-			err->m = (*ZIm);
-			err->n = (ZIn);
-
-			mark(&act_state->countstart, &(*ZI251));
-			mark(&act_state->countend,   &(ZIend));
-
-			goto ZL1;
-		}
-
-		AST_POS_OF_LX_POS(ast_start, (*ZI251));
-		AST_POS_OF_LX_POS(ast_end, (ZIend));
-
-		(ZIc) = ast_make_count((*ZIm), &ast_start, (ZIn), &ast_end);
-	
-#line 3004 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: atom-count */
-			/* BEGINNING OF ACTION: ast-make-expr-atom */
-			{
-#line 660 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_with_count((*ZIe), (ZIc));
-		if ((ZInode) == NULL) {
-			err->e = RE_EXEOF;
-			goto ZL1;
-		}
-	
-#line 3017 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: ast-make-expr-atom */
-		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
-	default:
-		goto ZL1;
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOnode = ZInode;
-}
-
 /* BEGINNING OF TRAILER */
 
-#line 960 "src/libre/parser.act"
+#line 978 "src/libre/parser.act"
 
 
 	static int
@@ -3177,6 +3005,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 3181 "src/libre/dialect/pcre/parser.c"
+#line 3009 "src/libre/dialect/pcre/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/pcre/parser.h
+++ b/src/libre/dialect/pcre/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__pcre(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 962 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/pcre/parser.h"

--- a/src/libre/dialect/pcre/parser.sid
+++ b/src/libre/dialect/pcre/parser.sid
@@ -86,7 +86,7 @@
 	<ast-make-expr-empty>:        ()                       -> (:ast_expr);
 	<ast-make-expr-literal>:      (:char)                  -> (:ast_expr);
 	<ast-make-expr-concat>:       ()                       -> (:ast_expr);
-	<ast-make-expr-alt>:          (:ast_expr, :ast_expr)   -> (:ast_expr);
+	<ast-make-expr-alt>:          ()                       -> (:ast_expr);
 	<ast-make-expr-any>:          ()                       -> (:ast_expr);
 	<ast-make-expr-atom>:         (:ast_expr, :ast_count)  -> (:ast_expr);
 	!<ast-make-expr-atom-any>:    (:ast_count)             -> (:ast_expr);
@@ -97,6 +97,7 @@
 	<ast-make-expr-anchor-end>:   ()                       -> (:ast_expr);
 
 	<ast-add-expr-concat>: (:ast_expr, :ast_expr) -> ();
+	<ast-add-expr-alt>:    (:ast_expr, :ast_expr) -> ();
 
 	<ast-make-class-concat>:      (:ast_class, :ast_class) -> (:ast_class);
 	<ast-make-class-literal>:     (:char)                  -> (:ast_class);
@@ -400,35 +401,30 @@
 		alt: () -> (node :ast_expr) = {
 			node = <ast-make-expr-concat>;
 			list-of-atoms(node);
+		||
+			/* explcitly allow an empty alt */
+			node = <ast-make-expr-empty>;
 		};
 
-		list-of-alts: () -> (node :ast_expr) = {
+		list-of-alts: (alts :ast_expr) -> () = {
 			a = alt();
-			r = <ast-make-expr-empty>;
-			node = <ast-make-expr-alt>(a,r);
-		||
-			/* Explicitly allow e.g. (xyz|) */
-			a = <ast-make-expr-empty>;
-			r = <ast-make-expr-empty>;
-			node = <ast-make-expr-alt>(a,r);
-	  	||
-			a = alt();
-			ALT;
-			r = list-of-alts();
-			node = <ast-make-expr-alt>(a, r);
+
+			<ast-add-expr-alt>(alts, a);
+
+			{
+				ALT;
+
+				list-of-alts(alts);
+			||
+				$;
+			};
 		##
-			node = <ast-make-expr-empty>();
+			<err-expected-alts>;
 		};
+
 	] = {
-		/* don't wrap a single alt in an alt chain */
-		node = alt();
-	||
-		/* keep alts into a linked list -- every right node
-		 * is either another alt or empty. */
-		a = alt();
-		ALT;
-		r = list-of-alts();
-		node = <ast-make-expr-alt>(a, r);
+		node = <ast-make-expr-alt>;
+		list-of-alts(node);
 	##
 		<err-expected-alts>;
 		node = <ast-make-expr-empty>();

--- a/src/libre/dialect/pcre/parser.sid
+++ b/src/libre/dialect/pcre/parser.sid
@@ -85,7 +85,7 @@
 
 	<ast-make-expr-empty>:        ()                       -> (:ast_expr);
 	<ast-make-expr-literal>:      (:char)                  -> (:ast_expr);
-	<ast-make-expr-concat>:       (:ast_expr, :ast_expr)   -> (:ast_expr);
+	<ast-make-expr-concat>:       ()                       -> (:ast_expr);
 	<ast-make-expr-alt>:          (:ast_expr, :ast_expr)   -> (:ast_expr);
 	<ast-make-expr-any>:          ()                       -> (:ast_expr);
 	<ast-make-expr-atom>:         (:ast_expr, :ast_count)  -> (:ast_expr);
@@ -95,6 +95,8 @@
 	<ast-make-expr-re-flags>:     (:re_flags, :re_flags)   -> (:ast_expr);
 	<ast-make-expr-anchor-start>: ()                       -> (:ast_expr);
 	<ast-make-expr-anchor-end>:   ()                       -> (:ast_expr);
+
+	<ast-add-expr-concat>: (:ast_expr, :ast_expr) -> ();
 
 	<ast-make-class-concat>:      (:ast_class, :ast_class) -> (:ast_class);
 	<ast-make-class-literal>:     (:char)                  -> (:ast_class);
@@ -383,18 +385,21 @@
 			};
 		};
 
-		list-of-atoms: () -> (node :ast_expr) = {
+		list-of-atoms: (cat :ast_expr) -> () = {
 			a = atom();
-			r = <ast-make-expr-empty>;
-			node = <ast-make-expr-concat>(a,r);
-		||
-			a = atom();
-			r = list-of-atoms();
-			node = <ast-make-expr-concat>(a,r);
+
+			<ast-add-expr-concat>(cat, a);
+
+			{
+				list-of-atoms(cat);
+			||
+				$;
+			};
 		};
 
 		alt: () -> (node :ast_expr) = {
-			node = list-of-atoms();
+			node = <ast-make-expr-concat>;
+			list-of-atoms(node);
 		};
 
 		list-of-alts: () -> (node :ast_expr) = {

--- a/src/libre/dialect/pcre/parser.sid
+++ b/src/libre/dialect/pcre/parser.sid
@@ -99,7 +99,7 @@
 	<ast-add-expr-concat>: (:ast_expr, :ast_expr) -> ();
 	<ast-add-expr-alt>:    (:ast_expr, :ast_expr) -> ();
 
-	<ast-make-class-concat>:      (:ast_class, :ast_class) -> (:ast_class);
+	<ast-make-class-concat>:      ()                       -> (:ast_class);
 	<ast-make-class-literal>:     (:char)                  -> (:ast_class);
 	<ast-make-class-range>:       (:endpoint, :pos, :endpoint, :pos) -> (:ast_class);
 	!<ast-make-class-subtract>:   (:ast_class, :ast_class) -> (:ast_class);
@@ -109,6 +109,8 @@
 	<ast-make-class-flag-invert>: () -> (:ast_class);
 	!<ast-make-class-flag-minus>: () -> (:ast_class);
 	!<ast-make-class-flag-invert-minus>: () -> (:ast_class);
+
+	<ast-add-class-concat>: (:ast_class, :ast_class) -> ();
 
 	<err-expected-term>;
 	<err-expected-count>;
@@ -140,14 +142,17 @@
 			node = <ast-make-expr-literal>(c);
 		};
 		    
-		class: () -> (node :ast_expr) [
-			class-head: () -> (f :ast_class) = {
-				(!) = INVERT;
-				f = <ast-make-class-flag-invert>();
-			||
-				f = <ast-make-class-flag-none>();
-			};
+		character-class: () -> (node :ast_expr) [
 
+			class-head: (class :ast_class) -> () = {
+				! = INVERT;
+				f = <ast-make-class-flag-invert>();
+				<ast-add-class-concat>(class, f);
+			||
+				/* XXX: why add a node at all? */
+				f = <ast-make-class-flag-none>();
+				<ast-add-class-concat>(class, f);
+			};
 
 			class-literal: () -> (node :ast_class) = {
 				{
@@ -160,16 +165,20 @@
 					(c, !, !) = CHAR;
 				||
 					(c, !, !) = CONTROL;
+					/* TODO: just construct the AST here;
+					 * complain about unsupported things at a later stage */
 					<err-unsupported>();
 				};
 				node = <ast-make-class-literal>(c);
 	  		};
 
-			class-named: () -> (k :ast_class_id, start :pos, end :pos) = {
-				(k, start, end) = NAMED_CLASS;
+			class-named: () -> (node :ast_class) = {
+				(id, !, !) = NAMED_CLASS;
+				node = <ast-make-class-named>(id);
 			};
 
-			class-range: () -> (node :ast_class, start :pos, end :pos) [
+			class-range: () -> (node :ast_class) [
+
 				range-endpoint-literal: () -> (r :endpoint, start :pos, end :pos) = {
 					{
 						(c, start, end) = ESC;
@@ -187,14 +196,15 @@
 				};
 
 				range-endpoint-class: () -> (r :endpoint, start :pos, end :pos) = {
-					(id, start, end) = class-named();
+					(id, start, end) = NAMED_CLASS;
 					r = <ast-range-endpoint-class>(id);
 				};
+
 			] = {
 				{
-					(lower, l_start, l_end) = range-endpoint-literal();
+					(lower, start, !) = range-endpoint-literal();
 				||
-					(lower, l_start, l_end) = range-endpoint-class();
+					(lower, start, !) = range-endpoint-class();
 				};
 
 				{
@@ -202,48 +212,51 @@
 				##
 					<err-expected-range>;
 				};
-	
+
 				{
-					(upper, u_start, u_end) = range-endpoint-literal();
+					(upper, !, end) = range-endpoint-literal();
 				||
-					(upper, u_start, u_end) = range-endpoint-class();
+					(upper, !, end) = range-endpoint-class();
 				||
 					/* allow literal '-' as end of range */
-					(c, u_start, u_end) = RANGE;
+					(c, !, end) = RANGE;
 					upper = <ast-range-endpoint-literal>(c);
 				};
-	
-				<mark-range>(l_start, u_end);
-				start = l_start;
-				end = u_end;
-				node = <ast-make-class-range>(lower, l_start, upper, u_end);
+
+				<mark-range>(start, end);
+				node = <ast-make-class-range>(lower, start, upper, end);
 			};
 
 			class-term: () -> (node :ast_class) = {
 				node = class-literal();
 			||
-				(node, !, !) = class-range();
+				node = class-range();
 			||
-				(id, !, !) = class-named();
-				node = <ast-make-class-named>(id);
-			##
-				<err-expected-term>;
-				node = <ast-make-class-flag-none>(); /* appease sid */
+				node = class-named();
 			};
 
-			list-of-class-terms: () -> (node :ast_class) = {
-				l = class-term();
+			list-of-class-terms: (class :ast_class) -> () = {
 				{
-					r = list-of-class-terms();
-					node = <ast-make-class-concat>(l, r);
+					node = class-term();
+					<ast-add-class-concat>(class, node);
+				##
+					<err-expected-term>;
+				};
+
+				{
+					list-of-class-terms(class);
 				||
-					node = l;
+					$;
 				};
 			};
+
 		] = {
 			(start, !) = OPENGROUP;
-			head = class-head();
-			body = list-of-class-terms();
+
+			class = <ast-make-class-concat>;
+
+			class-head(class);
+			list-of-class-terms(class);
 
 			{
 				(!, !, end) = CLOSEGROUP;
@@ -253,8 +266,7 @@
 				end = start; /* appease sid */
 			};
 
-			hb = <ast-make-class-concat>(head, body);
-			node = <ast-make-expr-class>(hb, start, end);
+			node = <ast-make-expr-class>(class, start, end);
 		};
 
 		type: () -> (node :ast_expr) = {
@@ -262,7 +274,7 @@
 			named = <ast-make-class-named>(id);
 			node = <ast-make-expr-class>(named, start, end);
 		};
-			
+
 		flags: () -> (node :ast_expr) [
 			flag_set: (i :re_flags) -> (o :re_flags) = {
 				c = FLAG_INSENSITIVE;
@@ -327,7 +339,7 @@
 					<err-expected-alts>;
 				};
 			||
-				e = class();
+				e = character-class();
 			||
 				e = type();
 			||

--- a/src/libre/dialect/sql/parser.c
+++ b/src/libre/dialect/sql/parser.c
@@ -220,26 +220,23 @@
 
 /* BEGINNING OF FUNCTION DECLARATIONS */
 
-static void p_expr_C_Cclass_C_Cterm(flags, lex_state, act_state, err, t_ast__class *);
+static void p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead(flags, lex_state, act_state, err, t_ast__class);
 extern void p_re__sql(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_expr_C_Cclass_C_Cclass_Hhead(flags, lex_state, act_state, err, t_ast__class *);
+static void p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms(flags, lex_state, act_state, err, t_ast__class);
+static void p_expr_C_Ccharacter_Hclass_C_Cclass_Htail(flags, lex_state, act_state, err, t_ast__class);
 static void p_expr_C_Cliteral(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_expr_C_Cclass_C_Clist_Hof_Hclass_Hterms(flags, lex_state, act_state, err, t_ast__class *);
 static void p_expr_C_Catom_Hsuffix(flags, lex_state, act_state, err, t_ast__count *);
-static void p_expr_C_Cclass_C_Cclass_Htail(flags, lex_state, act_state, err, t_ast__class *);
-static void p_188(flags, lex_state, act_state, err, t_ast__expr *, t_ast__expr *);
-static void p_189(flags, lex_state, act_state, err, t_ast__expr *, t_ast__expr *);
-static void p_190(flags, lex_state, act_state, err, t_pos *, t_unsigned *, t_ast__count *);
-static void p_193(flags, lex_state, act_state, err, t_pos *, t_ast__class *, t_ast__class *, t_ast__class *, t_ast__expr *);
+static void p_expr_C_Ccharacter_Hclass(flags, lex_state, act_state, err, t_ast__expr *);
+static void p_187(flags, lex_state, act_state, err, t_pos *, t_unsigned *, t_ast__count *);
+static void p_190(flags, lex_state, act_state, err, t_pos *, t_ast__class *, t_ast__expr *);
+static void p_192(flags, lex_state, act_state, err, t_ast__class *);
 static void p_expr(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_195(flags, lex_state, act_state, err, t_ast__class *);
-static void p_199(flags, lex_state, act_state, err, t_char *, t_pos *, t_ast__class *);
-static void p_200(flags, lex_state, act_state, err, t_ast__expr *, t_ast__expr *);
-static void p_expr_C_Clist_Hof_Hatoms(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_expr_C_Cclass(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_expr_C_Cclass_C_Cclass_Hast(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_expr_C_Clist_Hof_Halts(flags, lex_state, act_state, err, t_ast__expr *);
+static void p_196(flags, lex_state, act_state, err, t_char *, t_pos *, t_ast__class *);
+static void p_expr_C_Clist_Hof_Hatoms(flags, lex_state, act_state, err, t_ast__expr);
+static void p_expr_C_Clist_Hof_Halts(flags, lex_state, act_state, err, t_ast__expr);
+static void p_expr_C_Ccharacter_Hclass_C_Cterm(flags, lex_state, act_state, err, t_ast__class *);
 static void p_expr_C_Catom(flags, lex_state, act_state, err, t_ast__expr *);
+static void p_expr_C_Ccharacter_Hclass_C_Cnamed_Hclass(flags, lex_state, act_state, err, t_ast__class *);
 static void p_expr_C_Calt(flags, lex_state, act_state, err, t_ast__expr *);
 
 /* BEGINNING OF STATIC VARIABLES */
@@ -248,129 +245,110 @@ static void p_expr_C_Calt(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF FUNCTION DEFINITIONS */
 
 static void
-p_expr_C_Cclass_C_Cterm(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class *ZOnode)
+p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class ZIclass)
 {
-	t_ast__class ZInode;
-
 	switch (CURRENT_TERMINAL) {
-	case (TOK_CHAR):
+	case (TOK_INVERT):
 		{
-			t_char ZI196;
-			t_pos ZI197;
-			t_pos ZI198;
+			t_char ZI191;
 
-			/* BEGINNING OF EXTRACT: CHAR */
+			/* BEGINNING OF EXTRACT: INVERT */
 			{
-#line 401 "src/libre/parser.act"
+#line 239 "src/libre/parser.act"
 
-		/* the first byte may be '\x00' */
-		assert(lex_state->buf.a[1] == '\0');
-
-		ZI197 = lex_state->lx.start;
-		ZI198   = lex_state->lx.end;
-
-		ZI196 = lex_state->buf.a[0];
+		ZI191 = '^';
 	
-#line 275 "src/libre/dialect/sql/parser.c"
+#line 262 "src/libre/dialect/sql/parser.c"
 			}
-			/* END OF EXTRACT: CHAR */
+			/* END OF EXTRACT: INVERT */
 			ADVANCE_LEXER;
-			p_199 (flags, lex_state, act_state, err, &ZI196, &ZI197, &ZInode);
+			p_192 (flags, lex_state, act_state, err, &ZIclass);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
 			}
 		}
 		break;
-	case (TOK_NAMED__CLASS):
+	case (TOK_RANGE):
 		{
-			t_ast__class__id ZIid;
+			t_char ZI113;
+			t_pos ZI114;
+			t_pos ZI115;
+			t_ast__class ZIf;
 
-			/* BEGINNING OF INLINE: expr::class::named-class */
+			/* BEGINNING OF EXTRACT: RANGE */
 			{
-				{
-					t_pos ZI121;
-					t_pos ZI122;
+#line 243 "src/libre/parser.act"
 
-					switch (CURRENT_TERMINAL) {
-					case (TOK_NAMED__CLASS):
-						/* BEGINNING OF EXTRACT: NAMED_CLASS */
-						{
-#line 428 "src/libre/parser.act"
-
-		ZIid = DIALECT_CLASS(lex_state->buf.a);
-		if (ZIid == NULL) {
-			/* syntax error -- unrecognized class */
-			goto ZL1;
-		}
-
-		ZI121 = lex_state->lx.start;
-		ZI122   = lex_state->lx.end;
+		ZI113 = '-';
+		ZI114 = lex_state->lx.start;
+		ZI115   = lex_state->lx.end;
 	
-#line 311 "src/libre/dialect/sql/parser.c"
-						}
-						/* END OF EXTRACT: NAMED_CLASS */
-						break;
-					default:
-						goto ZL1;
-					}
-					ADVANCE_LEXER;
-				}
+#line 288 "src/libre/dialect/sql/parser.c"
 			}
-			/* END OF INLINE: expr::class::named-class */
-			/* BEGINNING OF ACTION: ast-make-class-named */
+			/* END OF EXTRACT: RANGE */
+			ADVANCE_LEXER;
+			/* BEGINNING OF ACTION: ast-make-class-flag-minus */
 			{
-#line 776 "src/libre/parser.act"
+#line 816 "src/libre/parser.act"
 
-		(ZInode) = ast_make_class_named((ZIid));
-		if ((ZInode) == NULL) {
+		(ZIf) = ast_make_class_flags(AST_CLASS_FLAG_MINUS);
+		if ((ZIf) == NULL) {
 			goto ZL1;
 		}
 	
-#line 331 "src/libre/dialect/sql/parser.c"
+#line 301 "src/libre/dialect/sql/parser.c"
 			}
-			/* END OF ACTION: ast-make-class-named */
+			/* END OF ACTION: ast-make-class-flag-minus */
+			/* BEGINNING OF ACTION: ast-add-class-concat */
+			{
+#line 830 "src/libre/parser.act"
+
+		if (!ast_add_class_concat((ZIclass), (ZIf))) {
+			goto ZL1;
+		}
+	
+#line 312 "src/libre/dialect/sql/parser.c"
+			}
+			/* END OF ACTION: ast-add-class-concat */
+		}
+		break;
+	default:
+		{
+			t_ast__class ZIf;
+
+			/* BEGINNING OF ACTION: ast-make-class-flag-none */
+			{
+#line 802 "src/libre/parser.act"
+
+		(ZIf) = ast_make_class_flags(AST_CLASS_FLAG_NONE);
+		if ((ZIf) == NULL) {
+			goto ZL1;
+		}
+	
+#line 330 "src/libre/dialect/sql/parser.c"
+			}
+			/* END OF ACTION: ast-make-class-flag-none */
+			/* BEGINNING OF ACTION: ast-add-class-concat */
+			{
+#line 830 "src/libre/parser.act"
+
+		if (!ast_add_class_concat((ZIclass), (ZIf))) {
+			goto ZL1;
+		}
+	
+#line 341 "src/libre/dialect/sql/parser.c"
+			}
+			/* END OF ACTION: ast-add-class-concat */
 		}
 		break;
 	case (ERROR_TERMINAL):
 		return;
-	default:
-		goto ZL1;
 	}
-	goto ZL0;
+	return;
 ZL1:;
-	{
-		/* BEGINNING OF ACTION: err-expected-term */
-		{
-#line 456 "src/libre/parser.act"
-
-		if (err->e == RE_ESUCCESS) {
-			err->e = RE_EXTERM;
-		}
-		goto ZL3;
-	
-#line 353 "src/libre/dialect/sql/parser.c"
-		}
-		/* END OF ACTION: err-expected-term */
-		/* BEGINNING OF ACTION: ast-make-class-flag-none */
-		{
-#line 790 "src/libre/parser.act"
-
-		(ZInode) = ast_make_class_flags(AST_CLASS_FLAG_NONE);
-		if ((ZInode) == NULL) {
-			goto ZL3;
-		}
-	
-#line 365 "src/libre/dialect/sql/parser.c"
-		}
-		/* END OF ACTION: ast-make-class-flag-none */
-	}
-	goto ZL0;
-ZL3:;
 	SAVE_LEXER ((ERROR_TERMINAL));
 	return;
-ZL0:;
-	*ZOnode = ZInode;
 }
 
 void
@@ -382,39 +360,18 @@ p_re__sql(flags flags, lex_state lex_state, act_state act_state, err err, t_ast_
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 176 */
+		/* BEGINNING OF INLINE: 175 */
 		{
-			switch (CURRENT_TERMINAL) {
-			case (TOK_ANY): case (TOK_MANY): case (TOK_OPENSUB): case (TOK_OPENGROUP):
-			case (TOK_CHAR):
-				{
-					p_expr (flags, lex_state, act_state, err, &ZInode);
-					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-						RESTORE_LEXER;
-						goto ZL1;
-					}
+			{
+				p_expr (flags, lex_state, act_state, err, &ZInode);
+				if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+					RESTORE_LEXER;
+					goto ZL1;
 				}
-				break;
-			default:
-				{
-					/* BEGINNING OF ACTION: ast-make-expr-empty */
-					{
-#line 625 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_empty();
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 410 "src/libre/dialect/sql/parser.c"
-					}
-					/* END OF ACTION: ast-make-expr-empty */
-				}
-				break;
 			}
 		}
-		/* END OF INLINE: 176 */
-		/* BEGINNING OF INLINE: 177 */
+		/* END OF INLINE: 175 */
+		/* BEGINNING OF INLINE: 176 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -437,13 +394,13 @@ p_re__sql(flags flags, lex_state lex_state, act_state act_state, err err, t_ast_
 		}
 		goto ZL1;
 	
-#line 441 "src/libre/dialect/sql/parser.c"
+#line 398 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 177 */
+		/* END OF INLINE: 176 */
 	}
 	goto ZL0;
 ZL1:;
@@ -454,89 +411,113 @@ ZL0:;
 }
 
 static void
-p_expr_C_Cclass_C_Cclass_Hhead(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class *ZOf)
+p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class ZIclass)
 {
-	t_ast__class ZIf;
-
-	switch (CURRENT_TERMINAL) {
-	case (TOK_INVERT):
+	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+		return;
+	}
+ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
+	{
+		/* BEGINNING OF INLINE: 144 */
 		{
-			t_char ZI194;
-
-			/* BEGINNING OF EXTRACT: INVERT */
 			{
-#line 239 "src/libre/parser.act"
+				t_ast__class ZInode;
 
-		ZI194 = '^';
-	
-#line 473 "src/libre/dialect/sql/parser.c"
-			}
-			/* END OF EXTRACT: INVERT */
-			ADVANCE_LEXER;
-			p_195 (flags, lex_state, act_state, err, &ZIf);
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-		}
-		break;
-	case (TOK_RANGE):
-		{
-			t_char ZI109;
-			t_pos ZI110;
-			t_pos ZI111;
+				p_expr_C_Ccharacter_Hclass_C_Cterm (flags, lex_state, act_state, err, &ZInode);
+				if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+					RESTORE_LEXER;
+					goto ZL4;
+				}
+				/* BEGINNING OF ACTION: ast-add-class-concat */
+				{
+#line 830 "src/libre/parser.act"
 
-			/* BEGINNING OF EXTRACT: RANGE */
-			{
-#line 243 "src/libre/parser.act"
-
-		ZI109 = '-';
-		ZI110 = lex_state->lx.start;
-		ZI111   = lex_state->lx.end;
-	
-#line 498 "src/libre/dialect/sql/parser.c"
-			}
-			/* END OF EXTRACT: RANGE */
-			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: ast-make-class-flag-minus */
-			{
-#line 804 "src/libre/parser.act"
-
-		(ZIf) = ast_make_class_flags(AST_CLASS_FLAG_MINUS);
-		if ((ZIf) == NULL) {
-			goto ZL1;
+		if (!ast_add_class_concat((ZIclass), (ZInode))) {
+			goto ZL4;
 		}
 	
-#line 511 "src/libre/dialect/sql/parser.c"
+#line 440 "src/libre/dialect/sql/parser.c"
+				}
+				/* END OF ACTION: ast-add-class-concat */
 			}
-			/* END OF ACTION: ast-make-class-flag-minus */
-		}
-		break;
-	default:
-		{
-			/* BEGINNING OF ACTION: ast-make-class-flag-none */
+			goto ZL3;
+		ZL4:;
 			{
-#line 790 "src/libre/parser.act"
+				/* BEGINNING OF ACTION: err-expected-term */
+				{
+#line 456 "src/libre/parser.act"
+
+		if (err->e == RE_ESUCCESS) {
+			err->e = RE_EXTERM;
+		}
+		goto ZL1;
+	
+#line 456 "src/libre/dialect/sql/parser.c"
+				}
+				/* END OF ACTION: err-expected-term */
+			}
+		ZL3:;
+		}
+		/* END OF INLINE: 144 */
+		/* BEGINNING OF INLINE: 145 */
+		{
+			switch (CURRENT_TERMINAL) {
+			case (TOK_NAMED__CLASS): case (TOK_CHAR):
+				{
+					/* BEGINNING OF INLINE: expr::character-class::list-of-class-terms */
+					goto ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms;
+					/* END OF INLINE: expr::character-class::list-of-class-terms */
+				}
+				/*UNREACHED*/
+			default:
+				break;
+			}
+		}
+		/* END OF INLINE: 145 */
+	}
+	return;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+}
+
+static void
+p_expr_C_Ccharacter_Hclass_C_Cclass_Htail(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class ZIclass)
+{
+	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+		return;
+	}
+	{
+		t_ast__class ZIf;
+
+		/* BEGINNING OF ACTION: ast-make-class-flag-none */
+		{
+#line 802 "src/libre/parser.act"
 
 		(ZIf) = ast_make_class_flags(AST_CLASS_FLAG_NONE);
 		if ((ZIf) == NULL) {
 			goto ZL1;
 		}
 	
-#line 527 "src/libre/dialect/sql/parser.c"
-			}
-			/* END OF ACTION: ast-make-class-flag-none */
+#line 503 "src/libre/dialect/sql/parser.c"
 		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
+		/* END OF ACTION: ast-make-class-flag-none */
+		/* BEGINNING OF ACTION: ast-add-class-concat */
+		{
+#line 830 "src/libre/parser.act"
+
+		if (!ast_add_class_concat((ZIclass), (ZIf))) {
+			goto ZL1;
+		}
+	
+#line 514 "src/libre/dialect/sql/parser.c"
+		}
+		/* END OF ACTION: ast-add-class-concat */
 	}
-	goto ZL0;
+	return;
 ZL1:;
 	SAVE_LEXER ((ERROR_TERMINAL));
 	return;
-ZL0:;
-	*ZOf = ZIf;
 }
 
 static void
@@ -549,8 +530,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 	}
 	{
 		t_char ZIc;
-		t_pos ZI93;
-		t_pos ZI94;
+		t_pos ZI96;
+		t_pos ZI97;
 
 		switch (CURRENT_TERMINAL) {
 		case (TOK_CHAR):
@@ -561,12 +542,12 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI93 = lex_state->lx.start;
-		ZI94   = lex_state->lx.end;
+		ZI96 = lex_state->lx.start;
+		ZI97   = lex_state->lx.end;
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 570 "src/libre/dialect/sql/parser.c"
+#line 551 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			break;
@@ -583,67 +564,9 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 			goto ZL1;
 		}
 	
-#line 587 "src/libre/dialect/sql/parser.c"
+#line 568 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-expr-literal */
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOnode = ZInode;
-}
-
-static void
-p_expr_C_Cclass_C_Clist_Hof_Hclass_Hterms(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class *ZOnode)
-{
-	t_ast__class ZInode;
-
-	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-		return;
-	}
-	{
-		t_ast__class ZIl;
-
-		p_expr_C_Cclass_C_Cterm (flags, lex_state, act_state, err, &ZIl);
-		/* BEGINNING OF INLINE: 141 */
-		{
-			switch (CURRENT_TERMINAL) {
-			case (TOK_NAMED__CLASS): case (TOK_CHAR):
-				{
-					t_ast__class ZIr;
-
-					p_expr_C_Cclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, &ZIr);
-					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-						RESTORE_LEXER;
-						goto ZL1;
-					}
-					/* BEGINNING OF ACTION: ast-make-class-concat */
-					{
-#line 729 "src/libre/parser.act"
-
-		(ZInode) = ast_make_class_concat((ZIl), (ZIr));
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 632 "src/libre/dialect/sql/parser.c"
-					}
-					/* END OF ACTION: ast-make-class-concat */
-				}
-				break;
-			default:
-				{
-					ZInode = ZIl;
-				}
-				break;
-			case (ERROR_TERMINAL):
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-		}
-		/* END OF INLINE: 141 */
 	}
 	goto ZL0;
 ZL1:;
@@ -672,7 +595,7 @@ p_expr_C_Catom_Hsuffix(flags flags, lex_state lex_state, act_state act_state, er
 		ZIpos__of = lex_state->lx.start;
 		ZIpos__ot   = lex_state->lx.end;
 	
-#line 676 "src/libre/dialect/sql/parser.c"
+#line 599 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: OPENCOUNT */
 			ADVANCE_LEXER;
@@ -700,7 +623,7 @@ p_expr_C_Catom_Hsuffix(flags flags, lex_state lex_state, act_state act_state, er
 
 		ZIm = (unsigned int) u;
 	
-#line 704 "src/libre/dialect/sql/parser.c"
+#line 627 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -708,7 +631,7 @@ p_expr_C_Catom_Hsuffix(flags flags, lex_state lex_state, act_state act_state, er
 				goto ZL1;
 			}
 			ADVANCE_LEXER;
-			p_190 (flags, lex_state, act_state, err, &ZIpos__of, &ZIm, &ZIf);
+			p_187 (flags, lex_state, act_state, err, &ZIpos__of, &ZIm, &ZIf);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -724,7 +647,7 @@ p_expr_C_Catom_Hsuffix(flags flags, lex_state lex_state, act_state act_state, er
 
 		(ZIf) = ast_make_count(0, NULL, 1, NULL);
 	
-#line 728 "src/libre/dialect/sql/parser.c"
+#line 651 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: atom-opt */
 		}
@@ -738,7 +661,7 @@ p_expr_C_Catom_Hsuffix(flags flags, lex_state lex_state, act_state act_state, er
 
 		(ZIf) = ast_make_count(1, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 742 "src/libre/dialect/sql/parser.c"
+#line 665 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: atom-plus */
 		}
@@ -752,7 +675,7 @@ p_expr_C_Catom_Hsuffix(flags flags, lex_state lex_state, act_state act_state, er
 
 		(ZIf) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 756 "src/libre/dialect/sql/parser.c"
+#line 679 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: atom-kleene */
 		}
@@ -765,7 +688,7 @@ p_expr_C_Catom_Hsuffix(flags flags, lex_state lex_state, act_state act_state, er
 
 		(ZIf) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 769 "src/libre/dialect/sql/parser.c"
+#line 692 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: atom-one */
 		}
@@ -782,72 +705,55 @@ ZL0:;
 }
 
 static void
-p_expr_C_Cclass_C_Cclass_Htail(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class *ZOf)
+p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
 {
-	t_ast__class ZIf;
+	t_ast__expr ZInode;
 
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 		return;
 	}
 	{
-		/* BEGINNING OF ACTION: ast-make-class-flag-none */
-		{
-#line 790 "src/libre/parser.act"
+		t_pos ZI188;
+		t_pos ZI189;
+		t_ast__class ZIclass;
 
-		(ZIf) = ast_make_class_flags(AST_CLASS_FLAG_NONE);
-		if ((ZIf) == NULL) {
-			goto ZL1;
-		}
-	
-#line 803 "src/libre/dialect/sql/parser.c"
-		}
-		/* END OF ACTION: ast-make-class-flag-none */
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOf = ZIf;
-}
-
-static void
-p_188(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZI186, t_ast__expr *ZOnode)
-{
-	t_ast__expr ZInode;
-
-	switch (CURRENT_TERMINAL) {
-	case (TOK_ALT):
-		{
-			t_ast__expr ZIr;
-
-			ADVANCE_LEXER;
-			p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, &ZIr);
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-			/* BEGINNING OF ACTION: ast-make-expr-alt */
+		switch (CURRENT_TERMINAL) {
+		case (TOK_OPENGROUP):
+			/* BEGINNING OF EXTRACT: OPENGROUP */
 			{
-#line 639 "src/libre/parser.act"
+#line 249 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_alt((*ZI186), (ZIr));
-		if ((ZInode) == NULL) {
+		ZI188 = lex_state->lx.start;
+		ZI189   = lex_state->lx.end;
+	
+#line 730 "src/libre/dialect/sql/parser.c"
+			}
+			/* END OF EXTRACT: OPENGROUP */
+			break;
+		default:
+			goto ZL1;
+		}
+		ADVANCE_LEXER;
+		/* BEGINNING OF ACTION: ast-make-class-concat */
+		{
+#line 741 "src/libre/parser.act"
+
+		(ZIclass) = ast_make_class_concat();
+		if ((ZIclass) == NULL) {
 			goto ZL1;
 		}
 	
-#line 840 "src/libre/dialect/sql/parser.c"
-			}
-			/* END OF ACTION: ast-make-expr-alt */
+#line 747 "src/libre/dialect/sql/parser.c"
 		}
-		break;
-	default:
-		{
-			ZInode = *ZI186;
+		/* END OF ACTION: ast-make-class-concat */
+		p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead (flags, lex_state, act_state, err, ZIclass);
+		p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, ZIclass);
+		p_expr_C_Ccharacter_Hclass_C_Cclass_Htail (flags, lex_state, act_state, err, ZIclass);
+		p_190 (flags, lex_state, act_state, err, &ZI188, &ZIclass, &ZInode);
+		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+			RESTORE_LEXER;
+			goto ZL1;
 		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
 	}
 	goto ZL0;
 ZL1:;
@@ -858,78 +764,7 @@ ZL0:;
 }
 
 static void
-p_189(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZIa, t_ast__expr *ZOnode)
-{
-	t_ast__expr ZInode;
-
-	switch (CURRENT_TERMINAL) {
-	case (TOK_ANY): case (TOK_MANY): case (TOK_OPENSUB): case (TOK_OPENGROUP):
-	case (TOK_CHAR):
-		{
-			t_ast__expr ZIr;
-
-			p_expr_C_Clist_Hof_Hatoms (flags, lex_state, act_state, err, &ZIr);
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-			/* BEGINNING OF ACTION: ast-make-expr-concat */
-			{
-#line 632 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_concat((*ZIa), (ZIr));
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 886 "src/libre/dialect/sql/parser.c"
-			}
-			/* END OF ACTION: ast-make-expr-concat */
-		}
-		break;
-	default:
-		{
-			t_ast__expr ZIr;
-
-			/* BEGINNING OF ACTION: ast-make-expr-empty */
-			{
-#line 625 "src/libre/parser.act"
-
-		(ZIr) = ast_make_expr_empty();
-		if ((ZIr) == NULL) {
-			goto ZL1;
-		}
-	
-#line 904 "src/libre/dialect/sql/parser.c"
-			}
-			/* END OF ACTION: ast-make-expr-empty */
-			/* BEGINNING OF ACTION: ast-make-expr-concat */
-			{
-#line 632 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_concat((*ZIa), (ZIr));
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 916 "src/libre/dialect/sql/parser.c"
-			}
-			/* END OF ACTION: ast-make-expr-concat */
-		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOnode = ZInode;
-}
-
-static void
-p_190(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIpos__of, t_unsigned *ZIm, t_ast__count *ZOf)
+p_187(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIpos__of, t_unsigned *ZIm, t_ast__count *ZOf)
 {
 	t_ast__count ZIf;
 
@@ -946,10 +781,20 @@ p_190(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIp
 		ZIpos__cf = lex_state->lx.start;
 		ZIpos__ct   = lex_state->lx.end;
 	
-#line 950 "src/libre/dialect/sql/parser.c"
+#line 785 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: CLOSECOUNT */
 			ADVANCE_LEXER;
+			/* BEGINNING OF ACTION: mark-count */
+			{
+#line 540 "src/libre/parser.act"
+
+		mark(&act_state->countstart, &(*ZIpos__of));
+		mark(&act_state->countend,   &(ZIpos__ct));
+	
+#line 796 "src/libre/dialect/sql/parser.c"
+			}
+			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: atom-count */
 			{
 #line 576 "src/libre/parser.act"
@@ -972,7 +817,7 @@ p_190(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIp
 
 		(ZIf) = ast_make_count((*ZIm), &ast_start, (*ZIm), &ast_end);
 	
-#line 976 "src/libre/dialect/sql/parser.c"
+#line 821 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: atom-count */
 		}
@@ -1008,7 +853,7 @@ p_190(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIp
 
 		ZIn = (unsigned int) u;
 	
-#line 1012 "src/libre/dialect/sql/parser.c"
+#line 857 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -1025,7 +870,7 @@ p_190(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIp
 		ZIpos__cf = lex_state->lx.start;
 		ZIpos__ct   = lex_state->lx.end;
 	
-#line 1029 "src/libre/dialect/sql/parser.c"
+#line 874 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: CLOSECOUNT */
 				break;
@@ -1033,6 +878,16 @@ p_190(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIp
 				goto ZL1;
 			}
 			ADVANCE_LEXER;
+			/* BEGINNING OF ACTION: mark-count */
+			{
+#line 540 "src/libre/parser.act"
+
+		mark(&act_state->countstart, &(*ZIpos__of));
+		mark(&act_state->countend,   &(ZIpos__ct));
+	
+#line 889 "src/libre/dialect/sql/parser.c"
+			}
+			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: atom-count */
 			{
 #line 576 "src/libre/parser.act"
@@ -1055,7 +910,7 @@ p_190(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIp
 
 		(ZIf) = ast_make_count((*ZIm), &ast_start, (ZIn), &ast_end);
 	
-#line 1059 "src/libre/dialect/sql/parser.c"
+#line 914 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: atom-count */
 		}
@@ -1074,85 +929,102 @@ ZL0:;
 }
 
 static void
-p_193(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI191, t_ast__class *ZIhead, t_ast__class *ZIbody, t_ast__class *ZItail, t_ast__expr *ZOnode)
+p_190(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI188, t_ast__class *ZIclass, t_ast__expr *ZOnode)
 {
 	t_ast__expr ZInode;
 
 	switch (CURRENT_TERMINAL) {
 	case (TOK_INVERT):
 		{
-			t_char ZI155;
-			t_ast__class ZImaskhead;
-			t_ast__class ZImaskbody;
-			t_ast__class ZImasktail;
-			t_ast__class ZIhb;
-			t_ast__class ZIhbt;
-			t_char ZI159;
-			t_pos ZI160;
+			t_char ZI152;
+			t_ast__class ZImask;
 			t_pos ZIend;
-			t_ast__class ZImhb;
-			t_ast__class ZImhbt;
-			t_ast__class ZImasked;
+			t_ast__class ZIsub;
 
 			/* BEGINNING OF EXTRACT: INVERT */
 			{
 #line 239 "src/libre/parser.act"
 
-		ZI155 = '^';
+		ZI152 = '^';
 	
-#line 1104 "src/libre/dialect/sql/parser.c"
+#line 951 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: INVERT */
 			ADVANCE_LEXER;
-			p_expr_C_Cclass_C_Cclass_Hhead (flags, lex_state, act_state, err, &ZImaskhead);
-			p_expr_C_Cclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, &ZImaskbody);
-			p_expr_C_Cclass_C_Cclass_Htail (flags, lex_state, act_state, err, &ZImasktail);
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			}
 			/* BEGINNING OF ACTION: ast-make-class-concat */
 			{
-#line 729 "src/libre/parser.act"
+#line 741 "src/libre/parser.act"
 
-		(ZIhb) = ast_make_class_concat((*ZIhead), (*ZIbody));
-		if ((ZIhb) == NULL) {
+		(ZImask) = ast_make_class_concat();
+		if ((ZImask) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1124 "src/libre/dialect/sql/parser.c"
+#line 964 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-class-concat */
-			/* BEGINNING OF ACTION: ast-make-class-concat */
+			p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead (flags, lex_state, act_state, err, ZImask);
+			p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, ZImask);
+			p_expr_C_Ccharacter_Hclass_C_Cclass_Htail (flags, lex_state, act_state, err, ZImask);
+			/* BEGINNING OF INLINE: 154 */
 			{
-#line 729 "src/libre/parser.act"
-
-		(ZIhbt) = ast_make_class_concat((ZIhb), (*ZItail));
-		if ((ZIhbt) == NULL) {
-			goto ZL1;
-		}
-	
-#line 1136 "src/libre/dialect/sql/parser.c"
-			}
-			/* END OF ACTION: ast-make-class-concat */
-			switch (CURRENT_TERMINAL) {
-			case (TOK_CLOSEGROUP):
-				/* BEGINNING OF EXTRACT: CLOSEGROUP */
+				if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+					RESTORE_LEXER;
+					goto ZL1;
+				}
 				{
+					t_char ZI155;
+					t_pos ZI156;
+
+					switch (CURRENT_TERMINAL) {
+					case (TOK_CLOSEGROUP):
+						/* BEGINNING OF EXTRACT: CLOSEGROUP */
+						{
 #line 254 "src/libre/parser.act"
 
-		ZI159 = ']';
-		ZI160 = lex_state->lx.start;
+		ZI155 = ']';
+		ZI156 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1149 "src/libre/dialect/sql/parser.c"
+#line 990 "src/libre/dialect/sql/parser.c"
+						}
+						/* END OF EXTRACT: CLOSEGROUP */
+						break;
+					default:
+						goto ZL3;
+					}
+					ADVANCE_LEXER;
+					/* BEGINNING OF ACTION: mark-group */
+					{
+#line 530 "src/libre/parser.act"
+
+		mark(&act_state->groupstart, &(*ZI188));
+		mark(&act_state->groupend,   &(ZIend));
+	
+#line 1005 "src/libre/dialect/sql/parser.c"
+					}
+					/* END OF ACTION: mark-group */
 				}
-				/* END OF EXTRACT: CLOSEGROUP */
-				break;
-			default:
-				goto ZL1;
+				goto ZL2;
+			ZL3:;
+				{
+					/* BEGINNING OF ACTION: err-expected-closegroup */
+					{
+#line 491 "src/libre/parser.act"
+
+		if (err->e == RE_ESUCCESS) {
+			err->e = RE_EXCLOSEGROUP;
+		}
+		goto ZL1;
+	
+#line 1021 "src/libre/dialect/sql/parser.c"
+					}
+					/* END OF ACTION: err-expected-closegroup */
+					ZIend = *ZI188;
+				}
+			ZL2:;
 			}
-			ADVANCE_LEXER;
+			/* END OF INLINE: 154 */
 			/* BEGINNING OF ACTION: err-unsupported */
 			{
 #line 526 "src/libre/parser.act"
@@ -1162,43 +1034,19 @@ p_193(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI1
 		}
 		goto ZL1;
 	
-#line 1166 "src/libre/dialect/sql/parser.c"
+#line 1038 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: err-unsupported */
-			/* BEGINNING OF ACTION: ast-make-class-concat */
-			{
-#line 729 "src/libre/parser.act"
-
-		(ZImhb) = ast_make_class_concat((ZImaskhead), (ZImaskbody));
-		if ((ZImhb) == NULL) {
-			goto ZL1;
-		}
-	
-#line 1178 "src/libre/dialect/sql/parser.c"
-			}
-			/* END OF ACTION: ast-make-class-concat */
-			/* BEGINNING OF ACTION: ast-make-class-concat */
-			{
-#line 729 "src/libre/parser.act"
-
-		(ZImhbt) = ast_make_class_concat((ZImhb), (ZImasktail));
-		if ((ZImhbt) == NULL) {
-			goto ZL1;
-		}
-	
-#line 1190 "src/libre/dialect/sql/parser.c"
-			}
-			/* END OF ACTION: ast-make-class-concat */
 			/* BEGINNING OF ACTION: ast-make-class-subtract */
 			{
-#line 783 "src/libre/parser.act"
+#line 795 "src/libre/parser.act"
 
-		(ZImasked) = ast_make_class_subtract((ZIhbt), (ZImhbt));
-		if ((ZImasked) == NULL) {
+		(ZIsub) = ast_make_class_subtract((*ZIclass), (ZImask));
+		if ((ZIsub) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1202 "src/libre/dialect/sql/parser.c"
+#line 1050 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-class-subtract */
 			/* BEGINNING OF ACTION: ast-make-expr-class */
@@ -1207,84 +1055,99 @@ p_193(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI1
 
 		struct ast_pos ast_start, ast_end;
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI191));
+		AST_POS_OF_LX_POS(ast_start, (*ZI188));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
-		mark(&act_state->groupstart, &(*ZI191));
+		mark(&act_state->groupstart, &(*ZI188));
 		mark(&act_state->groupend,   &(ZIend));
 
-		(ZInode) = ast_make_expr_class((ZImasked), &ast_start, &ast_end);
+		(ZInode) = ast_make_expr_class((ZIsub), &ast_start, &ast_end);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1222 "src/libre/dialect/sql/parser.c"
+#line 1070 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-expr-class */
 		}
 		break;
 	case (TOK_CLOSEGROUP):
 		{
-			t_ast__class ZIhb;
-			t_ast__class ZIhbt;
-			t_char ZI152;
-			t_pos ZI153;
 			t_pos ZIend;
 
-			/* BEGINNING OF ACTION: ast-make-class-concat */
+			/* BEGINNING OF INLINE: 147 */
 			{
-#line 729 "src/libre/parser.act"
+				{
+					t_char ZI148;
+					t_pos ZI149;
 
-		(ZIhb) = ast_make_class_concat((*ZIhead), (*ZIbody));
-		if ((ZIhb) == NULL) {
-			goto ZL1;
-		}
-	
-#line 1244 "src/libre/dialect/sql/parser.c"
-			}
-			/* END OF ACTION: ast-make-class-concat */
-			/* BEGINNING OF ACTION: ast-make-class-concat */
-			{
-#line 729 "src/libre/parser.act"
-
-		(ZIhbt) = ast_make_class_concat((ZIhb), (*ZItail));
-		if ((ZIhbt) == NULL) {
-			goto ZL1;
-		}
-	
-#line 1256 "src/libre/dialect/sql/parser.c"
-			}
-			/* END OF ACTION: ast-make-class-concat */
-			/* BEGINNING OF EXTRACT: CLOSEGROUP */
-			{
+					switch (CURRENT_TERMINAL) {
+					case (TOK_CLOSEGROUP):
+						/* BEGINNING OF EXTRACT: CLOSEGROUP */
+						{
 #line 254 "src/libre/parser.act"
 
-		ZI152 = ']';
-		ZI153 = lex_state->lx.start;
+		ZI148 = ']';
+		ZI149 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1267 "src/libre/dialect/sql/parser.c"
+#line 1095 "src/libre/dialect/sql/parser.c"
+						}
+						/* END OF EXTRACT: CLOSEGROUP */
+						break;
+					default:
+						goto ZL5;
+					}
+					ADVANCE_LEXER;
+					/* BEGINNING OF ACTION: mark-group */
+					{
+#line 530 "src/libre/parser.act"
+
+		mark(&act_state->groupstart, &(*ZI188));
+		mark(&act_state->groupend,   &(ZIend));
+	
+#line 1110 "src/libre/dialect/sql/parser.c"
+					}
+					/* END OF ACTION: mark-group */
+				}
+				goto ZL4;
+			ZL5:;
+				{
+					/* BEGINNING OF ACTION: err-expected-closegroup */
+					{
+#line 491 "src/libre/parser.act"
+
+		if (err->e == RE_ESUCCESS) {
+			err->e = RE_EXCLOSEGROUP;
+		}
+		goto ZL1;
+	
+#line 1126 "src/libre/dialect/sql/parser.c"
+					}
+					/* END OF ACTION: err-expected-closegroup */
+					ZIend = *ZI188;
+				}
+			ZL4:;
 			}
-			/* END OF EXTRACT: CLOSEGROUP */
-			ADVANCE_LEXER;
+			/* END OF INLINE: 147 */
 			/* BEGINNING OF ACTION: ast-make-expr-class */
 			{
 #line 684 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI191));
+		AST_POS_OF_LX_POS(ast_start, (*ZI188));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
-		mark(&act_state->groupstart, &(*ZI191));
+		mark(&act_state->groupstart, &(*ZI188));
 		mark(&act_state->groupend,   &(ZIend));
 
-		(ZInode) = ast_make_expr_class((ZIhbt), &ast_start, &ast_end);
+		(ZInode) = ast_make_expr_class((*ZIclass), &ast_start, &ast_end);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1288 "src/libre/dialect/sql/parser.c"
+#line 1151 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-expr-class */
 		}
@@ -1300,6 +1163,92 @@ ZL1:;
 	return;
 ZL0:;
 	*ZOnode = ZInode;
+}
+
+static void
+p_192(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class *ZIclass)
+{
+	switch (CURRENT_TERMINAL) {
+	case (TOK_RANGE):
+		{
+			t_char ZI117;
+			t_pos ZI118;
+			t_pos ZI119;
+			t_ast__class ZIf;
+
+			/* BEGINNING OF EXTRACT: RANGE */
+			{
+#line 243 "src/libre/parser.act"
+
+		ZI117 = '-';
+		ZI118 = lex_state->lx.start;
+		ZI119   = lex_state->lx.end;
+	
+#line 1188 "src/libre/dialect/sql/parser.c"
+			}
+			/* END OF EXTRACT: RANGE */
+			ADVANCE_LEXER;
+			/* BEGINNING OF ACTION: ast-make-class-flag-invert-minus */
+			{
+#line 823 "src/libre/parser.act"
+
+		(ZIf) = ast_make_class_flags(AST_CLASS_FLAG_INVERTED | AST_CLASS_FLAG_MINUS);
+		if ((ZIf) == NULL) {
+			goto ZL1;
+		}
+	
+#line 1201 "src/libre/dialect/sql/parser.c"
+			}
+			/* END OF ACTION: ast-make-class-flag-invert-minus */
+			/* BEGINNING OF ACTION: ast-add-class-concat */
+			{
+#line 830 "src/libre/parser.act"
+
+		if (!ast_add_class_concat((*ZIclass), (ZIf))) {
+			goto ZL1;
+		}
+	
+#line 1212 "src/libre/dialect/sql/parser.c"
+			}
+			/* END OF ACTION: ast-add-class-concat */
+		}
+		break;
+	default:
+		{
+			t_ast__class ZIf;
+
+			/* BEGINNING OF ACTION: ast-make-class-flag-invert */
+			{
+#line 809 "src/libre/parser.act"
+
+		(ZIf) = ast_make_class_flags(AST_CLASS_FLAG_INVERTED);
+		if ((ZIf) == NULL) {
+			goto ZL1;
+		}
+	
+#line 1230 "src/libre/dialect/sql/parser.c"
+			}
+			/* END OF ACTION: ast-make-class-flag-invert */
+			/* BEGINNING OF ACTION: ast-add-class-concat */
+			{
+#line 830 "src/libre/parser.act"
+
+		if (!ast_add_class_concat((*ZIclass), (ZIf))) {
+			goto ZL1;
+		}
+	
+#line 1241 "src/libre/dialect/sql/parser.c"
+			}
+			/* END OF ACTION: ast-add-class-concat */
+		}
+		break;
+	case (ERROR_TERMINAL):
+		return;
+	}
+	return;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
 }
 
 static void
@@ -1311,10 +1260,19 @@ p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__ex
 		return;
 	}
 	{
-		t_ast__expr ZI186;
+		/* BEGINNING OF ACTION: ast-make-expr-alt */
+		{
+#line 639 "src/libre/parser.act"
 
-		p_expr_C_Calt (flags, lex_state, act_state, err, &ZI186);
-		p_188 (flags, lex_state, act_state, err, &ZI186, &ZInode);
+		(ZInode) = ast_make_expr_alt();
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 1273 "src/libre/dialect/sql/parser.c"
+		}
+		/* END OF ACTION: ast-make-expr-alt */
+		p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, ZInode);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
@@ -1322,6 +1280,34 @@ p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__ex
 	}
 	goto ZL0;
 ZL1:;
+	{
+		/* BEGINNING OF ACTION: err-expected-alts */
+		{
+#line 477 "src/libre/parser.act"
+
+		if (err->e == RE_ESUCCESS) {
+			err->e = RE_EXALTS;
+		}
+		goto ZL2;
+	
+#line 1294 "src/libre/dialect/sql/parser.c"
+		}
+		/* END OF ACTION: err-expected-alts */
+		/* BEGINNING OF ACTION: ast-make-expr-empty */
+		{
+#line 625 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_empty();
+		if ((ZInode) == NULL) {
+			goto ZL2;
+		}
+	
+#line 1306 "src/libre/dialect/sql/parser.c"
+		}
+		/* END OF ACTION: ast-make-expr-empty */
+	}
+	goto ZL0;
+ZL2:;
 	SAVE_LEXER ((ERROR_TERMINAL));
 	return;
 ZL0:;
@@ -1329,72 +1315,7 @@ ZL0:;
 }
 
 static void
-p_195(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class *ZOf)
-{
-	t_ast__class ZIf;
-
-	switch (CURRENT_TERMINAL) {
-	case (TOK_RANGE):
-		{
-			t_char ZI113;
-			t_pos ZI114;
-			t_pos ZI115;
-
-			/* BEGINNING OF EXTRACT: RANGE */
-			{
-#line 243 "src/libre/parser.act"
-
-		ZI113 = '-';
-		ZI114 = lex_state->lx.start;
-		ZI115   = lex_state->lx.end;
-	
-#line 1352 "src/libre/dialect/sql/parser.c"
-			}
-			/* END OF EXTRACT: RANGE */
-			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: ast-make-class-flag-invert-minus */
-			{
-#line 811 "src/libre/parser.act"
-
-		(ZIf) = ast_make_class_flags(AST_CLASS_FLAG_INVERTED | AST_CLASS_FLAG_MINUS);
-		if ((ZIf) == NULL) {
-			goto ZL1;
-		}
-	
-#line 1365 "src/libre/dialect/sql/parser.c"
-			}
-			/* END OF ACTION: ast-make-class-flag-invert-minus */
-		}
-		break;
-	default:
-		{
-			/* BEGINNING OF ACTION: ast-make-class-flag-invert */
-			{
-#line 797 "src/libre/parser.act"
-
-		(ZIf) = ast_make_class_flags(AST_CLASS_FLAG_INVERTED);
-		if ((ZIf) == NULL) {
-			goto ZL1;
-		}
-	
-#line 1381 "src/libre/dialect/sql/parser.c"
-			}
-			/* END OF ACTION: ast-make-class-flag-invert */
-		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOf = ZIf;
-}
-
-static void
-p_199(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI196, t_pos *ZI197, t_ast__class *ZOnode)
+p_196(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI193, t_pos *ZI194, t_ast__class *ZOnode)
 {
 	t_ast__class ZInode;
 
@@ -1403,14 +1324,14 @@ p_199(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		{
 			/* BEGINNING OF ACTION: ast-make-class-literal */
 			{
-#line 736 "src/libre/parser.act"
+#line 748 "src/libre/parser.act"
 
-		(ZInode) = ast_make_class_literal((*ZI196));
+		(ZInode) = ast_make_class_literal((*ZI193));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1414 "src/libre/dialect/sql/parser.c"
+#line 1335 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-class-literal */
 		}
@@ -1418,11 +1339,11 @@ p_199(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 	case (TOK_RANGE):
 		{
 			t_endpoint ZIa;
-			t_char ZI129;
-			t_pos ZI130;
-			t_pos ZI131;
+			t_char ZI133;
+			t_pos ZI134;
+			t_pos ZI135;
 			t_char ZIcz;
-			t_pos ZI133;
+			t_pos ZI137;
 			t_pos ZIend;
 			t_endpoint ZIz;
 
@@ -1431,20 +1352,20 @@ p_199(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 #line 594 "src/libre/parser.act"
 
 		(ZIa).type = AST_ENDPOINT_LITERAL;
-		(ZIa).u.literal.c = (*ZI196);
+		(ZIa).u.literal.c = (*ZI193);
 	
-#line 1437 "src/libre/dialect/sql/parser.c"
+#line 1358 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
 #line 243 "src/libre/parser.act"
 
-		ZI129 = '-';
-		ZI130 = lex_state->lx.start;
-		ZI131   = lex_state->lx.end;
+		ZI133 = '-';
+		ZI134 = lex_state->lx.start;
+		ZI135   = lex_state->lx.end;
 	
-#line 1448 "src/libre/dialect/sql/parser.c"
+#line 1369 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
@@ -1457,12 +1378,12 @@ p_199(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI133 = lex_state->lx.start;
+		ZI137 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 
 		ZIcz = lex_state->buf.a[0];
 	
-#line 1466 "src/libre/dialect/sql/parser.c"
+#line 1387 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: CHAR */
 				break;
@@ -1477,17 +1398,27 @@ p_199(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		(ZIz).type = AST_ENDPOINT_LITERAL;
 		(ZIz).u.literal.c = (ZIcz);
 	
-#line 1481 "src/libre/dialect/sql/parser.c"
+#line 1402 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
+			/* BEGINNING OF ACTION: mark-range */
+			{
+#line 535 "src/libre/parser.act"
+
+		mark(&act_state->rangestart, &(*ZI194));
+		mark(&act_state->rangeend,   &(ZIend));
+	
+#line 1412 "src/libre/dialect/sql/parser.c"
+			}
+			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-make-class-range */
 			{
-#line 746 "src/libre/parser.act"
+#line 758 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI197));
+		AST_POS_OF_LX_POS(ast_start, (*ZI194));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		if ((ZIa).type != AST_ENDPOINT_LITERAL ||
@@ -1515,7 +1446,7 @@ p_199(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			goto ZL1;
 		}
 	
-#line 1519 "src/libre/dialect/sql/parser.c"
+#line 1450 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-class-range */
 		}
@@ -1532,193 +1463,98 @@ ZL0:;
 }
 
 static void
-p_200(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZIa, t_ast__expr *ZOnode)
+p_expr_C_Clist_Hof_Hatoms(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr ZIcat)
 {
-	t_ast__expr ZInode;
-
-	switch (CURRENT_TERMINAL) {
-	case (TOK_ALT):
-		{
-			t_ast__expr ZIr;
-
-			ADVANCE_LEXER;
-			p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, &ZIr);
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-			/* BEGINNING OF ACTION: ast-make-expr-alt */
-			{
-#line 639 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_alt((*ZIa), (ZIr));
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 1560 "src/libre/dialect/sql/parser.c"
-			}
-			/* END OF ACTION: ast-make-expr-alt */
-		}
-		break;
-	default:
-		{
-			t_ast__expr ZIr;
-
-			/* BEGINNING OF ACTION: ast-make-expr-empty */
-			{
-#line 625 "src/libre/parser.act"
-
-		(ZIr) = ast_make_expr_empty();
-		if ((ZIr) == NULL) {
-			goto ZL1;
-		}
-	
-#line 1578 "src/libre/dialect/sql/parser.c"
-			}
-			/* END OF ACTION: ast-make-expr-empty */
-			/* BEGINNING OF ACTION: ast-make-expr-alt */
-			{
-#line 639 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_alt((*ZIa), (ZIr));
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 1590 "src/libre/dialect/sql/parser.c"
-			}
-			/* END OF ACTION: ast-make-expr-alt */
-		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOnode = ZInode;
-}
-
-static void
-p_expr_C_Clist_Hof_Hatoms(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
-{
-	t_ast__expr ZInode;
-
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 		return;
 	}
+ZL2_expr_C_Clist_Hof_Hatoms:;
 	{
 		t_ast__expr ZIa;
 
 		p_expr_C_Catom (flags, lex_state, act_state, err, &ZIa);
-		p_189 (flags, lex_state, act_state, err, &ZIa, &ZInode);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
 		}
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOnode = ZInode;
-}
+		/* BEGINNING OF ACTION: ast-add-expr-concat */
+		{
+#line 725 "src/libre/parser.act"
 
-static void
-p_expr_C_Cclass(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
-{
-	t_ast__expr ZInode;
-
-	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-		return;
-	}
-	{
-		p_expr_C_Cclass_C_Cclass_Hast (flags, lex_state, act_state, err, &ZInode);
-		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-			RESTORE_LEXER;
+		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
 		}
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOnode = ZInode;
-}
-
-static void
-p_expr_C_Cclass_C_Cclass_Hast(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
-{
-	t_ast__expr ZInode;
-
-	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-		return;
-	}
-	{
-		t_pos ZI191;
-		t_pos ZI192;
-		t_ast__class ZIhead;
-		t_ast__class ZIbody;
-		t_ast__class ZItail;
-
-		switch (CURRENT_TERMINAL) {
-		case (TOK_OPENGROUP):
-			/* BEGINNING OF EXTRACT: OPENGROUP */
-			{
-#line 249 "src/libre/parser.act"
-
-		ZI191 = lex_state->lx.start;
-		ZI192   = lex_state->lx.end;
 	
-#line 1679 "src/libre/dialect/sql/parser.c"
+#line 1489 "src/libre/dialect/sql/parser.c"
+		}
+		/* END OF ACTION: ast-add-expr-concat */
+		/* BEGINNING OF INLINE: 167 */
+		{
+			switch (CURRENT_TERMINAL) {
+			case (TOK_ANY): case (TOK_MANY): case (TOK_OPENSUB): case (TOK_OPENGROUP):
+			case (TOK_CHAR):
+				{
+					/* BEGINNING OF INLINE: expr::list-of-atoms */
+					goto ZL2_expr_C_Clist_Hof_Hatoms;
+					/* END OF INLINE: expr::list-of-atoms */
+				}
+				/*UNREACHED*/
+			default:
+				break;
 			}
-			/* END OF EXTRACT: OPENGROUP */
-			break;
-		default:
-			goto ZL1;
 		}
-		ADVANCE_LEXER;
-		p_expr_C_Cclass_C_Cclass_Hhead (flags, lex_state, act_state, err, &ZIhead);
-		p_expr_C_Cclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, &ZIbody);
-		p_expr_C_Cclass_C_Cclass_Htail (flags, lex_state, act_state, err, &ZItail);
-		p_193 (flags, lex_state, act_state, err, &ZI191, &ZIhead, &ZIbody, &ZItail, &ZInode);
-		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-			RESTORE_LEXER;
-			goto ZL1;
-		}
+		/* END OF INLINE: 167 */
 	}
-	goto ZL0;
+	return;
 ZL1:;
 	SAVE_LEXER ((ERROR_TERMINAL));
 	return;
-ZL0:;
-	*ZOnode = ZInode;
 }
 
 static void
-p_expr_C_Clist_Hof_Halts(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
+p_expr_C_Clist_Hof_Halts(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr ZIalts)
 {
-	t_ast__expr ZInode;
-
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 		return;
 	}
+ZL2_expr_C_Clist_Hof_Halts:;
 	{
 		t_ast__expr ZIa;
 
 		p_expr_C_Calt (flags, lex_state, act_state, err, &ZIa);
-		p_200 (flags, lex_state, act_state, err, &ZIa, &ZInode);
 		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 			RESTORE_LEXER;
 			goto ZL1;
 		}
+		/* BEGINNING OF ACTION: ast-add-expr-alt */
+		{
+#line 731 "src/libre/parser.act"
+
+		if (!ast_add_expr_alt((ZIalts), (ZIa))) {
+			goto ZL1;
+		}
+	
+#line 1538 "src/libre/dialect/sql/parser.c"
+		}
+		/* END OF ACTION: ast-add-expr-alt */
+		/* BEGINNING OF INLINE: 173 */
+		{
+			switch (CURRENT_TERMINAL) {
+			case (TOK_ALT):
+				{
+					ADVANCE_LEXER;
+					/* BEGINNING OF INLINE: expr::list-of-alts */
+					goto ZL2_expr_C_Clist_Hof_Halts;
+					/* END OF INLINE: expr::list-of-alts */
+				}
+				/*UNREACHED*/
+			default:
+				break;
+			}
+		}
+		/* END OF INLINE: 173 */
 	}
-	goto ZL0;
+	return;
 ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-alts */
@@ -1728,26 +1564,70 @@ ZL1:;
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXALTS;
 		}
-		goto ZL2;
+		goto ZL4;
 	
-#line 1734 "src/libre/dialect/sql/parser.c"
+#line 1570 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
-		/* BEGINNING OF ACTION: ast-make-expr-empty */
-		{
-#line 625 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_empty();
-		if ((ZInode) == NULL) {
-			goto ZL2;
-		}
-	
-#line 1746 "src/libre/dialect/sql/parser.c"
-		}
-		/* END OF ACTION: ast-make-expr-empty */
 	}
 	goto ZL0;
-ZL2:;
+ZL4:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+ZL0:;
+}
+
+static void
+p_expr_C_Ccharacter_Hclass_C_Cterm(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class *ZOnode)
+{
+	t_ast__class ZInode;
+
+	switch (CURRENT_TERMINAL) {
+	case (TOK_CHAR):
+		{
+			t_char ZI193;
+			t_pos ZI194;
+			t_pos ZI195;
+
+			/* BEGINNING OF EXTRACT: CHAR */
+			{
+#line 401 "src/libre/parser.act"
+
+		/* the first byte may be '\x00' */
+		assert(lex_state->buf.a[1] == '\0');
+
+		ZI194 = lex_state->lx.start;
+		ZI195   = lex_state->lx.end;
+
+		ZI193 = lex_state->buf.a[0];
+	
+#line 1605 "src/libre/dialect/sql/parser.c"
+			}
+			/* END OF EXTRACT: CHAR */
+			ADVANCE_LEXER;
+			p_196 (flags, lex_state, act_state, err, &ZI193, &ZI194, &ZInode);
+			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+				RESTORE_LEXER;
+				goto ZL1;
+			}
+		}
+		break;
+	case (TOK_NAMED__CLASS):
+		{
+			p_expr_C_Ccharacter_Hclass_C_Cnamed_Hclass (flags, lex_state, act_state, err, &ZInode);
+			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+				RESTORE_LEXER;
+				goto ZL1;
+			}
+		}
+		break;
+	case (ERROR_TERMINAL):
+		return;
+	default:
+		goto ZL1;
+	}
+	goto ZL0;
+ZL1:;
 	SAVE_LEXER ((ERROR_TERMINAL));
 	return;
 ZL0:;
@@ -1786,7 +1666,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL1;
 		}
 	
-#line 1790 "src/libre/dialect/sql/parser.c"
+#line 1670 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-expr-atom-any */
 		}
@@ -1809,7 +1689,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 
 		(ZIf) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 1813 "src/libre/dialect/sql/parser.c"
+#line 1693 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: atom-kleene */
 			/* BEGINNING OF ACTION: ast-make-expr-atom-any */
@@ -1828,7 +1708,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL1;
 		}
 	
-#line 1832 "src/libre/dialect/sql/parser.c"
+#line 1712 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-expr-atom-any */
 			/* BEGINNING OF ACTION: ast-make-expr-atom */
@@ -1841,7 +1721,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL1;
 		}
 	
-#line 1845 "src/libre/dialect/sql/parser.c"
+#line 1725 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-expr-atom */
 		}
@@ -1867,7 +1747,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL1;
 		}
 	
-#line 1871 "src/libre/dialect/sql/parser.c"
+#line 1751 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-expr-group */
 			switch (CURRENT_TERMINAL) {
@@ -1892,7 +1772,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL1;
 		}
 	
-#line 1896 "src/libre/dialect/sql/parser.c"
+#line 1776 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-expr-atom */
 		}
@@ -1902,7 +1782,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			t_ast__expr ZIe;
 			t_ast__count ZIs;
 
-			p_expr_C_Cclass (flags, lex_state, act_state, err, &ZIe);
+			p_expr_C_Ccharacter_Hclass (flags, lex_state, act_state, err, &ZIe);
 			p_expr_C_Catom_Hsuffix (flags, lex_state, act_state, err, &ZIs);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
@@ -1918,7 +1798,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL1;
 		}
 	
-#line 1922 "src/libre/dialect/sql/parser.c"
+#line 1802 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-expr-atom */
 		}
@@ -1944,7 +1824,7 @@ p_expr_C_Catom(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL1;
 		}
 	
-#line 1948 "src/libre/dialect/sql/parser.c"
+#line 1828 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-expr-atom */
 		}
@@ -1963,19 +1843,108 @@ ZL0:;
 }
 
 static void
-p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
+p_expr_C_Ccharacter_Hclass_C_Cnamed_Hclass(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class *ZOnode)
 {
-	t_ast__expr ZInode;
+	t_ast__class ZInode;
 
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 		return;
 	}
 	{
-		p_expr_C_Clist_Hof_Hatoms (flags, lex_state, act_state, err, &ZInode);
-		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-			RESTORE_LEXER;
+		t_ast__class__id ZIid;
+		t_pos ZI125;
+		t_pos ZI126;
+
+		switch (CURRENT_TERMINAL) {
+		case (TOK_NAMED__CLASS):
+			/* BEGINNING OF EXTRACT: NAMED_CLASS */
+			{
+#line 428 "src/libre/parser.act"
+
+		ZIid = DIALECT_CLASS(lex_state->buf.a);
+		if (ZIid == NULL) {
+			/* syntax error -- unrecognized class */
 			goto ZL1;
 		}
+
+		ZI125 = lex_state->lx.start;
+		ZI126   = lex_state->lx.end;
+	
+#line 1874 "src/libre/dialect/sql/parser.c"
+			}
+			/* END OF EXTRACT: NAMED_CLASS */
+			break;
+		default:
+			goto ZL1;
+		}
+		ADVANCE_LEXER;
+		/* BEGINNING OF ACTION: ast-make-class-named */
+		{
+#line 788 "src/libre/parser.act"
+
+		(ZInode) = ast_make_class_named((ZIid));
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 1891 "src/libre/dialect/sql/parser.c"
+		}
+		/* END OF ACTION: ast-make-class-named */
+	}
+	goto ZL0;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+ZL0:;
+	*ZOnode = ZInode;
+}
+
+static void
+p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
+{
+	t_ast__expr ZInode;
+
+	switch (CURRENT_TERMINAL) {
+	case (TOK_ANY): case (TOK_MANY): case (TOK_OPENSUB): case (TOK_OPENGROUP):
+	case (TOK_CHAR):
+		{
+			/* BEGINNING OF ACTION: ast-make-expr-concat */
+			{
+#line 632 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_concat();
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 1921 "src/libre/dialect/sql/parser.c"
+			}
+			/* END OF ACTION: ast-make-expr-concat */
+			p_expr_C_Clist_Hof_Hatoms (flags, lex_state, act_state, err, ZInode);
+			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+				RESTORE_LEXER;
+				goto ZL1;
+			}
+		}
+		break;
+	default:
+		{
+			/* BEGINNING OF ACTION: ast-make-expr-empty */
+			{
+#line 625 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_empty();
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 1942 "src/libre/dialect/sql/parser.c"
+			}
+			/* END OF ACTION: ast-make-expr-empty */
+		}
+		break;
+	case (ERROR_TERMINAL):
+		return;
 	}
 	goto ZL0;
 ZL1:;
@@ -1987,7 +1956,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 960 "src/libre/parser.act"
+#line 978 "src/libre/parser.act"
 
 
 	static int
@@ -2131,6 +2100,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 2135 "src/libre/dialect/sql/parser.c"
+#line 2104 "src/libre/dialect/sql/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/sql/parser.h
+++ b/src/libre/dialect/sql/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__sql(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 962 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/sql/parser.h"

--- a/src/libre/dialect/sql/parser.sid
+++ b/src/libre/dialect/sql/parser.sid
@@ -97,7 +97,7 @@
 	<ast-add-expr-concat>: (:ast_expr, :ast_expr) -> ();
 	<ast-add-expr-alt>:    (:ast_expr, :ast_expr) -> ();
 
-	<ast-make-class-concat>:       (:ast_class, :ast_class) -> (:ast_class);
+	<ast-make-class-concat>:       ()                       -> (:ast_class);
 	<ast-make-class-literal>:      (:char)                  -> (:ast_class);
 	<ast-make-class-range>:        (:endpoint, :pos, :endpoint, :pos) -> (:ast_class);
 	<ast-make-class-named>:        (:ast_class_id)          -> (:ast_class);
@@ -108,21 +108,23 @@
 	<ast-make-class-flag-minus>:   () -> (:ast_class);
 	<ast-make-class-flag-invert-minus>: () -> (:ast_class);
 
+	<ast-add-class-concat>: (:ast_class, :ast_class) -> ();
+
 	<err-expected-term>;
 	!<err-expected-count>;
 	!<err-expected-atoms>;
 	<err-expected-alts>;
 	!<err-expected-range>;
-	!<err-expected-closegroup>;
+	<err-expected-closegroup>;
 	!<err-unknown-flag>;
 	!<err-expected-closeflags>;
 	!<err-expected-groupbody>;
 	<err-expected-eof>;
 	<err-unsupported>;
 
-	!<mark-group>: (:pos, :pos) -> ();
-	!<mark-range>: (:pos, :pos) -> ();
-	!<mark-count>: (:pos, :pos) -> ();
+	<mark-group>: (:pos, :pos) -> ();
+	<mark-range>: (:pos, :pos) -> ();
+	<mark-count>: (:pos, :pos) -> ();
 
 	expr: () -> (node :ast_expr) [
 		literal: () -> (node :ast_expr) = {
@@ -143,6 +145,7 @@
 			(pos_of, pos_ot) = OPENCOUNT;
 			m = COUNT;
 			(pos_cf, pos_ct) = CLOSECOUNT;
+			<mark-count>(pos_of, pos_ct);
 			f = <atom-count>(m, pos_of, m, pos_ct);
 		||
 			(pos_of, pos_ot) = OPENCOUNT;
@@ -150,6 +153,7 @@
 			SEP;
 			n = COUNT;
 			(pos_cf, pos_ct) = CLOSECOUNT;
+			<mark-count>(pos_of, pos_ct);
 			f = <atom-count>(m, pos_of, n, pos_ct);
 		||
 			f = <atom-one>();
@@ -169,34 +173,45 @@
 		 * [-] also allowed at the tail (just [-] is ambiguous)
 		 * [[:NAME:]] named character classes
 		 *
+		 * TODO: describe [abc^xyz]
+		 *
 		 * _ is the ANY character class
 		 */
-		class: () -> (node :ast_expr) [
-			class-head: () -> (f :ast_class) = {
-				(!) = INVERT;
+		character-class: () -> (node :ast_expr) [
+
+			class-head: (class :ast_class) -> () = {
+				! = INVERT;
 				f = <ast-make-class-flag-invert>();
+				<ast-add-class-concat>(class, f);
 			||
 				(!, !, !) = RANGE;
 				f = <ast-make-class-flag-minus>();
+				<ast-add-class-concat>(class, f);
 			||
-				(!) = INVERT;
+				! = INVERT;
 				(!, !, !) = RANGE;
 				f = <ast-make-class-flag-invert-minus>();
+				<ast-add-class-concat>(class, f);
 			||
+				/* XXX: why add a node at all? */
 				f = <ast-make-class-flag-none>();
+				<ast-add-class-concat>(class, f);
 			};
 
-			class-tail: () -> (f :ast_class) = {
-				/* This requires LL(2). */
+			class-tail: (class :ast_class) -> () = {
+				/* XXX: This requires LL(2). */
 
 			/* 	(!, !, !) = RANGE;
 			 * 	f = <ast-make-class-flag-minus>();
 			 * || */
+				/* XXX: why add a node at all? */
 				f = <ast-make-class-flag-none>();
+				<ast-add-class-concat>(class, f);
 			};
 
-			named-class: () -> (id :ast_class_id) = {
+			named-class: () -> (node :ast_class) = {
 				(id, !, !) = NAMED_CLASS;
+				node = <ast-make-class-named>(id);
 			};
 
 			term: () -> (node :ast_class) = {
@@ -208,63 +223,78 @@
 				(cz, !, end) = CHAR;
 				z = <ast-range-endpoint-literal>(cz);
 
+				<mark-range>(start, end);
 				node = <ast-make-class-range>(a, start, z, end);
 			||
 				(c, !, !) = CHAR;
 				node = <ast-make-class-literal>(c);
 			||
-				id = named-class();
-				node = <ast-make-class-named>(id);
-			##
-				<err-expected-term>();
-				node = <ast-make-class-flag-none>();
+				node = named-class();
 			};
 
-			list-of-class-terms: () -> (node :ast_class) = {
-				l = term();
+			list-of-class-terms: (class :ast_class) -> () = {
 				{
-					r = list-of-class-terms();
-					node = <ast-make-class-concat>(l, r);
+					node = term();
+					<ast-add-class-concat>(class, node);
+				##
+					<err-expected-term>;
+				};
+
+				{
+					list-of-class-terms(class);
 				||
-					node = l;
+					$;
 				};
 			};
 
-			class-ast: () -> (node :ast_expr) = {
-				(start, !) = OPENGROUP;
-
-				head = class-head();
-				body = list-of-class-terms();
-				tail = class-tail();
-
-				hb = <ast-make-class-concat>(head, body);
-				hbt = <ast-make-class-concat>(hb, tail);
-				(!, !, end) = CLOSEGROUP;
-				node = <ast-make-expr-class>(hbt, start, end);
-			||
-				(start, !) = OPENGROUP;
-				head = class-head();
-				body = list-of-class-terms();
-				tail = class-tail();
-				(!) = INVERT;
-				maskhead = class-head();
-				maskbody = list-of-class-terms();
-				masktail = class-tail();
-
-				hb = <ast-make-class-concat>(head, body);
-				hbt = <ast-make-class-concat>(hb, tail);
-				(!, !, end) = CLOSEGROUP;
-
-				/* Marking this unsupported for now */
-				<err-unsupported>();
-
-				mhb = <ast-make-class-concat>(maskhead, maskbody);
-				mhbt = <ast-make-class-concat>(mhb, masktail);
-				masked = <ast-make-class-subtract>(hbt, mhbt);
-				node = <ast-make-expr-class>(masked, start, end);
-			};
 		] = {
-			node = class-ast();
+			(start, !) = OPENGROUP;
+
+			class = <ast-make-class-concat>;
+
+			class-head(class);
+			list-of-class-terms(class);
+			class-tail(class);
+
+			{
+				(!, !, end) = CLOSEGROUP;
+				<mark-group>(start, end);
+			##
+				<err-expected-closegroup>;
+				end = start; /* appease sid */
+			};
+
+			node = <ast-make-expr-class>(class, start, end);
+		||
+			(start, !) = OPENGROUP;
+
+			class = <ast-make-class-concat>;
+
+			class-head(class);
+			list-of-class-terms(class);
+			class-tail(class);
+
+			! = INVERT;
+
+			mask = <ast-make-class-concat>;
+
+			class-head(mask);
+			list-of-class-terms(mask);
+			class-tail(mask);
+
+			{
+				(!, !, end) = CLOSEGROUP;
+				<mark-group>(start, end);
+			##
+				<err-expected-closegroup>;
+				end = start; /* appease sid */
+			};
+
+			/* Marking this unsupported for now */
+			<err-unsupported>;
+
+			sub = <ast-make-class-subtract>(class, mask);
+			node = <ast-make-expr-class>(sub, start, end);
 		};
 
 		/* TODO: is there a better name than 'atom' for
@@ -277,7 +307,7 @@
 			s = atom-suffix();
 			node = <ast-make-expr-atom>(e, s);
 		||
-			e = class();
+			e = character-class();
 			s = atom-suffix();
 			node = <ast-make-expr-atom>(e, s);
 		||

--- a/src/libre/dialect/sql/parser.sid
+++ b/src/libre/dialect/sql/parser.sid
@@ -84,7 +84,7 @@
 	<ast-make-expr-empty>:         ()                       -> (:ast_expr);
 	<ast-make-expr-literal>:       (:char)                  -> (:ast_expr);
 	<ast-make-expr-concat>:        ()                       -> (:ast_expr);
-	<ast-make-expr-alt>:           (:ast_expr, :ast_expr)   -> (:ast_expr);
+	<ast-make-expr-alt>:           ()                       -> (:ast_expr);
 	!<ast-make-expr-any>:          ()                       -> (:ast_expr);
 	<ast-make-expr-atom>:          (:ast_expr, :ast_count)  -> (:ast_expr);
 	<ast-make-expr-atom-any>:      (:ast_count)             -> (:ast_expr);
@@ -95,6 +95,7 @@
 	!<ast-make-expr-anchor-end>:   ()                       -> (:ast_expr);
 
 	<ast-add-expr-concat>: (:ast_expr, :ast_expr) -> ();
+	<ast-add-expr-alt>:    (:ast_expr, :ast_expr) -> ();
 
 	<ast-make-class-concat>:       (:ast_class, :ast_class) -> (:ast_class);
 	<ast-make-class-literal>:      (:char)                  -> (:ast_class);
@@ -310,38 +311,37 @@
 		alt: () -> (node :ast_expr) = {
 			node = <ast-make-expr-concat>;
 			list-of-atoms(node);
+		||
+			/* explcitly allow an empty alt */
+			node = <ast-make-expr-empty>;
 		};
 
-		list-of-alts: () -> (node :ast_expr) = {
+		list-of-alts: (alts :ast_expr) -> () = {
 			a = alt();
-			r = <ast-make-expr-empty>;
-			node = <ast-make-expr-alt>(a,r);
-		||
-			a = alt();
-			ALT;
-			r = list-of-alts();
-			node = <ast-make-expr-alt>(a, r);
+			<ast-add-expr-alt>(alts, a);
+
+			{
+				ALT;
+
+				list-of-alts(alts);
+			||
+				$;
+			};
 		##
 			<err-expected-alts>;
-			node = <ast-make-expr-empty>();
 		};
+
 	] = {
-		/* don't wrap a single alt in an alt chain */
-		node = alt();
-	||
-		/* keep alts into a linked list -- every right node
-		 * is either another alt or empty. */
-		a = alt();
-		ALT;
-		r = list-of-alts();
-		node = <ast-make-expr-alt>(a, r);
+		node = <ast-make-expr-alt>;
+		list-of-alts(node);
+	##
+		<err-expected-alts>;
+		node = <ast-make-expr-empty>;
 	};
 
 	re_sql: () -> (node :ast_expr) = {
 		{
 			node = expr();
-		||
-			node = <ast-make-expr-empty>();
 		};
 
 		{

--- a/src/libre/dialect/sql/parser.sid
+++ b/src/libre/dialect/sql/parser.sid
@@ -83,7 +83,7 @@
 
 	<ast-make-expr-empty>:         ()                       -> (:ast_expr);
 	<ast-make-expr-literal>:       (:char)                  -> (:ast_expr);
-	<ast-make-expr-concat>:        (:ast_expr, :ast_expr)   -> (:ast_expr);
+	<ast-make-expr-concat>:        ()                       -> (:ast_expr);
 	<ast-make-expr-alt>:           (:ast_expr, :ast_expr)   -> (:ast_expr);
 	!<ast-make-expr-any>:          ()                       -> (:ast_expr);
 	<ast-make-expr-atom>:          (:ast_expr, :ast_count)  -> (:ast_expr);
@@ -93,6 +93,8 @@
 	!<ast-make-expr-re-flags>:     (:re_flags, :re_flags)   -> (:ast_expr);
 	!<ast-make-expr-anchor-start>: ()                       -> (:ast_expr);
 	!<ast-make-expr-anchor-end>:   ()                       -> (:ast_expr);
+
+	<ast-add-expr-concat>: (:ast_expr, :ast_expr) -> ();
 
 	<ast-make-class-concat>:       (:ast_class, :ast_class) -> (:ast_class);
 	<ast-make-class-literal>:      (:char)                  -> (:ast_class);
@@ -293,18 +295,21 @@
 			node = <ast-make-expr-atom>(e, s);
 		};
 
-		list-of-atoms: () -> (node :ast_expr) = {
+		list-of-atoms: (cat :ast_expr) -> () = {
 			a = atom();
-			r = <ast-make-expr-empty>;
-			node = <ast-make-expr-concat>(a,r);
-		||
-			a = atom();
-			r = list-of-atoms();
-			node = <ast-make-expr-concat>(a,r);
+
+			<ast-add-expr-concat>(cat, a);
+
+			{
+				list-of-atoms(cat);
+			||
+				$;
+			};
 		};
 
 		alt: () -> (node :ast_expr) = {
-			node = list-of-atoms();
+			node = <ast-make-expr-concat>;
+			list-of-atoms(node);
 		};
 
 		list-of-alts: () -> (node :ast_expr) = {

--- a/src/libre/parser.act
+++ b/src/libre/parser.act
@@ -635,8 +635,8 @@
 		}
 	@};
 
-	<ast-make-expr-alt>: (l :ast_expr, r :ast_expr) -> (node :ast_expr) = @{
-		@node = ast_make_expr_alt(@l, @r);
+	<ast-make-expr-alt>: () -> (node :ast_expr) = @{
+		@node = ast_make_expr_alt_n();
 		if (@node == NULL) {
 			@!;
 		}
@@ -723,6 +723,12 @@
 
 	<ast-add-expr-concat>: (cat :ast_expr, node :ast_expr) -> () = @{
 		if (!ast_add_expr_concat(@cat, @node)) {
+			@!;
+		}
+	@};
+
+	<ast-add-expr-alt>: (alt :ast_expr, node :ast_expr) -> () = @{
+		if (!ast_add_expr_alt(@alt, @node)) {
 			@!;
 		}
 	@};

--- a/src/libre/parser.act
+++ b/src/libre/parser.act
@@ -737,8 +737,8 @@
 	 * Character classes
 	 */
 
-	<ast-make-class-concat>: (l :ast_class, r :ast_class) -> (node :ast_class) = @{
-		@node = ast_make_class_concat(@l, @r);
+	<ast-make-class-concat>: () -> (node :ast_class) = @{
+		@node = ast_make_class_concat_n();
 		if (@node == NULL) {
 			@!;
 		}
@@ -822,6 +822,12 @@
 	<ast-make-class-flag-invert-minus>: () -> (node :ast_class) = @{
 		@node = ast_make_class_flags(AST_CLASS_FLAG_INVERTED | AST_CLASS_FLAG_MINUS);
 		if (@node == NULL) {
+			@!;
+		}
+	@};
+
+	<ast-add-class-concat>: (cat :ast_class, node :ast_class) -> () = @{
+		if (!ast_add_class_concat(@cat, @node)) {
 			@!;
 		}
 	@};

--- a/src/libre/parser.act
+++ b/src/libre/parser.act
@@ -629,14 +629,14 @@
 	@};
 
 	<ast-make-expr-concat>: () -> (node :ast_expr) = @{
-		@node = ast_make_expr_concat_n();
+		@node = ast_make_expr_concat();
 		if (@node == NULL) {
 			@!;
 		}
 	@};
 
 	<ast-make-expr-alt>: () -> (node :ast_expr) = @{
-		@node = ast_make_expr_alt_n();
+		@node = ast_make_expr_alt();
 		if (@node == NULL) {
 			@!;
 		}
@@ -738,7 +738,7 @@
 	 */
 
 	<ast-make-class-concat>: () -> (node :ast_class) = @{
-		@node = ast_make_class_concat_n();
+		@node = ast_make_class_concat();
 		if (@node == NULL) {
 			@!;
 		}

--- a/src/libre/parser.act
+++ b/src/libre/parser.act
@@ -628,8 +628,8 @@
 		}
 	@};
 
-	<ast-make-expr-concat>: (l :ast_expr, r :ast_expr) -> (node :ast_expr) = @{
-		@node = ast_make_expr_concat(@l, @r);
+	<ast-make-expr-concat>: () -> (node :ast_expr) = @{
+		@node = ast_make_expr_concat_n();
 		if (@node == NULL) {
 			@!;
 		}
@@ -717,6 +717,12 @@
 	<ast-make-expr-anchor-end>: () -> (node :ast_expr) = @{
 		@node = ast_make_expr_anchor(AST_ANCHOR_END);
 		if (@node == NULL) {
+			@!;
+		}
+	@};
+
+	<ast-add-expr-concat>: (cat :ast_expr, node :ast_expr) -> () = @{
+		if (!ast_add_expr_concat(@cat, @node)) {
 			@!;
 		}
 	@};

--- a/src/libre/print/abnf.c
+++ b/src/libre/print/abnf.c
@@ -130,13 +130,13 @@ cc_pp_iter(FILE *f, const struct fsm_options *opt, struct ast_class *n)
 	assert(n != NULL);
 
 	switch (n->type) {
-	case AST_CLASS_CONCAT_N: {
+	case AST_CLASS_CONCAT: {
 		size_t i;
 
-		for (i = 0; i < n->u.concat_n.count; i++) {
-			cc_pp_iter(f, opt, n->u.concat_n.n[i]);
+		for (i = 0; i < n->u.concat.count; i++) {
+			cc_pp_iter(f, opt, n->u.concat.n[i]);
 
-			if (i + 1 < n->u.concat_n.count) {
+			if (i + 1 < n->u.concat.count) {
 				fprintf(f, " / ");
 			}
 		}
@@ -201,24 +201,24 @@ pp_iter(FILE *f, const struct fsm_options *opt, struct ast_expr *n)
 	case AST_EXPR_EMPTY:
 		break;
 
-	case AST_EXPR_CONCAT_N: {
+	case AST_EXPR_CONCAT: {
 		size_t i;
 
-		for (i = 0; i < n->u.concat_n.count; i++) {
-			pp_iter(f, opt, n->u.concat_n.n[i]);
-			if (i + 1 < n->u.concat_n.count) {
+		for (i = 0; i < n->u.concat.count; i++) {
+			pp_iter(f, opt, n->u.concat.n[i]);
+			if (i + 1 < n->u.concat.count) {
 				fprintf(f, " ");
 			}
 		}
 		break;
 	}
 
-	case AST_EXPR_ALT_N: {
+	case AST_EXPR_ALT: {
 		size_t i;
 
-		for (i = 0; i < n->u.alt_n.count; i++) {
-			pp_iter(f, opt, n->u.alt_n.n[i]);
-			if (i + 1 < n->u.alt_n.count) {
+		for (i = 0; i < n->u.alt.count; i++) {
+			pp_iter(f, opt, n->u.alt.n[i]);
+			if (i + 1 < n->u.alt.count) {
 				fprintf(f, " / "); /* XXX: indent */
 			}
 		}

--- a/src/libre/print/abnf.c
+++ b/src/libre/print/abnf.c
@@ -143,6 +143,19 @@ cc_pp_iter(FILE *f, const struct fsm_options *opt, struct ast_class *n)
 		}
 		break;
 
+	case AST_CLASS_CONCAT_N: {
+		size_t i;
+
+		for (i = 0; i < n->u.concat_n.count; i++) {
+			cc_pp_iter(f, opt, n->u.concat_n.n[i]);
+
+			if (i + 1 < n->u.concat_n.count) {
+				fprintf(f, " / ");
+			}
+		}
+		break;
+	}
+
 	case AST_CLASS_LITERAL:
 		abnf_escputc(f, opt, n->u.literal.c);
 		break;
@@ -212,7 +225,9 @@ pp_iter(FILE *f, const struct fsm_options *opt, struct ast_expr *n)
 
 		for (i = 0; i < n->u.concat_n.count; i++) {
 			pp_iter(f, opt, n->u.concat_n.n[i]);
-			if (i < n->u.concat_n.count - 1) { fprintf(f, " "); }
+			if (i + 1 < n->u.concat_n.count) {
+				fprintf(f, " ");
+			}
 		}
 		break;
 	}
@@ -228,7 +243,7 @@ pp_iter(FILE *f, const struct fsm_options *opt, struct ast_expr *n)
 
 		for (i = 0; i < n->u.alt_n.count; i++) {
 			pp_iter(f, opt, n->u.alt_n.n[i]);
-			if (i < n->u.alt_n.count - 1) {
+			if (i + 1 < n->u.alt_n.count) {
 				fprintf(f, " / "); /* XXX: indent */
 			}
 		}

--- a/src/libre/print/abnf.c
+++ b/src/libre/print/abnf.c
@@ -33,8 +33,6 @@ atomic(struct ast_expr *n)
 		return 1;
 
 	case AST_EXPR_REPEATED:
-	case AST_EXPR_CONCAT:
-	case AST_EXPR_ALT:
 		return 0;
 
 	case AST_EXPR_FLAGS:
@@ -132,17 +130,6 @@ cc_pp_iter(FILE *f, const struct fsm_options *opt, struct ast_class *n)
 	assert(n != NULL);
 
 	switch (n->type) {
-	case AST_CLASS_CONCAT:
-		if (n->u.concat.l != NULL && n->u.concat.l->type == AST_CLASS_FLAGS) {
-			/* XXX */
-			cc_pp_iter(f, opt, n->u.concat.r);
-		} else {
-			cc_pp_iter(f, opt, n->u.concat.l);
-			fprintf(f, " / ");
-			cc_pp_iter(f, opt, n->u.concat.r);
-		}
-		break;
-
 	case AST_CLASS_CONCAT_N: {
 		size_t i;
 
@@ -214,12 +201,6 @@ pp_iter(FILE *f, const struct fsm_options *opt, struct ast_expr *n)
 	case AST_EXPR_EMPTY:
 		break;
 
-	case AST_EXPR_CONCAT:
-		pp_iter(f, opt, n->u.concat.l);
-		fprintf(f, " ");
-		pp_iter(f, opt, n->u.concat.r);
-		break;
-
 	case AST_EXPR_CONCAT_N: {
 		size_t i;
 
@@ -231,12 +212,6 @@ pp_iter(FILE *f, const struct fsm_options *opt, struct ast_expr *n)
 		}
 		break;
 	}
-
-	case AST_EXPR_ALT:
-		pp_iter(f, opt, n->u.alt.l);
-		fprintf(f, " / "); /* XXX: indent */
-		pp_iter(f, opt, n->u.alt.r);
-		break;
 
 	case AST_EXPR_ALT_N: {
 		size_t i;

--- a/src/libre/print/dot.c
+++ b/src/libre/print/dot.c
@@ -66,12 +66,6 @@ cc_pp_iter(FILE *f, const struct fsm_options *opt,
 	fprintf(f, "\tn%p [ style = \"filled\", fillcolor = \"#eeeeee\" ];\n", (void *) n);
 
 	switch (n->type) {
-	case AST_CLASS_CONCAT:
-		fprintf(f, "\tn%p [ label = <CLASS-CONCAT> ];\n", (void *) n);
-		cc_pp_iter(f, opt, n, n->u.concat.l);
-		cc_pp_iter(f, opt, n, n->u.concat.r);
-		break;
-
 	case AST_CLASS_CONCAT_N: {
 		size_t i;
 
@@ -143,12 +137,6 @@ pp_iter(FILE *f, const struct fsm_options *opt,
 		fprintf(f, "\tn%p [ label = <EMPTY> ];\n", (void *) n);
 		break;
 
-	case AST_EXPR_CONCAT:
-		fprintf(f, "\tn%p [ label = <CONCAT> ];\n", (void *) n);
-		pp_iter(f, opt, n, n->u.concat.l);
-		pp_iter(f, opt, n, n->u.concat.r);
-		break;
-
 	case AST_EXPR_CONCAT_N:
 	{
 		size_t i;
@@ -159,12 +147,6 @@ pp_iter(FILE *f, const struct fsm_options *opt,
 		}
 		break;
 	}
-
-	case AST_EXPR_ALT:
-		fprintf(f, "\tn%p [ label = <ALT> ];\n", (void *) n);
-		pp_iter(f, opt, n, n->u.alt.l);
-		pp_iter(f, opt, n, n->u.alt.r);
-		break;
 
 	case AST_EXPR_ALT_N:
 	{

--- a/src/libre/print/dot.c
+++ b/src/libre/print/dot.c
@@ -66,13 +66,13 @@ cc_pp_iter(FILE *f, const struct fsm_options *opt,
 	fprintf(f, "\tn%p [ style = \"filled\", fillcolor = \"#eeeeee\" ];\n", (void *) n);
 
 	switch (n->type) {
-	case AST_CLASS_CONCAT_N: {
+	case AST_CLASS_CONCAT: {
 		size_t i;
 
 		fprintf(f, "\tn%p [ label = <CLASS-CONCAT|%lu> ];\n",
-			(void *) n, (unsigned long)  n->u.concat_n.count);
-		for (i = 0; i < n->u.concat_n.count; i++) {
-			cc_pp_iter(f, opt, n, n->u.concat_n.n[i]);
+			(void *) n, (unsigned long)  n->u.concat.count);
+		for (i = 0; i < n->u.concat.count; i++) {
+			cc_pp_iter(f, opt, n, n->u.concat.n[i]);
 		}
 		break;
 	}
@@ -137,24 +137,24 @@ pp_iter(FILE *f, const struct fsm_options *opt,
 		fprintf(f, "\tn%p [ label = <EMPTY> ];\n", (void *) n);
 		break;
 
-	case AST_EXPR_CONCAT_N:
+	case AST_EXPR_CONCAT:
 	{
 		size_t i;
 		fprintf(f, "\tn%p [ label = <CONCAT|%lu> ];\n",
-		    (void *) n, n->u.concat_n.count);
-		for (i = 0; i < n->u.concat_n.count; i++) {
-			pp_iter(f, opt, n, n->u.concat_n.n[i]);
+		    (void *) n, n->u.concat.count);
+		for (i = 0; i < n->u.concat.count; i++) {
+			pp_iter(f, opt, n, n->u.concat.n[i]);
 		}
 		break;
 	}
 
-	case AST_EXPR_ALT_N:
+	case AST_EXPR_ALT:
 	{
 		size_t i;
 		fprintf(f, "\tn%p [ label = <ALT|%lu> ];\n",
-		    (void *) n, n->u.alt_n.count);
-		for (i = 0; i < n->u.alt_n.count; i++) {
-			pp_iter(f, opt, n, n->u.alt_n.n[i]);
+		    (void *) n, n->u.alt.count);
+		for (i = 0; i < n->u.alt.count; i++) {
+			pp_iter(f, opt, n, n->u.alt.n[i]);
 		}
 		break;
 	}

--- a/src/libre/print/dot.c
+++ b/src/libre/print/dot.c
@@ -72,6 +72,17 @@ cc_pp_iter(FILE *f, const struct fsm_options *opt,
 		cc_pp_iter(f, opt, n, n->u.concat.r);
 		break;
 
+	case AST_CLASS_CONCAT_N: {
+		size_t i;
+
+		fprintf(f, "\tn%p [ label = <CLASS-CONCAT|%lu> ];\n",
+			(void *) n, (unsigned long)  n->u.concat_n.count);
+		for (i = 0; i < n->u.concat_n.count; i++) {
+			cc_pp_iter(f, opt, n, n->u.concat_n.n[i]);
+		}
+		break;
+	}
+
 	case AST_CLASS_LITERAL:
 		fprintf(f, "\tn%p [ label = <CLASS-LITERAL|", (void *) n);
 		dot_escputc_html(f, opt, n->u.literal.c);

--- a/src/libre/print/pcre.c
+++ b/src/libre/print/pcre.c
@@ -30,10 +30,6 @@ atomic(struct ast_expr *n)
 	case AST_EXPR_GROUP:
 		return 1;
 
-	case AST_EXPR_CONCAT:
-	case AST_EXPR_ALT:
-		return 0;
-
 	case AST_EXPR_FLAGS:
 		return 0; /* XXX */
 
@@ -148,11 +144,6 @@ cc_pp_iter(FILE *f, const struct fsm_options *opt, struct ast_class *n)
 	assert(n != NULL);
 
 	switch (n->type) {
-	case AST_CLASS_CONCAT:
-		cc_pp_iter(f, opt, n->u.concat.l);
-		cc_pp_iter(f, opt, n->u.concat.r);
-		break;
-
 	case AST_CLASS_CONCAT_N: {
 		size_t i;
 
@@ -208,11 +199,6 @@ pp_iter(FILE *f, const struct fsm_options *opt, struct ast_expr *n)
 	case AST_EXPR_EMPTY:
 		break;
 
-	case AST_EXPR_CONCAT:
-		pp_iter(f, opt, n->u.concat.l);
-		pp_iter(f, opt, n->u.concat.r);
-		break;
-
 	case AST_EXPR_CONCAT_N:
 	{
 		size_t i;
@@ -221,12 +207,6 @@ pp_iter(FILE *f, const struct fsm_options *opt, struct ast_expr *n)
 		}
 		break;
 	}
-
-	case AST_EXPR_ALT:
-		pp_iter(f, opt, n->u.alt.l);
-		fprintf(f, "|");
-		pp_iter(f, opt, n->u.alt.r);
-		break;
 
 	case AST_EXPR_ALT_N:
 	{

--- a/src/libre/print/pcre.c
+++ b/src/libre/print/pcre.c
@@ -144,11 +144,11 @@ cc_pp_iter(FILE *f, const struct fsm_options *opt, struct ast_class *n)
 	assert(n != NULL);
 
 	switch (n->type) {
-	case AST_CLASS_CONCAT_N: {
+	case AST_CLASS_CONCAT: {
 		size_t i;
 
-		for (i = 0; i < n->u.concat_n.count; i++) {
-			cc_pp_iter(f, opt, n->u.concat_n.n[i]);
+		for (i = 0; i < n->u.concat.count; i++) {
+			cc_pp_iter(f, opt, n->u.concat.n[i]);
 		}
 		break;
 	}
@@ -199,21 +199,21 @@ pp_iter(FILE *f, const struct fsm_options *opt, struct ast_expr *n)
 	case AST_EXPR_EMPTY:
 		break;
 
-	case AST_EXPR_CONCAT_N:
+	case AST_EXPR_CONCAT:
 	{
 		size_t i;
-		for (i = 0; i < n->u.concat_n.count; i++) {
-			pp_iter(f, opt, n->u.concat_n.n[i]);
+		for (i = 0; i < n->u.concat.count; i++) {
+			pp_iter(f, opt, n->u.concat.n[i]);
 		}
 		break;
 	}
 
-	case AST_EXPR_ALT_N:
+	case AST_EXPR_ALT:
 	{
 		size_t i;
-		for (i = 0; i < n->u.alt_n.count; i++) {
-			pp_iter(f, opt, n->u.alt_n.n[i]);
-			if (i + 1 < n->u.alt_n.count) {
+		for (i = 0; i < n->u.alt.count; i++) {
+			pp_iter(f, opt, n->u.alt.n[i]);
+			if (i + 1 < n->u.alt.count) {
 				fprintf(f, "|");
 			}
 		}

--- a/src/libre/print/pcre.c
+++ b/src/libre/print/pcre.c
@@ -153,6 +153,15 @@ cc_pp_iter(FILE *f, const struct fsm_options *opt, struct ast_class *n)
 		cc_pp_iter(f, opt, n->u.concat.r);
 		break;
 
+	case AST_CLASS_CONCAT_N: {
+		size_t i;
+
+		for (i = 0; i < n->u.concat_n.count; i++) {
+			cc_pp_iter(f, opt, n->u.concat_n.n[i]);
+		}
+		break;
+	}
+
 	case AST_CLASS_LITERAL:
 		pcre_escputc(f, opt, n->u.literal.c);
 		break;
@@ -224,7 +233,7 @@ pp_iter(FILE *f, const struct fsm_options *opt, struct ast_expr *n)
 		size_t i;
 		for (i = 0; i < n->u.alt_n.count; i++) {
 			pp_iter(f, opt, n->u.alt_n.n[i]);
-			if (i < n->u.alt_n.count - 1) {
+			if (i + 1 < n->u.alt_n.count) {
 				fprintf(f, "|");
 			}
 		}

--- a/src/libre/print/tree.c
+++ b/src/libre/print/tree.c
@@ -105,6 +105,16 @@ cc_pp_iter(FILE *f, const struct fsm_options *opt,
 		cc_pp_iter(f, opt, n->u.concat.r, indent + 4);
 		break;
 
+	case AST_CLASS_CONCAT_N: {
+		size_t i, count = n->u.concat_n.count;
+
+		fprintf(f, "CLASS-CONCAT (%u):\n", (unsigned) count);
+		for (i = 0; i < n->u.concat_n.count; i++) {
+			cc_pp_iter(f, opt, n->u.concat_n.n[i], indent + 4);
+		}
+		break;
+	}
+
 	case AST_CLASS_LITERAL:
 		fprintf(f, "CLASS-LITERAL %p: '", (void *) n);
 		print_char_or_esc(f, n->u.literal.c);

--- a/src/libre/print/tree.c
+++ b/src/libre/print/tree.c
@@ -99,12 +99,6 @@ cc_pp_iter(FILE *f, const struct fsm_options *opt,
 	INDENT(f, indent);
 
 	switch (n->type) {
-	case AST_CLASS_CONCAT:
-		fprintf(f, "CLASS-CONCAT %p: \n", (void *) n);
-		cc_pp_iter(f, opt, n->u.concat.l, indent + 4);
-		cc_pp_iter(f, opt, n->u.concat.r, indent + 4);
-		break;
-
 	case AST_CLASS_CONCAT_N: {
 		size_t i, count = n->u.concat_n.count;
 
@@ -178,33 +172,6 @@ pp_iter(FILE *f, const struct fsm_options *opt, size_t indent, struct ast_expr *
 	switch (n->type) {
 	case AST_EXPR_EMPTY:
 		fprintf(f, "EMPTY \n");
-		break;
-
-	/*
-	 * CONCAT and ALT should be removed once CONCAT_N and ALT_N are
-	 * built directly in the parser.
-	 */
-	case AST_EXPR_CONCAT:
-		fprintf(f, "CONCAT %p: {\n", (void *) n);
-		pp_iter(f, opt, indent + 1 * IND, n->u.concat.l);
-		INDENT(f, indent);
-
-		fprintf(f, ", (%p)\n", (void *) n);
-
-		pp_iter(f, opt, indent + 1 * IND, n->u.concat.r);
-		INDENT(f, indent);
-		fprintf(f, "} (%p)\n", (void *) n);
-		break;
-
-	case AST_EXPR_ALT:
-		fprintf(f, "ALT %p: {\n", (void *) n);
-		pp_iter(f, opt, indent + 1 * IND, n->u.alt.l);
-		INDENT(f, indent);
-
-		fprintf(f, ", (%p)\n", (void *) n);
-		pp_iter(f, opt, indent + 1 * IND, n->u.alt.r);
-		INDENT(f, indent);
-		fprintf(f, "} (%p)\n", (void *) n);
 		break;
 
 	case AST_EXPR_CONCAT_N: {

--- a/src/libre/print/tree.c
+++ b/src/libre/print/tree.c
@@ -99,12 +99,12 @@ cc_pp_iter(FILE *f, const struct fsm_options *opt,
 	INDENT(f, indent);
 
 	switch (n->type) {
-	case AST_CLASS_CONCAT_N: {
-		size_t i, count = n->u.concat_n.count;
+	case AST_CLASS_CONCAT: {
+		size_t i, count = n->u.concat.count;
 
 		fprintf(f, "CLASS-CONCAT (%u):\n", (unsigned) count);
-		for (i = 0; i < n->u.concat_n.count; i++) {
-			cc_pp_iter(f, opt, n->u.concat_n.n[i], indent + 4);
+		for (i = 0; i < n->u.concat.count; i++) {
+			cc_pp_iter(f, opt, n->u.concat.n[i], indent + 4);
 		}
 		break;
 	}
@@ -174,21 +174,21 @@ pp_iter(FILE *f, const struct fsm_options *opt, size_t indent, struct ast_expr *
 		fprintf(f, "EMPTY \n");
 		break;
 
-	case AST_EXPR_CONCAT_N: {
-		size_t i, count = n->u.concat_n.count;
+	case AST_EXPR_CONCAT: {
+		size_t i, count = n->u.concat.count;
 		fprintf(f, "CONCAT (%u):\n", (unsigned)count);
 
 		for (i = 0; i < count; i++) {
-			pp_iter(f, opt, indent + 1 * IND, n->u.concat_n.n[i]);
+			pp_iter(f, opt, indent + 1 * IND, n->u.concat.n[i]);
 		}
 		break;
 	}
 
-	case AST_EXPR_ALT_N: {
-		size_t i, count = n->u.alt_n.count;
+	case AST_EXPR_ALT: {
+		size_t i, count = n->u.alt.count;
 		fprintf(f, "ALT (%u):\n", (unsigned)count);
 		for (i = 0; i < count; i++) {
-			pp_iter(f, opt, indent + 1 * IND, n->u.alt_n.n[i]);
+			pp_iter(f, opt, indent + 1 * IND, n->u.alt.n[i]);
 		}
 		break;
 	}


### PR DESCRIPTION
The AST looks a little flatter now, instead of having lop-sided binary alts and concats:
![image](https://user-images.githubusercontent.com/1371085/68539635-2cee7400-033b-11ea-9888-efa367867caa.png)

I've also added a little tree rewriting, to remove redundant nodes and fold up single children and so on.