### PR TITLE
Convert edge sets to a single state per entry

### DIFF
--- a/include/adt/edgeset.h
+++ b/include/adt/edgeset.h
@@ -13,7 +13,8 @@ struct fsm_edge;
 struct edge_set;
 
 struct edge_iter {
-	struct set_iter iter;
+	size_t i;
+	const struct edge_set *set;
 };
 
 struct edge_set *

--- a/include/adt/edgeset.h
+++ b/include/adt/edgeset.h
@@ -24,7 +24,8 @@ void
 edge_set_free(struct edge_set *set);
 
 struct fsm_edge *
-edge_set_add(struct edge_set *set, unsigned char symbol);
+edge_set_add(struct edge_set *set, unsigned char symbol,
+	fsm_state_t state);
 
 struct fsm_edge *
 edge_set_contains(const struct edge_set *set, unsigned char symbol);
@@ -33,11 +34,13 @@ size_t
 edge_set_count(const struct edge_set *set);
 
 int
-edge_set_copy(struct edge_set *dst, const struct fsm_alloc *alloc,
-	const struct edge_set *src);
+edge_set_copy(struct edge_set *dst, const struct edge_set *src);
 
 void
 edge_set_remove(struct edge_set *set, unsigned char symbol);
+
+void
+edge_set_remove_state(struct edge_set *set, fsm_state_t state);
 
 struct fsm_edge *
 edge_set_first(struct edge_set *set, struct edge_iter *it);
@@ -46,13 +49,7 @@ struct fsm_edge *
 edge_set_next(struct edge_iter *it);
 
 int
-edge_set_hasnext(struct edge_iter *it);
-
-int
 edge_set_empty(const struct edge_set *s);
-
-struct fsm_edge *
-edge_set_only(const struct edge_set *s);
 
 #endif
 

--- a/include/adt/edgeset.h
+++ b/include/adt/edgeset.h
@@ -12,6 +12,7 @@ struct set;
 struct fsm_alloc;
 struct fsm_edge;
 struct edge_set;
+struct state_set;
 
 struct edge_iter {
 	size_t i;
@@ -24,6 +25,10 @@ edge_set_free(struct edge_set *set);
 int
 edge_set_add(struct edge_set **set, const struct fsm_alloc *alloc,
 	unsigned char symbol, fsm_state_t state);
+
+int
+edge_set_add_state_set(struct edge_set **setp, const struct fsm_alloc *alloc,
+	unsigned char symbol, const struct state_set *state_set);
 
 int
 edge_set_contains(const struct edge_set *set, unsigned char symbol);

--- a/include/adt/edgeset.h
+++ b/include/adt/edgeset.h
@@ -7,6 +7,7 @@
 #ifndef ADT_EDGESET_H
 #define ADT_EDGESET_H
 
+struct bm;
 struct set;
 struct fsm_alloc;
 struct fsm_edge;
@@ -27,8 +28,15 @@ struct fsm_edge *
 edge_set_add(struct edge_set *set, unsigned char symbol,
 	fsm_state_t state);
 
-struct fsm_edge *
+int
 edge_set_contains(const struct edge_set *set, unsigned char symbol);
+
+int
+edge_set_hasnondeterminism(const struct edge_set *set, struct bm *bm);
+
+int
+edge_set_transition(const struct edge_set *set, unsigned char symbol,
+	fsm_state_t *state);
 
 size_t
 edge_set_count(const struct edge_set *set);

--- a/include/adt/edgeset.h
+++ b/include/adt/edgeset.h
@@ -18,15 +18,12 @@ struct edge_iter {
 	const struct edge_set *set;
 };
 
-struct edge_set *
-edge_set_create(const struct fsm_alloc *a);
-
 void
 edge_set_free(struct edge_set *set);
 
-struct fsm_edge *
-edge_set_add(struct edge_set *set, unsigned char symbol,
-	fsm_state_t state);
+int
+edge_set_add(struct edge_set **set, const struct fsm_alloc *alloc,
+	unsigned char symbol, fsm_state_t state);
 
 int
 edge_set_contains(const struct edge_set *set, unsigned char symbol);
@@ -42,19 +39,26 @@ size_t
 edge_set_count(const struct edge_set *set);
 
 int
-edge_set_copy(struct edge_set *dst, const struct edge_set *src);
+edge_set_copy(struct edge_set **dst, const struct fsm_alloc *alloc,
+	const struct edge_set *src);
 
 void
-edge_set_remove(struct edge_set *set, unsigned char symbol);
+edge_set_remove(struct edge_set **set, unsigned char symbol);
 
 void
-edge_set_remove_state(struct edge_set *set, fsm_state_t state);
+edge_set_remove_state(struct edge_set **set, fsm_state_t state);
 
-struct fsm_edge *
-edge_set_first(struct edge_set *set, struct edge_iter *it);
+void
+edge_set_reset(struct edge_set *set, struct edge_iter *it);
 
-struct fsm_edge *
-edge_set_next(struct edge_iter *it);
+int
+edge_set_next(struct edge_iter *it, struct fsm_edge *e);
+
+void
+edge_set_rebase(struct edge_set **setp, fsm_state_t base);
+
+void
+edge_set_replace_state(struct edge_set **setp, fsm_state_t old, fsm_state_t new);
 
 int
 edge_set_empty(const struct edge_set *s);

--- a/include/adt/edgeset.h
+++ b/include/adt/edgeset.h
@@ -24,10 +24,10 @@ void
 edge_set_free(struct edge_set *set);
 
 struct fsm_edge *
-edge_set_add(struct edge_set *set, struct fsm_edge *e);
+edge_set_add(struct edge_set *set, unsigned char symbol);
 
 struct fsm_edge *
-edge_set_contains(const struct edge_set *set, const struct fsm_edge *e);
+edge_set_contains(const struct edge_set *set, unsigned char symbol);
 
 size_t
 edge_set_count(const struct edge_set *set);
@@ -37,13 +37,13 @@ edge_set_copy(struct edge_set *dst, const struct fsm_alloc *alloc,
 	const struct edge_set *src);
 
 void
-edge_set_remove(struct edge_set *set, const struct fsm_edge *e);
+edge_set_remove(struct edge_set *set, unsigned char symbol);
 
 struct fsm_edge *
 edge_set_first(struct edge_set *set, struct edge_iter *it);
 
 struct fsm_edge *
-edge_set_firstafter(const struct edge_set *set, struct edge_iter *it, const struct fsm_edge *e);
+edge_set_firstafter(const struct edge_set *set, struct edge_iter *it, unsigned char symbol);
 
 struct fsm_edge *
 edge_set_next(struct edge_iter *it);

--- a/include/adt/edgeset.h
+++ b/include/adt/edgeset.h
@@ -43,9 +43,6 @@ struct fsm_edge *
 edge_set_first(struct edge_set *set, struct edge_iter *it);
 
 struct fsm_edge *
-edge_set_firstafter(const struct edge_set *set, struct edge_iter *it, unsigned char symbol);
-
-struct fsm_edge *
 edge_set_next(struct edge_iter *it);
 
 int

--- a/include/adt/edgeset.h
+++ b/include/adt/edgeset.h
@@ -18,8 +18,7 @@ struct edge_iter {
 };
 
 struct edge_set *
-edge_set_create(const struct fsm_alloc *a,
-	int (*cmp)(const void *a, const void *b));
+edge_set_create(const struct fsm_alloc *a);
 
 void
 edge_set_free(struct edge_set *set);

--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -91,6 +91,12 @@ fsm_merge(struct fsm *a, struct fsm *b,
 int
 fsm_addstate(struct fsm *fsm, fsm_state_t *state);
 
+/*
+ * Add multiple states.
+ */
+int
+fsm_addstate_bulk(struct fsm *fsm, size_t n);
+
  /*
  * Remove a state. Any edges transitioning to this state are also removed.
  */

--- a/src/adt/edgeset.c
+++ b/src/adt/edgeset.c
@@ -111,6 +111,7 @@ edge_set_add(struct edge_set **setp, const struct fsm_alloc *alloc,
 
 		assert(!IS_SINGLETON(*setp));
 
+		/* TODO: bulk add */
 		if (!edge_set_add(setp, alloc, prev_symbol, prev_state)) {
 			return 0;
 		}
@@ -150,6 +151,25 @@ edge_set_add(struct edge_set **setp, const struct fsm_alloc *alloc,
 	set->i++;
 
 	assert(edge_set_contains(set, symbol));
+
+	return 1;
+}
+
+int
+edge_set_add_state_set(struct edge_set **setp, const struct fsm_alloc *alloc,
+	unsigned char symbol, const struct state_set *state_set)
+{
+	struct state_iter it;
+	fsm_state_t s;
+
+	assert(setp != NULL);
+
+	/* TODO: bulk add */
+	for (state_set_reset((void *) state_set, &it); state_set_next(&it, &s); ) {
+		if (!edge_set_add(setp, alloc, symbol, s)) {
+			return 0;
+		}
+	}
 
 	return 1;
 }
@@ -286,7 +306,10 @@ edge_set_copy(struct edge_set **dst, const struct fsm_alloc *alloc,
 	struct fsm_edge e;
 
 	assert(dst != NULL);
-	assert(src != NULL);
+
+	if (edge_set_empty(src)) {
+		return 1;
+	}
 
 	if (IS_SINGLETON(src)) {
 		if (!edge_set_add(dst, alloc, SINGLETON_DECODE_SYMBOL(src), SINGLETON_DECODE_STATE(src))) {
@@ -297,6 +320,7 @@ edge_set_copy(struct edge_set **dst, const struct fsm_alloc *alloc,
 	}
 
 	for (edge_set_reset((void *) src, &jt); edge_set_next(&jt, &e); ) {
+		/* TODO: bulk add */
 		if (!edge_set_add(dst, alloc, e.symbol, e.state)) {
 			return 0;
 		}

--- a/src/adt/edgeset.c
+++ b/src/adt/edgeset.c
@@ -264,39 +264,6 @@ edge_set_first(struct edge_set *set, struct edge_iter *it)
 }
 
 struct fsm_edge *
-edge_set_firstafter(const struct edge_set *set, struct edge_iter *it, unsigned char symbol)
-{
-	size_t i;
-	int r;
-
-	assert(set != NULL);
-	assert(set->a != NULL);
-	assert(it != NULL);
-
-	if (edge_set_empty(set)) {
-		it->set = NULL;
-		return NULL;
-	}
-
-	i = edge_set_search(set, symbol);
-	r = cmp(symbol, set->a[i].symbol);
-	assert(i <= set->i - 1);
-
-	if (r >= 0 && i == set->i - 1) {
-		it->set = NULL;
-		return NULL;
-	}
-
-	it->i = i;
-	if (r >= 0) {
-		it->i++;
-	}
-
-	it->set = set;
-	return &it->set->a[it->i];
-}
-
-struct fsm_edge *
 edge_set_next(struct edge_iter *it)
 {
 	assert(it != NULL);

--- a/src/adt/edgeset.c
+++ b/src/adt/edgeset.c
@@ -108,12 +108,12 @@ edge_set_add(struct edge_set *set, unsigned char symbol)
 
 	assert(set != NULL);
 
-	i = 0;
-
 	/*
 	 * If the item already exists in the set, return success.
 	 */
-	if (!edge_set_empty(set)) {
+	if (edge_set_empty(set)) {
+		i = 0;
+	} else {
 		i = edge_set_search(set, symbol);
 		if (cmp(symbol, set->a[i].symbol) == 0) {
 			return &set->a[i];
@@ -200,12 +200,9 @@ edge_set_copy(struct edge_set *dst, const struct fsm_alloc *alloc,
 	for (e = edge_set_first((void *) src, &jt); e != NULL; e = edge_set_next(&jt)) {
 		struct fsm_edge *en;
 
-		en = edge_set_contains(dst, e->symbol);
+		en = edge_set_add(dst, e->symbol);
 		if (en == NULL) {
-			en = edge_set_add(dst, e->symbol);
-			if (en == NULL) {
-				return 0;
-			}
+			return 0;
 		}
 
 		if (!state_set_copy(&en->sl, alloc, e->sl)) {

--- a/src/libfsm/capture.c
+++ b/src/libfsm/capture.c
@@ -61,20 +61,31 @@ fsm_capture_duplicate(struct fsm *fsm,
 	}
 
 	/* allocate new states */
-	new_start = new_end = 0;
-	for (ind = old_start; ind < old_end; ind++) {
-		fsm_state_t st;
-		if (!fsm_addstate(fsm, &st)) {
+	{
+		fsm_state_t base;
+
+		base = fsm->statecount;
+
+		if (!fsm_addstate_bulk(fsm, old_end - old_start)) {
 			return 0;
 		}
 
-		fsm_setend(fsm, st, fsm_isend(fsm, ind));
+		new_start = new_end = 0;
+		for (ind = old_start; ind < old_end; ind++) {
+			fsm_state_t st;
 
-		if (ind == old_start) {
-			new_start = st;
+			st = ind - old_start + base;
+
+			if (fsm_isend(fsm, ind)) {
+				fsm_setend(fsm, st, 1);
+			}
+
+			if (ind == old_start) {
+				new_start = st;
+			}
+
+			new_end = st+1;
 		}
-
-		new_end = st+1;
 	}
 
 	if (new_start == new_end) {

--- a/src/libfsm/capture.c
+++ b/src/libfsm/capture.c
@@ -107,21 +107,18 @@ fsm_capture_duplicate(struct fsm *fsm,
 		}
 
 		for (e = edge_set_first(fsm->states[old_src].edges, &it); e != NULL; e = edge_set_next(&it)) {
-			struct state_iter jt;
-			fsm_state_t old_dst;
+			fsm_state_t old_dst, new_dst;
 
-			for (state_set_reset(e->sl, &jt); state_set_next(&jt, &old_dst); ) {
-				fsm_state_t new_dst;
+			old_dst = e->state;
 
-				if (old_dst < old_start || old_dst >= old_end) {
-					continue;
-				}
+			if (old_dst < old_start || old_dst >= old_end) {
+				continue;
+			}
 
-				new_dst = new_start + (old_dst - old_start);
+			new_dst = new_start + (old_dst - old_start);
 
-				if (!fsm_addedge_literal(fsm, ind, new_dst, e->symbol)) {
-					return 0;
-				}
+			if (!fsm_addedge_literal(fsm, ind, new_dst, e->symbol)) {
+				return 0;
 			}
 		}
 	}

--- a/src/libfsm/capture.c
+++ b/src/libfsm/capture.c
@@ -85,7 +85,7 @@ fsm_capture_duplicate(struct fsm *fsm,
 	for (ind = new_start; ind < new_end; ind++) {
 		const fsm_state_t old_src = old_start + (ind - new_start);
 		struct edge_iter it;
-		struct fsm_edge *e;
+		struct fsm_edge e;
 
 		{
 			struct state_iter jt;
@@ -106,10 +106,10 @@ fsm_capture_duplicate(struct fsm *fsm,
 			}
 		}
 
-		for (e = edge_set_first(fsm->states[old_src].edges, &it); e != NULL; e = edge_set_next(&it)) {
+		for (edge_set_reset(fsm->states[old_src].edges, &it); edge_set_next(&it, &e); ) {
 			fsm_state_t old_dst, new_dst;
 
-			old_dst = e->state;
+			old_dst = e.state;
 
 			if (old_dst < old_start || old_dst >= old_end) {
 				continue;
@@ -117,7 +117,7 @@ fsm_capture_duplicate(struct fsm *fsm,
 
 			new_dst = new_start + (old_dst - old_start);
 
-			if (!fsm_addedge_literal(fsm, ind, new_dst, e->symbol)) {
+			if (!fsm_addedge_literal(fsm, ind, new_dst, e.symbol)) {
 				return 0;
 			}
 		}

--- a/src/libfsm/clone.c
+++ b/src/libfsm/clone.c
@@ -74,14 +74,9 @@ fsm_clone(const struct fsm *fsm)
 			}
 
 			for (e = edge_set_first(fsm->states[i].edges, &it); e != NULL; e = edge_set_next(&it)) {
-				struct state_iter jt;
-				fsm_state_t to;
-
-				for (state_set_reset(e->sl, &jt); state_set_next(&jt, &to); ) {
-					if (!fsm_addedge_literal(new, i, to, e->symbol)) {
-						fsm_free(new);
-						return NULL;
-					}
+				if (!fsm_addedge_literal(new, i, e->state, e->symbol)) {
+					fsm_free(new);
+					return NULL;
 				}
 			}
 		}

--- a/src/libfsm/clone.c
+++ b/src/libfsm/clone.c
@@ -55,7 +55,7 @@ fsm_clone(const struct fsm *fsm)
 		size_t i;
 
 		for (i = 0; i < fsm->statecount; i++) {
-			struct fsm_edge *e;
+			struct fsm_edge e;
 			struct edge_iter it;
 
 			fsm_setend(new, i, fsm_isend(fsm, i));
@@ -73,8 +73,8 @@ fsm_clone(const struct fsm *fsm)
 				}
 			}
 
-			for (e = edge_set_first(fsm->states[i].edges, &it); e != NULL; e = edge_set_next(&it)) {
-				if (!fsm_addedge_literal(new, i, e->state, e->symbol)) {
+			for (edge_set_reset(fsm->states[i].edges, &it); edge_set_next(&it, &e); ) {
+				if (!fsm_addedge_literal(new, i, e.state, e.symbol)) {
 					fsm_free(new);
 					return NULL;
 				}

--- a/src/libfsm/clone.c
+++ b/src/libfsm/clone.c
@@ -20,6 +20,7 @@ struct fsm *
 fsm_clone(const struct fsm *fsm)
 {
 	struct fsm *new;
+	size_t i;
 
 	assert(fsm != NULL);
 	assert(fsm->opt != NULL);
@@ -29,56 +30,25 @@ fsm_clone(const struct fsm *fsm)
 		return NULL;
 	}
 
-	/*
-	 * Create states corresponding to the origional FSM's states.
-	 * These are created in reverse order, but that's okay.
-	 */
-	/* TODO: possibly centralise as a state-cloning function */
-	{
-		size_t i;
-
-		/* TODO: malloc and memcpy in one shot, rather than
-		 * calling fsm_addstate() for each state. */
-		for (i = 0; i < fsm->statecount; i++) {
-			fsm_state_t q;
-
-			if (!fsm_addstate(new, &q)) {
-				fsm_free(new);
-				return NULL;
-			}
-
-			assert(q == i);
-		}
+	if (!fsm_addstate_bulk(new, fsm->statecount)) {
+		fsm_free(new);
+		return NULL;
 	}
 
-	{
-		size_t i;
+	for (i = 0; i < fsm->statecount; i++) {
+		if (fsm_isend(fsm, i)) {
+			fsm_setend(new, i, 1);
+		}
+		new->states[i].opaque = fsm->states[i].opaque;
 
-		for (i = 0; i < fsm->statecount; i++) {
-			struct fsm_edge e;
-			struct edge_iter it;
+		if (!state_set_copy(&new->states[i].epsilons, new->opt->alloc, fsm->states[i].epsilons)) {
+			fsm_free(new);
+			return NULL;
+		}
 
-			fsm_setend(new, i, fsm_isend(fsm, i));
-			new->states[i].opaque = fsm->states[i].opaque;
-
-			{
-				struct state_iter jt;
-				fsm_state_t to;
-
-				for (state_set_reset(fsm->states[i].epsilons, &jt); state_set_next(&jt, &to); ) {
-					if (!fsm_addedge_epsilon(new, i, to)) {
-						fsm_free(new);
-						return NULL;
-					}
-				}
-			}
-
-			for (edge_set_reset(fsm->states[i].edges, &it); edge_set_next(&it, &e); ) {
-				if (!fsm_addedge_literal(new, i, e.state, e.symbol)) {
-					fsm_free(new);
-					return NULL;
-				}
-			}
+		if (!edge_set_copy(&new->states[i].edges, new->opt->alloc, fsm->states[i].edges)) {
+			fsm_free(new);
+			return NULL;
 		}
 	}
 

--- a/src/libfsm/closure.c
+++ b/src/libfsm/closure.c
@@ -192,7 +192,7 @@ symbol_closure_without_epsilons(const struct fsm *fsm, fsm_state_t s,
 	struct state_set *sclosures[static FSM_SIGMA_COUNT])
 {
 	struct edge_iter jt;
-	struct fsm_edge *e;
+	struct fsm_edge e;
 
 	assert(fsm != NULL);
 	assert(sclosures != NULL);
@@ -207,8 +207,8 @@ symbol_closure_without_epsilons(const struct fsm *fsm, fsm_state_t s,
 	 * to avoid repeating that work by de-duplicating on the destination.
 	 */
 
-	for (e = edge_set_first(fsm->states[s].edges, &jt); e != NULL; e = edge_set_next(&jt)) {
-		if (!state_set_add(&sclosures[e->symbol], fsm->opt->alloc, e->state)) {
+	for (edge_set_reset(fsm->states[s].edges, &jt); edge_set_next(&jt, &e); ) {
+		if (!state_set_add(&sclosures[e.symbol], fsm->opt->alloc, e.state)) {
 			return 0;
 		}
 	}
@@ -222,7 +222,7 @@ symbol_closure(const struct fsm *fsm, fsm_state_t s,
 	struct state_set *sclosures[static FSM_SIGMA_COUNT])
 {
 	struct edge_iter jt;
-	struct fsm_edge *e;
+	struct fsm_edge e;
 
 	assert(fsm != NULL);
 	assert(eclosures != NULL);
@@ -241,8 +241,8 @@ symbol_closure(const struct fsm *fsm, fsm_state_t s,
 	 * so there's no need to explicitly copy the state itself here.
 	 */
 
-	for (e = edge_set_first(fsm->states[s].edges, &jt); e != NULL; e = edge_set_next(&jt)) {
-		if (!state_set_copy(&sclosures[e->symbol], fsm->opt->alloc, eclosures[e->state])) {
+	for (edge_set_reset(fsm->states[s].edges, &jt); edge_set_next(&jt, &e); ) {
+		if (!state_set_copy(&sclosures[e.symbol], fsm->opt->alloc, eclosures[e.state])) {
 			return 0;
 		}
 	}

--- a/src/libfsm/closure.c
+++ b/src/libfsm/closure.c
@@ -208,11 +208,7 @@ symbol_closure_without_epsilons(const struct fsm *fsm, fsm_state_t s,
 	 */
 
 	for (e = edge_set_first(fsm->states[s].edges, &jt); e != NULL; e = edge_set_next(&jt)) {
-		if (e->sl == NULL) {
-			continue;
-		}
-
-		if (!state_set_copy(&sclosures[e->symbol], fsm->opt->alloc, e->sl)) {
+		if (!state_set_add(&sclosures[e->symbol], fsm->opt->alloc, e->state)) {
 			return 0;
 		}
 	}
@@ -240,25 +236,14 @@ symbol_closure(const struct fsm *fsm, fsm_state_t s,
 	 * TODO: it's common for many symbols to have transitions to the same state
 	 * (the worst case being an "any" transition). It'd be nice to find a way
 	 * to avoid repeating that work by de-duplicating on the destination.
+	 *
+	 * The epsilon closure of a state will always include itself,
+	 * so there's no need to explicitly copy the state itself here.
 	 */
 
 	for (e = edge_set_first(fsm->states[s].edges, &jt); e != NULL; e = edge_set_next(&jt)) {
-		struct state_iter kt;
-		fsm_state_t es;
-
-		if (e->sl == NULL) {
-			continue;
-		}
-
-		/*
-		 * The epsilon closure of a state will always include itself,
-		 * so there's no need to explicitly copy e->sl here.
-		 */
-
-		for (state_set_reset(e->sl, &kt); state_set_next(&kt, &es); ) {
-			if (!state_set_copy(&sclosures[e->symbol], fsm->opt->alloc, eclosures[es])) {
-				return 0;
-			}
+		if (!state_set_copy(&sclosures[e->symbol], fsm->opt->alloc, eclosures[e->state])) {
+			return 0;
 		}
 	}
 

--- a/src/libfsm/complete.c
+++ b/src/libfsm/complete.c
@@ -58,7 +58,7 @@ fsm_complete(struct fsm *fsm,
 	}
 
 	for (s = 0; s < fsm->statecount; s++) {
-		const struct fsm_edge *e;
+		struct fsm_edge e;
 		struct edge_iter jt;
 		struct bm bm;
 		int i;
@@ -69,8 +69,8 @@ fsm_complete(struct fsm *fsm,
 
 		bm_clear(&bm);
 
-		for (e = edge_set_first(fsm->states[s].edges, &jt); e != NULL; e = edge_set_next(&jt)) {
-			bm_set(&bm, e->symbol);
+		for (edge_set_reset(fsm->states[s].edges, &jt); edge_set_next(&jt, &e); ) {
+			bm_set(&bm, e.symbol);
 		}
 
 		i = -1;

--- a/src/libfsm/complete.c
+++ b/src/libfsm/complete.c
@@ -73,6 +73,7 @@ fsm_complete(struct fsm *fsm,
 			bm_set(&bm, e.symbol);
 		}
 
+		/* TODO: bulk add symbols as the inverse of this bitmap */
 		i = -1;
 		while (i = bm_next(&bm, i, 0), i <= UCHAR_MAX) {
 			if (!fsm_addedge_literal(fsm, s, new, i)) {

--- a/src/libfsm/complete.c
+++ b/src/libfsm/complete.c
@@ -59,6 +59,7 @@ fsm_complete(struct fsm *fsm,
 			continue;
 		}
 
+/* TODO: instead construct a bitmap of missing symbols */
 		for (c = 0; c <= UCHAR_MAX; c++) {
 			if (fsm_hasedge_literal(fsm, i, c)) {
 				continue;

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -120,24 +120,16 @@ mapping_addedges(struct mapping *from, struct mapping *to,
 	if (from->edges == NULL) {
 		from->edges = edge_set_create(alloc);
 		if (from->edges == NULL) {
-			goto error;
+			return 0;
 		}
 	}
 
-	e = edge_set_add(from->edges, c);
+	e = edge_set_add(from->edges, c, to->dfastate);
 	if (e == NULL) {
-		goto error;
-	}
-
-	if (!state_set_add(&e->sl, alloc, to->dfastate)) {
-		goto error;
+		return 0;
 	}
 
 	return 1;
-
-error:
-
-	return 0;
 }
 
 /* TODO: this stack is just a placeholder for something more suitable */

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -112,18 +112,6 @@ mapping_addedges(struct mapping *from, struct mapping *to,
 {
 	struct fsm_edge *e;
 
-	e = f_malloc(alloc, sizeof *e);
-	if (e == NULL) {
-		return 0;
-	}
-
-	e->sl     = NULL;
-	e->symbol = c;
-
-	if (!state_set_add(&e->sl, alloc, to->dfastate)) {
-		goto error;
-	}
-
 	/*
 	 * Note there is no looking up of an edge by symbol;
 	 * TODO: this should suit the adjacency list for bulk-adding edges i hope
@@ -136,16 +124,18 @@ mapping_addedges(struct mapping *from, struct mapping *to,
 		}
 	}
 
-	if (!edge_set_add(from->edges, e)) {
+	e = edge_set_add(from->edges, c);
+	if (e == NULL) {
+		goto error;
+	}
+
+	if (!state_set_add(&e->sl, alloc, to->dfastate)) {
 		goto error;
 	}
 
 	return 1;
 
 error:
-
-	state_set_free(e->sl);
-	f_free(alloc, e);
 
 	return 0;
 }

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -130,7 +130,7 @@ mapping_addedges(struct mapping *from, struct mapping *to,
 	 */
 
 	if (from->edges == NULL) {
-		from->edges = edge_set_create(alloc, fsm_state_cmpedges);
+		from->edges = edge_set_create(alloc);
 		if (from->edges == NULL) {
 			goto error;
 		}

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -110,22 +110,12 @@ mapping_addedges(struct mapping *from, struct mapping *to,
 	const struct fsm_alloc *alloc,
 	unsigned char c)
 {
-	struct fsm_edge *e;
-
 	/*
 	 * Note there is no looking up of an edge by symbol;
 	 * TODO: this should suit the adjacency list for bulk-adding edges i hope
 	 */
 
-	if (from->edges == NULL) {
-		from->edges = edge_set_create(alloc);
-		if (from->edges == NULL) {
-			return 0;
-		}
-	}
-
-	e = edge_set_add(from->edges, c, to->dfastate);
-	if (e == NULL) {
+	if (!edge_set_add(&from->edges, alloc, c, to->dfastate)) {
 		return 0;
 	}
 

--- a/src/libfsm/edge.c
+++ b/src/libfsm/edge.c
@@ -109,23 +109,3 @@ fsm_addedge_bulk(struct fsm *fsm,
 	return 1;
 }
 
-struct fsm_edge *
-fsm_hasedge_literal(const struct fsm *fsm, fsm_state_t state, char c)
-{
-	struct fsm_edge *e;
-
-	assert(fsm != NULL);
-	assert(state < fsm->statecount);
-
-	if (fsm->states[state].edges == NULL) {
-		return NULL;
-	}
-
-	e = edge_set_contains(fsm->states[state].edges, c);
-	if (e == NULL) {
-		return NULL;
-	}
-
-	return e;
-}
-

--- a/src/libfsm/edge.c
+++ b/src/libfsm/edge.c
@@ -5,7 +5,6 @@
  */
 
 #include <assert.h>
-#include <string.h>
 #include <stdlib.h>
 #include <limits.h>
 
@@ -14,7 +13,6 @@
 #include <adt/set.h>
 #include <adt/stateset.h>
 #include <adt/edgeset.h>
-#include <adt/xalloc.h>
 
 #include "internal.h"
 
@@ -43,6 +41,7 @@ fsm_addedge_any(struct fsm *fsm,
 	assert(from < fsm->statecount);
 	assert(to < fsm->statecount);
 
+	/* TODO: bulk add by symbol, presumably as a bitmap */
 	for (i = 0; i <= UCHAR_MAX; i++) {
 		if (!fsm_addedge_literal(fsm, from, to, (unsigned char) i)) {
 			return 0;
@@ -63,30 +62,6 @@ fsm_addedge_literal(struct fsm *fsm,
 
 	if (!edge_set_add(&fsm->states[from].edges, fsm->opt->alloc, c, to)) {
 		return 0;
-	}
-
-	return 1;
-}
-
-int
-fsm_addedge_bulk(struct fsm *fsm,
-	fsm_state_t from, fsm_state_t *a, size_t n,
-	char c)
-{
-	size_t i;
-
-	assert(fsm != NULL);
-	assert(a != NULL);
-
-	if (n == 0) {
-		return 1;
-	}
-
-	/* TODO: would hope to have a bulk-add interface for edges */
-	for (i = 0; i < n; i++) {
-		if (!edge_set_add(&fsm->states[from].edges, fsm->opt->alloc, c, a[i])) {
-			return 0;
-		}
 	}
 
 	return 1;

--- a/src/libfsm/edge.c
+++ b/src/libfsm/edge.c
@@ -70,12 +70,8 @@ fsm_addedge_literal(struct fsm *fsm,
 		}
 	}
 
-	e = edge_set_add(fsm->states[from].edges, c);
+	e = edge_set_add(fsm->states[from].edges, c, to);
 	if (e == NULL) {
-		return 0;
-	}
-
-	if (!state_set_add(&e->sl, fsm->opt->alloc, to)) {
 		return 0;
 	}
 
@@ -87,7 +83,7 @@ fsm_addedge_bulk(struct fsm *fsm,
 	fsm_state_t from, fsm_state_t *a, size_t n,
 	char c)
 {
-	struct fsm_edge *e;
+	size_t i;
 
 	assert(fsm != NULL);
 	assert(a != NULL);
@@ -103,13 +99,11 @@ fsm_addedge_bulk(struct fsm *fsm,
 		}
 	}
 
-	e = edge_set_add(fsm->states[from].edges, c);
-	if (e == NULL) {
-		return 0;
-	}
-
-	if (!state_set_add_bulk(&e->sl, fsm->opt->alloc, a, n)) {
-		return 0;
+	/* TODO: would hope to have a bulk-add interface for edges */
+	for (i = 0; i < n; i++) {
+		if (!edge_set_add(fsm->states[from].edges, c, a[i])) {
+			return 0;
+		}
 	}
 
 	return 1;
@@ -128,7 +122,7 @@ fsm_hasedge_literal(const struct fsm *fsm, fsm_state_t state, char c)
 	}
 
 	e = edge_set_contains(fsm->states[state].edges, c);
-	if (e == NULL || state_set_empty(e->sl)) {
+	if (e == NULL) {
 		return NULL;
 	}
 

--- a/src/libfsm/edge.c
+++ b/src/libfsm/edge.c
@@ -57,21 +57,11 @@ fsm_addedge_literal(struct fsm *fsm,
 	fsm_state_t from, fsm_state_t to,
 	char c)
 {
-	struct fsm_edge *e;
-
 	assert(fsm != NULL);
 	assert(from < fsm->statecount);
 	assert(to < fsm->statecount);
 
-	if (fsm->states[from].edges == NULL) {
-		fsm->states[from].edges = edge_set_create(fsm->opt->alloc);
-		if (fsm->states[from].edges == NULL) {
-			return 0;
-		}
-	}
-
-	e = edge_set_add(fsm->states[from].edges, c, to);
-	if (e == NULL) {
+	if (!edge_set_add(&fsm->states[from].edges, fsm->opt->alloc, c, to)) {
 		return 0;
 	}
 
@@ -92,16 +82,9 @@ fsm_addedge_bulk(struct fsm *fsm,
 		return 1;
 	}
 
-	if (fsm->states[from].edges == NULL) {
-		fsm->states[from].edges = edge_set_create(fsm->opt->alloc);
-		if (fsm->states[from].edges == NULL) {
-			return 0;
-		}
-	}
-
 	/* TODO: would hope to have a bulk-add interface for edges */
 	for (i = 0; i < n; i++) {
-		if (!edge_set_add(fsm->states[from].edges, c, a[i])) {
+		if (!edge_set_add(&fsm->states[from].edges, fsm->opt->alloc, c, a[i])) {
 			return 0;
 		}
 	}

--- a/src/libfsm/edge.c
+++ b/src/libfsm/edge.c
@@ -19,21 +19,6 @@
 #include "internal.h"
 
 int
-fsm_state_cmpedges(const void *a, const void *b)
-{
-	const struct fsm_edge * const *ea = a, * const *eb = b;
-
-	assert(a != NULL);
-	assert(b != NULL);
-
-	/*
-	 * N.B. various edge iterations rely on the ordering of edges to be in
-	 * ascending order.
-	 */
-	return ((*ea)->symbol > (*eb)->symbol) - ((*ea)->symbol < (*eb)->symbol);
-}
-
-int
 fsm_addedge_epsilon(struct fsm *fsm,
 	fsm_state_t from, fsm_state_t to)
 {
@@ -79,7 +64,7 @@ fsm_addedge_literal(struct fsm *fsm,
 	assert(to < fsm->statecount);
 
 	if (fsm->states[from].edges == NULL) {
-		fsm->states[from].edges = edge_set_create(fsm->opt->alloc, fsm_state_cmpedges);
+		fsm->states[from].edges = edge_set_create(fsm->opt->alloc);
 		if (fsm->states[from].edges == NULL) {
 			return 0;
 		}
@@ -123,7 +108,7 @@ fsm_addedge_bulk(struct fsm *fsm,
 	}
 
 	if (fsm->states[from].edges == NULL) {
-		fsm->states[from].edges = edge_set_create(fsm->opt->alloc, fsm_state_cmpedges);
+		fsm->states[from].edges = edge_set_create(fsm->opt->alloc);
 		if (fsm->states[from].edges == NULL) {
 			return 0;
 		}

--- a/src/libfsm/edge.c
+++ b/src/libfsm/edge.c
@@ -57,7 +57,7 @@ fsm_addedge_literal(struct fsm *fsm,
 	fsm_state_t from, fsm_state_t to,
 	char c)
 {
-	struct fsm_edge *e, new;
+	struct fsm_edge *e;
 
 	assert(fsm != NULL);
 	assert(from < fsm->statecount);
@@ -70,18 +70,10 @@ fsm_addedge_literal(struct fsm *fsm,
 		}
 	}
 
-	new.symbol = c;
-	e = edge_set_contains(fsm->states[from].edges, &new);
+	e = edge_set_contains(fsm->states[from].edges, c);
 	if (e == NULL) {
-		e = f_malloc(fsm->opt->alloc, sizeof *e);
+		e = edge_set_add(fsm->states[from].edges, c);
 		if (e == NULL) {
-			return 0;
-		}
-
-		e->symbol = c;
-		e->sl = NULL;
-
-		if (!edge_set_add(fsm->states[from].edges, e)) {
 			return 0;
 		}
 	}
@@ -98,7 +90,7 @@ fsm_addedge_bulk(struct fsm *fsm,
 	fsm_state_t from, fsm_state_t *a, size_t n,
 	char c)
 {
-	struct fsm_edge *e, new;
+	struct fsm_edge *e;
 
 	assert(fsm != NULL);
 	assert(a != NULL);
@@ -114,18 +106,10 @@ fsm_addedge_bulk(struct fsm *fsm,
 		}
 	}
 
-	new.symbol = c;
-	e = edge_set_contains(fsm->states[from].edges, &new);
+	e = edge_set_contains(fsm->states[from].edges, c);
 	if (e == NULL) {
-		e = f_malloc(fsm->opt->alloc, sizeof *e);
+		e = edge_set_add(fsm->states[from].edges, c);
 		if (e == NULL) {
-			return 0;
-		}
-
-		e->symbol = c;
-		e->sl = NULL;
-
-		if (!edge_set_add(fsm->states[from].edges, e)) {
 			return 0;
 		}
 	}
@@ -140,7 +124,7 @@ fsm_addedge_bulk(struct fsm *fsm,
 struct fsm_edge *
 fsm_hasedge_literal(const struct fsm *fsm, fsm_state_t state, char c)
 {
-	struct fsm_edge *e, search;
+	struct fsm_edge *e;
 
 	assert(fsm != NULL);
 	assert(state < fsm->statecount);
@@ -149,8 +133,7 @@ fsm_hasedge_literal(const struct fsm *fsm, fsm_state_t state, char c)
 		return NULL;
 	}
 
-	search.symbol = (unsigned char) c;
-	e = edge_set_contains(fsm->states[state].edges, &search);
+	e = edge_set_contains(fsm->states[state].edges, c);
 	if (e == NULL || state_set_empty(e->sl)) {
 		return NULL;
 	}

--- a/src/libfsm/edge.c
+++ b/src/libfsm/edge.c
@@ -70,12 +70,9 @@ fsm_addedge_literal(struct fsm *fsm,
 		}
 	}
 
-	e = edge_set_contains(fsm->states[from].edges, c);
+	e = edge_set_add(fsm->states[from].edges, c);
 	if (e == NULL) {
-		e = edge_set_add(fsm->states[from].edges, c);
-		if (e == NULL) {
-			return 0;
-		}
+		return 0;
 	}
 
 	if (!state_set_add(&e->sl, fsm->opt->alloc, to)) {
@@ -106,12 +103,9 @@ fsm_addedge_bulk(struct fsm *fsm,
 		}
 	}
 
-	e = edge_set_contains(fsm->states[from].edges, c);
+	e = edge_set_add(fsm->states[from].edges, c);
 	if (e == NULL) {
-		e = edge_set_add(fsm->states[from].edges, c);
-		if (e == NULL) {
-			return 0;
-		}
+		return 0;
 	}
 
 	if (!state_set_add_bulk(&e->sl, fsm->opt->alloc, a, n)) {

--- a/src/libfsm/exec.c
+++ b/src/libfsm/exec.c
@@ -20,20 +20,16 @@
 #include "internal.h"
 
 static int
-nextstate(const struct fsm *fsm, fsm_state_t state, int c,
+transition(const struct fsm *fsm, fsm_state_t state, int c,
 	fsm_state_t *next)
 {
-	struct fsm_edge *e;
-
 	assert(state < fsm->statecount);
 	assert(next != NULL);
 
-	e = edge_set_contains(fsm->states[state].edges, c);
-	if (e == NULL) {
+	if (!edge_set_transition(fsm->states[state].edges, c, next)) {
 		return 0;
 	}
 
-	*next = e->state;
 	return 1;
 }
 
@@ -64,7 +60,7 @@ fsm_exec(const struct fsm *fsm,
 	}
 
 	while (c = fsm_getc(opaque), c != EOF) {
-		if (!nextstate(fsm, state, c, &state)) {
+		if (!transition(fsm, state, c, &state)) {
 			return 0;
 		}
 	}

--- a/src/libfsm/exec.c
+++ b/src/libfsm/exec.c
@@ -32,7 +32,7 @@ nextstate(const struct fsm *fsm, fsm_state_t state, int c,
 		return 0;
 	}
 
-	*next = state_set_only(e->sl);
+	*next = e->state;
 	return 1;
 }
 

--- a/src/libfsm/exec.c
+++ b/src/libfsm/exec.c
@@ -15,6 +15,7 @@
 
 #include <adt/set.h>
 #include <adt/stateset.h>
+#include <adt/edgeset.h>
 
 #include "internal.h"
 
@@ -27,7 +28,7 @@ nextstate(const struct fsm *fsm, fsm_state_t state, int c,
 	assert(state < fsm->statecount);
 	assert(next != NULL);
 
-	e = fsm_hasedge_literal(fsm, state, c);
+	e = edge_set_contains(fsm->states[state].edges, c);
 	if (e == NULL) {
 		return 0;
 	}

--- a/src/libfsm/fsm.c
+++ b/src/libfsm/fsm.c
@@ -34,7 +34,6 @@ free_contents(struct fsm *fsm)
 
 		for (e = edge_set_first(fsm->states[i].edges, &it); e != NULL; e = edge_set_next(&it)) {
 			state_set_free(e->sl);
-			f_free(fsm->opt->alloc, e);
 		}
 
 		state_set_free(fsm->states[i].epsilons);

--- a/src/libfsm/fsm.c
+++ b/src/libfsm/fsm.c
@@ -29,13 +29,6 @@ free_contents(struct fsm *fsm)
 	assert(fsm != NULL);
 
 	for (i = 0; i < fsm->statecount; i++) {
-		struct edge_iter it;
-		struct fsm_edge *e;
-
-		for (e = edge_set_first(fsm->states[i].edges, &it); e != NULL; e = edge_set_next(&it)) {
-			state_set_free(e->sl);
-		}
-
 		state_set_free(fsm->states[i].epsilons);
 		edge_set_free(fsm->states[i].edges);
 	}
@@ -222,18 +215,8 @@ fsm_countedges(const struct fsm *fsm)
 	unsigned int n = 0;
 	size_t i;
 
-	/*
-	 * XXX - this counts all src,lbl,dst tuples individually and
-	 * should be replaced with something better when possible
-	 */
 	for (i = 0; i < fsm->statecount; i++) {
-		struct edge_iter ei;
-		const struct fsm_edge *e;
-
-		for (e = edge_set_first(fsm->states[i].edges, &ei); e != NULL; e=edge_set_next(&ei)) {
-			assert(n + state_set_count(e->sl) > n); /* handle overflow with more grace? */
-			n += state_set_count(e->sl);
-		}
+		n += edge_set_count(fsm->states[i].edges);
 	}
 
 	return n;

--- a/src/libfsm/glushkovise.c
+++ b/src/libfsm/glushkovise.c
@@ -61,7 +61,7 @@ fsm_glushkovise(struct fsm *nfa)
 		/* TODO: bail out early if there are no edges to create? */
 
 		if (nfa->states[s].edges == NULL) {
-			nfa->states[s].edges = edge_set_create(nfa->opt->alloc, fsm_state_cmpedges);
+			nfa->states[s].edges = edge_set_create(nfa->opt->alloc);
 			if (nfa->states[s].edges == NULL) {
 				/* TODO: free stuff */
 				goto error;

--- a/src/libfsm/glushkovise.c
+++ b/src/libfsm/glushkovise.c
@@ -89,22 +89,17 @@ fsm_glushkovise(struct fsm *nfa)
 				continue;
 			}
 
-			new = f_malloc(nfa->opt->alloc, sizeof *new);
+			new = edge_set_add(nfa->states[s].edges, i);
 			if (new == NULL) {
 				/* TODO: free stuff */
 				goto error;
 			}
 
-			new->symbol = i;
+			assert(new->sl == NULL);
 			new->sl = sclosures[i];
 
 			/* ownership belongs to the newly-created edge now */
 			sclosures[i] = NULL;
-
-			if (!edge_set_add(nfa->states[s].edges, new)) {
-				/* TODO: free stuff */
-				goto error;
-			}
 		}
 
 		/* all elements in sclosures[] have been freed or moved to their

--- a/src/libfsm/glushkovise.c
+++ b/src/libfsm/glushkovise.c
@@ -59,7 +59,6 @@ fsm_glushkovise(struct fsm *nfa)
 		/* TODO: bail out early if there are no edges to create? */
 
 		for (i = 0; i <= FSM_SIGMA_MAX; i++) {
-			struct fsm_edge *new;
 			struct state_iter it;
 			fsm_state_t es;
 
@@ -68,16 +67,7 @@ fsm_glushkovise(struct fsm *nfa)
 			}
 
 			for (state_set_reset(sclosures[i], &it); state_set_next(&it, &es); ) {
-				if (nfa->states[s].edges == NULL) {
-					nfa->states[s].edges = edge_set_create(nfa->opt->alloc);
-					if (nfa->states[s].edges == NULL) {
-						/* TODO: free stuff */
-						goto error;
-					}
-				}
-
-				new = edge_set_add(nfa->states[s].edges, i, es);
-				if (new == NULL) {
+				if (!edge_set_add(&nfa->states[s].edges, nfa->opt->alloc, i, es)) {
 					/* TODO: free stuff */
 					goto error;
 				}

--- a/src/libfsm/glushkovise.c
+++ b/src/libfsm/glushkovise.c
@@ -59,18 +59,13 @@ fsm_glushkovise(struct fsm *nfa)
 		/* TODO: bail out early if there are no edges to create? */
 
 		for (i = 0; i <= FSM_SIGMA_MAX; i++) {
-			struct state_iter it;
-			fsm_state_t es;
-
 			if (sclosures[i] == NULL) {
 				continue;
 			}
 
-			for (state_set_reset(sclosures[i], &it); state_set_next(&it, &es); ) {
-				if (!edge_set_add(&nfa->states[s].edges, nfa->opt->alloc, i, es)) {
-					/* TODO: free stuff */
-					goto error;
-				}
+			if (!edge_set_add_state_set(&nfa->states[s].edges, nfa->opt->alloc, i, sclosures[i])) {
+				/* TODO: free stuff */
+				goto error;
 			}
 
 			/* XXX: we took a copy, but i would prefer to bulk transplant ownership instead */

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -41,7 +41,7 @@ struct state_array;
 #define FSM_ENDCOUNT_MAX ULONG_MAX
 
 struct fsm_edge {
-	struct state_set *sl;
+	fsm_state_t state; /* destination */
 	unsigned char symbol;
 };
 

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -69,9 +69,6 @@ struct fsm {
 	const struct fsm_options *opt;
 };
 
-int
-fsm_state_cmpedges(const void *a, const void *b);
-
 struct fsm_edge *
 fsm_hasedge_literal(const struct fsm *fsm, fsm_state_t state, char c);
 

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -70,11 +70,6 @@ struct fsm {
 	const struct fsm_options *opt;
 };
 
-int
-fsm_addedge_bulk(struct fsm *fsm,
-	fsm_state_t from, fsm_state_t *a, size_t n,
-	char c);
-
 void
 fsm_carryopaque_array(struct fsm *src_fsm, const fsm_state_t *src_set, size_t n,
     struct fsm *dst_fsm, fsm_state_t dst_state);

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -70,9 +70,6 @@ struct fsm {
 	const struct fsm_options *opt;
 };
 
-struct fsm_edge *
-fsm_hasedge_literal(const struct fsm *fsm, fsm_state_t state, char c);
-
 int
 fsm_addedge_bulk(struct fsm *fsm,
 	fsm_state_t from, fsm_state_t *a, size_t n,

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -13,6 +13,7 @@
 #include <fsm/fsm.h>
 #include <fsm/options.h>
 
+struct bm;
 struct edge_set;
 struct state_set;
 struct state_array;
@@ -88,6 +89,9 @@ fsm_carryopaque(struct fsm *fsm, const struct state_set *set,
 struct fsm *
 fsm_mergeab(struct fsm *a, struct fsm *b,
     fsm_state_t *base_b);
+
+int
+state_hasnondeterminism(const struct fsm *fsm, fsm_state_t state, struct bm *bm);
 
 /*
  * TODO: if this were a public API, we could present ragged array of { a, n } structs

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -44,6 +44,7 @@ fsm_getoptions
 fsm_move
 fsm_merge
 fsm_addstate
+fsm_addstate_bulk
 fsm_removestate
 
 fsm_addedge_any

--- a/src/libfsm/merge.c
+++ b/src/libfsm/merge.c
@@ -48,6 +48,7 @@ merge(struct fsm *dst, struct fsm *src,
 	 * XXX: base_a and base_b would become redundant if we change to the
 	 * shared global array idea.
 	 */
+	/* TODO: maybe make an edge_set_rebase() */
 	{
 		fsm_state_t i;
 
@@ -61,7 +62,7 @@ merge(struct fsm *dst, struct fsm *src,
 			state_set_rebase(&src->states[i].epsilons, *base_src);
 
 			for (e = edge_set_first(src->states[i].edges, &ei); e != NULL; e = edge_set_next(&ei)) {
-				state_set_rebase(&e->sl, *base_src);
+				e->state += *base_src;
 			}
 		}
 	}

--- a/src/libfsm/merge.c
+++ b/src/libfsm/merge.c
@@ -48,7 +48,6 @@ merge(struct fsm *dst, struct fsm *src,
 	 * XXX: base_a and base_b would become redundant if we change to the
 	 * shared global array idea.
 	 */
-	/* TODO: maybe make an edge_set_rebase() */
 	{
 		fsm_state_t i;
 
@@ -56,14 +55,8 @@ merge(struct fsm *dst, struct fsm *src,
 		*base_src = dst->statecount;
 
 		for (i = 0; i < src->statecount; i++) {
-			struct fsm_edge *e;
-			struct edge_iter ei;
-
 			state_set_rebase(&src->states[i].epsilons, *base_src);
-
-			for (e = edge_set_first(src->states[i].edges, &ei); e != NULL; e = edge_set_next(&ei)) {
-				e->state += *base_src;
-			}
+			edge_set_rebase(&src->states[i].edges, *base_src);
 		}
 	}
 

--- a/src/libfsm/mergestates.c
+++ b/src/libfsm/mergestates.c
@@ -28,20 +28,11 @@ fsm_mergestates(struct fsm *fsm, fsm_state_t a, fsm_state_t b,
 	assert(b < fsm->statecount);
 
 	/* edges from b */
-	{
-		struct state_iter jt;
-		fsm_state_t s;
-
-		for (state_set_reset(fsm->states[b].epsilons, &jt); state_set_next(&jt, &s); ) {
-			if (!fsm_addedge_epsilon(fsm, a, s)) {
-				return 0;
-			}
-		}
+	if (!state_set_copy(&fsm->states[a].epsilons, fsm->opt->alloc, fsm->states[b].epsilons)) {
+		return 0;
 	}
-	for (edge_set_reset(fsm->states[b].edges, &it); edge_set_next(&it, &e); ) {
-		if (!fsm_addedge_literal(fsm, a, e.state, e.symbol)) {
-			return 0;
-		}
+	if (!edge_set_copy(&fsm->states[a].edges, fsm->opt->alloc, fsm->states[b].edges)) {
+		return 0;
 	}
 
 	/* edges to b */
@@ -64,9 +55,7 @@ fsm_mergestates(struct fsm *fsm, fsm_state_t a, fsm_state_t b,
 			}
 		}
 
-		if (fsm->states[i].edges != NULL) {
-			edge_set_remove_state(&fsm->states[i].edges, b);
-		}
+		edge_set_remove_state(&fsm->states[i].edges, b);
 	}
 
 	fsm_removestate(fsm, b);

--- a/src/libfsm/mergestates.c
+++ b/src/libfsm/mergestates.c
@@ -19,7 +19,7 @@ int
 fsm_mergestates(struct fsm *fsm, fsm_state_t a, fsm_state_t b,
 	fsm_state_t *q)
 {
-	struct fsm_edge *e;
+	struct fsm_edge e;
 	struct edge_iter it;
 	fsm_state_t i;
 
@@ -38,8 +38,8 @@ fsm_mergestates(struct fsm *fsm, fsm_state_t a, fsm_state_t b,
 			}
 		}
 	}
-	for (e = edge_set_first(fsm->states[b].edges, &it); e != NULL; e = edge_set_next(&it)) {
-		if (!fsm_addedge_literal(fsm, a, e->state, e->symbol)) {
+	for (edge_set_reset(fsm->states[b].edges, &it); edge_set_next(&it, &e); ) {
+		if (!fsm_addedge_literal(fsm, a, e.state, e.symbol)) {
 			return 0;
 		}
 	}
@@ -54,18 +54,18 @@ fsm_mergestates(struct fsm *fsm, fsm_state_t a, fsm_state_t b,
 			}
 		}
 
-		for (e = edge_set_first(fsm->states[i].edges, &it); e != NULL; e = edge_set_next(&it)) {
-			if (e->state != b) {
+		for (edge_set_reset(fsm->states[i].edges, &it); edge_set_next(&it, &e); ) {
+			if (e.state != b) {
 				continue;
 			}
 
-			if (!fsm_addedge_literal(fsm, i, a, e->symbol)) {
+			if (!fsm_addedge_literal(fsm, i, a, e.symbol)) {
 				return 0;
 			}
 		}
 
 		if (fsm->states[i].edges != NULL) {
-			edge_set_remove_state(fsm->states[i].edges, b);
+			edge_set_remove_state(&fsm->states[i].edges, b);
 		}
 	}
 

--- a/src/libfsm/mergestates.c
+++ b/src/libfsm/mergestates.c
@@ -39,13 +39,8 @@ fsm_mergestates(struct fsm *fsm, fsm_state_t a, fsm_state_t b,
 		}
 	}
 	for (e = edge_set_first(fsm->states[b].edges, &it); e != NULL; e = edge_set_next(&it)) {
-		struct state_iter jt;
-		fsm_state_t s;
-
-		for (state_set_reset(e->sl, &jt); state_set_next(&jt, &s); ) {
-			if (!fsm_addedge_literal(fsm, a, s, e->symbol)) {
-				return 0;
-			}
+		if (!fsm_addedge_literal(fsm, a, e->state, e->symbol)) {
+			return 0;
 		}
 	}
 
@@ -60,13 +55,17 @@ fsm_mergestates(struct fsm *fsm, fsm_state_t a, fsm_state_t b,
 		}
 
 		for (e = edge_set_first(fsm->states[i].edges, &it); e != NULL; e = edge_set_next(&it)) {
-			state_set_remove(&e->sl, b);
-
-			if (state_set_contains(e->sl, b)) {
-				if (!fsm_addedge_literal(fsm, i, a, e->symbol)) {
-					return 0;
-				}
+			if (e->state != b) {
+				continue;
 			}
+
+			if (!fsm_addedge_literal(fsm, i, a, e->symbol)) {
+				return 0;
+			}
+		}
+
+		if (fsm->states[i].edges != NULL) {
+			edge_set_remove_state(fsm->states[i].edges, b);
 		}
 	}
 

--- a/src/libfsm/mode.c
+++ b/src/libfsm/mode.c
@@ -19,7 +19,7 @@ fsm_state_t
 fsm_findmode(const struct fsm *fsm, fsm_state_t state, unsigned int *freq)
 {
 	struct edge_iter it;
-	struct fsm_edge *e;
+	struct fsm_edge e;
 
 	struct {
 		fsm_state_t state;
@@ -31,9 +31,9 @@ fsm_findmode(const struct fsm *fsm, fsm_state_t state, unsigned int *freq)
 	assert(fsm != NULL);
 	assert(state < fsm->statecount);
 
-	for (e = edge_set_first(fsm->states[state].edges, &it); e != NULL; e = edge_set_next(&it)) {
+	for (edge_set_reset(fsm->states[state].edges, &it); edge_set_next(&it, &e); ) {
 		struct edge_iter kt = it;
-		struct fsm_edge *c;
+		struct fsm_edge c;
 		unsigned int curr;
 
 		curr = 1; /* including ourself */
@@ -41,15 +41,15 @@ fsm_findmode(const struct fsm *fsm, fsm_state_t state, unsigned int *freq)
 		/*
 		 * Count the remaining edes which have the same destination.
 		 */
-		for (c = edge_set_next(&kt); c != NULL; c = edge_set_next(&kt)) {
-			if (c->state == e->state) {
+		while (edge_set_next(&kt, &c)) {
+			if (c.state == e.state) {
 				curr++;
 			}
 		}
 
 		if (curr > mode.freq) {
 			mode.freq  = curr;
-			mode.state = e->state;
+			mode.state = e.state;
 		}
 	}
 

--- a/src/libfsm/mode.c
+++ b/src/libfsm/mode.c
@@ -18,9 +18,8 @@
 fsm_state_t
 fsm_findmode(const struct fsm *fsm, fsm_state_t state, unsigned int *freq)
 {
-	struct fsm_edge *e;
 	struct edge_iter it;
-	fsm_state_t s;
+	struct fsm_edge *e;
 
 	struct {
 		fsm_state_t state;
@@ -33,30 +32,24 @@ fsm_findmode(const struct fsm *fsm, fsm_state_t state, unsigned int *freq)
 	assert(state < fsm->statecount);
 
 	for (e = edge_set_first(fsm->states[state].edges, &it); e != NULL; e = edge_set_next(&it)) {
-		struct state_iter jt;
+		struct edge_iter kt = it;
+		struct fsm_edge *c;
+		unsigned int curr;
 
-		for (state_set_reset(e->sl, &jt); state_set_next(&jt, &s); ) {
-			struct edge_iter kt = it;
-			struct fsm_edge *c;
-			unsigned int curr;
+		curr = 1; /* including ourself */
 
-			curr = 1; /* including ourself */
-
-			/*
-			 * Count the remaining edes which have the same target.
-			 * This works because the edges are still sorted by
-			 * symbol, so we don't have to walk the whole thing.
-			 */
-			for (c = edge_set_next(&kt); c != NULL; c = edge_set_next(&kt)) {
-				if (state_set_contains(c->sl, s)) {
-					curr++;
-				}
+		/*
+		 * Count the remaining edes which have the same destination.
+		 */
+		for (c = edge_set_next(&kt); c != NULL; c = edge_set_next(&kt)) {
+			if (c->state == e->state) {
+				curr++;
 			}
+		}
 
-			if (curr > mode.freq) {
-				mode.freq  = curr;
-				mode.state = s;
-			}
+		if (curr > mode.freq) {
+			mode.freq  = curr;
+			mode.state = e->state;
 		}
 	}
 

--- a/src/libfsm/pred/epsilonsonly.c
+++ b/src/libfsm/pred/epsilonsonly.c
@@ -19,9 +19,6 @@
 int
 fsm_epsilonsonly(const struct fsm *fsm, fsm_state_t state)
 {
-	struct fsm_edge *e;
-	struct edge_iter it;
-
 	assert(fsm != NULL);
 	assert(state < fsm->statecount);
 
@@ -29,10 +26,8 @@ fsm_epsilonsonly(const struct fsm *fsm, fsm_state_t state)
 		return 0;
 	}
 
-	for (e = edge_set_first(fsm->states[state].edges, &it); e != NULL; e = edge_set_next(&it)) {
-		if (!state_set_empty(e->sl)) {
-			return 0;
-		}
+	if (!edge_set_empty(fsm->states[state].edges)) {
+		return 0;
 	}
 
 	return 1;

--- a/src/libfsm/pred/hasincoming.c
+++ b/src/libfsm/pred/hasincoming.c
@@ -25,15 +25,15 @@ fsm_hasincoming(const struct fsm *fsm, fsm_state_t state)
 	assert(state < fsm->statecount);
 
 	for (i = 0; i < fsm->statecount; i++) {
-		struct fsm_edge *e;
+		struct fsm_edge e;
 		struct edge_iter it;
 
 		if (state_set_contains(fsm->states[i].epsilons, state)) {
 			return 1;
 		}
 
-		for (e = edge_set_first(fsm->states[i].edges, &it); e != NULL; e = edge_set_next(&it)) {
-			if (e->state == state) {
+		for (edge_set_reset(fsm->states[i].edges, &it); edge_set_next(&it, &e); ) {
+			if (e.state == state) {
 				return 1;
 			}
 		}

--- a/src/libfsm/pred/hasincoming.c
+++ b/src/libfsm/pred/hasincoming.c
@@ -33,7 +33,7 @@ fsm_hasincoming(const struct fsm *fsm, fsm_state_t state)
 		}
 
 		for (e = edge_set_first(fsm->states[i].edges, &it); e != NULL; e = edge_set_next(&it)) {
-			if (e->sl != NULL && state_set_contains(e->sl, state)) {
+			if (e->state == state) {
 				return 1;
 			}
 		}

--- a/src/libfsm/pred/hasnondeterminism.c
+++ b/src/libfsm/pred/hasnondeterminism.c
@@ -76,10 +76,6 @@ state_hasnondeterminism(const struct fsm *fsm, fsm_state_t state, struct bm *bm)
 	assert(bm != NULL);
 
 	for (e = edge_set_first(fsm->states[state].edges, &jt); e != NULL; e = edge_set_next(&jt)) {
-		if (state_set_empty(e->sl)) {
-			continue;
-		}
-
 		/*
 		 * Instances of struct fsm_edge aren't unique, and are not ordered.
 		 * The bitmap here is to identify duplicate symbols between structs.
@@ -87,11 +83,6 @@ state_hasnondeterminism(const struct fsm *fsm, fsm_state_t state, struct bm *bm)
 		 * The same bitmap is shared between all states in an epsilon closure.
 		 */
 		if (bm_get(bm, e->symbol)) {
-			return 1;
-		}
-
-		/* Duplicate symbols within the same struct fsm_edge */
-		if (state_set_count(e->sl) > 1) {
 			return 1;
 		}
 

--- a/src/libfsm/pred/hasnondeterminism.c
+++ b/src/libfsm/pred/hasnondeterminism.c
@@ -68,28 +68,11 @@ state_epsilon_closure(const struct fsm *fsm, fsm_state_t state,
 int
 state_hasnondeterminism(const struct fsm *fsm, fsm_state_t state, struct bm *bm)
 {
-	const struct fsm_edge *e;
-	struct edge_iter jt;
-
 	assert(fsm != NULL);
 	assert(state < fsm->statecount);
 	assert(bm != NULL);
 
-	for (e = edge_set_first(fsm->states[state].edges, &jt); e != NULL; e = edge_set_next(&jt)) {
-		/*
-		 * Instances of struct fsm_edge aren't unique, and are not ordered.
-		 * The bitmap here is to identify duplicate symbols between structs.
-		 *
-		 * The same bitmap is shared between all states in an epsilon closure.
-		 */
-		if (bm_get(bm, e->symbol)) {
-			return 1;
-		}
-
-		bm_set(bm, e->symbol);
-	}
-
-	return 0;
+	return edge_set_hasnondeterminism(fsm->states[state].edges, bm);
 }
 
 int

--- a/src/libfsm/pred/hasoutgoing.c
+++ b/src/libfsm/pred/hasoutgoing.c
@@ -19,9 +19,6 @@
 int
 fsm_hasoutgoing(const struct fsm *fsm, fsm_state_t state)
 {
-	struct fsm_edge *e;
-	struct edge_iter it;
-
 	assert(fsm != NULL);
 	assert(state < fsm->statecount);
 
@@ -29,10 +26,8 @@ fsm_hasoutgoing(const struct fsm *fsm, fsm_state_t state)
 		return 1;
 	}
 
-	for (e = edge_set_first(fsm->states[state].edges, &it); e != NULL; e = edge_set_next(&it)) {
-		if (!state_set_empty(e->sl)) {
-			return 1;
-		}
+	if (!edge_set_empty(fsm->states[state].edges)) {
+		return 1;
 	}
 
 	return 0;

--- a/src/libfsm/pred/iscomplete.c
+++ b/src/libfsm/pred/iscomplete.c
@@ -5,13 +5,17 @@
  */
 
 #include <assert.h>
-#include <stddef.h>
 #include <limits.h>
+#include <stddef.h>
+#include <stdio.h>
 
 #include <fsm/fsm.h>
 #include <fsm/pred.h>
 
+#include <print/esc.h>
+
 #include <adt/set.h>
+#include <adt/bitmap.h>
 #include <adt/stateset.h>
 #include <adt/edgeset.h>
 
@@ -22,15 +26,15 @@ fsm_iscomplete(const struct fsm *fsm, fsm_state_t state)
 {
 	struct fsm_edge *e;
 	struct edge_iter it;
-	unsigned n;
+	struct bm bm;
 
 	assert(fsm != NULL);
 	assert(state < fsm->statecount);
 
-	n = 0;
-
 	/* epsilon transitions have no effect on completeness */
 	(void) fsm->states[state].epsilons;
+
+	bm_clear(&bm);
 
 	/* TODO: assert state is in fsm->sl */
 	for (e = edge_set_first(fsm->states[state].edges, &it); e != NULL; e = edge_set_next(&it)) {
@@ -38,9 +42,9 @@ fsm_iscomplete(const struct fsm *fsm, fsm_state_t state)
 			continue;
 		}
 
-		n++;
+		bm_set(&bm, e->symbol);
 	}
 
-	return n == FSM_SIGMA_COUNT;
+	return bm_count(&bm) == FSM_SIGMA_COUNT;
 }
 

--- a/src/libfsm/pred/iscomplete.c
+++ b/src/libfsm/pred/iscomplete.c
@@ -24,7 +24,7 @@
 int
 fsm_iscomplete(const struct fsm *fsm, fsm_state_t state)
 {
-	struct fsm_edge *e;
+	struct fsm_edge e;
 	struct edge_iter it;
 	struct bm bm;
 
@@ -36,10 +36,10 @@ fsm_iscomplete(const struct fsm *fsm, fsm_state_t state)
 
 	bm_clear(&bm);
 
-	for (e = edge_set_first(fsm->states[state].edges, &it); e != NULL; e = edge_set_next(&it)) {
-		assert(e->state < fsm->statecount);
+	for (edge_set_reset(fsm->states[state].edges, &it); edge_set_next(&it, &e); ) {
+		assert(e.state < fsm->statecount);
 
-		bm_set(&bm, e->symbol);
+		bm_set(&bm, e.symbol);
 	}
 
 	return bm_count(&bm) == FSM_SIGMA_COUNT;

--- a/src/libfsm/pred/iscomplete.c
+++ b/src/libfsm/pred/iscomplete.c
@@ -36,11 +36,8 @@ fsm_iscomplete(const struct fsm *fsm, fsm_state_t state)
 
 	bm_clear(&bm);
 
-	/* TODO: assert state is in fsm->sl */
 	for (e = edge_set_first(fsm->states[state].edges, &it); e != NULL; e = edge_set_next(&it)) {
-		if (state_set_empty(e->sl)) {
-			continue;
-		}
+		assert(e->state < fsm->statecount);
 
 		bm_set(&bm, e->symbol);
 	}

--- a/src/libfsm/print/api.c
+++ b/src/libfsm/print/api.c
@@ -145,9 +145,7 @@ fsm_print_api(FILE *f, const struct fsm *fsm_orig)
 		}
 
 		for (e = edge_set_first(fsm->states[from].edges, &it); e != NULL; e = edge_set_next(&it)) {
-			for (state_set_reset(e->sl, &jt); state_set_next(&jt, &to); ) {
-				bm_set(&a[to], e->symbol);
-			}
+			bm_set(&a[e->state], e->symbol);
 		}
 
 		for (i = 0; i < fsm->statecount; i++) {

--- a/src/libfsm/print/api.c
+++ b/src/libfsm/print/api.c
@@ -130,7 +130,7 @@ fsm_print_api(FILE *f, const struct fsm *fsm_orig)
 	}
 
 	for (from = 0; from < fsm->statecount; from++) {
-		struct fsm_edge *e;
+		struct fsm_edge e;
 		struct edge_iter it;
 		struct state_iter jt;
 		fsm_state_t i, to;
@@ -144,8 +144,8 @@ fsm_print_api(FILE *f, const struct fsm *fsm_orig)
 				from, to);
 		}
 
-		for (e = edge_set_first(fsm->states[from].edges, &it); e != NULL; e = edge_set_next(&it)) {
-			bm_set(&a[e->state], e->symbol);
+		for (edge_set_reset(fsm->states[from].edges, &it); edge_set_next(&it, &e); ) {
+			bm_set(&a[e.state], e.symbol);
 		}
 
 		for (i = 0; i < fsm->statecount; i++) {

--- a/src/libfsm/print/dot.c
+++ b/src/libfsm/print/dot.c
@@ -29,13 +29,12 @@
 static int
 contains(struct edge_set *edges, int o, fsm_state_t state)
 {
-	struct fsm_edge *e, search;
+	struct fsm_edge *e;
 	struct edge_iter it;
 
 	assert(edges != NULL);
 
-	search.symbol = o;
-	for (e = edge_set_firstafter(edges, &it, &search); e != NULL; e = edge_set_next(&it)) {
+	for (e = edge_set_firstafter(edges, &it, o); e != NULL; e = edge_set_next(&it)) {
 		if (state_set_contains(e->sl, state)) {
 			return 1;
 		}

--- a/src/libfsm/print/ir.c
+++ b/src/libfsm/print/ir.c
@@ -109,7 +109,7 @@ make_groups(const struct fsm *fsm, fsm_state_t state,
 				struct edge_iter jt;
 				fsm_state_t ns;
 
-				ne = edge_set_firstafter(fsm->states[state].edges, &jt, e);
+				ne = edge_set_firstafter(fsm->states[state].edges, &jt, e->symbol);
 				if (ne == NULL || ne->symbol != e->symbol + 1) {
 					break;
 				}

--- a/src/libfsm/print/ir.c
+++ b/src/libfsm/print/ir.c
@@ -71,7 +71,7 @@ make_groups(const struct fsm *fsm, fsm_state_t state,
 	struct fsm_edge *e;
 	struct edge_iter it;
 	size_t i, j, k;
-	size_t n;
+	size_t grp_ind, n;
 
 	assert(fsm != NULL);
 	assert(state < fsm->statecount);
@@ -85,7 +85,8 @@ make_groups(const struct fsm *fsm, fsm_state_t state,
 	 * in the second pass below.
 	 */
 
-	n = 0;
+	n = 0;          /* number of allocated ranges */
+	grp_ind = 0;    /* index of current working range */
 
 	for (e = edge_set_first(fsm->states[state].edges, &it); e != NULL; e = edge_set_next(&it)) {
 		fsm_state_t s;
@@ -99,37 +100,15 @@ make_groups(const struct fsm *fsm, fsm_state_t state,
 			continue;
 		}
 
-		ranges[n].start = e->symbol;
-		ranges[n].end   = e->symbol;
-		ranges[n].to    = s;
+		if (n > 0 && e->symbol == ranges[grp_ind].end + 1 && s == ranges[grp_ind].to) {
+			ranges[grp_ind].end = e->symbol;
+		} else {
+			grp_ind = n++;
 
-		if (e->symbol <= UCHAR_MAX - 1) {
-			do {
-				const struct fsm_edge *ne;
-				struct edge_iter jt;
-				fsm_state_t ns;
-
-				ne = edge_set_firstafter(fsm->states[state].edges, &jt, e->symbol);
-				if (ne == NULL || ne->symbol != e->symbol + 1) {
-					break;
-				}
-
-				if (state_set_empty(ne->sl)) {
-					break;
-				}
-
-				ns = state_set_only(ne->sl);
-				if ((have_mode && ns == mode) || ns != s) {
-					break;
-				}
-
-				ranges[n].end = ne->symbol;
-
-				e = edge_set_next(&it);
-			} while (e != NULL);
+			ranges[grp_ind].start = e->symbol;
+			ranges[grp_ind].end   = e->symbol;
+			ranges[grp_ind].to    = s;
 		}
-
-		n++;
 	}
 
 	assert(n > 0);

--- a/src/libfsm/print/ir.c
+++ b/src/libfsm/print/ir.c
@@ -89,25 +89,18 @@ make_groups(const struct fsm *fsm, fsm_state_t state,
 	grp_ind = 0;    /* index of current working range */
 
 	for (e = edge_set_first(fsm->states[state].edges, &it); e != NULL; e = edge_set_next(&it)) {
-		fsm_state_t s;
-
-		if (state_set_empty(e->sl)) {
+		if (have_mode && e->state == mode) {
 			continue;
 		}
 
-		s = state_set_only(e->sl);
-		if (have_mode && s == mode) {
-			continue;
-		}
-
-		if (n > 0 && e->symbol == ranges[grp_ind].end + 1 && s == ranges[grp_ind].to) {
+		if (n > 0 && e->symbol == ranges[grp_ind].end + 1 && e->state == ranges[grp_ind].to) {
 			ranges[grp_ind].end = e->symbol;
 		} else {
 			grp_ind = n++;
 
 			ranges[grp_ind].start = e->symbol;
 			ranges[grp_ind].end   = e->symbol;
-			ranges[grp_ind].to    = s;
+			ranges[grp_ind].to    = e->state;
 		}
 	}
 

--- a/src/libfsm/print/ir.c
+++ b/src/libfsm/print/ir.c
@@ -68,7 +68,7 @@ make_groups(const struct fsm *fsm, fsm_state_t state,
 {
 	struct range ranges[FSM_SIGMA_COUNT]; /* worst case, one per symbol */
 	struct ir_group *groups;
-	struct fsm_edge *e;
+	struct fsm_edge e;
 	struct edge_iter it;
 	size_t i, j, k;
 	size_t grp_ind, n;
@@ -88,19 +88,19 @@ make_groups(const struct fsm *fsm, fsm_state_t state,
 	n = 0;          /* number of allocated ranges */
 	grp_ind = 0;    /* index of current working range */
 
-	for (e = edge_set_first(fsm->states[state].edges, &it); e != NULL; e = edge_set_next(&it)) {
-		if (have_mode && e->state == mode) {
+	for (edge_set_reset(fsm->states[state].edges, &it); edge_set_next(&it, &e); ) {
+		if (have_mode && e.state == mode) {
 			continue;
 		}
 
-		if (n > 0 && e->symbol == ranges[grp_ind].end + 1 && e->state == ranges[grp_ind].to) {
-			ranges[grp_ind].end = e->symbol;
+		if (n > 0 && e.symbol == ranges[grp_ind].end + 1 && e.state == ranges[grp_ind].to) {
+			ranges[grp_ind].end = e.symbol;
 		} else {
 			grp_ind = n++;
 
-			ranges[grp_ind].start = e->symbol;
-			ranges[grp_ind].end   = e->symbol;
-			ranges[grp_ind].to    = e->state;
+			ranges[grp_ind].start = e.symbol;
+			ranges[grp_ind].end   = e.symbol;
+			ranges[grp_ind].to    = e.state;
 		}
 	}
 

--- a/src/libfsm/print/json.c
+++ b/src/libfsm/print/json.c
@@ -70,29 +70,24 @@ fsm_print_json(FILE *f, const struct fsm *fsm)
 			}
 
 			for (e = edge_set_first(fsm->states[i].edges, &it); e != NULL; e = edge_set_next(&it)) {
-				struct state_iter jt;
-				fsm_state_t st;
-
-				for (state_set_reset(e->sl, &jt); state_set_next(&jt, &st); ) {
-					if (!first) {
-						fprintf(f, ",\n");
-					}
-
-					fprintf(f, "\t\t\t\t{ ");
-
-					fprintf(f, "\"char\": ");
-					fputs(" \"", f);
-					json_escputc(f, fsm->opt, e->symbol);
-					putc('\"', f);
-
-					fprintf(f, ", ");
-
-					fprintf(f, "\"to\": %u", st);
-
-					fprintf(f, " }");
-
-					first = 0;
+				if (!first) {
+					fprintf(f, ",\n");
 				}
+
+				fprintf(f, "\t\t\t\t{ ");
+
+				fprintf(f, "\"char\": ");
+				fputs(" \"", f);
+				json_escputc(f, fsm->opt, e->symbol);
+				putc('\"', f);
+
+				fprintf(f, ", ");
+
+				fprintf(f, "\"to\": %u", e->state);
+
+				fprintf(f, " }");
+
+				first = 0;
 			}
 
 			if (!first) {

--- a/src/libfsm/print/json.c
+++ b/src/libfsm/print/json.c
@@ -34,7 +34,7 @@ fsm_print_json(FILE *f, const struct fsm *fsm)
 		fprintf(f, "\t\"states\": [\n");
 
 		for (i = 0; i < fsm->statecount; i++) {
-			struct fsm_edge *e;
+			struct fsm_edge e;
 			struct edge_iter it;
 			int first = 1;
 
@@ -69,7 +69,7 @@ fsm_print_json(FILE *f, const struct fsm *fsm)
 				}
 			}
 
-			for (e = edge_set_first(fsm->states[i].edges, &it); e != NULL; e = edge_set_next(&it)) {
+			for (edge_set_reset(fsm->states[i].edges, &it); edge_set_next(&it, &e); ) {
 				if (!first) {
 					fprintf(f, ",\n");
 				}
@@ -78,12 +78,12 @@ fsm_print_json(FILE *f, const struct fsm *fsm)
 
 				fprintf(f, "\"char\": ");
 				fputs(" \"", f);
-				json_escputc(f, fsm->opt, e->symbol);
+				json_escputc(f, fsm->opt, e.symbol);
 				putc('\"', f);
 
 				fprintf(f, ", ");
 
-				fprintf(f, "\"to\": %u", e->state);
+				fprintf(f, "\"to\": %u", e.state);
 
 				fprintf(f, " }");
 

--- a/src/libfsm/reverse.c
+++ b/src/libfsm/reverse.c
@@ -165,20 +165,12 @@ fsm_reverse(struct fsm *fsm)
 						}
 					}
 
-					en = edge_set_contains(edges[se], e);
+					en = edge_set_contains(edges[se], e->symbol);
 					if (en == NULL) {
-						en = f_malloc(fsm->opt->alloc, sizeof *en);
+						en = edge_set_add(edges[se], e->symbol);
 						if (en == NULL) {
-							goto error1;
+							return 0;
 						}
-
-						en->symbol = e->symbol;
-						en->sl = NULL;
-					}
-
-					en = edge_set_add(edges[se], en);
-					if (en == NULL) {
-						return 0;
 					}
 
 					if (!state_set_add(&en->sl, fsm->opt->alloc, i)) {

--- a/src/libfsm/reverse.c
+++ b/src/libfsm/reverse.c
@@ -165,12 +165,9 @@ fsm_reverse(struct fsm *fsm)
 						}
 					}
 
-					en = edge_set_contains(edges[se], e->symbol);
+					en = edge_set_add(edges[se], e->symbol);
 					if (en == NULL) {
-						en = edge_set_add(edges[se], e->symbol);
-						if (en == NULL) {
-							return 0;
-						}
+						return 0;
 					}
 
 					if (!state_set_add(&en->sl, fsm->opt->alloc, i)) {

--- a/src/libfsm/reverse.c
+++ b/src/libfsm/reverse.c
@@ -134,10 +134,10 @@ fsm_reverse(struct fsm *fsm)
 		for (i = 0; i < fsm->statecount; i++) {
 			struct edge_iter it;
 			struct fsm_edge *e;
-			fsm_state_t se;
 
 			{
 				struct state_iter jt;
+				fsm_state_t se;
 
 				/* TODO: eventually to be a predicate bit cached for the whole fsm */
 				if (fsm->states[i].epsilons != NULL) {
@@ -151,28 +151,20 @@ fsm_reverse(struct fsm *fsm)
 				}
 			}
 			for (e = edge_set_first(fsm->states[i].edges, &it); e != NULL; e = edge_set_next(&it)) {
-				struct state_iter jt;
+				struct fsm_edge *en;
 
-				for (state_set_reset(e->sl, &jt); state_set_next(&jt, &se); ) {
-					struct fsm_edge *en;
+				assert(e->state < fsm->statecount);
 
-					assert(se < fsm->statecount);
-
-					if (edges[se] == NULL) {
-						edges[se] = edge_set_create(fsm->opt->alloc);
-						if (edges[se] == NULL) {
-							goto error1;
-						}
+				if (edges[e->state] == NULL) {
+					edges[e->state] = edge_set_create(fsm->opt->alloc);
+					if (edges[e->state] == NULL) {
+						goto error1;
 					}
+				}
 
-					en = edge_set_add(edges[se], e->symbol);
-					if (en == NULL) {
-						return 0;
-					}
-
-					if (!state_set_add(&en->sl, fsm->opt->alloc, i)) {
-						return 0;
-					}
+				en = edge_set_add(edges[e->state], e->symbol, i);
+				if (en == NULL) {
+					return 0;
 				}
 			}
 		}
@@ -231,7 +223,7 @@ fsm_reverse(struct fsm *fsm)
 				continue;
 			}
 
-			if (!edge_set_copy(edges[start], fsm->opt->alloc, edges[s])) {
+			if (!edge_set_copy(edges[start], edges[s])) {
 				goto error;
 			}
 		}

--- a/src/libfsm/reverse.c
+++ b/src/libfsm/reverse.c
@@ -159,7 +159,7 @@ fsm_reverse(struct fsm *fsm)
 					assert(se < fsm->statecount);
 
 					if (edges[se] == NULL) {
-						edges[se] = edge_set_create(fsm->opt->alloc, fsm_state_cmpedges);
+						edges[se] = edge_set_create(fsm->opt->alloc);
 						if (edges[se] == NULL) {
 							goto error1;
 						}
@@ -227,7 +227,7 @@ fsm_reverse(struct fsm *fsm)
 		fsm_state_t s;
 
 		if (edges[start] == NULL) {
-			edges[start] = edge_set_create(fsm->opt->alloc, fsm_state_cmpedges);
+			edges[start] = edge_set_create(fsm->opt->alloc);
 			if (edges[start] == NULL) {
 				goto error;
 			}

--- a/src/libfsm/shortest.c
+++ b/src/libfsm/shortest.c
@@ -89,7 +89,7 @@ fsm_shortest(const struct fsm *fsm,
 
 	while (u = priq_pop(&todo), u != NULL) {
 		struct edge_iter it;
-		struct fsm_edge *e;
+		struct fsm_edge e;
 
 		priq_move(&done, u);
 
@@ -102,27 +102,27 @@ fsm_shortest(const struct fsm *fsm,
 			goto done;
 		}
 
-		for (e = edge_set_first(fsm->states[u->state].edges, &it); e != NULL; e = edge_set_next(&it)) {
+		for (edge_set_reset(fsm->states[u->state].edges, &it); edge_set_next(&it, &e); ) {
 			struct priq *v;
 			unsigned c;
 
-			v = priq_find(todo, e->state);
+			v = priq_find(todo, e.state);
 
 			/* visited already */
 			if (v == NULL) {
-				assert(priq_find(done, e->state));
+				assert(priq_find(done, e.state));
 				continue;
 			}
 
-			assert(v->state == e->state);
+			assert(v->state == e.state);
 
-			c = cost(u->state, v->state, e->symbol);
+			c = cost(u->state, v->state, e.symbol);
 
 			/* relax */
 			if (v->cost > u->cost + c) {
 				v->cost = u->cost + c;
 				v->prev = u;
-				v->c    = e->symbol;
+				v->c    = e.symbol;
 
 				priq_update(&todo, v, v->cost);
 			}

--- a/src/libfsm/state.c
+++ b/src/libfsm/state.c
@@ -93,7 +93,6 @@ fsm_removestate(struct fsm *fsm, fsm_state_t state)
 
 	for (e = edge_set_first(fsm->states[state].edges, &it); e != NULL; e = edge_set_next(&it)) {
 		state_set_free(e->sl);
-		f_free(fsm->opt->alloc, e);
 	}
 	state_set_free(fsm->states[state].epsilons);
 	edge_set_free(fsm->states[state].edges);

--- a/src/libfsm/state.c
+++ b/src/libfsm/state.c
@@ -52,21 +52,56 @@ fsm_addstate(struct fsm *fsm, fsm_state_t *state)
 
 		new = &fsm->states[fsm->statecount];
 
-		new->end = 0;
-		new->visited = 0;
-		new->opaque = NULL;
-
-		/*
-		 * Sets for epsilon and labelled transitions are kept NULL
-		 * until populated; this suits the most nodes in the bodies of
-		 * typical FSM that do not have epsilons, and (less often)
-		 * nodes that have no edges.
-		 */
+		new->end      = 0;
+		new->visited  = 0;
+		new->opaque   = NULL;
 		new->epsilons = NULL;
 		new->edges    = NULL;
 	}
 
 	fsm->statecount++;
+
+	return 1;
+}
+
+int
+fsm_addstate_bulk(struct fsm *fsm, size_t n)
+{
+	size_t i;
+
+	assert(fsm != NULL);
+
+	if (fsm->statecount + n <= fsm->statealloc) {
+		for (i = 0; i < n; i++) {
+			struct fsm_state *new;
+
+			new = &fsm->states[fsm->statecount + i];
+
+			new->end      = 0;
+			new->visited  = 0;
+			new->opaque   = NULL;
+			new->epsilons = NULL;
+			new->edges    = NULL;
+		}
+
+		fsm->statecount += n;
+
+		return 1;
+	}
+
+/*
+TODO: bulk add
+if there's space already, just increment statecount
+otherwise realloc to += twice as much more
+*/
+
+	for (i = 0; i < n; i++) {
+		fsm_state_t dummy;
+
+		if (!fsm_addstate(fsm, &dummy)) {
+			return 0;
+		}
+	}
 
 	return 1;
 }

--- a/src/libfsm/state.c
+++ b/src/libfsm/state.c
@@ -86,14 +86,11 @@ fsm_removestate(struct fsm *fsm, fsm_state_t state)
 
 	for (i = 0; i < fsm->statecount; i++) {
 		state_set_remove(&fsm->states[i].epsilons, state);
-		for (e = edge_set_first(fsm->states[i].edges, &it); e != NULL; e = edge_set_next(&it)) {
-			state_set_remove(&e->sl, state);
+		if (fsm->states[i].edges != NULL) {
+			edge_set_remove_state(fsm->states[i].edges, state);
 		}
 	}
 
-	for (e = edge_set_first(fsm->states[state].edges, &it); e != NULL; e = edge_set_next(&it)) {
-		state_set_free(e->sl);
-	}
 	state_set_free(fsm->states[state].epsilons);
 	edge_set_free(fsm->states[state].edges);
 
@@ -116,7 +113,9 @@ fsm_removestate(struct fsm *fsm, fsm_state_t state)
 		for (i = 0; i < fsm->statecount - 1; i++) {
 			state_set_replace(&fsm->states[i].epsilons, fsm->statecount - 1, state);
 			for (e = edge_set_first(fsm->states[i].edges, &it); e != NULL; e = edge_set_next(&it)) {
-				state_set_replace(&e->sl, fsm->statecount - 1, state);
+				if (e->state == fsm->statecount - 1) {
+					e->state = state;
+				}
 			}
 		}
 	}

--- a/src/libfsm/state.c
+++ b/src/libfsm/state.c
@@ -74,8 +74,6 @@ fsm_addstate(struct fsm *fsm, fsm_state_t *state)
 void
 fsm_removestate(struct fsm *fsm, fsm_state_t state)
 {
-	struct fsm_edge *e;
-	struct edge_iter it;
 	fsm_state_t start, i;
 
 	assert(fsm != NULL);
@@ -87,7 +85,7 @@ fsm_removestate(struct fsm *fsm, fsm_state_t state)
 	for (i = 0; i < fsm->statecount; i++) {
 		state_set_remove(&fsm->states[i].epsilons, state);
 		if (fsm->states[i].edges != NULL) {
-			edge_set_remove_state(fsm->states[i].edges, state);
+			edge_set_remove_state(&fsm->states[i].edges, state);
 		}
 	}
 
@@ -112,11 +110,7 @@ fsm_removestate(struct fsm *fsm, fsm_state_t state)
 
 		for (i = 0; i < fsm->statecount - 1; i++) {
 			state_set_replace(&fsm->states[i].epsilons, fsm->statecount - 1, state);
-			for (e = edge_set_first(fsm->states[i].edges, &it); e != NULL; e = edge_set_next(&it)) {
-				if (e->state == fsm->statecount - 1) {
-					e->state = state;
-				}
-			}
+			edge_set_replace_state(&fsm->states[i].edges, fsm->statecount - 1, state);
 		}
 	}
 

--- a/src/libfsm/trim.c
+++ b/src/libfsm/trim.c
@@ -40,7 +40,7 @@ mark_states(struct fsm *fsm)
 	fsm->states[start].visited = 1;
 
 	for (;;) {
-		const struct fsm_edge *e;
+		struct fsm_edge e;
 		struct edge_iter edge_iter;
 		fsm_state_t s;
 
@@ -65,19 +65,16 @@ mark_states(struct fsm *fsm)
 			}
 		}
 
-		for (e = edge_set_first(fsm->states[s].edges, &edge_iter);
-		     e != NULL;
-		     e = edge_set_next(&edge_iter))
-		{
-			if (fsm->states[e->state].visited) {
+		for (edge_set_reset(fsm->states[s].edges, &edge_iter); edge_set_next(&edge_iter, &e); ) {
+			if (fsm->states[e.state].visited) {
 				continue;
 			}
 
-			if (!queue_push(q, e->state)) {
+			if (!queue_push(q, e.state)) {
 				goto cleanup;
 			}
 
-			fsm->states[e->state].visited = 1;
+			fsm->states[e.state].visited = 1;
 		}
 	}
 

--- a/src/libfsm/trim.c
+++ b/src/libfsm/trim.c
@@ -69,20 +69,15 @@ mark_states(struct fsm *fsm)
 		     e != NULL;
 		     e = edge_set_next(&edge_iter))
 		{
-			struct state_iter state_iter;
-			fsm_state_t es;
-
-			for (state_set_reset(e->sl, &state_iter); state_set_next(&state_iter, &es); ) {
-				if (fsm->states[es].visited) {
-					continue;
-				}
-
-				if (!queue_push(q, es)) {
-					goto cleanup;
-				}
-
-				fsm->states[es].visited = 1;
+			if (fsm->states[e->state].visited) {
+				continue;
 			}
+
+			if (!queue_push(q, e->state)) {
+				goto cleanup;
+			}
+
+			fsm->states[e->state].visited = 1;
 		}
 	}
 

--- a/src/libfsm/walk/iter.c
+++ b/src/libfsm/walk/iter.c
@@ -50,13 +50,8 @@ fsm_walk_edges(const struct fsm *fsm, void *opaque,
 		struct edge_iter ei;
 
 		for (e = edge_set_first(fsm->states[i].edges, &ei); e != NULL; e = edge_set_next(&ei)) {
-			struct state_iter di;
-			fsm_state_t dst;
-
-			for (state_set_reset(e->sl, &di); state_set_next(&di, &dst); ) {
-				if (!callback_literal(fsm, i, dst, e->symbol, opaque)) {
-					return 0;
-				}
+			if (!callback_literal(fsm, i, e->state, e->symbol, opaque)) {
+				return 0;
 			}
 		}
 

--- a/src/libfsm/walk/iter.c
+++ b/src/libfsm/walk/iter.c
@@ -46,11 +46,11 @@ fsm_walk_edges(const struct fsm *fsm, void *opaque,
 	assert(callback_epsilon != NULL);
 
 	for (i = 0; i < fsm->statecount; i++) {
-		const struct fsm_edge *e;
+		struct fsm_edge e;
 		struct edge_iter ei;
 
-		for (e = edge_set_first(fsm->states[i].edges, &ei); e != NULL; e = edge_set_next(&ei)) {
-			if (!callback_literal(fsm, i, e->state, e->symbol, opaque)) {
+		for (edge_set_reset(fsm->states[i].edges, &ei); edge_set_next(&ei, &e); ) {
+			if (!callback_literal(fsm, i, e.state, e.symbol, opaque)) {
 				return 0;
 			}
 		}

--- a/src/libfsm/walk/reachable.c
+++ b/src/libfsm/walk/reachable.c
@@ -40,7 +40,7 @@ fsm_reachable(const struct fsm *fsm, fsm_state_t state,
 
 	while (p = dlist_nextnotdone(list), p != NULL) {
 		struct edge_iter it;
-		struct fsm_edge *e;
+		struct fsm_edge e;
 
 		if (any) {
 			if (predicate(fsm, p->state)) {
@@ -54,13 +54,13 @@ fsm_reachable(const struct fsm *fsm, fsm_state_t state,
 			}
 		}
 
-		for (e = edge_set_first(fsm->states[p->state].edges, &it); e != NULL; e = edge_set_next(&it)) {
+		for (edge_set_reset(fsm->states[p->state].edges, &it); edge_set_next(&it, &e); ) {
 			/* not a list operation... */
-			if (dlist_contains(list, e->state)) {
+			if (dlist_contains(list, e.state)) {
 				continue;
 			}
 
-			if (!dlist_push(fsm->opt->alloc, &list, e->state)) {
+			if (!dlist_push(fsm->opt->alloc, &list, e.state)) {
 				return -1;
 			}
 		}

--- a/src/libfsm/walk/reachable.c
+++ b/src/libfsm/walk/reachable.c
@@ -55,18 +55,13 @@ fsm_reachable(const struct fsm *fsm, fsm_state_t state,
 		}
 
 		for (e = edge_set_first(fsm->states[p->state].edges, &it); e != NULL; e = edge_set_next(&it)) {
-			struct state_iter jt;
-			fsm_state_t st;
+			/* not a list operation... */
+			if (dlist_contains(list, e->state)) {
+				continue;
+			}
 
-			for (state_set_reset(e->sl, &jt); state_set_next(&jt, &st); ) {
-				/* not a list operation... */
-				if (dlist_contains(list, st)) {
-					continue;
-				}
-
-				if (!dlist_push(fsm->opt->alloc, &list, st)) {
-					return -1;
-				}
+			if (!dlist_push(fsm->opt->alloc, &list, e->state)) {
+				return -1;
 			}
 		}
 

--- a/src/libfsm/walk2.c
+++ b/src/libfsm/walk2.c
@@ -417,7 +417,7 @@ fsm_walk2_edges(struct fsm_walk2_data *data,
 			continue;
 		}
 
-		eb = have_qb ? fsm_hasedge_literal(b, qb, i) : NULL;
+		eb = have_qb ? edge_set_contains(b->states[qb].edges, i) : NULL;
 
 		/*
 		 * If eb == NULL we can only follow this edge if ONLYA
@@ -470,7 +470,7 @@ only_b:
 		}
 
 		/* if A has the edge, it's not an only B edge */
-		if (have_qa && fsm_hasedge_literal(a, qa, i)) {
+		if (have_qa && edge_set_contains(a->states[qa].edges].edges, i)) {
 			continue;
 		}
 

--- a/src/libfsm/walk2.c
+++ b/src/libfsm/walk2.c
@@ -332,8 +332,8 @@ fsm_walk2_edges(struct fsm_walk2_data *data,
 {
 	fsm_state_t qa, qb, qc;
 	int have_qa, have_qb;
-	struct edge_iter ei, ej;
 	const struct fsm_edge *ea, *eb;
+	int i;
 
 	assert(a != NULL);
 	assert(b != NULL);
@@ -409,9 +409,21 @@ fsm_walk2_edges(struct fsm_walk2_data *data,
 	}
 
 	/* take care of only A and both A&B edges */
-	for (ea = edge_set_first(a->states[qa].edges, &ei); ea != NULL; ea = edge_set_next(&ei)) {
+	for (i = 0; i <= FSM_SIGMA_MAX; i++) {
 		struct state_iter dia, dib;
 		fsm_state_t da;
+
+		ea = edge_set_contains(a->states[qa].edges, i);
+		if (ea == NULL) {
+			continue;
+		}
+
+		/* just in case our DFA has unpopulated edges */
+		if (ea->sl == NULL) {
+			continue;
+		}
+
+		assert(state_set_count(ea->sl) == 1); /* qa is a DFA */
 
 		eb = have_qb ? fsm_hasedge_literal(b, qb, ea->symbol) : NULL;
 
@@ -484,9 +496,21 @@ only_b:
 	}
 
 	/* take care of only B edges */
-	for (eb = edge_set_first(b->states[qb].edges, &ej); eb != NULL; eb = edge_set_next(&ej)) {
+	for (i = 0; i <= FSM_SIGMA_MAX; i++) {
 		struct state_iter dib;
 		fsm_state_t db;
+
+		eb = edge_set_contains(b->states[qb].edges, i);
+		if (eb == NULL) {
+			continue;
+		}
+
+		/* just in case our DFA has unpopulated edges */
+		if (eb->sl == NULL) {
+			continue;
+		}
+
+		assert(state_set_count(eb->sl) == 1); /* qb is a DFA */
 
 		/* if A has the edge, it's not an only B edge */
 		if (have_qa && fsm_hasedge_literal(a, qa, eb->symbol)) {

--- a/src/libfsm/walk2.c
+++ b/src/libfsm/walk2.c
@@ -413,11 +413,13 @@ fsm_walk2_edges(struct fsm_walk2_data *data,
 		fsm_state_t eas, ebs;
 		int have_ebs;
 
+		assert(!have_qa || qa < a->statecount);
 		if (!edge_set_transition(a->states[qa].edges, i, &eas)) {
 			continue;
 		}
 
-		have_ebs = edge_set_transition(b->states[qb].edges, i, &ebs);
+		assert(!have_qb || qb < b->statecount);
+		have_ebs = have_qb ? edge_set_transition(b->states[qb].edges, i, &ebs) : 0;
 
 		/*
 		 * If !have_ebs we can only follow this edge if ONLYA

--- a/src/libre/ac.c
+++ b/src/libre/ac.c
@@ -288,6 +288,7 @@ trie_to_fsm_state(struct trie_state *ts, struct fsm *fsm,
 		return 1;
 	}
 
+	/* TODO: bulk add states in advance */
 	if (!fsm_addstate(fsm, &st)) {
 		return 0;
 	}
@@ -373,5 +374,4 @@ trie_dump(struct trie_graph *g, FILE *f)
 
 	dump_state(g->root,f,0, buf);
 }
-
 

--- a/src/libre/ast_compile.c
+++ b/src/libre/ast_compile.c
@@ -730,7 +730,7 @@ comp_iter(struct comp_env *env,
 
 	case AST_EXPR_CONCAT:
 	{
-		fsm_state_t z;
+		fsm_state_t base, z;
 		fsm_state_t curr_x;
 		enum re_flags saved;
 		size_t i;
@@ -742,6 +742,12 @@ comp_iter(struct comp_env *env,
 
 		assert(count >= 1);
 
+		base = env->fsm->statecount;
+
+		if (!fsm_addstate_bulk(env->fsm, count - 1)) {
+			return 0;
+		}
+
 		for (i = 0; i < count; i++) {
 			struct ast_expr *curr = n->u.concat.n[i];
 			struct ast_expr *next = i == count - 1
@@ -749,7 +755,7 @@ comp_iter(struct comp_env *env,
 				: n->u.concat.n[i + 1];
 
 			if (i + 1 < count) {
-				NEWSTATE(z);
+				z = base + i;
 			} else {
 				z = y;
 			}


### PR DESCRIPTION
This PR converts edge sets to a single state per edge struct, rather than a state set per edge struct.

The implementation of the edge set is now concrete (as opposed to sharing the generic set ADT), and now also uses similar interned singleton items as for the state sets.

The change to edges storing a single state relies on duplication between multiple instances of `struct fsm_edge` within an edge set. Effectively here, the concept of duplication of state items is merged with the concept of duplication of symbols; both are now implemented in the same place.

This simplifies a lot of the edge traversal code, but also allows for future work indexing edges by a (now single) state, rather than by a set of states.

Future work would be to have `struct fsm_edge` items carry a bitmap for symbols, rather than a single symbol per edge.