### PR TITLE
A different kind of json

### DIFF
--- a/src/libfsm/print/json.c
+++ b/src/libfsm/print/json.c
@@ -52,12 +52,20 @@ print_edge_symbol(FILE *f, int *notfirst, const struct fsm_options *opt,
 	}
 
 	/* "symbol" as opposed to "label" because this is a literal value */
-	fprintf(f, "    { \"src\": %u, \"dst\": %u, \"symbol\": \"",
+	fprintf(f, "    { \"src\": %u, \"dst\": %u, \"symbol\": ",
 		src, dst);
 
-	json_escputc(f, opt, symbol);
+	if (opt->always_hex) {
+		/* json doesn't have hex numeric literals, but this idea here is
+		 * to output a numeric value rather than a string, so %u will do. */
+		fprintf(f, "%u", symbol);
+	} else {
+		fprintf(f, "\"");
+		json_escputc(f, opt, symbol);
+		fprintf(f, "\"");
+	}
 
-	fprintf(f, "\" }");
+	fprintf(f, " }");
 
 	*notfirst = 1;
 }

--- a/src/libfsm/print/json.c
+++ b/src/libfsm/print/json.c
@@ -5,113 +5,241 @@
  */
 
 #include <assert.h>
+#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <limits.h>
+
+#include "libfsm/internal.h" /* XXX: up here for bitmap.h */
 
 #include <print/esc.h>
+
+#include <adt/set.h>
+#include <adt/bitmap.h>
+#include <adt/stateset.h>
+#include <adt/edgeset.h>
 
 #include <fsm/fsm.h>
 #include <fsm/pred.h>
 #include <fsm/print.h>
 #include <fsm/options.h>
 
-#include <adt/set.h>
-#include <adt/stateset.h>
-#include <adt/edgeset.h>
+static void
+print_edge_epsilon(FILE *f, int *notfirst,
+	fsm_state_t src, fsm_state_t dst)
+{
+	assert(f != NULL);
+	assert(notfirst != NULL);
 
-#include "libfsm/internal.h"
+	if (*notfirst) {
+		fprintf(f, ",\n");
+	}
+
+	fprintf(f, "    { \"src\": %u, \"dst\": %u }", src, dst);
+
+	*notfirst = 1;
+}
+
+static void
+print_edge_symbol(FILE *f, int *notfirst, const struct fsm_options *opt,
+	fsm_state_t src, fsm_state_t dst, unsigned char symbol)
+{
+	assert(f != NULL);
+	assert(notfirst != NULL);
+
+	if (*notfirst) {
+		fprintf(f, ",\n");
+	}
+
+	/* "symbol" as opposed to "label" because this is a literal value */
+	fprintf(f, "    { \"src\": %u, \"dst\": %u, \"symbol\": \"",
+		src, dst);
+
+	json_escputc(f, opt, symbol);
+
+	fprintf(f, "\" }");
+
+	*notfirst = 1;
+}
+
+static void
+print_edge_bitmap(FILE *f, int *notfirst, const struct fsm_options *opt,
+	fsm_state_t src, fsm_state_t dst, const struct bm *bm)
+{
+	assert(f != NULL);
+	assert(notfirst != NULL);
+	assert(opt != NULL);
+	assert(bm != NULL);
+
+	if (*notfirst) {
+		fprintf(f, ",\n");
+	}
+
+	fprintf(f, "    { \"src\": %u, \"dst\": %u, ", src, dst);
+
+	/* "label" as opposed to "symbol" because this is a human-readable string */
+	fprintf(f, "\"label\": \"");
+
+	(void) bm_print(f, opt, bm, 0, json_escputc);
+
+	fprintf(f, "\" }");
+
+	*notfirst = 1;
+}
+
+static void
+print_edge_label(FILE *f, int *notfirst,
+	fsm_state_t src, fsm_state_t dst, const char *label)
+{
+	assert(f != NULL);
+	assert(notfirst != NULL);
+	assert(label != NULL);
+
+	if (*notfirst) {
+		fprintf(f, ",\n");
+	}
+
+	fprintf(f, "    { \"src\": %u, \"dst\": %u, \"label\": \"%s\" }",
+		src, dst, label);
+
+	*notfirst = 1;
+}
+
+static void
+singlestate(FILE *f, const struct fsm *fsm, fsm_state_t s, int *notfirst)
+{
+	struct fsm_edge e;
+	struct edge_iter it;
+	struct state_set *unique;
+
+	assert(f != NULL);
+	assert(fsm != NULL);
+	assert(fsm->opt != NULL);
+	assert(s < fsm->statecount);
+	assert(notfirst != NULL);
+
+	if (!fsm->opt->consolidate_edges) {
+		struct state_iter jt;
+		fsm_state_t st;
+
+		for (state_set_reset(fsm->states[s].epsilons, &jt); state_set_next(&jt, &st); ) {
+			print_edge_epsilon(f, notfirst, s, st);
+		}
+
+		for (edge_set_reset(fsm->states[s].edges, &it); edge_set_next(&it, &e); ) {
+			print_edge_symbol(f, notfirst, fsm->opt,
+				s, e.state, e.symbol);
+		}
+
+		return;
+	}
+
+	unique = NULL;
+
+	for (edge_set_reset(fsm->states[s].edges, &it); edge_set_next(&it, &e); ) {
+		if (!state_set_add(&unique, fsm->opt->alloc, e.state)) {
+			/* TODO: error */
+			return;
+		}
+	}
+
+	/*
+	 * The consolidate_edges option is an aesthetic optimisation.
+	 * For a state which has multiple edges all transitioning to the same state,
+	 * all these edges are combined into a single edge, labelled with a more
+	 * concise form of all their values.
+	 *
+	 * To implement this, we loop through all unique states, rather than
+	 * looping through each edge.
+	 */
+	for (edge_set_reset(fsm->states[s].edges, &it); edge_set_next(&it, &e); ) {
+		struct fsm_edge ne;
+		struct edge_iter kt;
+		struct bm bm;
+
+		/* unique states only */
+		if (!state_set_contains(unique, e.state)) {
+			continue;
+		}
+
+		state_set_remove(&unique, e.state);
+
+		bm_clear(&bm);
+
+		/* find all edges which go from this state to the same target state */
+		for (edge_set_reset(fsm->states[s].edges, &kt); edge_set_next(&kt, &ne); ) {
+			if (ne.state == e.state) {
+				bm_set(&bm, ne.symbol);
+			}
+		}
+
+		print_edge_bitmap(f, notfirst, fsm->opt, s, e.state, &bm);
+	}
+
+	/*
+	 * Special edges are not consolidated above
+	 */
+	{
+		struct state_iter jt;
+		fsm_state_t st;
+
+		for (state_set_reset(fsm->states[s].epsilons, &jt); state_set_next(&jt, &st); ) {
+			print_edge_label(f, notfirst, s, st, "\\u03B5");
+		}
+	}
+}
 
 void
 fsm_print_json(FILE *f, const struct fsm *fsm)
 {
+	fsm_state_t start;
 	fsm_state_t i;
 
 	assert(f != NULL);
 	assert(fsm != NULL);
+	assert(fsm->opt != NULL);
 
 	fprintf(f, "{\n");
 
-	{
-		fprintf(f, "\t\"states\": [\n");
+	fprintf(f, "  \"statecount\": %u,\n", (unsigned) fsm->statecount);
 
-		for (i = 0; i < fsm->statecount; i++) {
-			struct fsm_edge e;
-			struct edge_iter it;
-			int first = 1;
-
-			fprintf(f, "\t\t{\n");
-
-			fprintf(f, "\t\t\t\"end\": %s,\n",
-				fsm_isend(fsm, i) ? "true" : "false");
-
-			fprintf(f, "\t\t\t\"edges\": [\n");
-
-			{
-				struct state_iter jt;
-				fsm_state_t st;
-
-				for (state_set_reset(fsm->states[i].epsilons, &jt); state_set_next(&jt, &st); ) {
-					if (!first) {
-						fprintf(f, ",\n");
-					}
-
-					fprintf(f, "\t\t\t\t{ ");
-
-					fprintf(f, "\"char\": ");
-					fputs(" false", f);
-					fprintf(f, ", ");
-
-					fprintf(f, "\"to\": %u", st);
-
-					/* XXX: should count .sl inside an edge */
-					fprintf(f, " }");
-
-					first = 0;
-				}
-			}
-
-			for (edge_set_reset(fsm->states[i].edges, &it); edge_set_next(&it, &e); ) {
-				if (!first) {
-					fprintf(f, ",\n");
-				}
-
-				fprintf(f, "\t\t\t\t{ ");
-
-				fprintf(f, "\"char\": ");
-				fputs(" \"", f);
-				json_escputc(f, fsm->opt, e.symbol);
-				putc('\"', f);
-
-				fprintf(f, ", ");
-
-				fprintf(f, "\"to\": %u", e.state);
-
-				fprintf(f, " }");
-
-				first = 0;
-			}
-
-			if (!first) {
-				fprintf(f, "\n");
-			}
-
-			fprintf(f, "\t\t\t]\n");
-
-			fprintf(f, "\t\t}%s\n", (i + 1) < fsm->statecount ? "," : "");
-		}
-
-		fprintf(f, "\t],\n");
+	if (fsm_getstart(fsm, &start)) {
+		fprintf(f, "  \"start\": %u,\n", start);
 	}
 
 	{
-		fsm_state_t start;
+		int notfirst;
 
-		if (!fsm_getstart(fsm, &start)) {
-			return;
+		notfirst = 0;
+
+		fprintf(f, "  \"end\": [ ");
+		for (i = 0; i < fsm->statecount; i++) {
+			if (fsm_isend(fsm, i)) {
+				if (notfirst) {
+					fprintf(f, ", ");
+				}
+
+				fprintf(f, "%u", i);
+
+				notfirst = 1;
+			}
 		}
+		fprintf(f, " ],\n");
+	}
 
-		fprintf(f, "\t\"start\": %u\n", start);
+	{
+		int notfirst;
+
+		notfirst = 0;
+
+		fprintf(f, "  \"edges\": [\n");
+			for (i = 0; i < fsm->statecount; i++) {
+				singlestate(f, fsm, i, &notfirst);
+			}
+		fprintf(f, "\n  ]\n");
 	}
 
 	fprintf(f, "}\n");
+	fprintf(f, "\n");
 }
 

--- a/src/libfsm/print/json.c
+++ b/src/libfsm/print/json.c
@@ -235,6 +235,30 @@ fsm_print_json(FILE *f, const struct fsm *fsm)
 		fprintf(f, " ],\n");
 	}
 
+	if (fsm->opt->endleaf != NULL) {
+		int notfirst;
+
+		notfirst = 0;
+
+		fprintf(f, "  \"endleaf\": [ ");
+		for (i = 0; i < fsm->statecount; i++) {
+			if (fsm_isend(fsm, i)) {
+				if (notfirst) {
+					fprintf(f, ", ");
+				}
+
+				fprintf(f, "{ %u, ", i);
+
+				fsm->opt->endleaf(f, &fsm->states[i], fsm->opt->endleaf_opaque);
+
+				fprintf(f, " }");
+
+				notfirst = 1;
+			}
+		}
+		fprintf(f, " ],\n");
+	}
+
 	{
 		int notfirst;
 

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -437,6 +437,35 @@ endleaf_dot(FILE *f, const void *state_opaque, const void *endleaf_opaque)
 	return 0;
 }
 
+static int
+endleaf_json(FILE *f, const void *state_opaque, const void *endleaf_opaque)
+{
+	const struct match *m;
+
+	assert(f != NULL);
+	assert(state_opaque != NULL);
+	assert(endleaf_opaque == NULL);
+
+	(void) endleaf_opaque;
+
+	fprintf(f, "[ ");
+
+	for (m = state_opaque; m != NULL; m = m->next) {
+		fprintf(f, "%u", m->i);
+
+		if (m->next != NULL) {
+			fprintf(f, ", ");
+		}
+	}
+
+	fprintf(f, " ]");
+
+	/* TODO: only if comments */
+	/* TODO: centralise to libfsm/print/json.c */
+
+	return 0;
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -869,6 +898,8 @@ main(int argc, char *argv[])
 			opt.endleaf = endleaf_c;
 		} else if (print_fsm == fsm_print_dot) {
 			opt.endleaf = patterns ? endleaf_dot : NULL;
+		} else if (print_fsm == fsm_print_json) {
+			opt.endleaf = patterns ? endleaf_json : NULL;
 		}
 
 		print_fsm(stdout, fsm);


### PR DESCRIPTION
Replacement of the libfsm json output with json that I hope is a little more convenient.

Typically it looks like this, with output for human-readable labels:
```json
; bmake -r CC=clang DEBUG=1 && ./build/bin/re -pl json '[abc][^x]'
{
  "statecount": 3,
  "start": 0,
  "end": [ 2 ],
  "edges": [ 
    { "src": 0, "dst": 0, "label": "[^abc]" },
    { "src": 0, "dst": 1, "label": "[abc]" },
    { "src": 1, "dst": 2, "label": "[^x]" },
    { "src": 1, "dst": 0, "label": "x" },
    { "src": 2, "dst": 2, "label": "/./" }
  ]
}
```
and similarly as an NFA:
```json
; bmake -r CC=clang DEBUG=1 && ./build/bin/re -npl json '[abc][^x]'
{
  "statecount": 9,
  "start": 0,
  "end": [ 1 ],
  "edges": [ 
    { "src": 0, "dst": 2, "label": "\u03B5" },
    { "src": 2, "dst": 2, "label": "/./" },
    { "src": 2, "dst": 4, "label": "[abc]" },
    { "src": 3, "dst": 3, "label": "/./" }, 
    { "src": 3, "dst": 1, "label": "\u03B5" },
    { "src": 4, "dst": 5, "label": "\u03B5" },
    { "src": 5, "dst": 6, "label": "\u03B5" },
    { "src": 6, "dst": 7, "label": "[^x]" },
    { "src": 6, "dst": 8, "label": "x" },
    { "src": 7, "dst": 3, "label": "\u03B5" }
  ]
}
```

With the `.consolidate_edges` option disabled, edges are given independently and this is visible with a `symbol` attribute (as opposed to `label`, which is intended for human consumption):
```json
; bmake -r CC=clang DEBUG=1 && ./build/bin/re -cbpl json 'a|b*c?e|d+'
{
  "statecount": 5,
  "start": 0, 
  "end": [ 1, 4 ],
  "edges": [ 
    { "src": 0, "dst": 1, "symbol": "a" },
    { "src": 0, "dst": 2, "symbol": "b" },
    { "src": 0, "dst": 3, "symbol": "c" },
    { "src": 0, "dst": 4, "symbol": "d" },
    { "src": 0, "dst": 1, "symbol": "e" },
    { "src": 2, "dst": 2, "symbol": "b" },
    { "src": 2, "dst": 3, "symbol": "c" },
    { "src": 2, "dst": 1, "symbol": "e" },
    { "src": 3, "dst": 1, "symbol": "e" },
    { "src": 4, "dst": 4, "symbol": "d" }
  ]
}
```

And with numeric output for byte values (intended for machine consumption):
```json

; bmake -r CC=clang DEBUG=1 && ./build/bin/re -Xcbpl json 'abc'
{
  "statecount": 4,
  "start": 0,
  "end": [ 3 ],
  "edges": [
    { "src": 0, "dst": 1, "symbol": 97 },
    { "src": 1, "dst": 2, "symbol": 98 },
    { "src": 2, "dst": 3, "symbol": 99 }
  ]
}
```

I didn't write a json schema for this, sorry. I should provide one, I know.

I did experiment with using [dagre](https://github.com/dagrejs/dagre) for node placement.
Here's Graphviz's rendering for the above anchored `/a|b*c?e|d+/` regexp:

![image](https://user-images.githubusercontent.com/1371085/72593842-deb99c00-38ba-11ea-995a-d5f795229aa0.png)

And the same FSM with a quick mock-up page rendering that using [dagre-D3](https://github.com/dagrejs/dagre-d3):

![image](https://user-images.githubusercontent.com/1371085/72593936-1b859300-38bb-11ea-8abf-1760c481a33d.png)

I had wanted to use this json to model using dagre's algorithm for node placement,
in combination with dot(1)'s algorithm for edges. Unfortunately Graphviz will only
heed pre-defined coordinates when rendering using neato, which produces straight
lines for edges, which is of course not what I had hoped for:

![image](https://user-images.githubusercontent.com/1371085/72593985-3a842500-38bb-11ea-94e5-52bb9b24bc0a.png)

Regardless, I wrote a nodejs script to read in this new json, and to format it out
to .dot format with the coordinates populated:

```js
#!/usr/bin/env nodejs

var dagre = require("dagre");

const fs = require("fs");
const data = JSON.parse(fs.readFileSync(0, "utf-8"));

function json_read(graphlib, json) {
    var g;

    g = new graphlib.Graph({
            directed: true,
            multigraph: true,
            compound: false,
        });

    g.setGraph({ rankdir: "lr", nodesep: 30, edgesep: 30 });

    g.setNode("start", { label: "" });

    for (var i = 0; i < json.statecount; i++) {
        g.setNode(i, { label: "" });
    }

    var i = 0;
    json.edges.forEach(function (entry) {
        g.setEdge({ v: entry.src, w: entry.dst, name: i },
            { label: entry.label });
        i++;
    });

    g.setEdge({ v: "start", w: data.start }, { label: "" });

    return g;
}

var g = json_read(dagre.graphlib, data);

dagre.layout(g);

console.log("digraph G {");

console.log("\trankdir = LR;");
console.log("\tnode [ shape = circle ];");
console.log("\tedge [ weight = 2 ];");
console.log("\tnode [ label = \"\", width = 0.3 ];");
console.log("\tlayout = neato;"); // needed for pos="" XXX: but i want to use dot's edges!
console.log("\troot = start;");
console.log("");

console.log("\tSstart [ shape = none, label = \"\" ];");
console.log("");

// mapping from dagre's coordinates to graphviz's
var xscale = 0.03;
var yscale = 0.02;

g.nodes().forEach(function(v) {
    var n = g.node(v);
    if (data.end.indexOf(parseInt(v)) > -1) {
        console.log(`\tS${v} [ shape = \"doublecircle\" ];`);
    }
    console.log(`\tS${v} [ pos = "${n.x * xscale},${n.y * yscale}!" ];`);
});
console.log("");

g.edges().forEach(function(e) {
    var q = g.edge(e);
    console.log(`\tS${e.v} -> S${e.w} [ label = <${q.label}> ];`);
});

console.log("}");
console.log("");
```
which produces output like:
```
; ~/gh/libfsm-pristine/build/bin/re -pl json 'ab?c|de+x?' | ~/gh/libfsm-pristine/dagre/w2.js                    digraph G {
        rankdir = LR;
        node [ shape = circle ];
        edge [ weight = 2 ];
        node [ label = "", width = 0.3 ];
        layout = neato;
        root = start;

        Sstart [ shape = none, label = "" ];

        S0 [ pos = "1.5,3!" ];
        S1 [ pos = "3,0!" ];
        S2 [ pos = "6,1.85!" ];
        S3 [ shape = "doublecircle" ];
        S3 [ pos = "7.5,0.35000000000000003!" ];
        S4 [ pos = "4.5,0.9!" ];
        Sstart [ pos = "0,3!" ];

        S0 -> S0 [ label = <[^ad]> ];
        S0 -> S1 [ label = <a> ];
        S0 -> S2 [ label = <d> ];
        S1 -> S0 [ label = <[^a-d]> ];
        S1 -> S1 [ label = <a> ];
        S1 -> S4 [ label = <b> ];
        S1 -> S3 [ label = <c> ];
        S1 -> S2 [ label = <d> ];
        S2 -> S0 [ label = <[^ade]> ];
        S2 -> S1 [ label = <a> ];
        S2 -> S2 [ label = <d> ];
        S2 -> S3 [ label = <e> ];
        S3 -> S3 [ label = </./> ];
        S4 -> S0 [ label = <[^acd]> ];
        S4 -> S1 [ label = <a> ];
        S4 -> S3 [ label = <c> ];
        S4 -> S2 [ label = <d> ];
        Sstart -> S0 [ label = <> ];
}
```