### PR TITLE
Improves duplicating subgraphs (speeding up AST_EXPR_REPEATED node -> NFA translation)

### DIFF
--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -226,6 +226,38 @@ fsm_state_duplicatesubgraphx(struct fsm *fsm, fsm_state_t state,
 	fsm_state_t *x,
 	fsm_state_t *q);
 
+/* Captures nodes added between fsm_subgraph_capture_start() and
+ * fsm_subgraph_capture_end()
+ *
+ * Can be used by fsm_subgraph_capture_duplicate() to make copies of the
+ * subgraph.
+ *
+ * The subgraph capture is only valid as long as no nodes are deleted after
+ * fsm_subgraph_capture_start() is called.
+ */
+struct fsm_subgraph_capture {
+	fsm_state_t start;
+	fsm_state_t end;
+};
+
+void
+fsm_subgraph_capture_start(struct fsm *fsm, struct fsm_subgraph_capture *capture);
+
+void
+fsm_subgraph_capture_stop(struct fsm *fsm, struct fsm_subgraph_capture *capture);
+
+/* As with fsm_state_duplicatesubgraphx(), if x is non-NULL, *x must be a state
+ * in the captured subgraph.  *x is overwritten with its equivalent state in
+ * the duplicated subgraph.
+ *
+ * *q is the start of the subgraph.
+ */
+int
+fsm_subgraph_capture_duplicate(struct fsm *fsm,
+	const struct fsm_subgraph_capture *capture,
+	fsm_state_t *x,
+	fsm_state_t *q);
+
 /*
  * Merge two states. A new state is output to q.
  *

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -54,6 +54,9 @@ fsm_findmode
 fsm_collate
 fsm_state_duplicatesubgraph
 fsm_state_duplicatesubgraphx
+fsm_subgraph_capture_start
+fsm_subgraph_capture_stop
+fsm_subgraph_capture_duplicate
 fsm_mergestates
 
 fsm_setstart

--- a/src/libfsm/subgraph.c
+++ b/src/libfsm/subgraph.c
@@ -182,3 +182,125 @@ fsm_state_duplicatesubgraphx(struct fsm *fsm, fsm_state_t state,
 	return 1;
 }
 
+void
+fsm_subgraph_capture_start(struct fsm *fsm, struct fsm_subgraph_capture *capture)
+{
+	assert(fsm != NULL);
+	assert(capture != NULL);
+
+	capture->start = fsm_countstates(fsm);
+}
+
+void
+fsm_subgraph_capture_stop(struct fsm *fsm, struct fsm_subgraph_capture *capture)
+{
+	assert(fsm != NULL);
+	assert(capture != NULL);
+
+	capture->end = fsm_countstates(fsm);
+}
+
+/* As with fsm_state_duplicatesubgraphx(), if x is non-NULL, *x must be a state
+ * in the captured subgraph.  *x is overwritten with its equivalent state in
+ * the duplicated subgraph.
+ *
+ * *q is the start of the subgraph.
+ */
+int
+fsm_subgraph_capture_duplicate(struct fsm *fsm,
+	const struct fsm_subgraph_capture *capture,
+	fsm_state_t *x,
+	fsm_state_t *q)
+{
+	fsm_state_t old_start, old_end;
+	fsm_state_t new_start, new_end;
+	fsm_state_t ind;
+
+	assert(fsm     != NULL);
+	assert(capture != NULL);
+	assert(q       != NULL);
+	assert(x == NULL || (*x >= capture->start && *x < capture->end));
+
+	old_start = capture->start;
+	old_end   = capture->end;
+
+	if (old_start >= old_end) {
+		return 0;
+	}
+
+	/* allocate new states */
+	new_start = new_end = 0;
+	for (ind = old_start; ind < old_end; ind++) {
+		fsm_state_t st;
+		if (!fsm_addstate(fsm, &st)) {
+			return 0;
+		}
+
+		fsm_setend(fsm, st, fsm_isend(fsm, ind));
+
+		if (ind == old_start) {
+			new_start = st;
+		}
+
+		new_end = st+1;
+	}
+
+	if (new_start == new_end) {
+		return 0;
+	}
+
+	/* allocate edges */
+	for (ind = new_start; ind < new_end; ind++) {
+		const fsm_state_t old_src = old_start + (ind - new_start);
+		struct edge_iter it;
+		struct fsm_edge *e;
+
+		{
+			struct state_iter jt;
+			fsm_state_t old_dst;
+
+			for (state_set_reset(fsm->states[old_src].epsilons, &jt); state_set_next(&jt, &old_dst); ) {
+				fsm_state_t new_dst;
+
+				if (old_dst < old_start || old_dst >= old_end) {
+					continue;
+				}
+
+				new_dst = new_start + (old_dst - old_start);
+
+				if (!fsm_addedge_epsilon(fsm, ind, new_dst)) {
+					return 0;
+				}
+			}
+		}
+
+		for (e = edge_set_first(fsm->states[old_src].edges, &it); e != NULL; e = edge_set_next(&it)) {
+			struct state_iter jt;
+			fsm_state_t old_dst;
+
+			for (state_set_reset(e->sl, &jt); state_set_next(&jt, &old_dst); ) {
+				fsm_state_t new_dst;
+
+				if (old_dst < old_start || old_dst >= old_end) {
+					continue;
+				}
+
+				new_dst = new_start + (old_dst - old_start);
+
+				if (!fsm_addedge_literal(fsm, ind, new_dst, e->symbol)) {
+					return 0;
+				}
+			}
+		}
+	}
+
+	if (x != NULL && *x >= old_start && *x < old_end) {
+		fsm_state_t old_x = *x;
+		*x = new_start + (old_x - old_start);
+	}
+
+	*q = new_start;
+
+	return 1;
+}
+


### PR DESCRIPTION
This adds an additional way to duplicate the subgraph that's much faster than `fsm_state_duplicatesubgraphx()`.

This splits out the improvement from #182 into a separate PR, as requested by @katef.

Along with #183, this replaces #182.