### PR TITLE
Inline state storage into state array

### DIFF
--- a/src/libfsm/clone.c
+++ b/src/libfsm/clone.c
@@ -59,13 +59,13 @@ fsm_clone(const struct fsm *fsm)
 			struct edge_iter it;
 
 			fsm_setend(new, i, fsm_isend(fsm, i));
-			new->states[i]->opaque = fsm->states[i]->opaque;
+			new->states[i].opaque = fsm->states[i].opaque;
 
 			{
 				struct state_iter jt;
 				fsm_state_t to;
 
-				for (state_set_reset(fsm->states[i]->epsilons, &jt); state_set_next(&jt, &to); ) {
+				for (state_set_reset(fsm->states[i].epsilons, &jt); state_set_next(&jt, &to); ) {
 					if (!fsm_addedge_epsilon(new, i, to)) {
 						fsm_free(new);
 						return NULL;
@@ -73,7 +73,7 @@ fsm_clone(const struct fsm *fsm)
 				}
 			}
 
-			for (e = edge_set_first(fsm->states[i]->edges, &it); e != NULL; e = edge_set_next(&it)) {
+			for (e = edge_set_first(fsm->states[i].edges, &it); e != NULL; e = edge_set_next(&it)) {
 				struct state_iter jt;
 				fsm_state_t to;
 

--- a/src/libfsm/clone.c
+++ b/src/libfsm/clone.c
@@ -47,7 +47,7 @@ fsm_clone(const struct fsm *fsm)
 				return NULL;
 			}
 
-			fsm->states[i]->tmp.equiv = q;
+			assert(q == i);
 		}
 	}
 
@@ -58,15 +58,15 @@ fsm_clone(const struct fsm *fsm)
 			struct fsm_edge *e;
 			struct edge_iter it;
 
-			fsm_setend(new, fsm->states[i]->tmp.equiv, fsm_isend(fsm, i));
-			new->states[fsm->states[i]->tmp.equiv]->opaque = fsm->states[i]->opaque;
+			fsm_setend(new, i, fsm_isend(fsm, i));
+			new->states[i]->opaque = fsm->states[i]->opaque;
 
 			{
 				struct state_iter jt;
 				fsm_state_t to;
 
 				for (state_set_reset(fsm->states[i]->epsilons, &jt); state_set_next(&jt, &to); ) {
-					if (!fsm_addedge_epsilon(new, fsm->states[i]->tmp.equiv, fsm->states[to]->tmp.equiv)) {
+					if (!fsm_addedge_epsilon(new, i, to)) {
 						fsm_free(new);
 						return NULL;
 					}
@@ -78,7 +78,7 @@ fsm_clone(const struct fsm *fsm)
 				fsm_state_t to;
 
 				for (state_set_reset(e->sl, &jt); state_set_next(&jt, &to); ) {
-					if (!fsm_addedge_literal(new, fsm->states[i]->tmp.equiv, fsm->states[to]->tmp.equiv, e->symbol)) {
+					if (!fsm_addedge_literal(new, i, to, e->symbol)) {
 						fsm_free(new);
 						return NULL;
 					}
@@ -91,7 +91,7 @@ fsm_clone(const struct fsm *fsm)
 		fsm_state_t start;
 
 		if (fsm_getstart(fsm, &start)) {
-			fsm_setstart(new, fsm->states[start]->tmp.equiv);
+			fsm_setstart(new, start);
 		}
 	}
 

--- a/src/libfsm/clone.c
+++ b/src/libfsm/clone.c
@@ -95,8 +95,6 @@ fsm_clone(const struct fsm *fsm)
 		}
 	}
 
-	fsm_clear_tmp(new);
-
 	return new;
 }
 

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -330,7 +330,7 @@ glushkov_buildtransitions(const struct fsm *fsm, struct fsm *dfa,
 		struct fsm_edge *e;
 		struct edge_iter jt;
 
-		for (e = edge_set_first(fsm->states[s]->edges, &jt); e != NULL; e = edge_set_next(&jt)) {
+		for (e = edge_set_first(fsm->states[s].edges, &jt); e != NULL; e = edge_set_next(&jt)) {
 			struct state_iter kt;
 			fsm_state_t st;
 
@@ -450,7 +450,7 @@ dfa_buildtransitions(const struct fsm *fsm, struct fsm *dfa,
 		struct fsm_edge *e;
 		struct edge_iter jt;
 
-		for (e = edge_set_first(fsm->states[s]->edges, &jt); e != NULL; e = edge_set_next(&jt)) {
+		for (e = edge_set_first(fsm->states[s].edges, &jt); e != NULL; e = edge_set_next(&jt)) {
 			sym = e->symbol;
 
 			assert(sym >= 0);

--- a/src/libfsm/eclosure.c
+++ b/src/libfsm/eclosure.c
@@ -50,7 +50,7 @@ epsilon_closure(const struct fsm *fsm, fsm_state_t state, struct state_set *clos
 	}
 
 	/* Follow each epsilon transition */
-	for (state_set_reset(fsm->states[state]->epsilons, &it); state_set_next(&it, &s); ) {
+	for (state_set_reset(fsm->states[state].epsilons, &it); state_set_next(&it, &s); ) {
 		if (epsilon_closure(fsm, s, closure) == NULL) {
 			return NULL;
 		}

--- a/src/libfsm/edge.c
+++ b/src/libfsm/edge.c
@@ -41,14 +41,14 @@ fsm_addedge_epsilon(struct fsm *fsm,
 	assert(from < fsm->statecount);
 	assert(to < fsm->statecount);
 
-	if (fsm->states[from]->epsilons == NULL) {
-		fsm->states[from]->epsilons = state_set_create(fsm->opt->alloc);
-		if (fsm->states[from]->epsilons == NULL) {
+	if (fsm->states[from].epsilons == NULL) {
+		fsm->states[from].epsilons = state_set_create(fsm->opt->alloc);
+		if (fsm->states[from].epsilons == NULL) {
 			return 0;
 		}
 	}
 
-	if (!state_set_add(fsm->states[from]->epsilons, to)) {
+	if (!state_set_add(fsm->states[from].epsilons, to)) {
 		return 0;
 	}
 
@@ -85,15 +85,15 @@ fsm_addedge_literal(struct fsm *fsm,
 	assert(from < fsm->statecount);
 	assert(to < fsm->statecount);
 
-	if (fsm->states[from]->edges == NULL) {
-		fsm->states[from]->edges = edge_set_create(fsm->opt->alloc, fsm_state_cmpedges);
-		if (fsm->states[from]->edges == NULL) {
+	if (fsm->states[from].edges == NULL) {
+		fsm->states[from].edges = edge_set_create(fsm->opt->alloc, fsm_state_cmpedges);
+		if (fsm->states[from].edges == NULL) {
 			return 0;
 		}
 	}
 
 	new.symbol = c;
-	e = edge_set_contains(fsm->states[from]->edges, &new);
+	e = edge_set_contains(fsm->states[from].edges, &new);
 	if (e == NULL) {
 		e = malloc(sizeof *e);
 		if (e == NULL) {
@@ -106,7 +106,7 @@ fsm_addedge_literal(struct fsm *fsm,
 			return 0;
 		}
 
-		if (!edge_set_add(fsm->states[from]->edges, e)) {
+		if (!edge_set_add(fsm->states[from].edges, e)) {
 			return 0;
 		}
 	}
@@ -132,15 +132,15 @@ fsm_addedge_bulk(struct fsm *fsm,
 		return 1;
 	}
 
-	if (fsm->states[from]->edges == NULL) {
-		fsm->states[from]->edges = edge_set_create(fsm->opt->alloc, fsm_state_cmpedges);
-		if (fsm->states[from]->edges == NULL) {
+	if (fsm->states[from].edges == NULL) {
+		fsm->states[from].edges = edge_set_create(fsm->opt->alloc, fsm_state_cmpedges);
+		if (fsm->states[from].edges == NULL) {
 			return 0;
 		}
 	}
 
 	new.symbol = c;
-	e = edge_set_contains(fsm->states[from]->edges, &new);
+	e = edge_set_contains(fsm->states[from].edges, &new);
 	if (e == NULL) {
 		e = malloc(sizeof *e);
 		if (e == NULL) {
@@ -153,7 +153,7 @@ fsm_addedge_bulk(struct fsm *fsm,
 			return 0;
 		}
 
-		if (!edge_set_add(fsm->states[from]->edges, e)) {
+		if (!edge_set_add(fsm->states[from].edges, e)) {
 			return 0;
 		}
 	}
@@ -173,12 +173,12 @@ fsm_hasedge_literal(const struct fsm *fsm, fsm_state_t state, char c)
 	assert(fsm != NULL);
 	assert(state < fsm->statecount);
 
-	if (fsm->states[state]->edges == NULL) {
+	if (fsm->states[state].edges == NULL) {
 		return NULL;
 	}
 
 	search.symbol = (unsigned char) c;
-	e = edge_set_contains(fsm->states[state]->edges, &search);
+	e = edge_set_contains(fsm->states[state].edges, &search);
 	if (e == NULL || state_set_empty(e->sl)) {
 		return NULL;
 	}

--- a/src/libfsm/end.c
+++ b/src/libfsm/end.c
@@ -22,7 +22,7 @@ fsm_setend(struct fsm *fsm, fsm_state_t state, int end)
 	assert(fsm != NULL);
 	assert(state < fsm->statecount);
 
-	if (fsm->states[state]->end == !!end) {
+	if (fsm->states[state].end == !!end) {
 		return;
 	}
 
@@ -30,13 +30,13 @@ fsm_setend(struct fsm *fsm, fsm_state_t state, int end)
 	case 0:
 		assert(fsm->endcount > 0);
 		fsm->endcount--;
-		fsm->states[state]->end = 0;
+		fsm->states[state].end = 0;
 		break;
 
 	case 1:
 		assert(fsm->endcount < FSM_ENDCOUNT_MAX);
 		fsm->endcount++;
-		fsm->states[state]->end = 1;
+		fsm->states[state].end = 1;
 		break;
 	}
 }
@@ -63,9 +63,9 @@ fsm_setopaque(struct fsm *fsm, fsm_state_t state, void *opaque)
 	assert(fsm != NULL);
 	assert(state < fsm->statecount);
 
-	assert(fsm->states[state]->end);
+	assert(fsm->states[state].end);
 
-	fsm->states[state]->opaque = opaque;
+	fsm->states[state].opaque = opaque;
 }
 
 void *
@@ -76,8 +76,8 @@ fsm_getopaque(const struct fsm *fsm, fsm_state_t state)
 	assert(fsm != NULL);
 	assert(state < fsm->statecount);
 
-	assert(fsm->states[state]->end);
+	assert(fsm->states[state].end);
 
-	return fsm->states[state]->opaque;
+	return fsm->states[state].opaque;
 }
 

--- a/src/libfsm/fsm.c
+++ b/src/libfsm/fsm.c
@@ -32,14 +32,13 @@ free_contents(struct fsm *fsm)
 		struct edge_iter it;
 		struct fsm_edge *e;
 
-		for (e = edge_set_first(fsm->states[i]->edges, &it); e != NULL; e = edge_set_next(&it)) {
+		for (e = edge_set_first(fsm->states[i].edges, &it); e != NULL; e = edge_set_next(&it)) {
 			state_set_free(e->sl);
 			f_free(fsm->opt->alloc, e);
 		}
 
-		state_set_free(fsm->states[i]->epsilons);
-		edge_set_free(fsm->states[i]->edges);
-		f_free(fsm->opt->alloc, fsm->states[i]);
+		state_set_free(fsm->states[i].epsilons);
+		edge_set_free(fsm->states[i].edges);
 	}
 
 	f_free(fsm->opt->alloc, fsm->states);
@@ -218,7 +217,7 @@ fsm_countedges(const struct fsm *fsm)
 		struct edge_iter ei;
 		const struct fsm_edge *e;
 
-		for (e = edge_set_first(fsm->states[i]->edges, &ei); e != NULL; e=edge_set_next(&ei)) {
+		for (e = edge_set_first(fsm->states[i].edges, &ei); e != NULL; e=edge_set_next(&ei)) {
 			assert(n + state_set_count(e->sl) > n); /* handle overflow with more grace? */
 			n += state_set_count(e->sl);
 		}

--- a/src/libfsm/fsm.c
+++ b/src/libfsm/fsm.c
@@ -227,15 +227,3 @@ fsm_countedges(const struct fsm *fsm)
 	return n;
 }
 
-void
-fsm_clear_tmp(struct fsm *fsm)
-{
-	size_t i;
-
-	assert(fsm != NULL);
-
-	for (i = 0; i < fsm->statecount; i++) {
-		fsm_state_clear_tmp(fsm->states[i]);
-	}
-}
-

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -56,8 +56,6 @@ struct fsm_state {
 	/* these are only valid within one particular transformation.
 	 * expected to be NULL at start and set back to NULL after. */
 	union {
-		/* temporary relation between one FSM and another */
-		fsm_state_t equiv;
 		/* tracks which states have been visited in walk2 */
 		unsigned int visited:1;
 	} tmp;

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -57,7 +57,7 @@ struct fsm_state {
 };
 
 struct fsm {
-	struct fsm_state **states; /* array */
+	struct fsm_state *states; /* array */
 
 	size_t statealloc; /* number of elements allocated */
 	size_t statecount; /* number of elements populated */

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -46,19 +46,14 @@ struct fsm_edge {
 
 struct fsm_state {
 	unsigned int end:1;
-	unsigned int reachable:1;
+
+	/* meaningful within one particular transformation only */
+	unsigned int visited:1;
 
 	struct edge_set *edges;
 	struct state_set *epsilons;
 
 	void *opaque;
-
-	/* these are only valid within one particular transformation.
-	 * expected to be NULL at start and set back to NULL after. */
-	union {
-		/* tracks which states have been visited in walk2 */
-		unsigned int visited:1;
-	} tmp;
 };
 
 struct fsm {
@@ -89,12 +84,6 @@ fsm_carryopaque_array(struct fsm *src_fsm, const fsm_state_t *src_set, size_t n,
 void
 fsm_carryopaque(struct fsm *fsm, const struct state_set *set,
 	struct fsm *new, fsm_state_t state);
-
-void
-fsm_clear_tmp(struct fsm *fsm);
-
-void
-fsm_state_clear_tmp(struct fsm_state *state);
 
 struct fsm *
 fsm_mergeab(struct fsm *a, struct fsm *b,

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -96,5 +96,3 @@ free_ir # XXX: workaround for lx
 indexof # XXX: workaround for lx
 
 fsm_mergeab
-fsm_clear_tmp
-fsm_state_clear_tmp

--- a/src/libfsm/merge.c
+++ b/src/libfsm/merge.c
@@ -57,9 +57,9 @@ merge(struct fsm *dst, struct fsm *src,
 			const struct fsm_edge *e;
 			struct edge_iter ei;
 
-			state_set_rebase(src->states[i]->epsilons, *base_src);
+			state_set_rebase(src->states[i].epsilons, *base_src);
 
-			for (e = edge_set_first(src->states[i]->edges, &ei); e != NULL; e = edge_set_next(&ei)) {
+			for (e = edge_set_first(src->states[i].edges, &ei); e != NULL; e = edge_set_next(&ei)) {
 				state_set_rebase(e->sl, *base_src);
 			}
 		}

--- a/src/libfsm/mergestates.c
+++ b/src/libfsm/mergestates.c
@@ -32,13 +32,13 @@ fsm_mergestates(struct fsm *fsm, fsm_state_t a, fsm_state_t b,
 		struct state_iter jt;
 		fsm_state_t s;
 
-		for (state_set_reset(fsm->states[b]->epsilons, &jt); state_set_next(&jt, &s); ) {
+		for (state_set_reset(fsm->states[b].epsilons, &jt); state_set_next(&jt, &s); ) {
 			if (!fsm_addedge_epsilon(fsm, a, s)) {
 				return 0;
 			}
 		}
 	}
-	for (e = edge_set_first(fsm->states[b]->edges, &it); e != NULL; e = edge_set_next(&it)) {
+	for (e = edge_set_first(fsm->states[b].edges, &it); e != NULL; e = edge_set_next(&it)) {
 		struct state_iter jt;
 		fsm_state_t s;
 
@@ -51,15 +51,15 @@ fsm_mergestates(struct fsm *fsm, fsm_state_t a, fsm_state_t b,
 
 	/* edges to b */
 	for (i = 0; i < fsm->statecount; i++) {
-		if (state_set_contains(fsm->states[i]->epsilons, b)) {
-			state_set_remove(fsm->states[i]->epsilons, b);
+		if (state_set_contains(fsm->states[i].epsilons, b)) {
+			state_set_remove(fsm->states[i].epsilons, b);
 
 			if (!fsm_addedge_epsilon(fsm, i, a)) {
 				return 0;
 			}
 		}
 
-		for (e = edge_set_first(fsm->states[i]->edges, &it); e != NULL; e = edge_set_next(&it)) {
+		for (e = edge_set_first(fsm->states[i].edges, &it); e != NULL; e = edge_set_next(&it)) {
 			state_set_remove(e->sl, b);
 
 			if (state_set_contains(e->sl, b)) {

--- a/src/libfsm/mode.c
+++ b/src/libfsm/mode.c
@@ -32,7 +32,7 @@ fsm_findmode(const struct fsm *fsm, fsm_state_t state, unsigned int *freq)
 	assert(fsm != NULL);
 	assert(state < fsm->statecount);
 
-	for (e = edge_set_first(fsm->states[state]->edges, &it); e != NULL; e = edge_set_next(&it)) {
+	for (e = edge_set_first(fsm->states[state].edges, &it); e != NULL; e = edge_set_next(&it)) {
 		struct state_iter jt;
 
 		for (state_set_reset(e->sl, &jt); state_set_next(&jt, &s); ) {

--- a/src/libfsm/pred/epsilonsonly.c
+++ b/src/libfsm/pred/epsilonsonly.c
@@ -25,11 +25,11 @@ fsm_epsilonsonly(const struct fsm *fsm, fsm_state_t state)
 	assert(fsm != NULL);
 	assert(state < fsm->statecount);
 
-	if (state_set_empty(fsm->states[state]->epsilons)) {
+	if (state_set_empty(fsm->states[state].epsilons)) {
 		return 0;
 	}
 
-	for (e = edge_set_first(fsm->states[state]->edges, &it); e != NULL; e = edge_set_next(&it)) {
+	for (e = edge_set_first(fsm->states[state].edges, &it); e != NULL; e = edge_set_next(&it)) {
 		if (!state_set_empty(e->sl)) {
 			return 0;
 		}

--- a/src/libfsm/pred/hasepsilons.c
+++ b/src/libfsm/pred/hasepsilons.c
@@ -22,6 +22,6 @@ fsm_hasepsilons(const struct fsm *fsm, fsm_state_t state)
 	assert(fsm != NULL);
 	assert(state < fsm->statecount);
 
-	return !state_set_empty(fsm->states[state]->epsilons);
+	return !state_set_empty(fsm->states[state].epsilons);
 }
 

--- a/src/libfsm/pred/hasincoming.c
+++ b/src/libfsm/pred/hasincoming.c
@@ -28,11 +28,11 @@ fsm_hasincoming(const struct fsm *fsm, fsm_state_t state)
 		struct fsm_edge *e;
 		struct edge_iter it;
 
-		if (state_set_contains(fsm->states[i]->epsilons, state)) {
+		if (state_set_contains(fsm->states[i].epsilons, state)) {
 			return 1;
 		}
 
-		for (e = edge_set_first(fsm->states[i]->edges, &it); e != NULL; e = edge_set_next(&it)) {
+		for (e = edge_set_first(fsm->states[i].edges, &it); e != NULL; e = edge_set_next(&it)) {
 			if (e->sl != NULL && state_set_contains(e->sl, state)) {
 				return 1;
 			}

--- a/src/libfsm/pred/hasnondeterminism.c
+++ b/src/libfsm/pred/hasnondeterminism.c
@@ -30,7 +30,7 @@ state_hasnondeterminism(const struct fsm *fsm, fsm_state_t state, struct bm *bm)
 	assert(fsm != NULL);
 	assert(state < fsm->statecount);
 
-	for (e = edge_set_first(fsm->states[state]->edges, &jt); e != NULL; e = edge_set_next(&jt)) {
+	for (e = edge_set_first(fsm->states[state].edges, &jt); e != NULL; e = edge_set_next(&jt)) {
 		size_t n;
 
 		n = state_set_count(e->sl);

--- a/src/libfsm/pred/hasoutgoing.c
+++ b/src/libfsm/pred/hasoutgoing.c
@@ -25,11 +25,11 @@ fsm_hasoutgoing(const struct fsm *fsm, fsm_state_t state)
 	assert(fsm != NULL);
 	assert(state < fsm->statecount);
 
-	if (!state_set_empty(fsm->states[state]->epsilons)) {
+	if (!state_set_empty(fsm->states[state].epsilons)) {
 		return 1;
 	}
 
-	for (e = edge_set_first(fsm->states[state]->edges, &it); e != NULL; e = edge_set_next(&it)) {
+	for (e = edge_set_first(fsm->states[state].edges, &it); e != NULL; e = edge_set_next(&it)) {
 		if (!state_set_empty(e->sl)) {
 			return 1;
 		}

--- a/src/libfsm/pred/iscomplete.c
+++ b/src/libfsm/pred/iscomplete.c
@@ -30,10 +30,10 @@ fsm_iscomplete(const struct fsm *fsm, fsm_state_t state)
 	n = 0;
 
 	/* epsilon transitions have no effect on completeness */
-	(void) fsm->states[state]->epsilons;
+	(void) fsm->states[state].epsilons;
 
 	/* TODO: assert state is in fsm->sl */
-	for (e = edge_set_first(fsm->states[state]->edges, &it); e != NULL; e = edge_set_next(&it)) {
+	for (e = edge_set_first(fsm->states[state].edges, &it); e != NULL; e = edge_set_next(&it)) {
 		if (state_set_empty(e->sl)) {
 			continue;
 		}

--- a/src/libfsm/pred/isdfa.c
+++ b/src/libfsm/pred/isdfa.c
@@ -37,14 +37,14 @@ fsm_isdfa(const struct fsm *fsm, fsm_state_t state)
 	/*
 	 * DFA may not have epsilon edges.
 	 */
-	if (!state_set_empty(fsm->states[state]->epsilons)) {
+	if (!state_set_empty(fsm->states[state].epsilons)) {
 		return 0;
 	}
 
 	/*
 	 * DFA may not have duplicate edges.
 	 */
-	for (e = edge_set_first(fsm->states[state]->edges, &it); e != NULL; e = edge_set_next(&it)) {
+	for (e = edge_set_first(fsm->states[state].edges, &it); e != NULL; e = edge_set_next(&it)) {
 		if (state_set_empty(e->sl)) {
 			continue;
 		}

--- a/src/libfsm/pred/isend.c
+++ b/src/libfsm/pred/isend.c
@@ -18,6 +18,6 @@ fsm_isend(const struct fsm *fsm, fsm_state_t state)
 	assert(fsm != NULL);
 	assert(state < fsm->statecount);
 
-	return !!fsm->states[state]->end;
+	return !!fsm->states[state].end;
 }
 

--- a/src/libfsm/print/api.c
+++ b/src/libfsm/print/api.c
@@ -139,12 +139,12 @@ fsm_print_api(FILE *f, const struct fsm *fsm_orig)
 			bm_clear(&a[i]);
 		}
 
-		for (state_set_reset(fsm->states[from]->epsilons, &jt); state_set_next(&jt, &to); ) {
+		for (state_set_reset(fsm->states[from].epsilons, &jt); state_set_next(&jt, &to); ) {
 			fprintf(f, "\tif (!fsm_addedge_epsilon(fsm, s[%u], s[%u])) { return 0; }\n",
 				from, to);
 		}
 
-		for (e = edge_set_first(fsm->states[from]->edges, &it); e != NULL; e = edge_set_next(&it)) {
+		for (e = edge_set_first(fsm->states[from].edges, &it); e != NULL; e = edge_set_next(&it)) {
 			for (state_set_reset(e->sl, &jt); state_set_next(&jt, &to); ) {
 				bm_set(&a[to], e->symbol);
 			}

--- a/src/libfsm/print/dot.c
+++ b/src/libfsm/print/dot.c
@@ -70,7 +70,7 @@ singlestate(FILE *f, const struct fsm *fsm, fsm_state_t s)
 			struct state_iter jt;
 			fsm_state_t st;
 
-			for (state_set_reset(fsm->states[s]->epsilons, &jt); state_set_next(&jt, &st); ) {
+			for (state_set_reset(fsm->states[s].epsilons, &jt); state_set_next(&jt, &st); ) {
 				fprintf(f, "\t%sS%-2u -> %sS%-2u [ label = <",
 					fsm->opt->prefix != NULL ? fsm->opt->prefix : "",
 					s,
@@ -83,7 +83,7 @@ singlestate(FILE *f, const struct fsm *fsm, fsm_state_t s)
 			}
 		}
 
-		for (e = edge_set_first(fsm->states[s]->edges, &it); e != NULL; e = edge_set_next(&it)) {
+		for (e = edge_set_first(fsm->states[s].edges, &it); e != NULL; e = edge_set_next(&it)) {
 			struct state_iter jt;
 			fsm_state_t st;
 
@@ -113,7 +113,7 @@ singlestate(FILE *f, const struct fsm *fsm, fsm_state_t s)
 	 * looping through each edge.
 	 */
 	/* TODO: handle special edges upto FSM_EDGE_MAX separately */
-	for (e = edge_set_first(fsm->states[s]->edges, &it); e != NULL; e = edge_set_next(&it)) {
+	for (e = edge_set_first(fsm->states[s].edges, &it); e != NULL; e = edge_set_next(&it)) {
 		struct state_iter jt;
 		fsm_state_t st;
 
@@ -123,14 +123,14 @@ singlestate(FILE *f, const struct fsm *fsm, fsm_state_t s)
 			struct bm bm;
 
 			/* unique states only */
-			if (contains(fsm->states[s]->edges, e->symbol, st)) {
+			if (contains(fsm->states[s].edges, e->symbol, st)) {
 				continue;
 			}
 
 			bm_clear(&bm);
 
 			/* find all edges which go from this state to the same target state */
-			for (ne = edge_set_first(fsm->states[s]->edges, &kt); ne != NULL; ne = edge_set_next(&kt)) {
+			for (ne = edge_set_first(fsm->states[s].edges, &kt); ne != NULL; ne = edge_set_next(&kt)) {
 				if (state_set_contains(ne->sl, st)) {
 					bm_set(&bm, ne->symbol);
 				}
@@ -161,7 +161,7 @@ singlestate(FILE *f, const struct fsm *fsm, fsm_state_t s)
 		struct state_iter jt;
 		fsm_state_t st;
 
-		for (state_set_reset(fsm->states[s]->epsilons, &jt); state_set_next(&jt, &st); ) {
+		for (state_set_reset(fsm->states[s].epsilons, &jt); state_set_next(&jt, &st); ) {
 			fprintf(f, "\t%sS%-2u -> %sS%-2u [ weight = 1, label = <",
 				fsm->opt->prefix != NULL ? fsm->opt->prefix : "",
 				s,
@@ -191,7 +191,7 @@ print_dotfrag(FILE *f, const struct fsm *fsm)
 
 			if (fsm->opt->endleaf != NULL) {
 				fprintf(f, ", ");
-				fsm->opt->endleaf(f, fsm->states[i], fsm->opt->endleaf_opaque);
+				fsm->opt->endleaf(f, &fsm->states[i], fsm->opt->endleaf_opaque);
 			}
 
 			fprintf(f, " ];\n");

--- a/src/libfsm/print/fsm.c
+++ b/src/libfsm/print/fsm.c
@@ -51,7 +51,7 @@ findany(const struct fsm *fsm, fsm_state_t state, fsm_state_t *a)
 
 	bm_clear(&bm);
 
-	e = edge_set_first(fsm->states[state]->edges, &it);
+	e = edge_set_first(fsm->states[state].edges, &it);
 	if (e == NULL) {
 		return 0;
 	}
@@ -67,7 +67,7 @@ findany(const struct fsm *fsm, fsm_state_t state, fsm_state_t *a)
 		return 0;
 	}
 
-	for (e = edge_set_first(fsm->states[state]->edges, &it); e != NULL; e = edge_set_next(&it)) {
+	for (e = edge_set_first(fsm->states[state].edges, &it); e != NULL; e = edge_set_next(&it)) {
 		if (state_set_count(e->sl) != 1) {
 			return 0;
 		}
@@ -107,7 +107,7 @@ fsm_print_fsm(FILE *f, const struct fsm *fsm)
 			struct state_iter jt;
 			fsm_state_t st;
 
-			for (state_set_reset(fsm->states[s]->epsilons, &jt); state_set_next(&jt, &st); ) {
+			for (state_set_reset(fsm->states[s].epsilons, &jt); state_set_next(&jt, &st); ) {
 				fprintf(f, "%-2u -> %2u;\n", s, st);
 			}
 		}
@@ -121,7 +121,7 @@ fsm_print_fsm(FILE *f, const struct fsm *fsm)
 			}
 		}
 
-		for (e = edge_set_first(fsm->states[s]->edges, &it); e != NULL; e = edge_set_next(&it)) {
+		for (e = edge_set_first(fsm->states[s].edges, &it); e != NULL; e = edge_set_next(&it)) {
 			struct state_iter jt;
 			fsm_state_t st;
 

--- a/src/libfsm/print/ir.c
+++ b/src/libfsm/print/ir.c
@@ -87,7 +87,7 @@ make_groups(const struct fsm *fsm, fsm_state_t state,
 
 	n = 0;
 
-	for (e = edge_set_first(fsm->states[state]->edges, &it); e != NULL; e = edge_set_next(&it)) {
+	for (e = edge_set_first(fsm->states[state].edges, &it); e != NULL; e = edge_set_next(&it)) {
 		fsm_state_t s;
 
 		if (state_set_empty(e->sl)) {
@@ -109,7 +109,7 @@ make_groups(const struct fsm *fsm, fsm_state_t state,
 				struct edge_iter jt;
 				fsm_state_t ns;
 
-				ne = edge_set_firstafter(fsm->states[state]->edges, &jt, e);
+				ne = edge_set_firstafter(fsm->states[state].edges, &jt, e);
 				if (ne == NULL || ne->symbol != e->symbol + 1) {
 					break;
 				}
@@ -357,7 +357,7 @@ make_state(const struct fsm *fsm, fsm_state_t state,
 
 	/* no edges */
 	{
-		if (edge_set_empty(fsm->states[state]->edges)) {
+		if (edge_set_empty(fsm->states[state].edges)) {
 			cs->strategy = IR_NONE;
 			return 0;
 		}

--- a/src/libfsm/print/json.c
+++ b/src/libfsm/print/json.c
@@ -31,7 +31,7 @@ hasmore(const struct fsm *fsm, fsm_state_t s, int i)
 
 	i++;
 	search.symbol = i;
-	for (e = edge_set_firstafter(fsm->states[s]->edges, &it, &search); e != NULL; e = edge_set_next(&it)) {
+	for (e = edge_set_firstafter(fsm->states[s].edges, &it, &search); e != NULL; e = edge_set_next(&it)) {
 		if (!state_set_empty(e->sl)) {
 			return 1;
 		}
@@ -68,7 +68,7 @@ fsm_print_json(FILE *f, const struct fsm *fsm)
 				struct state_iter jt;
 				fsm_state_t st;
 
-				for (state_set_reset(fsm->states[i]->epsilons, &jt); state_set_next(&jt, &st); ) {
+				for (state_set_reset(fsm->states[i].epsilons, &jt); state_set_next(&jt, &st); ) {
 					fprintf(f, "\t\t\t\t{ ");
 
 					fprintf(f, "\"char\": ");
@@ -78,11 +78,11 @@ fsm_print_json(FILE *f, const struct fsm *fsm)
 					fprintf(f, "\"to\": %u", st);
 
 					/* XXX: should count .sl inside an edge */
-					fprintf(f, "}%s\n", !edge_set_empty(fsm->states[i]->edges) ? "," : "");
+					fprintf(f, "}%s\n", !edge_set_empty(fsm->states[i].edges) ? "," : "");
 				}
 			}
 
-			for (e = edge_set_first(fsm->states[i]->edges, &it); e != NULL; e = edge_set_next(&it)) {
+			for (e = edge_set_first(fsm->states[i].edges, &it); e != NULL; e = edge_set_next(&it)) {
 				struct state_iter jt;
 				fsm_state_t st;
 

--- a/src/libfsm/reverse.c
+++ b/src/libfsm/reverse.c
@@ -226,8 +226,6 @@ fsm_reverse(struct fsm *fsm)
 
 	state_set_free(endset);
 
-	fsm_clear_tmp(fsm);
-
 	fsm_move(fsm, new);
 
 	return 1;

--- a/src/libfsm/reverse.c
+++ b/src/libfsm/reverse.c
@@ -121,7 +121,7 @@ fsm_reverse(struct fsm *fsm)
 			{
 				struct state_iter jt;
 
-				for (state_set_reset(fsm->states[i]->epsilons, &jt); state_set_next(&jt, &se); ) {
+				for (state_set_reset(fsm->states[i].epsilons, &jt); state_set_next(&jt, &se); ) {
 					assert(se < fsm->statecount);
 					assert(se < new->statecount);
 
@@ -132,7 +132,7 @@ fsm_reverse(struct fsm *fsm)
 					}
 				}
 			}
-			for (e = edge_set_first(fsm->states[i]->edges, &it); e != NULL; e = edge_set_next(&it)) {
+			for (e = edge_set_first(fsm->states[i].edges, &it); e != NULL; e = edge_set_next(&it)) {
 				struct state_iter jt;
 
 				for (state_set_reset(e->sl, &jt); state_set_next(&jt, &se); ) {

--- a/src/libfsm/reverse.c
+++ b/src/libfsm/reverse.c
@@ -80,7 +80,7 @@ fsm_reverse(struct fsm *fsm)
 				return 0;
 			}
 
-			fsm->states[i]->tmp.equiv = p;
+			assert(p == i);
 
 			if (hasstart && i == start) {
 				end = p;
@@ -114,7 +114,7 @@ fsm_reverse(struct fsm *fsm)
 			fsm_state_t to;
 			fsm_state_t se;
 
-			to = fsm->states[i]->tmp.equiv;
+			to = i;
 
 			assert(to < new->statecount);
 
@@ -122,9 +122,10 @@ fsm_reverse(struct fsm *fsm)
 				struct state_iter jt;
 
 				for (state_set_reset(fsm->states[i]->epsilons, &jt); state_set_next(&jt, &se); ) {
-					assert(fsm->states[se]->tmp.equiv < fsm->statecount);
+					assert(se < fsm->statecount);
+					assert(se < new->statecount);
 
-					if (!fsm_addedge_epsilon(new, fsm->states[se]->tmp.equiv, to)) {
+					if (!fsm_addedge_epsilon(new, se, to)) {
 						state_set_free(endset);
 						fsm_free(new);
 						return 0;
@@ -135,9 +136,10 @@ fsm_reverse(struct fsm *fsm)
 				struct state_iter jt;
 
 				for (state_set_reset(e->sl, &jt); state_set_next(&jt, &se); ) {
-					assert(fsm->states[se]->tmp.equiv < fsm->statecount);
+					assert(se < fsm->statecount);
+					assert(se < new->statecount);
 
-					if (!fsm_addedge_literal(new, fsm->states[se]->tmp.equiv, to, e->symbol)) {
+					if (!fsm_addedge_literal(new, se, to, e->symbol)) {
 						state_set_free(endset);
 						fsm_free(new);
 						return 0;
@@ -190,7 +192,7 @@ fsm_reverse(struct fsm *fsm)
 			for (state_set_reset(endset, &it); state_set_next(&it, &s); ) {
 				if (!fsm_hasincoming(fsm, s)) {
 					have_start = 1;
-					start = fsm->states[s]->tmp.equiv;
+					start = s;
 					break;
 				}
 			}
@@ -210,11 +212,11 @@ fsm_reverse(struct fsm *fsm)
 		}
 
 		for (state_set_reset(endset, &it); state_set_next(&it, &s); ) {
-			if (fsm->states[s]->tmp.equiv == start) {
+			if (s == start) {
 				continue;
 			}
 
-			if (!fsm_addedge_epsilon(new, start, fsm->states[s]->tmp.equiv)) {
+			if (!fsm_addedge_epsilon(new, start, s)) {
 				state_set_free(endset);
 				fsm_free(new);
 				return 0;

--- a/src/libfsm/shortest.c
+++ b/src/libfsm/shortest.c
@@ -101,7 +101,7 @@ fsm_shortest(const struct fsm *fsm,
 			goto done;
 		}
 
-		for (e = edge_set_first(fsm->states[u->state]->edges, &it); e != NULL; e = edge_set_next(&it)) {
+		for (e = edge_set_first(fsm->states[u->state].edges, &it); e != NULL; e = edge_set_next(&it)) {
 			struct state_iter jt;
 
 			for (state_set_reset(e->sl, &jt); state_set_next(&jt, &s); ) {

--- a/src/libfsm/state.c
+++ b/src/libfsm/state.c
@@ -31,6 +31,7 @@ fsm_addstate(struct fsm *fsm, fsm_state_t *state)
 	}
 
 	new->end = 0;
+	new->visited = 0;
 	new->opaque = NULL;
 
 	/*
@@ -41,8 +42,6 @@ fsm_addstate(struct fsm *fsm, fsm_state_t *state)
 	 */
 	new->epsilons = NULL;
 	new->edges    = NULL;
-
-	fsm_state_clear_tmp(new);
 
 	if (fsm->statecount == (fsm_state_t) -1) {
 		errno = ENOMEM;
@@ -73,12 +72,6 @@ fsm_addstate(struct fsm *fsm, fsm_state_t *state)
 	fsm->statecount++;
 
 	return 1;
-}
-
-void
-fsm_state_clear_tmp(struct fsm_state *state)
-{
-	memset(&state->tmp, 0x00, sizeof(state->tmp));
 }
 
 void

--- a/src/libfsm/state.c
+++ b/src/libfsm/state.c
@@ -21,27 +21,7 @@
 int
 fsm_addstate(struct fsm *fsm, fsm_state_t *state)
 {
-	struct fsm_state *new;
-
 	assert(fsm != NULL);
-
-	new = f_malloc(fsm->opt->alloc, sizeof *new);
-	if (new == NULL) {
-		return 0;
-	}
-
-	new->end = 0;
-	new->visited = 0;
-	new->opaque = NULL;
-
-	/*
-	 * Sets for epsilon and labelled transitions are kept NULL
-	 * until populated; this suits the most nodes in the bodies of
-	 * typical FSM that do not have epsilons, and (less often)
-	 * nodes that have no edges.
-	 */
-	new->epsilons = NULL;
-	new->edges    = NULL;
 
 	if (fsm->statecount == (fsm_state_t) -1) {
 		errno = ENOMEM;
@@ -56,7 +36,6 @@ fsm_addstate(struct fsm *fsm, fsm_state_t *state)
 
 		tmp = f_realloc(fsm->opt->alloc, fsm->states, n * sizeof *fsm->states);
 		if (tmp == NULL) {
-			f_free(fsm->opt->alloc, new);
 			return 0;
 		}
 
@@ -68,7 +47,25 @@ fsm_addstate(struct fsm *fsm, fsm_state_t *state)
 		*state = fsm->statecount;
 	}
 
-	fsm->states[fsm->statecount] = new;
+	{
+		struct fsm_state *new;
+
+		new = &fsm->states[fsm->statecount];
+
+		new->end = 0;
+		new->visited = 0;
+		new->opaque = NULL;
+
+		/*
+		 * Sets for epsilon and labelled transitions are kept NULL
+		 * until populated; this suits the most nodes in the bodies of
+		 * typical FSM that do not have epsilons, and (less often)
+		 * nodes that have no edges.
+		 */
+		new->epsilons = NULL;
+		new->edges    = NULL;
+	}
+
 	fsm->statecount++;
 
 	return 1;
@@ -88,24 +85,22 @@ fsm_removestate(struct fsm *fsm, fsm_state_t state)
 	fsm_setend(fsm, state, 0);
 
 	for (i = 0; i < fsm->statecount; i++) {
-		state_set_remove(fsm->states[i]->epsilons, state);
-		for (e = edge_set_first(fsm->states[i]->edges, &it); e != NULL; e = edge_set_next(&it)) {
+		state_set_remove(fsm->states[i].epsilons, state);
+		for (e = edge_set_first(fsm->states[i].edges, &it); e != NULL; e = edge_set_next(&it)) {
 			state_set_remove(e->sl, state);
 		}
 	}
 
-	for (e = edge_set_first(fsm->states[state]->edges, &it); e != NULL; e = edge_set_next(&it)) {
+	for (e = edge_set_first(fsm->states[state].edges, &it); e != NULL; e = edge_set_next(&it)) {
 		state_set_free(e->sl);
 		f_free(fsm->opt->alloc, e);
 	}
-	state_set_free(fsm->states[state]->epsilons);
-	edge_set_free(fsm->states[state]->edges);
+	state_set_free(fsm->states[state].epsilons);
+	edge_set_free(fsm->states[state].edges);
 
 	if (fsm_getstart(fsm, &start) && start == state) {
 		fsm_clearstart(fsm);
 	}
-
-	f_free(fsm->opt->alloc, fsm->states[state]);
 
 	assert(fsm->statecount >= 1);
 
@@ -120,8 +115,8 @@ fsm_removestate(struct fsm *fsm, fsm_state_t state)
 		fsm->states[state] = fsm->states[fsm->statecount - 1];
 
 		for (i = 0; i < fsm->statecount - 1; i++) {
-			state_set_replace(fsm->states[i]->epsilons, fsm->statecount - 1, state);
-			for (e = edge_set_first(fsm->states[i]->edges, &it); e != NULL; e = edge_set_next(&it)) {
+			state_set_replace(fsm->states[i].epsilons, fsm->statecount - 1, state);
+			for (e = edge_set_first(fsm->states[i].edges, &it); e != NULL; e = edge_set_next(&it)) {
 				state_set_replace(e->sl, fsm->statecount - 1, state);
 			}
 		}

--- a/src/libfsm/subgraph.c
+++ b/src/libfsm/subgraph.c
@@ -143,7 +143,7 @@ fsm_state_duplicatesubgraphx(struct fsm *fsm, fsm_state_t state,
 		}
 
 		{
-			for (state_set_reset(fsm->states[m->old]->epsilons, &jt); state_set_next(&jt, &s); ) {
+			for (state_set_reset(fsm->states[m->old].epsilons, &jt); state_set_next(&jt, &s); ) {
 				struct mapping *to;
 
 				to = mapping_ensure(fsm, &mappings, s);
@@ -157,7 +157,7 @@ fsm_state_duplicatesubgraphx(struct fsm *fsm, fsm_state_t state,
 				}
 			}
 		}
-		for (e = edge_set_first(fsm->states[m->old]->edges, &it); e != NULL; e = edge_set_next(&it)) {
+		for (e = edge_set_first(fsm->states[m->old].edges, &it); e != NULL; e = edge_set_next(&it)) {
 			for (state_set_reset(e->sl, &jt); state_set_next(&jt, &s); ) {
 				struct mapping *to;
 

--- a/src/libfsm/trim.c
+++ b/src/libfsm/trim.c
@@ -37,7 +37,7 @@ mark_states(struct fsm *fsm)
 	if (!queue_push(q, start)) {
 		goto cleanup;
 	}
-	fsm->states[start]->visited = 1;
+	fsm->states[start].visited = 1;
 
 	for (;;) {
 		const struct fsm_edge *e;
@@ -52,8 +52,8 @@ mark_states(struct fsm *fsm)
 			struct state_iter state_iter;
 			fsm_state_t es;
 
-			for (state_set_reset(fsm->states[s]->epsilons, &state_iter); state_set_next(&state_iter, &es); ) {
-				if (fsm->states[es]->visited) {
+			for (state_set_reset(fsm->states[s].epsilons, &state_iter); state_set_next(&state_iter, &es); ) {
+				if (fsm->states[es].visited) {
 					continue;
 				}
 
@@ -61,11 +61,11 @@ mark_states(struct fsm *fsm)
 					goto cleanup;
 				}
 
-				fsm->states[es]->visited = 1;
+				fsm->states[es].visited = 1;
 			}
 		}
 
-		for (e = edge_set_first(fsm->states[s]->edges, &edge_iter);
+		for (e = edge_set_first(fsm->states[s].edges, &edge_iter);
 		     e != NULL;
 		     e = edge_set_next(&edge_iter))
 		{
@@ -73,7 +73,7 @@ mark_states(struct fsm *fsm)
 			fsm_state_t es;
 
 			for (state_set_reset(e->sl, &state_iter); state_set_next(&state_iter, &es); ) {
-				if (fsm->states[es]->visited) {
+				if (fsm->states[es].visited) {
 					continue;
 				}
 
@@ -81,7 +81,7 @@ mark_states(struct fsm *fsm)
 					goto cleanup;
 				}
 
-				fsm->states[es]->visited = 1;
+				fsm->states[es].visited = 1;
 			}
 		}
 	}
@@ -123,7 +123,7 @@ sweep_states(struct fsm *fsm)
 	 */
 	i = 0;
 	while (i < fsm->statecount) {
-		if (fsm->states[i]->visited) {
+		if (fsm->states[i].visited) {
 			i++;
 			continue;
 		}
@@ -149,7 +149,7 @@ fsm_trim(struct fsm *fsm)
 	assert(fsm != NULL);
 
 	for (i = 0; i < fsm->statecount; i++) {
-		fsm->states[i]->visited = 0;
+		fsm->states[i].visited = 0;
 	}
 
 	if (!mark_states(fsm)) {

--- a/src/libfsm/trim.c
+++ b/src/libfsm/trim.c
@@ -37,7 +37,7 @@ mark_states(struct fsm *fsm)
 	if (!queue_push(q, start)) {
 		goto cleanup;
 	}
-	fsm->states[start]->reachable = 1;
+	fsm->states[start]->visited = 1;
 
 	for (;;) {
 		const struct fsm_edge *e;
@@ -53,7 +53,7 @@ mark_states(struct fsm *fsm)
 			fsm_state_t es;
 
 			for (state_set_reset(fsm->states[s]->epsilons, &state_iter); state_set_next(&state_iter, &es); ) {
-				if (fsm->states[es]->reachable) {
+				if (fsm->states[es]->visited) {
 					continue;
 				}
 
@@ -61,7 +61,7 @@ mark_states(struct fsm *fsm)
 					goto cleanup;
 				}
 
-				fsm->states[es]->reachable = 1;
+				fsm->states[es]->visited = 1;
 			}
 		}
 
@@ -73,7 +73,7 @@ mark_states(struct fsm *fsm)
 			fsm_state_t es;
 
 			for (state_set_reset(e->sl, &state_iter); state_set_next(&state_iter, &es); ) {
-				if (fsm->states[es]->reachable) {
+				if (fsm->states[es]->visited) {
 					continue;
 				}
 
@@ -81,7 +81,7 @@ mark_states(struct fsm *fsm)
 					goto cleanup;
 				}
 
-				fsm->states[es]->reachable = 1;
+				fsm->states[es]->visited = 1;
 			}
 		}
 	}
@@ -123,7 +123,7 @@ sweep_states(struct fsm *fsm)
 	 */
 	i = 0;
 	while (i < fsm->statecount) {
-		if (fsm->states[i]->reachable) {
+		if (fsm->states[i]->visited) {
 			i++;
 			continue;
 		}
@@ -149,7 +149,7 @@ fsm_trim(struct fsm *fsm)
 	assert(fsm != NULL);
 
 	for (i = 0; i < fsm->statecount; i++) {
-		fsm->states[i]->reachable = 0;
+		fsm->states[i]->visited = 0;
 	}
 
 	if (!mark_states(fsm)) {

--- a/src/libfsm/walk/iter.c
+++ b/src/libfsm/walk/iter.c
@@ -49,7 +49,7 @@ fsm_walk_edges(const struct fsm *fsm, void *opaque,
 		const struct fsm_edge *e;
 		struct edge_iter ei;
 
-		for (e = edge_set_first(fsm->states[i]->edges, &ei); e != NULL; e = edge_set_next(&ei)) {
+		for (e = edge_set_first(fsm->states[i].edges, &ei); e != NULL; e = edge_set_next(&ei)) {
 			struct state_iter di;
 			fsm_state_t dst;
 
@@ -64,7 +64,7 @@ fsm_walk_edges(const struct fsm *fsm, void *opaque,
 			struct state_iter di;
 			fsm_state_t dst;
 
-			for (state_set_reset(fsm->states[i]->epsilons, &di); state_set_next(&di, &dst); ) {
+			for (state_set_reset(fsm->states[i].epsilons, &di); state_set_next(&di, &dst); ) {
 				if (!callback_epsilon(fsm, i, dst, opaque)) {
 					return 0;
 				}

--- a/src/libfsm/walk/reachable.c
+++ b/src/libfsm/walk/reachable.c
@@ -54,7 +54,7 @@ fsm_reachable(const struct fsm *fsm, fsm_state_t state,
 			}
 		}
 
-		for (e = edge_set_first(fsm->states[p->state]->edges, &it); e != NULL; e = edge_set_next(&it)) {
+		for (e = edge_set_first(fsm->states[p->state].edges, &it); e != NULL; e = edge_set_next(&it)) {
 			struct state_iter jt;
 			fsm_state_t st;
 

--- a/src/libfsm/walk2.c
+++ b/src/libfsm/walk2.c
@@ -316,7 +316,7 @@ fsm_walk2_tuple_new(struct fsm_walk2_data *data,
 		return NULL;
 	}
 
-	assert(!data->new->states[p->comb]->tmp.visited);
+	assert(!data->new->states[p->comb]->visited);
 
 	if (!tuple_set_add(data->states, p)) {
 		return NULL;
@@ -356,12 +356,12 @@ fsm_walk2_edges(struct fsm_walk2_data *data,
 	assert(qc < data->new->statecount);
 
 	/* fast exit if we've already visited the combined state */
-	if (data->new->states[qc]->tmp.visited) {
+	if (data->new->states[qc]->visited) {
 		return 1;
 	}
 
 	/* mark combined state as visited */
-	data->new->states[qc]->tmp.visited = 1;
+	data->new->states[qc]->visited = 1;
 
 	/*
 	 * fsm_walk2_edges walks the edges of two graphs, generating combined
@@ -456,7 +456,7 @@ fsm_walk2_edges(struct fsm_walk2_data *data,
 				 * depth-first traversal of the graph, but only traverse
 				 * if the state has not yet been visited
 				 */
-				if (!data->new->states[dst->comb]->tmp.visited) {
+				if (!data->new->states[dst->comb]->visited) {
 					if (!fsm_walk2_edges(data, a, b, dst)) {
 						return 0;
 					}
@@ -515,7 +515,7 @@ only_b:
 				 * depth-first traversal of the graph, but only traverse
 				 * if the state has not yet been visited
 				 */
-				if (!data->new->states[dst->comb]->tmp.visited) {
+				if (!data->new->states[dst->comb]->visited) {
 					if (!fsm_walk2_edges(data, a, b, dst)) {
 						return 0;
 					}
@@ -553,7 +553,7 @@ fsm_walk2(const struct fsm *a, const struct fsm *b,
 		 * if both A and B lack start states,
 		 * the result will be empty
 		 */
-		goto done;
+		goto empty;
 	}
 
 	if (!have_b) {
@@ -566,7 +566,7 @@ fsm_walk2(const struct fsm *a, const struct fsm *b,
 		 * !have_b and combined states cannot be ONLYA,
 		 * so the result will be empty
 		 */
-		goto done;
+		goto empty;
 	}
 
 	if (!have_a) {
@@ -579,7 +579,7 @@ fsm_walk2(const struct fsm *a, const struct fsm *b,
 		 * !have_a and combined states cannot be ONLYB, so the
 		 * result will be empty
 		 */
-		goto done;
+		goto empty;
 	}
 
 	data.edgemask = edgemask;
@@ -603,23 +603,23 @@ fsm_walk2(const struct fsm *a, const struct fsm *b,
 	assert(tup0->a == sa);
 	assert(tup0->b == sb);
 	assert(tup0->comb < data.new->statecount);
-	assert(!data.new->states[tup0->comb]->tmp.visited); /* comb not yet been traversed */
+	assert(!data.new->states[tup0->comb]->visited); /* comb not yet been traversed */
 
 	fsm_setstart(data.new, tup0->comb);
 	if (!fsm_walk2_edges(&data, a, b, tup0)) {
 		goto error;
 	}
 
-done:
-
 	new = data.new;
 	data.new = NULL; /* avoid freeing new FSM */
-
-	fsm_clear_tmp(new);
 
 	fsm_walk2_data_free(a, &data);
 
 	return new;
+
+empty:
+
+	return fsm_new(a->opt);
 
 error:
 


### PR DESCRIPTION
Following on from #176, now states are presented as a numeric `fsm_state_t` index, this PR inlines their storage into the `(struct fsm).states` array rather than allocating each separately.

This was less work than I expected, and I keep having the feeling I've missed something important.