### PR TITLE
Reimplementation of reversing an FSM to better suit parallelisation

### DIFF
--- a/include/adt/edgeset.h
+++ b/include/adt/edgeset.h
@@ -32,6 +32,10 @@ edge_set_contains(const struct edge_set *set, const struct fsm_edge *e);
 size_t
 edge_set_count(const struct edge_set *set);
 
+int
+edge_set_copy(struct edge_set *dst, const struct fsm_alloc *alloc,
+	const struct edge_set *src);
+
 void
 edge_set_remove(struct edge_set *set, const struct fsm_edge *e);
 

--- a/src/adt/Makefile
+++ b/src/adt/Makefile
@@ -18,7 +18,7 @@ SRC += src/adt/hashset.c
 SRC += src/adt/mappinghashset.c
 SRC += src/adt/statehashset.c
 
-.for src in ${SRC:Msrc/adt/bitmap.c}
+.for src in ${SRC:Msrc/adt/bitmap.c} ${SRC:Msrc/adt/edgeset.c}
 CFLAGS.${src} += -I src # XXX: for internal.h
 DFLAGS.${src} += -I src # XXX: for internal.h
 .endfor


### PR DESCRIPTION
This PR is a rewrite of `fsm_reverse()`, in the style of the current determinisation and Glushkov implementations.

The reversing here is done in-situ (that is, without recreating FSM states), although edges are constructed separately.

As for determinisation and the construction for Glushkov NFA, I'm not introducing the actual parallelisation just yet. Rather, this is just to get the idea of batch processing in place.