### PR TITLE
Various fixups related to fsm_state_t change

### DIFF
--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -93,6 +93,5 @@ fsm_sgetc
 fsm_print_cfrag # XXX: workaround for lx
 make_ir # XXX: workaround for lx
 free_ir # XXX: workaround for lx
-indexof # XXX: workaround for lx
 
 fsm_mergeab

--- a/src/libfsm/merge.c
+++ b/src/libfsm/merge.c
@@ -31,16 +31,17 @@ merge(struct fsm *dst, struct fsm *src,
 	if (dst->statealloc < src->statecount + dst->statecount) {
 		void *tmp;
 
+		size_t newalloc = src->statecount + dst->statecount;
+
 		/* TODO: round up to next power of two here?
 		 * or let realloc do that internally */
-		tmp = f_realloc(dst->opt->alloc, dst->states,
-			(src->statecount + dst->statecount) * sizeof *dst->states);
+		tmp = f_realloc(dst->opt->alloc, dst->states, newalloc * sizeof *dst->states);
 		if (tmp == NULL) {
 			return NULL;
 		}
 
 		dst->states = tmp;
-		dst->statealloc += src->statecount;
+		dst->statealloc = newalloc;
 	}
 
 	/*


### PR DESCRIPTION
- Removes indexof from libfsm.syms
- Fixes statealloc miscount in merge()