### PR TITLE
Initial version of the dfavm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ SUBDIR += src/libre/print
 SUBDIR += src/libre
 SUBDIR += src/fsm
 SUBDIR += src/re
+SUBDIR += src/retest
 SUBDIR += src/lx/print
 SUBDIR += src/lx
 SUBDIR += src

--- a/extract_pcre_tests.py
+++ b/extract_pcre_tests.py
@@ -1,0 +1,80 @@
+import sys, os, io
+import json
+import subprocess
+
+RE_PROGRAM = '/Users/stew/sandbox/libfsm/build/bin/re'
+
+input_stream = open('/Users/stew/soft/pcre2-10.33/testdata/testinput1', encoding='latin-1')
+# input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding='latin-1')
+
+regexps = []
+
+# states:
+#   default    - looking for a regexp
+#   matches    - reading strings that should match
+#   notmatches - reading strings that should not match
+#   done       - finished entry, add to regexps list
+
+state = 'default'
+re_pattern    = None
+re_matches    = []
+re_notmatches = []
+
+sys.stderr.write('Reading tests\n')
+
+count = 0
+nparsed = 0
+
+for linenum,line in enumerate(input_stream,1):
+    if line.endswith('\n'):
+        line = line[:-1]
+    if state == 'default':
+        if line.startswith('/') and line.endswith('/'):
+            re_pattern = line[1:-1]
+            state = 'matches'
+            count += 1
+    elif state == 'matches':
+        if line.startswith('\\='):
+            state = 'notmatches'
+        elif len(line.strip()) == 0:
+            state = 'done'
+        elif line.startswith('/'):
+            sys.stderr.write(f"state machine failure at line {linenum}: regexp before notmatches ends")
+            state = 'done'
+        else:
+            re_matches.append(line.lstrip())
+    elif state == 'notmatches':
+        if len(line.strip()) == 0:
+            state = 'done'
+        elif line.startswith('/'):
+            sys.stderr.write(f"state machine failure at line {linenum}: regexp before notmatches ends")
+            state = 'done'
+        else:
+            re_notmatches.append(line.lstrip())
+    
+    if state == 'done':
+        ret = subprocess.run([RE_PROGRAM, '-r', 'pcre', '-l', 'tree', re_pattern], capture_output=True)
+        parsed = (ret.returncode == 0)
+        entry = dict(pattern=re_pattern,matches=re_matches,not_matches=re_notmatches,parsed=parsed)
+
+        if parsed:
+            nparsed += 1
+        else:
+            err = ret.stderr.decode('latin-1')
+            err = err[:-1] if err[-1] == '\n' else err
+            entry['parse_error'] = err
+
+        regexps.append(entry)
+        state = 'default'
+        re_pattern = None
+        re_matches = []
+        re_notmatches = []
+
+    if linenum % 500 == 0:
+        sys.stderr.write(f'line {linenum:5d}: {count} entries, {nparsed} parsed correctly\n')
+
+sys.stderr.write(f'{count} entries, {nparsed} parsed correctly\n')
+sys.stderr.write('Generating test json\n')
+
+json.dump(regexps, sys.stdout, indent=4)
+

--- a/format_pcre_tests.sh
+++ b/format_pcre_tests.sh
@@ -1,0 +1,15 @@
+#! /bin/sh
+
+jq --raw-output \
+    '.[]                              | 
+     select(.parsed)                  | 
+     [ .pattern, 
+       (.matches|map("+" + .)|join("\n")), 
+       (.not_matches|map("-" + .)|join("\n")) 
+     ]                                | 
+     select(.[0] != null)             |
+     select(.[1] != "" or .[2] != "") | 
+     [ (.[]|select(. != "")) ]        |
+     join("\n") + "\n"                |
+     @text' $@
+

--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -368,12 +368,5 @@ fsm_exec(const struct fsm *fsm, int (*fsm_getc)(void *opaque), void *opaque,
 int fsm_sgetc(void *opaque); /* expects opaque to be char ** */
 int fsm_fgetc(void *opaque); /* expects opaque to be FILE *  */
 
-struct fsm_dfavm;
-
-struct fsm_dfavm *
-fsm_vm_compile(const struct fsm *fsm);
-
-void fsm_vm_free(struct fsm_dfavm *);
-
 #endif
 

--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -368,5 +368,12 @@ fsm_exec(const struct fsm *fsm, int (*fsm_getc)(void *opaque), void *opaque,
 int fsm_sgetc(void *opaque); /* expects opaque to be char ** */
 int fsm_fgetc(void *opaque); /* expects opaque to be FILE *  */
 
+struct fsm_dfavm;
+
+struct fsm_dfavm *
+fsm_vm_compile(const struct fsm *fsm);
+
+void fsm_vm_free(struct fsm_dfavm *);
+
 #endif
 

--- a/include/fsm/vm.h
+++ b/include/fsm/vm.h
@@ -1,0 +1,31 @@
+#ifndef FSM_VM_H
+#define FSM_VM_H
+
+#include <stdio.h>
+#include <stddef.h>
+
+struct fsm;
+struct fsm_dfavm;
+
+struct fsm_dfavm *
+fsm_vm_compile(const struct fsm *fsm);
+
+struct fsm_dfavm *
+fsm_vm_read(FILE *f);
+
+struct fsm_dfavm *
+fsm_vm_write(const struct fsm_dfavm *vm, FILE *f);
+
+struct fsm_dfavm *
+fsm_vm_print(const struct fsm_dfavm *vm, FILE *f);
+
+int
+fsm_vm_match_file(const struct fsm_dfavm *mv, FILE *f);
+
+int
+fsm_vm_match_buffer(const struct fsm_dfavm *mv, const char *buf, size_t n);
+
+void fsm_vm_free(struct fsm_dfavm *);
+
+#endif /* FSM_VM_H */
+

--- a/src/fsm/Makefile
+++ b/src/fsm/Makefile
@@ -3,6 +3,8 @@
 SRC += src/fsm/lexer.c
 SRC += src/fsm/parser.c
 SRC += src/fsm/main.c
+SRC += src/fsm/wordgen.c
+SRC += src/fsm/xoroshiro256starstar.c
 
 .for src in ${SRC:Msrc/fsm/parser.c} ${SRC:Msrc/fsm/main.c}
 CFLAGS.${src} += -I src # XXX: for internal.h
@@ -12,6 +14,21 @@ DFLAGS.${src} += -I src # XXX: for internal.h
 .for src in ${SRC:Msrc/fsm/lexer.c}
 CFLAGS.${src} += -D LX_HEADER='"lexer.h"'
 DFLAGS.${src} += -D LX_HEADER='"lexer.h"'
+.endfor
+
+.for src in ${SRC:Msrc/fsm/main.c}
+CFLAGS.${src} += -std=c99 # XXX: for internal.h
+DFLAGS.${src} += -std=c99 # XXX: for internal.h
+.endfor
+
+.for src in ${SRC:Msrc/fsm/wordgen.c}
+CFLAGS.${src} += -std=c99 # XXX: for internal.h
+DFLAGS.${src} += -std=c99 # XXX: for internal.h
+.endfor
+
+.for src in ${SRC:Msrc/fsm/xoroshiro256starstar.c}
+CFLAGS.${src} += -std=c99 # XXX: for internal.h
+DFLAGS.${src} += -std=c99 # XXX: for internal.h
 .endfor
 
 LEXER  += src/fsm/lexer.lx

--- a/src/fsm/Makefile
+++ b/src/fsm/Makefile
@@ -3,8 +3,8 @@
 SRC += src/fsm/lexer.c
 SRC += src/fsm/parser.c
 SRC += src/fsm/main.c
-SRC += src/fsm/wordgen.c
-SRC += src/fsm/xoroshiro256starstar.c
+# SRC += src/fsm/wordgen.c
+# SRC += src/fsm/xoroshiro256starstar.c
 
 .for src in ${SRC:Msrc/fsm/parser.c} ${SRC:Msrc/fsm/main.c}
 CFLAGS.${src} += -I src # XXX: for internal.h

--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -314,6 +314,7 @@ xopen(const char *s)
 	return f;
 }
 
+#if 0
 static unsigned int word_maxlen = 16;
 static unsigned int num_words = 8;
 static uint64_t seed = 0xdfa7231bc;
@@ -336,6 +337,7 @@ gen_words(FILE *f, const struct fsm *fsm)
 
 	fsm_generate_words_to_file(fsm, &params, &prng, num_words, f);
 }
+#endif /* 0 */
 
 
 int
@@ -394,9 +396,11 @@ main(int argc, char *argv[])
 			case 't': op = op_name(optarg);               break;
 			case 'G': op = op_name("glushkovise");        break;
 			case 'W':
-				print = gen_words;
-				num_words = strtoul(optarg, NULL, 10);
+				/* print = gen_words; */
+				/* num_words = strtoul(optarg, NULL, 10); */
 				/* XXX: error handling */
+				fprintf(stderr, "not yet implemented.\n");
+				exit(EXIT_FAILURE);
 				break;
 
 			case 'h':

--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -27,6 +27,7 @@
 #include "libfsm/internal.h" /* XXX */
 
 #include "parser.h"
+#include "wordgen.h"
 
 #if defined(__APPLE__) && defined(__MACH__) && defined(MACOS_HAS_NO_CLOCK_GETITME)
 #include <mach/clock.h>
@@ -108,6 +109,7 @@ usage(void)
 	printf("       fsm {-p} [-l <language>] [-acwX] [-k <io>] [-e <prefix>]\n");
 	printf("       fsm {-dmr | -t <transformation>} [-i <iterations>] [<file.fsm> | <file-a> <file-b>]\n");
 	printf("       fsm {-q <query>} [<file>]\n");
+	printf("       fsm {-W <maxlen>} <file.fsm>\n");
 	printf("       fsm -h\n");
 }
 
@@ -312,6 +314,30 @@ xopen(const char *s)
 	return f;
 }
 
+static unsigned int word_maxlen = 16;
+static unsigned int num_words = 8;
+static uint64_t seed = 0xdfa7231bc;
+
+static void
+gen_words(FILE *f, const struct fsm *fsm)
+{
+	struct dfa_wordgen_params params = {
+		.minlen = 1,
+		.maxlen = word_maxlen,
+
+		.prob_stop  = 0.3f,
+		.eps_weight = 0.0f,
+	};
+
+	struct prng_state prng;
+
+	memset(&prng, 0, sizeof prng);
+	prng_seed(&prng, seed);
+
+	fsm_generate_words_to_file(fsm, &params, &prng, num_words, f);
+}
+
+
 int
 main(int argc, char *argv[])
 {
@@ -343,7 +369,7 @@ main(int argc, char *argv[])
 	{
 		int c;
 
-		while (c = getopt(argc, argv, "h" "acwXe:k:i:" "xpq:l:dGmrt:"), c != -1) {
+		while (c = getopt(argc, argv, "h" "acwXe:k:i:" "xpq:l:dGmrt:W:"), c != -1) {
 			switch (c) {
 			case 'a': opt.anonymous_states  = 1;          break;
 			case 'c': opt.consolidate_edges = 1;          break;
@@ -367,6 +393,11 @@ main(int argc, char *argv[])
 			case 'r': op = op_name("reverse");            break;
 			case 't': op = op_name(optarg);               break;
 			case 'G': op = op_name("glushkovise");        break;
+			case 'W':
+				print = gen_words;
+				num_words = strtoul(optarg, NULL, 10);
+				/* XXX: error handling */
+				break;
 
 			case 'h':
 				usage();

--- a/src/fsm/wordgen.c
+++ b/src/fsm/wordgen.c
@@ -1,0 +1,512 @@
+#include "wordgen.h"
+
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
+#include <assert.h>
+
+#include <fsm/fsm.h>
+#include <fsm/pred.h>
+#include <fsm/walk.h>
+
+struct state_gather {
+	unsigned nstates;
+	unsigned ind;
+	const struct fsm_state **states;
+};
+
+static int
+state_gather_callback(const struct fsm *fsm, const struct fsm_state *st, void *ud)
+{
+	struct state_gather *sg = ud;
+
+	(void)fsm;
+
+	assert(sg->ind < sg->nstates);
+	sg->states[sg->ind++] = st;
+
+	return 1;
+}
+
+static void
+state_gather_finalize(struct state_gather *sg)
+{
+	free(sg->states);
+}
+
+static int
+state_cmp(const void *a, const void *b)
+{
+	const struct fsm_state *const *ppa = a;
+	const struct fsm_state *const *ppb = b;
+
+	const struct fsm_state *pa = *ppa;
+	const struct fsm_state *pb = *ppb;
+
+	return (pa > pb) - (pb > pa);
+}
+
+static int
+gather_all_states(const struct fsm *fsm, struct state_gather *states)
+{
+	static const struct state_gather zero;
+
+	*states = zero;
+
+	states->nstates = fsm_countstates(fsm);
+	states->ind = 0;
+	states->states = calloc(states->nstates, sizeof states->states[0]);
+	if (states->states == NULL) {
+		return -1;
+	}
+
+	fsm_walk_states(fsm, states, state_gather_callback);
+
+	assert(states->ind == states->nstates);
+
+	qsort(states->states, states->nstates, sizeof states->states[0], state_cmp);
+
+	return 0;
+}
+
+struct dfa_edge {
+	unsigned from;
+	unsigned to;
+	unsigned char sym;
+};
+
+struct edge_gather {
+	const struct state_gather *states;
+
+	unsigned nedges;
+	unsigned ind;
+	struct dfa_edge *edges;
+};
+
+static int
+edge_gather_callback_eps(const struct fsm *fsm, const struct fsm_state *from, const struct fsm_state *to, void *ud)
+{
+	(void)fsm;
+	(void)from;
+	(void)to;
+	(void)ud;
+
+	/* nop */
+	return 1;
+}
+
+static long
+find_state(const struct state_gather *sg, const struct fsm_state *st)
+{
+	unsigned lo, hi;
+
+	/*
+	for (lo=0; lo < sg->nstates; lo++) {
+		fprintf(stderr, "[%3u] %p%s\n", lo, (void *)sg->states[lo], sg->states[lo] == st ? "  ***" : "");
+	}
+	*/
+
+	lo = 0;
+	hi = sg->nstates;
+
+	for (;;) {
+		unsigned mid;
+		const struct fsm_state *mid_st;
+
+		mid = lo + (hi-lo)/2;
+		assert(mid < sg->nstates);
+
+		mid_st = sg->states[mid];
+
+		// fprintf(stderr, "%u -- %u -- %u | %p | %p\n", lo,mid,hi, (void *)mid_st, (void *)st);
+
+		if (st == mid_st) {
+			return mid;
+		}
+
+		if (st < mid_st) {
+			hi = mid-1;
+		}
+		else {
+			lo = mid+1;
+		}
+
+		if (lo > hi) {
+			break;
+		}
+	}
+
+	return -1;
+}
+
+static int
+edge_gather_callback(const struct fsm *fsm, const struct fsm_state *from, const struct fsm_state *to, char c, void *ud)
+{
+	struct edge_gather *eg = ud;
+	long ind_from, ind_to;
+
+	assert(fsm  != NULL);
+	assert(eg   != NULL);
+	assert(from != NULL);
+	assert(to   != NULL);
+
+	(void)fsm;
+	assert(eg->ind < eg->nedges);
+
+	ind_from = find_state(eg->states, from);
+	ind_to   = find_state(eg->states, to);
+
+	assert(ind_from >= 0);
+	assert(ind_from < eg->states->nstates);
+
+	assert(ind_to >= 0);
+	assert(ind_to < eg->states->nstates);
+
+	eg->edges[eg->ind].from = ind_from;
+	eg->edges[eg->ind].to   = ind_to;
+	eg->edges[eg->ind].sym  = c;
+
+	eg->ind++;
+
+	return 1;
+}
+
+static int
+edge_cmp(const void *a, const void *b)
+{
+	const struct dfa_edge *pa = a;
+	const struct dfa_edge *pb = b;
+
+	if (pa->from < pb->from) {
+		return -1;
+	}
+	else if (pa->from > pb->from) {
+		return 1;
+	}
+	else if (pa->sym < pb->sym) {
+		return -1;
+	}
+	else if (pa->sym > pb->sym) {
+		return 1;
+	}
+	else {
+		return 0;
+	}
+}
+
+static void
+edge_gather_finalize(struct edge_gather *eg)
+{
+	free(eg->edges);
+}
+
+static int
+gather_all_edges(const struct fsm *fsm, const struct state_gather *sg, struct edge_gather *edges)
+{
+	static const struct edge_gather zero;
+
+	*edges = zero;
+
+	edges->states = sg;
+
+	edges->nedges = fsm_countedges(fsm);
+	edges->ind = 0;
+	edges->edges = calloc(edges->nedges, sizeof edges->edges[0]);
+	if (edges->edges == NULL) {
+		return -1;
+	}
+
+	fsm_walk_edges(fsm, edges,
+		edge_gather_callback,
+		edge_gather_callback_eps);
+
+	assert(edges->ind == edges->nedges);
+
+	qsort(edges->edges, edges->nedges, sizeof edges->edges[0], edge_cmp);
+
+	return 0;
+}
+
+void
+dfa_table_finalize(struct dfa_table *table)
+{
+	static const struct dfa_table zero;
+
+	assert(table != NULL);
+
+	free(table->offsets);
+	free(table->syms);
+	free(table->dests);
+	free(table->isend);
+
+	*table = zero;
+}
+
+int
+dfa_table_initialize(struct dfa_table *table, const struct fsm *fsm)
+{
+	static const struct dfa_table zero;
+	static const struct state_gather sg_zero;
+	static const struct edge_gather  eg_zero;
+
+	struct state_gather sg = sg_zero;
+	struct edge_gather eg = eg_zero;
+	const struct fsm_state *start_state;
+	unsigned i, from0;
+
+	*table = zero;
+
+	if (!fsm_all(fsm, fsm_isdfa)) {
+		return -1;
+	}
+
+	if (gather_all_states(fsm, &sg) < 0) {
+		goto error;
+	}
+
+	if (gather_all_edges(fsm, &sg, &eg) < 0) {
+		goto error;
+	}
+
+	table->offsets = calloc(sg.nstates+1, sizeof table->offsets[0]);
+	if (table->offsets == NULL) {
+		goto error;
+	}
+
+	table->syms = calloc(eg.nedges, sizeof table->syms[0]);
+	if (table->syms == NULL) {
+		goto error;
+	}
+
+	table->dests = calloc(eg.nedges, sizeof table->dests[0]);
+	if (table->dests == NULL) {
+		goto error;
+	}
+
+	table->isend = calloc(sg.nstates, 1);
+	if (table->isend == NULL) {
+		goto error;
+	}
+
+	table->nstates = sg.nstates;
+	table->nedges  = eg.nedges;
+
+	start_state = fsm_getstart(fsm);
+	for (i=0; i < sg.nstates; i++) {
+		if (sg.states[i] == start_state) {
+			table->start = i;
+		}
+
+		if (fsm_isend(fsm, sg.states[i])) {
+			table->isend[i] = 1;
+		}
+	}
+
+	from0 = 0;
+	for (i=0; i < eg.nedges; i++) {
+		unsigned from1 = eg.edges[i].from;
+		if (from1 != from0) {
+			unsigned fr;
+			for(fr = from0; fr < from1; fr++) {
+				table->offsets[fr+1] = i;
+			}
+
+			from0 = from1;
+		}
+
+		table->syms[i]  = eg.edges[i].sym;
+		table->dests[i] = eg.edges[i].to;
+	}
+
+	for (; from0 < table->nstates; from0++) {
+		table->offsets[from0+1] = i;
+	}
+
+	state_gather_finalize(&sg);
+	edge_gather_finalize(&eg);
+
+	return 0;
+
+error:
+	state_gather_finalize(&sg);
+	edge_gather_finalize(&eg);
+
+	dfa_table_finalize(table);
+
+	return -1;
+}
+
+static int
+generate_word(const struct dfa_table *table, const struct dfa_wordgen_params *params, struct prng_state *prng, char *s)
+{
+	unsigned state;
+	unsigned len;
+
+	assert(table != NULL);
+	assert(params != NULL);
+	assert(s != NULL);
+
+	len = 0;
+	state = table->start;
+
+	while (len < params->maxlen) {
+		unsigned edge, nedges;
+		int ch;
+
+		nedges = table->offsets[state+1] - table->offsets[state];
+		if (nedges == 0) {
+			break;
+		}
+
+		if (nedges == 1) {
+			edge = 0;
+		} else {
+			double pick = prng_double(prng);
+			edge = floor(pick * nedges);
+			/*
+			fprintf(stderr, "> st = %u, nedges = %u, roll = %f, pick = %u\n",
+				state, nedges, pick, edge);
+			*/
+		}
+
+		assert(edge < nedges);
+
+		edge += table->offsets[state];
+		assert(edge < table->nedges);
+
+		/*
+		fprintf(stderr, "@ state %u edge %u sym '%c' dest %u\n",
+			state, edge, isprint(table->syms[edge]) ? table->syms[edge] : ' ',
+			table->dests[edge]);
+		*/
+
+		ch = table->syms[edge];
+		s[len++] = isprint(ch) ? ch : ' ';
+		state = table->dests[edge];
+
+		assert(state < table->nstates);
+		if (table->isend[state] && len >= params->minlen && prng_double(prng) <= params->prob_stop) {
+			break;
+		}
+	}
+
+	if (len < params->minlen || !table->isend[state]) {
+		return -1;
+	}
+
+	s[len] = '\0';
+	return len;
+}
+
+char **dfa_generate_words(const struct dfa_table *table, const struct dfa_wordgen_params *params, struct prng_state *prng, unsigned num_words)
+{
+	char **words = NULL;
+	char *block = NULL;
+	unsigned offset, i, w;
+	size_t block_size;
+
+	assert(table != NULL);
+	assert(params != NULL);
+
+	assert(params->minlen > 0);
+	assert(params->minlen < params->maxlen);
+
+	block_size = (size_t)(params->maxlen+1) * num_words;
+
+	block = malloc(block_size);
+	if (block == NULL) {
+		goto error;
+	}
+
+	words = calloc(num_words, sizeof words[0]);
+	if (words == NULL) {
+		goto error;
+	}
+
+	offset = 0;
+	w = 0;
+
+	for (i=0; i < num_words; i++) {
+		int len;
+
+		len = generate_word(table, params, prng, &block[offset]);
+
+		if (len > 0) {
+			words[w++] = &block[offset];
+			offset += len+1;
+		}
+	}
+
+	if (w==0) {
+		goto error;
+	}
+
+	return words;
+
+error:
+	free(words);
+	free(block);
+
+	return NULL;
+}
+
+int dfa_generate_words_to_file(const struct dfa_table *table, const struct dfa_wordgen_params *params, struct prng_state *prng, unsigned num_words, FILE *f)
+{
+	char *temp = NULL;
+	unsigned i;
+
+	assert(table != NULL);
+	assert(params != NULL);
+
+	assert(params->minlen > 0);
+	assert(params->minlen < params->maxlen);
+
+	temp = malloc(params->maxlen+1);
+	if (temp == NULL) {
+		goto error;
+	}
+
+	for (i=0; i < num_words; i++) {
+		int len;
+
+		memset(&temp[0], 0, params->maxlen+1);
+		len = generate_word(table, params, prng, &temp[0]);
+
+		if (len > 0) {
+			temp[len] = '\0';
+			fprintf(f, "%s\n", &temp[0]);
+		}
+	}
+
+	free(temp);
+	return 0;
+
+error:
+	return -1;
+}
+
+/* convenience wrappers */
+int fsm_generate_words_to_file(const struct fsm *fsm, const struct dfa_wordgen_params *params, struct prng_state *prng, unsigned num_words, FILE *f)
+{
+	struct dfa_table table;
+	int ret;
+
+	if (dfa_table_initialize(&table, fsm) < 0) {
+		return -1;
+	}
+
+	ret = dfa_generate_words_to_file(&table, params, prng, num_words, f);
+	dfa_table_finalize(&table);
+
+	return ret;
+}
+
+void
+free_dfa_generated_words(char **w) {
+	if (w != NULL) {
+		free(w[0]);
+		free(w);
+	}
+}

--- a/src/fsm/wordgen.h
+++ b/src/fsm/wordgen.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Shannon F. Stewman
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#ifndef WORDGEN_H
+#define WORDGEN_H
+
+#include <stdio.h>
+
+#include "xoroshiro256starstar.h"
+
+struct fsm;
+
+struct dfa_table {
+	unsigned *offsets;
+	unsigned char *syms;
+	unsigned *dests;
+
+	unsigned char *isend;
+
+	unsigned nstates;
+	unsigned nedges;
+	unsigned start;
+};
+
+int dfa_table_initialize(struct dfa_table *table, const struct fsm *fsm);
+void dfa_table_finalize(struct dfa_table *table);
+
+struct dfa_wordgen_params {
+	unsigned minlen;
+	unsigned maxlen;
+
+	float prob_stop;
+	float eps_weight;
+};
+
+char **dfa_generate_words(const struct dfa_table *table, const struct dfa_wordgen_params *params, struct prng_state *prng, unsigned num_words);
+int dfa_generate_words_to_file(const struct dfa_table *table, const struct dfa_wordgen_params *params, struct prng_state *prng, unsigned num_words, FILE *f);
+
+void free_dfa_generated_words(char **w);
+
+/* convenience wrappers */
+char **fsm_generate_words(const struct fsm *fsm, const struct dfa_wordgen_params *params, struct prng_state *prng, unsigned num_words);
+int fsm_generate_words_to_file(const struct fsm *fsm, const struct dfa_wordgen_params *params, struct prng_state *prng, unsigned num_words, FILE *f);
+
+#endif /* WORDGEN_H */
+

--- a/src/fsm/xoroshiro256starstar.c
+++ b/src/fsm/xoroshiro256starstar.c
@@ -1,0 +1,123 @@
+/*  Written in 2018 by David Blackman and Sebastiano Vigna (vigna@acm.org)
+
+To the extent possible under law, the author has dedicated all copyright
+and related and neighboring rights to this software to the public domain
+worldwide. This software is distributed without any warranty.
+
+See <http://creativecommons.org/publicdomain/zero/1.0/>. */
+
+#include "xoroshiro256starstar.h"
+
+/* This is xoshiro256** 1.0, one of our all-purpose, rock-solid
+   generators. It has excellent (sub-ns) speed, a state (256 bits) that is
+   large enough for any parallel application, and it passes all tests we
+   are aware of.
+
+   For generating just floating-point numbers, xoshiro256+ is even faster.
+
+   The state must be seeded so that it is not everywhere zero. If you have
+   a 64-bit seed, we suggest to seed a splitmix64 generator and use its
+   output to fill s. */
+
+static inline uint64_t rotl(const uint64_t x, int k) {
+	return (x << k) | (x >> (64 - k));
+}
+
+uint64_t prng_next(struct prng_state *st) {
+	const uint64_t result = rotl(st->s[1] * 5, 7) * 9;
+
+	const uint64_t t = st->s[1] << 17;
+
+	st->s[2] ^= st->s[0];
+	st->s[3] ^= st->s[1];
+	st->s[1] ^= st->s[2];
+	st->s[0] ^= st->s[3];
+
+	st->s[2] ^= t;
+
+	st->s[3] = rotl(st->s[3], 45);
+
+	return result;
+}
+
+void prng_seed_array(struct prng_state *st, unsigned char bits[32]) 
+{
+	memcpy(&st->s[0], &bits[0], sizeof st->s);
+}
+
+static uint64_t splitmix64_next(uint64_t *x) {
+	uint64_t z = (*x += 0x9e3779b97f4a7c15);
+	z = (z ^ (z >> 30)) * 0xbf58476d1ce4e5b9;
+	z = (z ^ (z >> 27)) * 0x94d049bb133111eb;
+	return z ^ (z >> 31);
+}
+
+void prng_seed(struct prng_state *st, uint64_t x)
+{
+	int i;
+	for (i=0; i < sizeof st->s / sizeof st->s[0]; i++) {
+		st->s[i] = splitmix64_next(&x);
+	}
+}
+
+#if 0
+/* This is the jump function for the generator. It is equivalent
+   to 2^128 calls to next(); it can be used to generate 2^128
+   non-overlapping subsequences for parallel computations. */
+
+void jump(void) {
+	static const uint64_t JUMP[] = { 0x180ec6d33cfd0aba, 0xd5a61266f0c9392c, 0xa9582618e03fc9aa, 0x39abdc4529b1661c };
+
+	uint64_t s0 = 0;
+	uint64_t s1 = 0;
+	uint64_t s2 = 0;
+	uint64_t s3 = 0;
+	for(int i = 0; i < sizeof JUMP / sizeof *JUMP; i++)
+		for(int b = 0; b < 64; b++) {
+			if (JUMP[i] & UINT64_C(1) << b) {
+				s0 ^= s[0];
+				s1 ^= s[1];
+				s2 ^= s[2];
+				s3 ^= s[3];
+			}
+			next();	
+		}
+		
+	s[0] = s0;
+	s[1] = s1;
+	s[2] = s2;
+	s[3] = s3;
+}
+#endif
+
+
+#if 0
+/* This is the long-jump function for the generator. It is equivalent to
+   2^192 calls to next(); it can be used to generate 2^64 starting points,
+   from each of which jump() will generate 2^64 non-overlapping
+   subsequences for parallel distributed computations. */
+
+void long_jump(void) {
+	static const uint64_t LONG_JUMP[] = { 0x76e15d3efefdcbbf, 0xc5004e441c522fb3, 0x77710069854ee241, 0x39109bb02acbe635 };
+
+	uint64_t s0 = 0;
+	uint64_t s1 = 0;
+	uint64_t s2 = 0;
+	uint64_t s3 = 0;
+	for(int i = 0; i < sizeof LONG_JUMP / sizeof *LONG_JUMP; i++)
+		for(int b = 0; b < 64; b++) {
+			if (LONG_JUMP[i] & UINT64_C(1) << b) {
+				s0 ^= s[0];
+				s1 ^= s[1];
+				s2 ^= s[2];
+				s3 ^= s[3];
+			}
+			next();	
+		}
+		
+	s[0] = s0;
+	s[1] = s1;
+	s[2] = s2;
+	s[3] = s3;
+}
+#endif

--- a/src/fsm/xoroshiro256starstar.h
+++ b/src/fsm/xoroshiro256starstar.h
@@ -1,0 +1,30 @@
+#ifndef XOROSHIRO256STARSTAR_H
+#define XOROSHIRO256STARSTAR_H
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct prng_state {
+	uint64_t s[4];
+};
+
+uint64_t prng_next(struct prng_state *st);
+
+void prng_seed_array(struct prng_state *st, unsigned char bits[32]);
+void prng_seed(struct prng_state *st, uint64_t x);
+
+static inline double u64_to_f64(uint64_t x) {
+	uint64_t v = ((uint64_t)0x3ff << 52) | (x >> 12);
+	double d;
+	memcpy(&d, &v, sizeof d);
+
+	return d - 1.0;
+}
+
+static inline double prng_double(struct prng_state *st) {
+	return u64_to_f64(prng_next(st));
+}
+
+#endif /* XOROSHIRO256STARSTAR_H */
+

--- a/src/libfsm/Makefile
+++ b/src/libfsm/Makefile
@@ -37,6 +37,7 @@ SRC += src/libfsm/union.c
 SRC += src/libfsm/intersect.c
 SRC += src/libfsm/subtract.c
 SRC += src/libfsm/walk2.c
+SRC += src/libfsm/dfavm.c
 
 .for src in ${SRC:Msrc/libfsm/closure.c}
 CFLAGS.${src} += -std=c99
@@ -45,6 +46,11 @@ DFLAGS.${src} += -std=c99
 
 LIB         += libfsm
 SYMS.libfsm += src/libfsm/libfsm.syms
+
+.for src in ${SRC:Msrc/libfsm/dfavm.c}
+CFLAGS.${src} += -std=c99 # XXX: for internal.h
+DFLAGS.${src} += -std=c99 # XXX: for internal.h
+.endfor
 
 .for src in ${SRC:Msrc/libfsm/*.c}
 ${BUILD}/lib/libfsm.o:    ${BUILD}/${src:R}.o

--- a/src/libfsm/dfavm.c
+++ b/src/libfsm/dfavm.c
@@ -18,8 +18,9 @@
 #include "internal.h"
 #include "print/ir.h"
 
-#define DEBUG_ENCODING 0
+#define DEBUG_ENCODING     0
 #define DEBUG_VM_EXECUTION 0
+#define DEBUG_VM_OPCODES   0
 
 // Instructions are 1-6 bytes each.  First byte is the opcode.  Second is the
 // (optional) argument.  Additional bytes encode the branch destination.
@@ -1364,7 +1365,9 @@ dfavm_compile(struct ir *ir)
 
 	assign_rel_dests(&a);
 
+#if DEBUG_VM_OPCODES
 	dump_states(stdout, &a);
+#endif /* DEBUG_VM_OPCODES */
 
 	vm = encode_opasm(&a);
 	if (vm == NULL) {
@@ -1385,6 +1388,8 @@ fsm_vm_compile(const struct fsm *fsm)
 {
 	struct ir *ir;
 	struct fsm_dfavm *vm;
+
+	(void)dump_states;  /* make clang happy */
 
 	ir = make_ir(fsm);
 	if (ir == NULL) {
@@ -1539,6 +1544,7 @@ vm_match(const struct fsm_dfavm *vm, struct vm_state *st, const char *buf, size_
 		b = vm->ops[st->pc];
 		op = (b>>3)&0x03;
 
+		(void)running_print_op;  /* make clang happy */
 #if DEBUG_VM_EXECUTION
 		running_print_op(vm->ops, st->pc, sp, buf, n, ch, stderr);
 #endif /* DEBUG_VM_EXECUTION */

--- a/src/libfsm/dfavm.c
+++ b/src/libfsm/dfavm.c
@@ -24,7 +24,7 @@
 //
 //          76543210
 // BR       CCC1DDDD
-// STOP     CCC0xxxE
+// STOP     CCC00xxE
 // FETCH    00001xxE
 //
 // bits marked x are reserved for future use, and should be 0

--- a/src/libfsm/dfavm.c
+++ b/src/libfsm/dfavm.c
@@ -1417,8 +1417,8 @@ printop(const unsigned char *ops, uint32_t pc, const char *sp, const char *buf, 
 	dest = b & 0x03;
 	end  = b & 0x01;
 
-	fprintf(f, "[%4lu sp=%zd n=%zu ch=%3d '%c' end=%d] ",
-		(unsigned long)pc, sp-buf, n, ch, isprint(ch) ? ch : ' ', end);
+	fprintf(f, "[%4lu sp=%zd n=%zu ch=%3u '%c' end=%d] ",
+		(unsigned long)pc, sp-buf, n, (unsigned char)ch, isprint(ch) ? ch : ' ', end);
 
 	switch (op) {
 	case VM_OP_FETCH:
@@ -1505,7 +1505,7 @@ static enum dfavm_state
 vm_match(const struct fsm_dfavm *vm, struct vm_state *st, const char *buf, size_t n)
 {
 	const char *sp, *last;
-	char ch;
+	int ch;
 
 	if (st->state != VM_MATCHING) {
 		return st->state;
@@ -1534,7 +1534,7 @@ vm_match(const struct fsm_dfavm *vm, struct vm_state *st, const char *buf, size_
 				return VM_MATCHING;
 			}
 
-			ch = *sp++;
+			ch = (unsigned char) *sp++;
 			st->pc++;
 		} else {
 			int cmp, end, dest, dest_nbytes;

--- a/src/libfsm/dfavm.c
+++ b/src/libfsm/dfavm.c
@@ -1,0 +1,859 @@
+#include <stdio.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <assert.h>
+#include <ctype.h>
+#include <errno.h>
+
+#include <fsm/fsm.h>
+#include "internal.h"
+#include "print/ir.h"
+
+// Instructions are 1-6 bytes each.  First byte is the opcode.  Second is the
+// (optional) argument.  Additional bytes encode the branch destination.
+//
+// There are four instructions:
+// BRANCH, MATCH, and STOP.  The opcodes for each are:
+//
+//          76543210
+// BR       CC10DDDD
+// STOP     CC00xxxE
+// FETCH    0001xxxE
+//
+// bits marked x are reserved for future use, and should be 0
+//
+// Possible future instruction:
+// IBRANCH  CC11DDDD
+//
+// Comparison bits:
+// 
+// CC
+// 00  always (no compare arg)
+// 01  less than or equal to (one compare arg)
+// 10  greater than or equal to (one compare arg)
+// 11  equal to (one compare arg)
+//
+// FETCH - fetch instructions
+//
+//   Fetch instructions fetch the next character from the stream and have a stop
+//   bit that indicates success/failure if the stream has no more characters.
+//
+//   E = 0 indicates FETCHF, failure if EOS
+//   E = 1 indicates FETCHS, success if EOS
+//
+//   FETCHS/F instructions should currently have comparison bits set to 00
+//   (always).  A future version reserves the right to support conditional
+//   FETCH.
+//
+//   (NB: the comparison bits are currently just ignored for FETCH instructions)
+//
+// STOP - stop instructions
+//
+// Stop instructions have an end bit: 
+//     E = 0 indicates STOPF, stop w/ failure
+//     E = 1 indicates STOPS, stop w/ success
+//
+//    STOPF generally indicates that there is no transition from the current
+//         state matching the read character
+//
+//    STOPS generally indicates that the current state is an end state, is
+//         complete, and all edges point back to the current state.
+//
+// BR - branch instructions
+//
+//   Branch instructions always have a signed relative destination argument.
+//   The D bits specify its length:
+//
+//   DDDD
+//   0AAA   11-bit destination, 1-byte destination argument
+//   10AA   18-bit destination, 2-byte destination argument
+//   110x   32-bit destination, 4-byte destination argument, LSB ignored
+//
+//   for 110x, x should be 0.  x=1 is reserved for future use
+//   111x is also reserved for future use for x=0 and x=1.
+//
+
+enum dfavm_instr_bits {
+	// Stop the VM, mark match or failure
+	VM_OP_STOP   = 0,
+
+	// Start of each state: fetch next character.  Indicates
+	// match / fail if EOS.
+	VM_OP_FETCH  = 1,
+
+	// Branch to another state
+	VM_OP_BRANCH = 2,
+};
+
+enum dfavm_cmp_bits {
+	VM_CMP_ALWAYS = 0,
+	VM_CMP_LE     = 1,
+	VM_CMP_EQ     = 2,
+	VM_CMP_GE     = 3,
+};
+
+enum dfavm_end_bits {
+	VM_END_FAIL = 0,
+	VM_END_SUCC = 1,
+};
+
+enum dfavm_dest_bits {
+	VM_DEST_NONE  = 0,
+	VM_DEST_SHORT = 1,  // 11-bit dest
+	VM_DEST_NEAR  = 2,  // 18-bit dest
+	VM_DEST_FAR   = 3,  // 32-bit dest
+};
+
+struct dfavm_op {
+	struct dfavm_op *next;
+	uint32_t count;
+	uint32_t offset;
+
+	enum dfavm_cmp_bits cmp;
+	enum dfavm_instr_bits instr;
+
+	union {
+		struct {
+			unsigned state;
+			enum dfavm_end_bits end_bits;
+		} fetch;
+
+		struct {
+			enum dfavm_end_bits end_bits;
+		} stop;
+
+		struct {
+			struct dfavm_op *dest_arg;
+			enum dfavm_dest_bits dest;
+			uint32_t dest_state;
+			int32_t  rel_dest;
+		} br;
+	} u;
+
+	unsigned char cmp_arg;
+	unsigned char num_encoded_bytes;
+};
+
+enum dfavm_state {
+	VM_STOPPED  = 0,
+	VM_MATCHING = 1,
+};
+
+struct dfavm_op_pool {
+	struct dfavm_op_pool *next;
+
+	unsigned int top;
+	struct dfavm_op ops[1024];
+};
+
+struct dfavm_assembler {
+	struct dfavm_op_pool *pool;
+
+	struct dfavm_op **ops;
+	struct dfavm_op *linked;
+
+	size_t nstates;
+	size_t start;
+
+	uint32_t count;
+};
+
+struct fsm_dfavm {
+	unsigned char *sp;
+	unsigned char *end;
+
+	unsigned char *ops;
+	uint32_t len;
+
+	uint32_t pc;
+	enum dfavm_state state;
+};
+
+static void
+print_op(FILE *f, struct dfavm_op *op)
+{
+	const char *cmp;
+	int nargs = 0;
+
+	switch (op->cmp) {
+	case VM_CMP_ALWAYS: cmp = "";   break;
+	case VM_CMP_LE:     cmp = "LE"; break;
+	case VM_CMP_EQ:     cmp = "EQ"; break;
+	case VM_CMP_GE:     cmp = "GE"; break;
+	default:            cmp = "??"; break;
+	}
+
+	fprintf(f, "[%4lu] %1lu\t", (unsigned long)op->offset, (unsigned long)op->num_encoded_bytes);
+
+	switch (op->instr) {
+	case VM_OP_FETCH:
+		fprintf(f, "FETCH%c%s",
+			(op->u.fetch.end_bits == VM_END_FAIL) ? 'F' : 'S',
+			cmp);
+		break;
+
+	case VM_OP_STOP:
+		fprintf(f, "STOP%c%s",
+			(op->u.stop.end_bits == VM_END_FAIL) ? 'F' : 'S',
+			cmp);
+		break;
+
+	case VM_OP_BRANCH:
+		{
+			char dst;
+			switch (op->u.br.dest) {
+			case VM_DEST_NONE:  dst = 'Z'; break;
+			case VM_DEST_SHORT: dst = 'S'; break;
+			case VM_DEST_NEAR:  dst = 'N'; break;
+			case VM_DEST_FAR:   dst = 'F'; break;
+			default:            dst = '!'; break;
+			}
+
+			fprintf(f, "BR%c%s", dst, cmp);
+		}
+		break;
+
+	default:
+		fprintf(f, "UNK_%d_%s", (int)op->instr, cmp);
+	}
+
+	if (op->cmp != VM_CMP_ALWAYS) {
+		if (isprint(op->cmp_arg)) {
+			fprintf(f, " '%c'", op->cmp_arg);
+		} else {
+			fprintf(f, " 0x%02x",(unsigned)op->cmp_arg);
+		}
+
+		nargs++;
+	}
+
+	if (op->instr == VM_OP_BRANCH) {
+		if (nargs > 0) { fprintf(f, ", "); }
+		fprintf(f, "%s%ld [st=%lu]", ((nargs>0) ? ", " : " "),
+			(long)op->u.br.rel_dest, (unsigned long)op->u.br.dest_state);
+		nargs++;
+	}
+
+	fprintf(f, "\t; %6lu bytes", (unsigned long)op->num_encoded_bytes);
+	switch (op->instr) {
+	case VM_OP_FETCH:
+		fprintf(f, "  [state %u]", op->u.fetch.state);
+		break;
+
+	case VM_OP_BRANCH:
+		fprintf(f, "  [dest=%p]", (void *)op->u.br.dest_arg);
+		break;
+
+	default:
+		break;
+	}
+
+	fprintf(f, "\n");
+}
+
+#define ARRAYLEN(a) (sizeof (a) / sizeof ((a)[0]))
+
+static struct dfavm_op_pool *
+new_op_pool(struct dfavm_op_pool *pcurr)
+{
+	static const struct dfavm_op_pool zero;
+
+	struct dfavm_op_pool *p;
+
+	p = malloc(sizeof *p);
+	if (p != NULL) {
+		*p = zero;
+		p->next = pcurr;
+	}
+
+	return p;
+}
+
+static struct dfavm_op *
+pool_newop(struct dfavm_op_pool **poolp)
+{
+	struct dfavm_op_pool *p;
+
+	assert(poolp != NULL);
+
+	p = *poolp;
+
+	if (p == NULL || p->top >= ARRAYLEN(p->ops)) {
+		p = new_op_pool(*poolp);
+		if (p == NULL) {
+			return NULL;
+		}
+
+		*poolp = p;
+	}
+
+	return &p->ops[p->top++];
+}
+
+static struct dfavm_op *
+opasm_new(struct dfavm_assembler *a, enum dfavm_instr_bits instr, enum dfavm_cmp_bits cmp, unsigned char arg)
+{
+	struct dfavm_op *op;
+
+	op = pool_newop(&a->pool);
+	if (op != NULL) {
+		op->count = a->count++;
+
+		op->cmp   = cmp;
+		op->instr = instr;
+
+		op->cmp_arg = arg;
+	}
+
+	return op;
+}
+
+static struct dfavm_op *
+opasm_new_fetch(struct dfavm_assembler *a, unsigned state, enum dfavm_end_bits end)
+{
+	struct dfavm_op *op;
+
+	op = opasm_new(a, VM_OP_FETCH, VM_CMP_ALWAYS, 0);
+	if (op != NULL) {
+		op->u.fetch.state    = state;
+		op->u.fetch.end_bits = end;
+	}
+
+	return op;
+}
+
+static struct dfavm_op *
+opasm_new_stop(struct dfavm_assembler *a, enum dfavm_cmp_bits cmp, unsigned char arg, enum dfavm_end_bits end)
+{
+	struct dfavm_op *op;
+
+	op = opasm_new(a, VM_OP_STOP, cmp, arg);
+	if (op != NULL) {
+		op->u.stop.end_bits = end;
+	}
+
+	return op;
+}
+
+static struct dfavm_op *
+opasm_new_branch(struct dfavm_assembler *a, enum dfavm_cmp_bits cmp, unsigned char arg, uint32_t dest_state)
+{
+	struct dfavm_op *op;
+
+	assert(dest_state < a->nstates);
+
+	op = opasm_new(a, VM_OP_BRANCH, cmp, arg);
+	if (op != NULL) {
+		op->u.br.dest  = VM_DEST_FAR;  // start with all branches as 'far'
+		op->u.br.dest_state = dest_state;
+	}
+
+	return op;
+}
+
+void
+dfavm_opasm_finalize(struct dfavm_assembler *a)
+{
+	(void)a;
+}
+
+static int
+initial_translate_table(struct dfavm_assembler *a, long table[FSM_SIGMA_COUNT], struct dfavm_op **opp)
+{
+	int i,lo;
+
+	/* ... this can definitely be made more intelligent ... */
+
+	lo = 0;
+	for (i=1; i < FSM_SIGMA_COUNT; i++) {
+		int64_t dst;
+		struct dfavm_op *op;
+
+		assert(lo < FSM_SIGMA_COUNT);
+
+		if (table[lo] != table[i]) {
+			dst = table[lo];
+
+			/* emit instr */
+			int arg = i-1;
+			enum dfavm_cmp_bits cmp = (i > lo+1) ? VM_CMP_LE : VM_CMP_EQ;
+
+			op = (dst < 0)
+				? opasm_new_stop(a, cmp, arg, VM_END_FAIL)
+				: opasm_new_branch(a, cmp, arg, dst);
+
+			if (op == NULL) {
+				return -1;
+			}
+
+			*opp = op;
+			opp = &(*opp)->next;
+
+			lo = i;
+		}
+	}
+
+	if (lo < FSM_SIGMA_COUNT-1) {
+		int64_t dst = table[lo];
+		*opp = (dst < 0)
+			? opasm_new_stop(a, VM_CMP_ALWAYS, 0, VM_END_FAIL)
+			: opasm_new_branch(a, VM_CMP_ALWAYS, 0, dst);
+		opp = &(*opp)->next;
+	}
+
+	return 0;
+}
+
+static void
+ranges_to_table(long table[FSM_SIGMA_COUNT], const struct ir_range *r, const size_t n, const long to)
+{
+	size_t i;
+
+	for (i=0; i < n; i++) {
+		int c, end;
+
+		end = r[i].end;
+		for (c = r[i].start; c <= end; c++) {
+			table[c] = to;
+		}
+	}
+}
+
+static void
+error_to_table(long table[FSM_SIGMA_COUNT], const struct ir_error *err)
+{
+	ranges_to_table(table, err->ranges, err->n, -1);
+}
+
+static void
+group_to_table(long table[FSM_SIGMA_COUNT], const struct ir_group *grp)
+{
+	ranges_to_table(table, grp->ranges, grp->n, grp->to);
+}
+
+static int
+initial_translate_partial(struct dfavm_assembler *a, struct ir_state *st, struct dfavm_op **opp)
+{
+	long table[FSM_SIGMA_COUNT];
+	size_t i, ngrps;
+
+	assert(st->strategy == IR_PARTIAL);
+
+	for (i=0; i < FSM_SIGMA_COUNT; i++) {
+		table[i] = -1;
+	}
+
+	ngrps = st->u.partial.n;
+	for (i=0; i < ngrps; i++) {
+		group_to_table(table, &st->u.partial.groups[i]);
+	}
+
+	return initial_translate_table(a, table, opp);
+}
+
+static int
+initial_translate_dominant(struct dfavm_assembler *a, struct ir_state *st, struct dfavm_op **opp)
+{
+	long table[FSM_SIGMA_COUNT];
+	size_t i, ngrps;
+
+	assert(st->strategy == IR_DOMINANT);
+
+	for (i=0; i < FSM_SIGMA_COUNT; i++) {
+		table[i] = st->u.dominant.mode;
+	}
+
+	ngrps = st->u.dominant.n;
+	for (i=0; i < ngrps; i++) {
+		group_to_table(table, &st->u.dominant.groups[i]);
+	}
+
+	return initial_translate_table(a, table, opp);
+}
+
+static int
+initial_translate_error(struct dfavm_assembler *a, struct ir_state *st, struct dfavm_op **opp)
+{
+	long table[FSM_SIGMA_COUNT];
+	size_t i, ngrps;
+
+	assert(st->strategy == IR_ERROR);
+
+	for (i=0; i < FSM_SIGMA_COUNT; i++) {
+		table[i] = st->u.error.mode;
+	}
+
+	error_to_table(table, &st->u.error.error);
+
+	ngrps = st->u.error.n;
+	for (i=0; i < ngrps; i++) {
+		group_to_table(table, &st->u.error.groups[i]);
+	}
+
+	return initial_translate_table(a, table, opp);
+}
+
+static struct dfavm_op *
+initial_translate_state(struct dfavm_assembler *a, struct ir *ir, size_t ind)
+{
+	struct ir_state *st;
+	struct dfavm_op **opp;
+
+	st = &ir->states[ind];
+	opp = &a->ops[ind];
+
+	if (st->isend && st->strategy == IR_SAME && st->u.same.to == ind) {
+		*opp = opasm_new_stop(a, VM_CMP_ALWAYS, 0, VM_END_SUCC);
+		return a->ops[ind];
+	}
+
+	*opp = opasm_new_fetch(a, ind, (st->isend) ? VM_END_SUCC : VM_END_FAIL);
+	opp = &(*opp)->next;
+
+	switch (st->strategy) {
+	case IR_NONE:
+		*opp = opasm_new_stop(a, VM_CMP_ALWAYS, 0, VM_END_FAIL);
+		opp = &(*opp)->next;
+		break;
+
+	case IR_SAME:
+		*opp = opasm_new_branch(a, VM_CMP_ALWAYS, 0, st->u.same.to);
+		opp = &(*opp)->next;
+		break;
+
+	case IR_COMPLETE:
+		/* groups should be sorted */
+
+	/* _currently_ expand these into a table and build the
+	 * transitions off of the table.  We can do this more
+	 * intelligently.
+	 */
+	case IR_PARTIAL:
+		if (initial_translate_partial(a, st, opp) < 0) {
+			return NULL;
+		}
+		break;
+
+	case IR_DOMINANT:
+		if (initial_translate_dominant(a, st, opp) < 0) {
+			return NULL;
+		}
+		break;
+
+	case IR_ERROR:
+		if (initial_translate_error(a, st, opp) < 0) {
+			return NULL;
+		}
+		break;
+
+	case IR_TABLE:
+		/* currently not used */
+		fprintf(stderr, "implement IR_TABLE!\n");
+		abort();
+
+	default:
+		fprintf(stderr, "unknown strategy!\n");
+		abort();
+	}
+
+	return a->ops[ind];
+}
+
+static int
+initial_translate(struct ir *ir, struct dfavm_assembler *a)
+{
+	size_t i,n;
+
+	n = a->nstates;
+
+	for (i=0; i < n; i++) {
+		a->ops[i] = initial_translate_state(a, ir, i);
+	}
+
+	return 0;
+}
+
+static void
+fixup_dests(struct dfavm_assembler *a)
+{
+	size_t i,n;
+
+	n = a->nstates;
+	for (i=0; i < n; i++) {
+		struct dfavm_op *op;
+
+		for (op = a->ops[i]; op != NULL; op = op->next) {
+			if (op->instr != VM_OP_BRANCH) {
+				continue;
+			}
+
+			op->u.br.dest_arg = a->ops[op->u.br.dest_state];
+		}
+	}
+}
+
+struct dfavm_op **find_opchain_end(struct dfavm_op **opp)
+{
+	assert(opp != NULL);
+
+	while (*opp != NULL) {
+		opp = &(*opp)->next;
+	}
+
+	return opp;
+}
+
+static void
+reorder_basic_blocks(struct dfavm_assembler *a)
+{
+	size_t i,n;
+	struct dfavm_op **opp;
+
+	/* replace this with something that actually
+	 * orders basic blocks ...
+	 */
+
+	opp = &a->linked;
+	n = a->nstates;
+
+	/* begin with starting state */
+	*opp = a->ops[a->start];
+	opp = find_opchain_end(opp);
+
+	assert(opp != NULL);
+	assert(*opp == NULL);
+
+	for (i=0; i < n; i++) {
+		if (i == a->start) {
+			continue;
+		}
+
+		*opp = a->ops[i];
+		opp = find_opchain_end(opp);
+
+		assert(opp != NULL);
+		assert(*opp == NULL);
+	}
+}
+
+static const long min_dest_1b = -(1L << 10);
+static const long max_dest_1b =  (1L << 10)-1;
+
+static const long min_dest_2b = -(1L << 17);
+static const long max_dest_2b =  (1L << 17)-1;
+
+// static const long min_dest_4b = INT32_MIN;
+// static const long max_dest_4b = INT32_MAX;
+
+static int
+op_encoding_size(struct dfavm_op *op, int max_enc)
+{
+	int nbytes = 1;
+
+	assert(op != NULL);
+
+	if (op->cmp != VM_CMP_ALWAYS) {
+		nbytes++;
+	}
+
+	if (op->instr == VM_OP_BRANCH) {
+		int32_t rel_dest = op->u.br.rel_dest;
+		if (!max_enc && rel_dest >= min_dest_1b && rel_dest <= max_dest_1b) {
+			nbytes += 1;
+			op->u.br.dest = VM_DEST_SHORT;
+		}
+		else if (!max_enc && rel_dest >= min_dest_2b && rel_dest <= max_dest_2b) {
+			nbytes += 2;
+			op->u.br.dest = VM_DEST_NEAR;
+		}
+		else {
+			// need 32 bits
+			nbytes += 4;
+			op->u.br.dest = VM_DEST_FAR;
+		}
+	}
+
+	return nbytes;
+}
+
+static void
+assign_rel_dests(struct dfavm_assembler *a)
+{
+	uint32_t off;
+	struct dfavm_op *op;
+
+	assert(a != NULL);
+	assert(a->linked != NULL);
+
+	/* start with maximum branch encoding */
+	off = 0;
+	for (op = a->linked; op != NULL; op = op->next) {
+		int nenc;
+
+		nenc = op_encoding_size(op, 1);
+
+		assert(nenc > 0 && nenc <= 6);
+
+		op->offset = off;
+		op->num_encoded_bytes = nenc;
+		off += nenc;
+	}
+
+	/* iterate until we converge */
+	for (;;) {
+		int nchanged = 0;
+
+		for (op = a->linked; op != NULL; op = op->next) {
+			if (op->instr == VM_OP_BRANCH) {
+				struct dfavm_op *dest;
+				int64_t diff;
+				int nenc;
+
+				dest = op->u.br.dest_arg;
+
+				assert(dest != NULL);
+
+				diff = (int64_t)dest->offset - (int64_t)op->offset;
+
+				assert(diff >= INT32_MIN && diff <= INT32_MAX);
+
+				op->u.br.rel_dest = diff;
+				
+				nenc = op_encoding_size(op, 0);
+				if (nenc != op->num_encoded_bytes) {
+					op->num_encoded_bytes = nenc;
+					nchanged++;
+				}
+			}
+		}
+
+		if (nchanged == 0) {
+			break;
+		}
+
+		/* adjust offsets */
+		off = 0;
+		for (op = a->linked; op != NULL; op = op->next) {
+			op->offset = off;
+			off += op->num_encoded_bytes;
+		}
+	}
+}
+
+static struct fsm_dfavm *
+encode_opasm(struct dfavm_assembler *a)
+{
+	(void)a;
+	return NULL;
+}
+
+static void
+dump_states(FILE *f, struct dfavm_assembler *a)
+{
+	struct dfavm_op *op;
+	size_t count;
+
+	count = 0;
+	for (op = a->linked; op != NULL; op = op->next) {
+		if (op->instr == VM_OP_FETCH) {
+			unsigned state = op->u.fetch.state;
+			fprintf(f, "%6s |    ; state %u %p %s\n", "", state, (void *)op, (state == a->start) ? "(start)" : "");
+		}
+
+		fprintf(f, "%6zu |    ", count++);
+		print_op(f, op);
+	}
+}
+
+static struct fsm_dfavm *
+dfavm_compile(struct ir *ir)
+{
+	static const struct dfavm_assembler zero;
+
+	struct fsm_dfavm *vm;
+	struct dfavm_assembler a;
+	size_t nstates;
+
+	nstates = ir->n;
+	a = zero;
+
+	a.nstates = nstates;
+	a.start = ir->start;
+
+	a.ops = calloc(nstates, sizeof a.ops[0]);
+	if (a.ops == NULL) {
+		goto error;
+	}
+
+	if (initial_translate(ir, &a) < 0) {
+		goto error;
+	}
+
+	fixup_dests(&a);
+
+	reorder_basic_blocks(&a);
+
+	assign_rel_dests(&a);
+
+	dump_states(stdout, &a);
+
+	vm = encode_opasm(&a);
+	if (vm == NULL) {
+		goto error;
+	}
+
+	dfavm_opasm_finalize(&a);
+
+	return vm;
+
+error:
+	dfavm_opasm_finalize(&a);
+	return NULL;
+}
+
+struct fsm_dfavm *
+fsm_vm_compile(const struct fsm *fsm)
+{
+	struct ir *ir;
+	struct fsm_dfavm *vm;
+
+	ir = make_ir(fsm);
+	if (ir == NULL) {
+		return NULL;
+	}
+
+	vm = dfavm_compile(ir);
+
+	if (vm == NULL) {
+		int errsv = errno;
+		free_ir(fsm,ir);
+		errno = errsv;
+
+		return NULL;
+	}
+
+	free_ir(fsm,ir);
+	return vm;
+
+}
+
+void fsm_vm_free(struct fsm_dfavm *vm)
+{
+	(void)vm;
+}
+
+/* -- Notes --
+
+   1. Need to reorder states like basic blocks.
+   2. Start state should be the first state.
+
+ */
+
+
+
+
+
+
+
+

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -103,4 +103,6 @@ fsm_mergeab
 
 fsm_vm_compile
 fsm_vm_free
+fsm_vm_match_buffer
+fsm_vm_match_file
 

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -100,3 +100,7 @@ epsilon_closure_bulk # XXX: workaround for fsm
 closure_free # XXX: workaround for fsm
 
 fsm_mergeab
+
+fsm_vm_compile
+fsm_vm_free
+

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -445,6 +445,7 @@ main(int argc, char *argv[])
 	int keep_nfa;
 	int patterns;
 	int ambig;
+	int makevm;
 
 	/* note these defaults are the opposite than for fsm(1) */
 	opt.anonymous_states  = 1;
@@ -460,6 +461,7 @@ main(int argc, char *argv[])
 	keep_nfa  = 0;
 	patterns  = 0;
 	ambig     = 0;
+	makevm    = 0;
 	print_fsm = NULL;
 	print_ast = NULL;
 	query     = NULL;
@@ -469,7 +471,7 @@ main(int argc, char *argv[])
 	{
 		int c;
 
-		while (c = getopt(argc, argv, "h" "acwXe:k:" "bi" "sq:r:l:" "upmnxyz"), c != -1) {
+		while (c = getopt(argc, argv, "h" "acwXe:k:" "bi" "sq:r:l:" "upMmnxyz"), c != -1) {
 			switch (c) {
 			case 'a': opt.anonymous_states  = 0;          break;
 			case 'c': opt.consolidate_edges = 0;          break;
@@ -499,6 +501,7 @@ main(int argc, char *argv[])
 			case 'm': example  = 1; break;
 			case 'n': keep_nfa = 1; break;
 			case 'z': patterns = 1; break;
+			case 'M': makevm   = 1; break;
 
 			case 'h':
 				usage();
@@ -527,6 +530,11 @@ main(int argc, char *argv[])
 
 	if (!!print_fsm + !!print_ast + example + !!query && xfiles) {
 		fprintf(stderr, "-x applies only when executing\n");
+		return EXIT_FAILURE;
+	}
+
+	if (keep_nfa && makevm) {
+		fprintf(stderr, "-n and -M cannot be used together\n");
 		return EXIT_FAILURE;
 	}
 
@@ -803,6 +811,13 @@ main(int argc, char *argv[])
 		}
 
 		opt.carryopaque = NULL;
+
+		if (makevm) {
+			struct fsm_dfavm *vm;
+
+			vm = fsm_vm_compile(fsm);
+			fsm_vm_free(vm);
+		}
 	}
 
 	if (example) {

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -662,6 +662,10 @@ process_test_file(const char *fname, enum re_dialect dialect)
 			continue;
 		}
 
+		if (s[0] == '#') {
+			continue;
+		}
+
 		if (regexp == NULL) {
 			static const struct re_err err_zero;
 
@@ -741,10 +745,6 @@ process_test_file(const char *fname, enum re_dialect dialect)
 			char *err;
 			int tlen;
 			int ret;
-
-			if (s[0] == '#') {
-				continue;
-			}
 
 			if (s[0] != '-' && s[0] != '+') {
 				fprintf(stderr, "line %d: unrecognized record type '%c': %s\n", linenum, s[0], s);

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -495,9 +495,12 @@ bare:
 			case 'r':  s[j++] = '\r'; st = ST_BARE; break;
 			case 't':  s[j++] = '\t'; st = ST_BARE; break;
 			case 'v':  s[j++] = '\v'; st = ST_BARE; break;
+			case '"':  s[j++] = '\"'; st = ST_BARE; break;
 			case '\\': s[j++] = '\\'; st = ST_BARE; break;
 
-			case '0': ccode = 0; ndig = 0; st = ST_OCT; goto octdig;
+			case '0': case '1': case '2': case '3':
+			case '4': case '5': case '6': case '7':
+				   ccode = 0; ndig = 0; st = ST_OCT; goto octdig;
 			case 'x': ccode = 0; ndig = 0; hexcurly = 0; st = ST_HEX; break;
 
 			default:

--- a/src/retest/Makefile
+++ b/src/retest/Makefile
@@ -1,0 +1,19 @@
+.include "../../share/mk/top.mk"
+
+SRC += src/retest/main.c
+
+.for src in ${SRC:Msrc/retest/main.c}
+CFLAGS.${src} += -I src # XXX: for internal.h
+DFLAGS.${src} += -I src # XXX: for internal.h
+.endfor
+
+PROG += retest
+
+.for lib in ${LIB:Mlibfsm} ${LIB:Mlibre}
+${BUILD}/bin/retest: ${BUILD}/lib/${lib:R}.a
+.endfor
+
+.for src in ${SRC:Msrc/retest/*.c}
+${BUILD}/bin/retest: ${BUILD}/${src:R}.o
+.endfor
+

--- a/src/retest/main.c
+++ b/src/retest/main.c
@@ -1,0 +1,845 @@
+/*
+ * Copyright 2019 Shannon F. Stewman
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#define _POSIX_C_SOURCE 2
+
+#include <unistd.h>
+
+#include <assert.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <ctype.h>
+
+#include <fsm/fsm.h>
+#include <fsm/bool.h>
+#include <fsm/pred.h>
+#include <fsm/print.h>
+#include <fsm/options.h>
+#include <fsm/vm.h>
+
+#include <re/re.h>
+
+#include "libfsm/internal.h" /* XXX */
+#include "libre/print.h" /* XXX */
+#include "libre/class.h" /* XXX */
+#include "libre/ast.h" /* XXX */
+
+
+#define DEBUG_ESCAPES     0
+#define DEBUG_VM_FSM      0
+#define DEBUG_TEST_REGEXP 0
+
+/*
+ * TODO: accepting a delimiter would be useful: /abc/. perhaps provide that as
+ * a convenience function, especially wrt. escaping for lexing. Also convenient
+ * for specifying flags: /abc/g
+ * TODO: flags; -r for RE_REVERSE, etc
+ */
+
+struct match {
+	int i;
+	const char *s;
+	struct match *next;
+};
+
+static struct fsm_options opt;
+
+static void
+usage(void)
+{
+	fprintf(stderr, "usage: re    [-r <dialect>] [-nbiusyz] [-x] <re> ... [ <text> | -- <text> ... ]\n");
+	fprintf(stderr, "       re -p [-r <dialect>] [-nbiusyz] [-l <language>] [-acwX] [-k <io>] [-e <prefix>] <re> ...\n");
+	fprintf(stderr, "       re -m [-r <dialect>] [-nbiusyz] <re> ...\n");
+	fprintf(stderr, "       re -h\n");
+}
+
+static enum fsm_io
+io(const char *name)
+{
+	size_t i;
+
+	struct {
+		const char *name;
+		enum fsm_io io;
+	} a[] = {
+		{ "getc", FSM_IO_GETC },
+		{ "str",  FSM_IO_STR  },
+		{ "pair", FSM_IO_PAIR }
+	};
+
+	assert(name != NULL);
+
+	for (i = 0; i < sizeof a / sizeof *a; i++) {
+		if (0 == strcmp(a[i].name, name)) {
+			return a[i].io;
+		}
+	}
+
+	fprintf(stderr, "unrecognised IO API; valid IO APIs are: ");
+
+	for (i = 0; i < sizeof a / sizeof *a; i++) {
+		fprintf(stderr, "%s%s",
+			a[i].name,
+			i + 1 < sizeof a / sizeof *a ? ", " : "\n");
+	}
+
+	exit(EXIT_FAILURE);
+}
+
+static enum re_dialect
+dialect_name(const char *name)
+{
+	size_t i;
+
+	struct {
+		const char *name;
+		enum re_dialect dialect;
+	} a[] = {
+/* TODO:
+		{ "ere",     RE_ERE     },
+		{ "bre",     RE_BRE     },
+		{ "plan9",   RE_PLAN9   },
+		{ "js",      RE_JS      },
+		{ "python",  RE_PYTHON  },
+		{ "sql99",   RE_SQL99   },
+*/
+		{ "like",    RE_LIKE    },
+		{ "literal", RE_LITERAL },
+		{ "glob",    RE_GLOB    },
+		{ "native",  RE_NATIVE  },
+		{ "pcre",    RE_PCRE    },
+		{ "sql",     RE_SQL     }
+	};
+
+	assert(name != NULL);
+
+	for (i = 0; i < sizeof a / sizeof *a; i++) {
+		if (0 == strcmp(a[i].name, name)) {
+			return a[i].dialect;
+		}
+	}
+
+	fprintf(stderr, "unrecognised regexp dialect \"%s\"; valid dialects are: ", name);
+
+	for (i = 0; i < sizeof a / sizeof *a; i++) {
+		fprintf(stderr, "%s%s",
+			a[i].name,
+			i + 1 < sizeof a / sizeof *a ? ", " : "\n");
+	}
+
+	exit(EXIT_FAILURE);
+}
+
+static int
+(*comparison(const char *name))
+(const struct fsm *, const struct fsm *)
+{
+	size_t i;
+
+	struct {
+		const char *name;
+		int (*comparison)(const struct fsm *, const struct fsm *);
+	} a[] = {
+		{ "equal",    fsm_equal },
+		{ "isequal",  fsm_equal },
+		{ "areequal", fsm_equal }
+	};
+
+	assert(name != NULL);
+
+	for (i = 0; i < sizeof a / sizeof *a; i++) {
+		if (0 == strcmp(a[i].name, name)) {
+			return a[i].comparison;
+		}
+	}
+
+	fprintf(stderr, "unrecognised comparison; valid comparisons are: ");
+
+	for (i = 0; i < sizeof a / sizeof *a; i++) {
+		fprintf(stderr, "%s%s",
+			a[i].name,
+			i + 1 < sizeof a / sizeof *a ? ", " : "\n");
+	}
+
+	exit(EXIT_FAILURE);
+}
+
+static void *
+xmalloc(size_t n)
+{
+	void *p = malloc(n);
+	if (p == NULL) {
+		perror("xmalloc");
+		exit(EXIT_FAILURE);
+	}
+
+	return p;
+}
+
+static FILE *
+xopen(const char *s)
+{
+	FILE *f;
+
+	assert(s != NULL);
+
+	if (0 == strcmp(s, "-")) {
+		return stdin;
+	}
+
+	f = fopen(s, "r");
+	if (f == NULL) {
+		perror(s);
+		exit(EXIT_FAILURE);
+	}
+
+	return f;
+}
+
+static struct match *
+addmatch(struct match **head, int i, const char *s)
+{
+	struct match *new;
+
+	assert(head != NULL);
+	assert(s != NULL);
+
+	if ((1U << i) > INT_MAX) {
+		fprintf(stderr, "Too many patterns for int bitmap\n");
+		exit(EXIT_FAILURE);
+	}
+
+	/* TODO: explain we find duplicate; return success */
+	/*
+	 * This is a purposefully shallow comparison (rather than calling strcmp)
+	 * so that 're xyz xyz' will find the ambiguity.
+	 */
+	{
+		struct match *p;
+
+		for (p = *head; p != NULL; p = p->next) {
+			if (p->s == s) {
+				return p;
+			}
+		}
+	}
+
+	new = malloc(sizeof *new);
+	if (new == NULL) {
+		return NULL;
+	}
+
+	new->i = i;
+	new->s = s;
+
+	new->next = *head;
+	*head     = new;
+
+	return new;
+}
+
+static void
+carryopaque(struct fsm *src_fsm, const fsm_state_t *src_set, size_t n,
+	struct fsm *dst_fsm, fsm_state_t dst_state)
+{
+	struct match *matches;
+	struct match *m;
+	size_t i;
+
+	assert(src_fsm != NULL);
+	assert(src_set != NULL);
+	assert(n > 0);
+	assert(dst_fsm != NULL);
+	assert(fsm_isend(dst_fsm, dst_state));
+	assert(fsm_getopaque(dst_fsm, dst_state) == NULL);
+
+	/*
+	 * Here we mark newly-created DFA states with the same regexp string
+	 * as from their corresponding source NFA states.
+	 *
+	 * Because all the accepting states are reachable together, they
+	 * should all share the same regexp, unless re(1) was invoked with
+	 * a regexp which is a subset of (or equal to) another.
+	 */
+
+	matches = NULL;
+
+	for (i = 0; i < n; i++) {
+		/*
+		 * The opaque data is attached to end states only, so we skip
+		 * non-end states here.
+		 */
+		if (!fsm_isend(src_fsm, src_set[i])) {
+			continue;
+		}
+
+		assert(fsm_getopaque(src_fsm, src_set[i]) != NULL);
+
+		for (m = fsm_getopaque(src_fsm, src_set[i]); m != NULL; m = m->next) {
+			if (!addmatch(&matches, m->i, m->s)) {
+				perror("addmatch");
+				goto error;
+			}
+		}
+	}
+
+	fsm_setopaque(dst_fsm, dst_state, matches);
+
+	return;
+
+error:
+
+	/* XXX: free matches */
+
+	fsm_setopaque(dst_fsm, dst_state, NULL);
+
+	return;
+}
+
+static void
+printexample(FILE *f, const struct fsm *fsm, fsm_state_t state)
+{
+	char buf[256]; /* TODO */
+	int n;
+
+	assert(f != NULL);
+	assert(fsm != NULL);
+
+	n = fsm_example(fsm, state, buf, sizeof buf);
+	if (-1 == n) {
+		perror("fsm_example");
+		exit(EXIT_FAILURE);
+	}
+
+	/* TODO: escape hex etc */
+	fprintf(f, "%s%s", buf,
+		n >= (int) sizeof buf - 1 ? "..." : "");
+}
+
+static int
+endleaf_c(FILE *f, const void *state_opaque, const void *endleaf_opaque)
+{
+	const struct match *m;
+	int n;
+
+	assert(state_opaque != NULL);
+	assert(endleaf_opaque == NULL);
+
+	(void) f;
+	(void) endleaf_opaque;
+
+	n = 0;
+
+	for (m = state_opaque; m != NULL; m = m->next) {
+		n |= 1 << m->i;
+	}
+
+	fprintf(f, "return %#x;", (unsigned) n);
+
+	fprintf(f, " /* ");
+
+	for (m = state_opaque; m != NULL; m = m->next) {
+		fprintf(f, "\"%s\"", m->s); /* XXX: escape string (and comment) */
+
+		if (m->next != NULL) {
+			fprintf(f, ", ");
+		}
+	}
+
+	fprintf(f, " */");
+
+	return 0;
+}
+
+static int
+endleaf_dot(FILE *f, const void *state_opaque, const void *endleaf_opaque)
+{
+	const struct match *m;
+
+	assert(f != NULL);
+	assert(state_opaque != NULL);
+	assert(endleaf_opaque == NULL);
+
+	(void) endleaf_opaque;
+
+	fprintf(f, "label = <");
+
+	for (m = state_opaque; m != NULL; m = m->next) {
+		fprintf(f, "#%u", m->i);
+
+		if (m->next != NULL) {
+			fprintf(f, ",");
+		}
+	}
+
+	fprintf(f, ">");
+
+	/* TODO: only if comments */
+	/* TODO: centralise to libfsm/print/dot.c */
+
+#if 0
+	fprintf(f, " # ");
+
+	for (m = state_opaque; m != NULL; m = m->next) {
+		fprintf(f, "\"%s\"", m->s); /* XXX: escape string (and comment) */
+
+		if (m->next != NULL) {
+			fprintf(f, ", ");
+		}
+	}
+
+	fprintf(f, "\n");
+#endif
+
+	return 0;
+}
+
+enum parse_escape_result {
+	PARSE_OK = 0,
+	PARSE_INVALID_ESCAPE,
+	PARSE_INCOMPLETE_ESCAPE
+};
+
+static int
+parse_escapes(char *s, char **errpos, int *lenp)
+{
+	int i,j,st;
+	unsigned char ccode;
+	int hexcurly, ndig;
+
+	enum { ST_BARE, ST_ESC, ST_OCT, ST_HEX, ST_HEX_DIGIT };
+
+	ccode = 0;
+	hexcurly = 0;
+
+	st = ST_BARE;
+	for (i=0, j=0; s[i] != '\0'; i++) {
+#if DEBUG_ESCAPES
+		fprintf(stderr, "%3d | st=%d hexcurly=%d ndig=%d ccode=0x%02x | %2d %c\n",
+			i, st, hexcurly, ndig, (unsigned int)ccode, s[i], 
+			isprint(s[i]) ? s[i] : ' ');
+#endif /* DEBUG_ESCAPES */
+
+		if (s[i] == '\0') {
+			break;
+		}
+
+		switch (st) {
+		case ST_BARE:
+bare:
+			if (s[i] == '\\') {
+				st = ST_ESC;
+			} else {
+				s[j++] = s[i];
+			}
+			break;
+
+		case ST_ESC:
+			switch (s[i]) {
+			case 'a':  s[j++] = '\a'; st = ST_BARE; break;
+			case 'b':  s[j++] = '\b'; st = ST_BARE; break;
+			case 'e':  s[j++] = '\033'; st = ST_BARE; break;
+			case 'f':  s[j++] = '\f'; st = ST_BARE; break;
+			case 'n':  s[j++] = '\n'; st = ST_BARE; break;
+			case 'r':  s[j++] = '\r'; st = ST_BARE; break;
+			case 't':  s[j++] = '\t'; st = ST_BARE; break;
+			case 'v':  s[j++] = '\v'; st = ST_BARE; break;
+			case '"':  s[j++] = '\"'; st = ST_BARE; break;
+			case '\\': s[j++] = '\\'; st = ST_BARE; break;
+
+			case '0': case '1': case '2': case '3':
+			case '4': case '5': case '6': case '7':
+				   ccode = 0; ndig = 0; st = ST_OCT; goto octdig;
+			case 'x': ccode = 0; ndig = 0; hexcurly = 0; st = ST_HEX; break;
+
+			default:
+				if (errpos) {
+					*errpos = &s[i];
+					return PARSE_INVALID_ESCAPE;
+				}
+				break;
+			}
+			break;
+
+		case ST_OCT:
+octdig:
+			if (ndig < 3 && s[i] >= '0' && s[i] <= '7') {
+				ccode = (ccode * 8) + (s[i] - '0');
+				ndig++;
+			} else {
+				s[j++] = ccode;
+				st = ST_BARE;
+				goto bare;
+			}
+
+			break;
+
+		case ST_HEX:
+			st = ST_HEX_DIGIT;
+			if (s[i] != '{') {
+				hexcurly = 0;
+				goto hexdigit;
+			}
+
+			hexcurly = 1;
+			break;
+
+		case ST_HEX_DIGIT:
+hexdigit:
+			{
+				unsigned char uc = toupper(s[i]);
+				if (ndig < 2 && isxdigit(uc)) {
+					if (uc >= '0' && uc <= '9') {
+						ccode = (ccode * 16) + (uc - '0');
+					} else {
+						ccode = (ccode * 16) + (uc - 'A' + 10);
+					}
+
+					ndig++;
+				} else {
+					s[j++] = ccode;
+					st = ST_BARE;
+
+					if (!hexcurly) {
+						goto bare;
+					} else if (uc != '}') {
+						if (errpos) {
+							*errpos = &s[i];
+						}
+						return PARSE_INCOMPLETE_ESCAPE;
+					}
+				}
+			}
+			break;
+		}
+	}
+
+	switch (st) {
+	case ST_BARE:
+		break;
+
+	case ST_ESC:
+		if (errpos) {
+			*errpos = &s[i];
+		}
+		return PARSE_INVALID_ESCAPE;
+
+	case ST_HEX:
+	case ST_OCT:
+	case ST_HEX_DIGIT:
+		if (hexcurly && st == ST_HEX_DIGIT) {
+			if (errpos) {
+				*errpos = &s[i];
+			}
+			return PARSE_INCOMPLETE_ESCAPE;
+		}
+
+		s[j++] = ccode;
+		break;
+	}
+
+	s[j] = '\0';
+
+	*lenp = j;
+
+	return PARSE_OK;
+}
+
+/* test file format:
+ *
+ * 1. lines starting with '#' are skipped
+ * 2. (TODO) lines starting with 'R' set the dialect
+ * 3. records are separated by empty lines
+ * 4. the first line of each record is the regular expression to be
+ *    tested 
+ * 5. after the regular expression, valid lines start with '#', '+', or '-'
+ *     a. '+' indicates that the rest of the line should be matched with the
+ *        current regular expression
+ *     b. '-' indicates the the rest of the line should *not* be matched with
+ *        the current regular expression
+ *     c. '#' lines are comments
+ */
+static int
+process_test_file(const char *fname, enum re_dialect dialect, int max_errors)
+{
+	char buf[4096];
+	char cpy[sizeof buf];
+	char *s;
+	FILE *f;
+	int num_re_errors, num_errors;
+	int num_regexps, num_test_cases;
+	int linenum;
+
+	char *regexp;
+	struct fsm_dfavm *vm;
+
+	regexp = NULL;
+	vm     = NULL;
+
+	/* XXX - fix this */
+	opt.comments = 0;
+
+	f = xopen(fname);
+
+	num_regexps    = 0;
+	num_re_errors  = 0;
+	num_test_cases = 0;
+	num_errors     = 0;
+
+	linenum        = 0;
+
+	while (s = fgets(buf, sizeof buf, f), s != NULL) {
+		int len;
+
+		linenum++;
+		len = strlen(s);
+		if (len > 0 & s[len-1] == '\n') {
+			s[--len] = '\0';
+		}
+
+		if (len == 0) {
+			free(regexp);
+			regexp = NULL;
+
+			fsm_vm_free(vm);
+			vm = NULL;
+
+			continue;
+		}
+
+		if (s[0] == '#') {
+			continue;
+		}
+
+		if (regexp == NULL) {
+			static const struct re_err err_zero;
+
+			struct fsm *fsm;
+			struct re_err err;
+			enum re_flags flags;
+			char *re_str;
+
+			assert(vm == NULL);
+			assert(s  != NULL);
+
+			regexp = xmalloc(len+1);
+			memcpy(regexp, s, len+1);
+
+			assert(strlen(regexp) == (size_t)len);
+			assert(strcmp(regexp,s) == 0);
+
+			flags = 0;
+			err   = err_zero;
+
+			num_regexps++;
+
+			re_str = regexp;
+			fsm = re_comp(dialect, fsm_sgetc, &re_str, &opt, flags, &err);
+			if (fsm == NULL) {
+				fprintf(stderr, "line %d: error with regexp /%s/: %s\n",
+					linenum, regexp, re_strerror(err.e));
+
+				/* don't exit; instead we leave vm==NULL so we
+				 * skip to next regexp ... */
+
+				num_re_errors++;
+				continue;
+			}
+
+			/* XXX - minimize or determinize? */
+			if (!fsm_determinise(fsm)) {
+				fprintf(stderr, "line %d: error determinising /%s/: %s\n", linenum, regexp, strerror(errno));
+
+				/* don't exit; instead we leave vm==NULL so we
+				 * skip to next regexp ... */
+
+				num_re_errors++;
+				continue;
+			}
+
+#if DEBUG_VM_FSM
+			fprintf(stderr, "FSM:\n");
+			fsm_print_fsm(stderr, fsm);
+			fprintf(stderr, "---\n");
+			{
+				FILE *f = fopen("dump.fsm", "w");
+				fsm_print_fsm(f, fsm);
+				fclose(f);
+			}
+#endif /* DEBUG_VM_FSM */
+
+#if DEBUG_TEST_REGEXP
+			fprintf(stderr, "REGEXP matching for /%s/\n", regexp);
+#endif /* DEBUG_TEST_REGEXP */
+			vm = fsm_vm_compile(fsm);
+			if (vm == NULL) {
+				fprintf(stderr, "line %d: error compiling /%s/: %s\n", linenum, regexp, strerror(errno));
+
+				/* don't exit; instead we leave vm==NULL so we
+				 * skip to next regexp ... */
+
+				num_re_errors++;
+				continue;
+			}
+
+			fsm_free(fsm);
+		} else if (vm != NULL) {
+			int matching;
+			char *orig;
+			char *test;
+			char *err;
+			int tlen;
+			int ret;
+
+			if (s[0] != '-' && s[0] != '+') {
+				fprintf(stderr, "line %d: unrecognized record type '%c': %s\n", linenum, s[0], s);
+				num_errors++;
+				continue;
+			}
+
+			num_test_cases++;
+
+			matching = (s[0] == '+');
+			orig = &s[1];
+			test = strcpy(cpy, orig);
+			tlen = len-1;
+
+			err = NULL;
+			ret = parse_escapes(test, &err, &tlen);
+			if (ret != PARSE_OK) {
+				fprintf(stderr, "line %d: invalid/incomplete escape sequence at column %zd\n",
+					linenum, err - test);
+				num_errors++;
+				continue;
+			}
+
+			ret = fsm_vm_match_buffer(vm, test, tlen);
+			if (!!ret == !!matching) {
+				printf("[OK    ] line %d: regexp /%s/ %s \"%s\"\n",
+					linenum, regexp, matching ? "matched" : "did not match", orig);
+			} else {
+				printf("[NOT OK] line %d: regexp /%s/ expected to %s \"%s\", but %s\n",
+					linenum, regexp,
+					matching ? "match" : "not match",
+					orig,
+					ret ? "did" : "did not");
+				num_errors++;
+
+				if (max_errors > 0 && num_errors >= max_errors) {
+					fprintf(stderr, "too many errors\n");
+					goto finish;
+				}
+			}
+		}
+	}
+
+	free(regexp);
+
+	if (vm) {
+		fsm_vm_free(vm);
+		vm = NULL;
+	}
+
+	fclose(f);
+
+	if (ferror(f)) {
+		fprintf(stderr, "line %d: error reading %s: %s\n", linenum, fname, strerror(errno));
+		if (regexp != NULL) {
+			num_errors++;
+		}
+	}
+
+finish:
+	printf("%s: %d regexps, %d test cases\n", fname, num_regexps, num_test_cases);
+	printf("%s: %d re errors, %d errors\n", fname, num_re_errors, num_errors);
+
+	if (max_errors > 0 && num_errors >= max_errors) {
+		exit(EXIT_FAILURE);
+	}
+
+	return (num_errors > 0);
+}
+
+int
+main(int argc, char *argv[])
+{
+	enum re_dialect dialect;
+	struct fsm *fsm;
+
+	int max_test_errors;
+
+	/* note these defaults are the opposite than for fsm(1) */
+	opt.anonymous_states  = 1;
+	opt.consolidate_edges = 1;
+
+	opt.comments          = 1;
+	opt.io                = FSM_IO_GETC;
+
+	dialect   = RE_NATIVE;
+
+	max_test_errors = 0;
+
+	{
+		int c;
+
+		while (c = getopt(argc, argv, "h" "e:E:" "r:" ), c != -1) {
+			switch (c) {
+			case 'e': opt.prefix            = optarg;     break;
+
+			case 'r': dialect   = dialect_name(optarg); break;
+
+			case 'E':
+				max_test_errors = strtoul(optarg, NULL, 10);
+				/* XXX: error handling */
+				break;
+
+			case 'h':
+				usage();
+				return EXIT_SUCCESS;
+
+			case '?':
+			default:
+				usage();
+				return EXIT_FAILURE;
+			}
+		}
+
+		argc -= optind;
+		argv += optind;
+	}
+
+	if (argc < 1) {
+		usage();
+		return EXIT_FAILURE;
+	}
+
+	{
+		int r, i;
+
+		r = 0;
+
+		if (argc == 0) {
+			fprintf(stderr, "-t requires at least one test file\n");
+			return EXIT_FAILURE;
+		}
+
+		for (i = 0; i < argc; i++) {
+			int succ;
+
+			succ = process_test_file(argv[i], dialect, max_test_errors);
+
+			if (!succ) {
+				r |= 1;
+				continue;
+			}
+		}
+
+		return r;
+	}
+}
+


### PR DESCRIPTION
dfavm is a bytecode based way to run DFA matching.  This commit provides:

1. Initial cut at the dfavm "compiler", dfavm bytecode, and dfavm vm to run the bytecode.
2. `retest`, a program to test dfavm matching of regular expressions.
3. Two utility programs to adapt the PCRE test suites to something `retest` can run
