### PR TITLE
Minor fixups to eliminate clang warnings

### DIFF
--- a/src/libfsm/print/c.c
+++ b/src/libfsm/print/c.c
@@ -75,6 +75,8 @@ print_ranges(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 	size_t k;
 	size_t c;
 
+	(void)ir; /* unused */
+
 	assert(f != NULL);
 	assert(ir != NULL);
 	assert(opt != NULL);

--- a/src/libfsm/print/ir.c
+++ b/src/libfsm/print/ir.c
@@ -348,6 +348,8 @@ make_state(const struct fsm *fsm, fsm_state_t state,
 		unsigned int freq; /* 0 meaning no mode */
 	} mode;
 
+	(void)ir; /* unused */
+
 	assert(fsm != NULL);
 	assert(fsm->opt != NULL);
 	assert(state < fsm->statecount);

--- a/src/libfsm/print/irdot.c
+++ b/src/libfsm/print/irdot.c
@@ -85,6 +85,8 @@ print_errorrows(FILE *f, const struct fsm_options *opt,
 	assert(error != NULL);
 	assert(error->ranges != NULL);
 
+	(void)ir; /* unused */
+
 	for (k = 0; k < error->n; k++) {
 		fprintf(f, "\t\t  <TR>");
 
@@ -122,6 +124,8 @@ print_grouprows(FILE *f, const struct fsm_options *opt,
 	assert(opt != NULL);
 	assert(ir != NULL);
 	assert(groups != NULL);
+
+	(void)ir; /* unused */
 
 	for (j = 0; j < n; j++) {
 		assert(groups[j].ranges != NULL);
@@ -165,6 +169,8 @@ print_grouplinks(FILE *f, const struct ir *ir, unsigned self,
 	assert(f != NULL);
 	assert(ir != NULL);
 	assert(groups != NULL);
+
+	(void)ir; /* unused */
 
 	for (j = 0; j < n; j++) {
 		if (groups[j].to == self) {

--- a/src/libfsm/print/irjson.c
+++ b/src/libfsm/print/irjson.c
@@ -65,6 +65,8 @@ print_ranges(FILE *f, const struct fsm_options *opt,
 	assert(ir != NULL);
 	assert(ranges != NULL);
 
+	(void)ir; /* unused */
+
 	for (k = 0; k < n; k++) {
 		fprintf(f, "\t\t\t\t\t\t{ ");
 

--- a/src/libfsm/shortest.c
+++ b/src/libfsm/shortest.c
@@ -36,6 +36,8 @@ fsm_shortest(const struct fsm *fsm,
 	assert(goal < fsm->statecount);
 	assert(cost != NULL);
 
+	(void)start; /* unused */
+
 	/*
 	 * We find a least-cost ("shortest") path by Dijkstra's algorithm.
 	 *

--- a/src/libre/ast.c
+++ b/src/libre/ast.c
@@ -285,6 +285,7 @@ ast_expr_equal(const struct ast_expr *a, const struct ast_expr *b)
 
 	default:
 		assert(!"unreached");
+		abort();
 	}
 }
 

--- a/src/libre/class/utf8_Cs.c
+++ b/src/libre/class/utf8_Cs.c
@@ -12,6 +12,8 @@ utf8_Cs_fsm(struct fsm *fsm, fsm_state_t x, fsm_state_t y)
 	fsm_state_t s[1];
 	size_t i;
 
+	(void)y; /* unused */
+
 	for (i = 0; i < 1; i++) {
 		if (i == 0) {
 			s[0] = x;

--- a/src/libre/print/abnf.c
+++ b/src/libre/print/abnf.c
@@ -41,6 +41,7 @@ atomic(struct ast_expr *n)
 
 	default:
 		assert(!"unreached");
+		abort();
 	}
 }
 

--- a/src/libre/print/pcre.c
+++ b/src/libre/print/pcre.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
+#include <stdlib.h>
 
 #include <re/re.h>
 
@@ -34,6 +35,7 @@ atomic(struct ast_expr *n)
 
 	default:
 		assert(!"unreached");
+		abort();
 	}
 }
 


### PR DESCRIPTION
These fall into two classes:
1. Unused parameters.  clang seems a lot noisier about these.
2. switch `default` clauses with an assertion.  When compiled with `-DNDEBUG`, the compiler warns about returning without a value from a function that has a return value.