### PR TITLE
A little more AST rewriting for a simpler tree

### DIFF
--- a/src/libre/ast.h
+++ b/src/libre/ast.h
@@ -187,12 +187,21 @@ struct ast_count
 ast_make_count(unsigned low, const struct ast_pos *start,
 	unsigned high, const struct ast_pos *end);
 
+int
+ast_endpoint_equal(const struct ast_endpoint *a, const struct ast_endpoint *b);
+
 /*
  * Expressions
  */
 
 void
 ast_expr_free(struct ast_expr *n);
+
+int
+ast_expr_equal(const struct ast_expr *a, const struct ast_expr *b);
+
+int
+ast_contains_expr(const struct ast_expr *node, struct ast_expr * const *a, size_t n);
 
 struct ast_expr *
 ast_make_expr_empty(void);

--- a/src/libre/ast_analysis.c
+++ b/src/libre/ast_analysis.c
@@ -692,6 +692,25 @@ flatten(struct ast_expr *n)
 			i++;
 		}
 
+		/* de-duplicate children */
+		if (n->u.alt.count > 1) {
+			for (i = 0; i < n->u.alt.count; ) {
+				if (ast_contains_expr(n->u.alt.n[i], n->u.alt.n + i + 1, n->u.alt.count - i - 1)) {
+					ast_expr_free(n->u.concat.n[i]);
+
+					if (i + 1 < n->u.concat.count) {
+						memmove(&n->u.concat.n[i], &n->u.concat.n[i + 1],
+							(n->u.concat.count - i - 1) * sizeof *n->u.concat.n);
+					}
+
+					n->u.concat.count--;
+					continue;
+				}
+
+				i++;
+			}
+		}
+
 		if (n->u.alt.count == 0) {
 			free(n->u.alt.n);
 			n->type = AST_EXPR_EMPTY;

--- a/src/libre/ast_analysis.c
+++ b/src/libre/ast_analysis.c
@@ -599,22 +599,10 @@ flatten(struct ast_expr *n)
 			}
 		}
 
-		/* remove empty children; these have no semantic effect */
-		for (i = 0; i < n->u.alt.count; ) {
-			if (n->u.alt.n[i]->type == AST_EXPR_EMPTY) {
-				ast_expr_free(n->u.alt.n[i]);
-
-				if (i + 1 < n->u.alt.count) {
-					memmove(&n->u.alt.n[i], &n->u.alt.n[i + 1],
-						(n->u.alt.count - i - 1) * sizeof n->u.alt.n[i]);
-				}
-
-				n->u.alt.count--;
-				continue;
-			}
-
-			i++;
-		}
+		/*
+		 * Empty children do have a semantic effect; for dialects with anchors,
+		 * they affect the anchoring. So we cannot remove those in general here.
+		 */
 
 		if (n->u.alt.count == 0) {
 			free(n->u.alt.n);

--- a/src/libre/ast_compile.c
+++ b/src/libre/ast_compile.c
@@ -127,48 +127,6 @@ fsm_unionxy(struct fsm *a, struct fsm *b, struct fsm_state *x, struct fsm_state 
 	return 1;
 }
 
-static struct fsm*
-fsm_class(const struct fsm_options *opt, class_constructor *ctor)
-{
-	struct fsm_state *start, *end;
-	struct fsm *fsm;
-
-	assert(ctor != NULL);
-
-	fsm = fsm_new(opt);
-	if (fsm == NULL) {
-		goto error;
-	}
-
-	start = fsm_addstate(fsm);
-	if (start == NULL) {
-		goto error;
-	}
-
-	end = fsm_addstate(fsm);
-	if (end == NULL) {
-		goto error;
-	}
-
-	fsm_setstart(fsm, start);
-	fsm_setend(fsm, end, 1);
-
-	if (!ctor(fsm, start, end)) {
-		goto error;
-	}
-
-	fsm_setstart(fsm, start);
-	fsm_setend(fsm, end, 1);
-
-	return fsm;
-
-error:
-
-	fsm_free(fsm);
-
-	return NULL;
-}
-
 static struct fsm *
 expr_compile(struct ast_expr *e, enum re_flags flags,
 	const struct fsm_options *opt, struct re_err *err)


### PR DESCRIPTION
Here I've introduced some node substitutions for flattening out children of alts and concats, and for de-duplicating alts. I'm pleased that in combination these transformations find the redundant node from `[xyz]|x`.

Example:
![x](https://user-images.githubusercontent.com/1371085/69488360-69cb6800-0e1d-11ea-8b3c-75aad21f26ab.png)
