### PR TITLE
Splits the dfavm opcodes into "IR" opcodes and "VM" opcodes, adds new encoding, utilities

### DIFF
--- a/include/fsm/vm.h
+++ b/include/fsm/vm.h
@@ -13,16 +13,10 @@ enum fsm_vm_compile_flags {
 
 	FSM_VM_COMPILE_PRINT_ENC       = 0x0004,
 
-	FSM_VM_COMPILE_OPTIM1          = 0X0008,
-	FSM_VM_COMPILE_OPTIM2          = 0X0010
-
-	/*
-	FSM_VM_COMPILE_VAR_ENC         = 0x0020,
-	FSM_VM_COMPILE_FIXED_ENC       = 0x0040,
-	*/
+	FSM_VM_COMPILE_OPTIM           = 0X0008
 };
 
-#define FSM_VM_COMPILE_DEFAULT_FLAGS (FSM_VM_COMPILE_OPTIM1 | FSM_VM_COMPILE_OPTIM2)
+#define FSM_VM_COMPILE_DEFAULT_FLAGS FSM_VM_COMPILE_OPTIM
 
 struct fsm_vm_compile_opts {
 	unsigned int flags;
@@ -33,7 +27,7 @@ struct fsm_dfavm *
 fsm_vm_compile(const struct fsm *fsm);
 
 struct fsm_dfavm *
-fsm_vm_compile_with_opts(const struct fsm *fsm, struct fsm_vm_compile_opts opts);
+fsm_vm_compile_with_options(const struct fsm *fsm, struct fsm_vm_compile_opts opts);
 
 struct fsm_dfavm *
 fsm_vm_read(FILE *f);

--- a/include/fsm/vm.h
+++ b/include/fsm/vm.h
@@ -18,9 +18,16 @@ enum fsm_vm_compile_flags {
 
 #define FSM_VM_COMPILE_DEFAULT_FLAGS FSM_VM_COMPILE_OPTIM
 
+enum fsm_vm_compile_output {
+	FSM_VM_COMPILE_VM_V1 = 0,
+	FSM_VM_COMPILE_VM_V2 = 1
+};
+
 struct fsm_vm_compile_opts {
 	unsigned int flags;
-	FILE *out;
+	enum fsm_vm_compile_output output;
+
+	FILE *log;
 };
 
 struct fsm_dfavm *

--- a/include/fsm/vm.h
+++ b/include/fsm/vm.h
@@ -7,8 +7,33 @@
 struct fsm;
 struct fsm_dfavm;
 
+enum fsm_vm_compile_flags {
+	FSM_VM_COMPILE_PRINT_IR        = 0x0001,
+	FSM_VM_COMPILE_PRINT_IR_PREOPT = 0x0002,
+
+	FSM_VM_COMPILE_PRINT_ENC       = 0x0004,
+
+	FSM_VM_COMPILE_OPTIM1          = 0X0008,
+	FSM_VM_COMPILE_OPTIM2          = 0X0010
+
+	/*
+	FSM_VM_COMPILE_VAR_ENC         = 0x0020,
+	FSM_VM_COMPILE_FIXED_ENC       = 0x0040,
+	*/
+};
+
+#define FSM_VM_COMPILE_DEFAULT_FLAGS (FSM_VM_COMPILE_OPTIM1 | FSM_VM_COMPILE_OPTIM2)
+
+struct fsm_vm_compile_opts {
+	unsigned int flags;
+	FILE *out;
+};
+
 struct fsm_dfavm *
 fsm_vm_compile(const struct fsm *fsm);
+
+struct fsm_dfavm *
+fsm_vm_compile_with_opts(const struct fsm *fsm, struct fsm_vm_compile_opts opts);
 
 struct fsm_dfavm *
 fsm_vm_read(FILE *f);

--- a/src/libfsm/dfavm.c
+++ b/src/libfsm/dfavm.c
@@ -1680,14 +1680,11 @@ dfavm_compile(struct ir *ir, struct fsm_vm_compile_opts opts)
 		fprintf(f, "\n");
 	}
 
-	/* basic optimizations */
-	if (opts.flags & FSM_VM_COMPILE_OPTIM1) {
-		order_basic_blocks(&a);
+	order_basic_blocks(&a);
 
-		/* medium optimizations */
-		if (opts.flags & FSM_VM_COMPILE_OPTIM2) {
-			eliminate_unnecessary_branches(&a);
-		}
+	/* basic optimizations */
+	if (opts.flags & FSM_VM_COMPILE_OPTIM) {
+		eliminate_unnecessary_branches(&a);
 	}
 
 	/* optimization is finished.  now assign opcode indexes */
@@ -1712,12 +1709,6 @@ dfavm_compile(struct ir *ir, struct fsm_vm_compile_opts opts)
 #if DEBUG_VM_OPCODES
 	dump_states(stdout, &a);
 #endif /* DEBUG_VM_OPCODES */
-
-	/*
-	fprintf(stderr,"\n---[ vm instructions ]---\n");
-	print_vm_instr(stderr, &a);
-	fprintf(stderr,"\n");
-	*/
 
 	vm = encode_opasm_v1(&a);
 	if (vm == NULL) {
@@ -1985,7 +1976,7 @@ vm_match_v1(const struct dfavm_v1 *vm, struct vm_state *st, const char *buf, siz
 static enum dfavm_state
 vm_match(const struct fsm_dfavm *vm, struct vm_state *st, const char *buf, size_t n)
 {
-	if ((vm->version_major == DFAVM_VARENC_MAJOR) && (vm->version_minor == DFAVM_VARENC_MINOR)) {
+	if (vm->version_major == DFAVM_VARENC_MAJOR && vm->version_minor == DFAVM_VARENC_MINOR) {
 		return vm_match_v1(&vm->u.v1, st, buf, n);
 	}
 

--- a/src/libfsm/dfavm.c
+++ b/src/libfsm/dfavm.c
@@ -451,6 +451,13 @@ print_vm_instr(FILE *f, const struct dfavm_assembler *a)
 	}
 }
 
+struct dfavm_op_ir_pool {
+	struct dfavm_op_ir_pool *next;
+
+	unsigned int top;
+	struct dfavm_op_ir ops[1024];
+};
+
 #define ARRAYLEN(a) (sizeof (a) / sizeof ((a)[0]))
 
 static struct dfavm_op_ir_pool *

--- a/src/libfsm/dfavm.c
+++ b/src/libfsm/dfavm.c
@@ -26,10 +26,11 @@
 
 // VM state:
 //
-//   Conceptually, the VM has is composed of:
+//   Conceptually, the VM is composed of:
 //   - string buffer: holds 8-bit bytes to match
 //   - program buffer: holds the VM bytecode
 //   - address buffer: holds various tables and data
+//   - string buffer: holds string constant data
 //   - three additional registers:
 //
 //     SP - string pointer  - 32-bit unsigned offset into string buffer
@@ -37,7 +38,7 @@
 //                                   string buffer byte at SP
 //     PC - program counter - 32-bit unsigned offset into program buffer
 //
-// Note: currently the address buffer is not used and should be empty
+// Note: currently the address buffer and string buffer are currently not used
 
 // VM intermediate representation
 //

--- a/src/libfsm/dfavm.c
+++ b/src/libfsm/dfavm.c
@@ -198,10 +198,6 @@
 //   DD=11 is reserved for future use
 //
 
-struct fsm_dfavm {
-	unsigned char *ops;
-	uint32_t len;
-};
 
 #define DFAVM_VERSION_MAJOR 0x00
 #define DFAVM_VERSION_MINOR 0x01

--- a/src/libfsm/dfavm.c
+++ b/src/libfsm/dfavm.c
@@ -18,6 +18,8 @@
 #include "internal.h"
 #include "print/ir.h"
 
+#include "dfavm.h"
+
 #define DEBUG_ENCODING     0
 #define DEBUG_VM_EXECUTION 0
 #define DEBUG_VM_OPCODES   0
@@ -196,94 +198,6 @@
 //   DD=11 is reserved for future use
 //
 
-enum dfavm_instr_bits {
-	// Stop the VM, mark match or failure
-	VM_OP_STOP   = 0,
-
-	// Start of each state: fetch next character.  Indicates
-	// match / fail if EOS.
-	VM_OP_FETCH  = 1,
-
-	// Branch to another state
-	VM_OP_BRANCH = 2,
-};
-
-enum dfavm_cmp_bits {
-	VM_CMP_ALWAYS = 0,
-	VM_CMP_LT     = 1,
-	VM_CMP_LE     = 2,
-	VM_CMP_GE     = 3,
-	VM_CMP_GT     = 4,
-	VM_CMP_EQ     = 5,
-	VM_CMP_NE     = 6,
-};
-
-enum dfavm_end_bits {
-	VM_END_FAIL = 0,
-	VM_END_SUCC = 1,
-};
-
-enum dfavm_dest_bits {
-	VM_DEST_NONE  = 0,
-	VM_DEST_SHORT = 1,  // 11-bit dest
-	VM_DEST_NEAR  = 2,  // 18-bit dest
-	VM_DEST_FAR   = 3,  // 32-bit dest
-};
-
-struct dfavm_op {
-	struct dfavm_op *next;
-	uint32_t count;
-	uint32_t offset;
-
-	uint32_t num_incoming; // number of branches to this instruction
-
-	enum dfavm_cmp_bits cmp;
-	enum dfavm_instr_bits instr;
-
-	union {
-		struct {
-			unsigned state;
-			enum dfavm_end_bits end_bits;
-		} fetch;
-
-		struct {
-			enum dfavm_end_bits end_bits;
-		} stop;
-
-		struct {
-			struct dfavm_op *dest_arg;
-			enum dfavm_dest_bits dest;
-			uint32_t dest_state;
-			int32_t  rel_dest;
-		} br;
-	} u;
-
-	unsigned char cmp_arg;
-	unsigned char num_encoded_bytes;
-	int in_trace;
-};
-
-struct dfavm_op_pool {
-	struct dfavm_op_pool *next;
-
-	unsigned int top;
-	struct dfavm_op ops[1024];
-};
-
-struct dfavm_assembler {
-	struct dfavm_op_pool *pool;
-	struct dfavm_op *freelist;
-
-	struct dfavm_op **ops;
-	struct dfavm_op *linked;
-
-	size_t nstates;
-	size_t start;
-
-	uint32_t nbytes;
-	uint32_t count;
-};
-
 struct fsm_dfavm {
 	unsigned char *ops;
 	uint32_t len;
@@ -292,16 +206,6 @@ struct fsm_dfavm {
 #define DFAVM_VERSION_MAJOR 0x00
 #define DFAVM_VERSION_MINOR 0x01
 #define DFAVM_MAGIC "DFAVM$"
-
-enum dfavm_io_result {
-	DFAVM_IO_OK = 0,
-	DFAVM_IO_ERROR_WRITING,
-	DFAVM_IO_ERROR_READING,
-	DFAVM_IO_OUT_OF_MEMORY,
-	DFAVM_IO_BAD_HEADER,
-	DFAVM_IO_UNSUPPORTED_VERSION,
-	DFAVM_IO_SHORT_READ,
-};
 
 enum dfavm_io_result
 fsm_dfavm_save(FILE *f, const struct fsm_dfavm *vm)

--- a/src/libfsm/dfavm.c
+++ b/src/libfsm/dfavm.c
@@ -196,11 +196,6 @@
 //   DD=11 is reserved for future use
 //
 
-#define MASK_OP   0x18
-#define MASK_CMP  0xE0
-#define MASK_END  0x01
-#define MASK_DEST 0x03
-
 enum dfavm_instr_bits {
 	// Stop the VM, mark match or failure
 	VM_OP_STOP   = 0,

--- a/src/libfsm/dfavm.c
+++ b/src/libfsm/dfavm.c
@@ -1752,18 +1752,6 @@ fsm_vm_free(struct fsm_dfavm *vm)
 	(void)vm;
 }
 
-enum dfavm_state {
-	VM_FAIL     = -1,
-	VM_MATCHING =  0,
-	VM_SUCCESS  =  1,
-};
-
-struct vm_state {
-	uint32_t pc;
-	enum dfavm_state state;
-	int fetch_state;
-};
-
 static uint32_t
 running_print_op(const unsigned char *ops, uint32_t pc, const char *sp, const char *buf, size_t n, char ch, FILE *f) {
 	int op, cmp, end, dest;

--- a/src/libfsm/dfavm.c
+++ b/src/libfsm/dfavm.c
@@ -436,7 +436,7 @@ opasm_free_list(struct dfavm_assembler *a, struct dfavm_op *op)
 }
 
 static struct dfavm_op *
-opasm_new(struct dfavm_assembler *a, enum dfavm_instr_bits instr, enum dfavm_cmp_bits cmp, unsigned char arg)
+opasm_new(struct dfavm_assembler *a, enum dfavm_op_instr instr, enum dfavm_op_cmp cmp, unsigned char arg)
 {
 	static const struct dfavm_op zero;
 
@@ -464,7 +464,7 @@ opasm_new(struct dfavm_assembler *a, enum dfavm_instr_bits instr, enum dfavm_cmp
 }
 
 static struct dfavm_op *
-opasm_new_fetch(struct dfavm_assembler *a, unsigned state, enum dfavm_end_bits end)
+opasm_new_fetch(struct dfavm_assembler *a, unsigned state, enum dfavm_op_end end)
 {
 	struct dfavm_op *op;
 
@@ -478,7 +478,7 @@ opasm_new_fetch(struct dfavm_assembler *a, unsigned state, enum dfavm_end_bits e
 }
 
 static struct dfavm_op *
-opasm_new_stop(struct dfavm_assembler *a, enum dfavm_cmp_bits cmp, unsigned char arg, enum dfavm_end_bits end)
+opasm_new_stop(struct dfavm_assembler *a, enum dfavm_op_cmp cmp, unsigned char arg, enum dfavm_op_end end)
 {
 	struct dfavm_op *op;
 
@@ -491,7 +491,7 @@ opasm_new_stop(struct dfavm_assembler *a, enum dfavm_cmp_bits cmp, unsigned char
 }
 
 static struct dfavm_op *
-opasm_new_branch(struct dfavm_assembler *a, enum dfavm_cmp_bits cmp, unsigned char arg, uint32_t dest_state)
+opasm_new_branch(struct dfavm_assembler *a, enum dfavm_op_cmp cmp, unsigned char arg, uint32_t dest_state)
 {
 	struct dfavm_op *op;
 
@@ -674,7 +674,7 @@ xlate_table_ranges(struct dfavm_assembler *a, struct dfa_table *table, struct df
 
 			/* emit instr */
 			int arg = i-1;
-			enum dfavm_cmp_bits cmp = (i > lo+1) ? VM_CMP_LE : VM_CMP_EQ;
+			enum dfavm_op_cmp cmp = (i > lo+1) ? VM_CMP_LE : VM_CMP_EQ;
 
 			op = (dst < 0)
 				? opasm_new_stop(a, cmp, arg, VM_END_FAIL)

--- a/src/libfsm/dfavm.c
+++ b/src/libfsm/dfavm.c
@@ -1702,7 +1702,7 @@ encode_opasm_v2(const struct dfavm_assembler *a)
 				uint32_t dest_state = op->u.br.dest_index;
 				int64_t state_diff = (int64_t)dest_state - (int64_t)i;
 
-				if (state_diff >= INT16_MIN || state_diff <= INT16_MAX) {
+				if (state_diff >= INT16_MIN && state_diff <= INT16_MAX) {
 					instr_bits = VM_V2_OP_BRANCH;
 					dest_arg = (int16_t)state_diff;
 				}
@@ -1722,7 +1722,7 @@ encode_opasm_v2(const struct dfavm_assembler *a)
 							new_acap = acap + acap/2;
 						}
 
-						new_abuf = realloc(abuf, acap * sizeof abuf[0]);
+						new_abuf = realloc(abuf, new_acap * sizeof abuf[0]);
 						if (new_abuf == NULL) {
 							goto error;
 						}

--- a/src/libfsm/dfavm.c
+++ b/src/libfsm/dfavm.c
@@ -1784,7 +1784,7 @@ dump_states(FILE *f, struct dfavm_assembler *a)
 			fprintf(f, "%6s |    ; state %u %p %s\n", "", state, (void *)op, (state == a->start) ? "(start)" : "");
 		}
 
-		fprintf(f, "%6zu |    ", count++);
+		fprintf(f, "%6zu | %p | %6lu |  ", count++, (void*)op, (unsigned long)op->index);
 		print_op_ir(f, op);
 	}
 

--- a/src/libfsm/dfavm.c
+++ b/src/libfsm/dfavm.c
@@ -307,7 +307,7 @@ print_op_ir(FILE *f, struct dfavm_op_ir *op)
 
 	cmp = cmp_name(op->cmp);
 
-	fprintf(f, "[%4lu] %1lu\t", (unsigned long)op->offset, (unsigned long)op->num_encoded_bytes);
+	// fprintf(f, "[%4lu] %1lu\t", (unsigned long)op->offset, (unsigned long)op->num_encoded_bytes);
 
 	switch (op->instr) {
 	case VM_OP_FETCH:
@@ -324,16 +324,7 @@ print_op_ir(FILE *f, struct dfavm_op_ir *op)
 
 	case VM_OP_BRANCH:
 		{
-			char dst;
-			switch (op->u.br.dest) {
-			case VM_DEST_NONE:  dst = 'Z'; break;
-			case VM_DEST_SHORT: dst = 'S'; break;
-			case VM_DEST_NEAR:  dst = 'N'; break;
-			case VM_DEST_FAR:   dst = 'F'; break;
-			default:            dst = '!'; break;
-			}
-
-			fprintf(f, "BR%c%s", dst, cmp);
+			fprintf(f, "BR%s", cmp);
 		}
 		break;
 
@@ -352,13 +343,12 @@ print_op_ir(FILE *f, struct dfavm_op_ir *op)
 	}
 
 	if (op->instr == VM_OP_BRANCH) {
-		fprintf(f, "%s%ld [st=%lu]", ((nargs>0) ? ", " : " "),
-			(long)op->u.br.rel_dest, (unsigned long)op->u.br.dest_state);
+		fprintf(f, "%s [st=%lu]", ((nargs>0) ? ", " : " "),
+			(unsigned long)op->u.br.dest_state);
 		nargs++;
 	}
 
-	fprintf(f, "\t; %6lu bytes [%u incoming]",
-		(unsigned long)op->num_encoded_bytes, op->num_incoming);
+	fprintf(f, "\t; [%u incoming]", op->num_incoming);
 	switch (op->instr) {
 	case VM_OP_FETCH:
 		fprintf(f, "  [state %u]", op->u.fetch.state);
@@ -586,7 +576,7 @@ opasm_new_branch(struct dfavm_assembler *a, enum dfavm_op_cmp cmp, unsigned char
 
 	op = opasm_new(a, VM_OP_BRANCH, cmp, arg);
 	if (op != NULL) {
-		op->u.br.dest  = VM_DEST_FAR;  // start with all branches as 'far'
+		// op->u.br.dest  = VM_DEST_FAR;  // start with all branches as 'far'
 		op->u.br.dest_state = dest_state;
 	}
 

--- a/src/libfsm/dfavm.h
+++ b/src/libfsm/dfavm.h
@@ -82,13 +82,6 @@ struct dfavm_op_ir {
 	} u;
 };
 
-struct dfavm_op_ir_pool {
-	struct dfavm_op_ir_pool *next;
-
-	unsigned int top;
-	struct dfavm_op_ir ops[1024];
-};
-
 struct dfavm_vm_op {
 	const struct dfavm_op_ir *ir;
 	uint32_t offset;
@@ -117,6 +110,8 @@ struct dfavm_vm_op {
 	unsigned char cmp_arg;
 	unsigned char num_encoded_bytes;
 };
+
+struct dfavm_op_ir_pool;
 
 struct dfavm_assembler {
 	struct dfavm_op_ir_pool *pool;

--- a/src/libfsm/dfavm.h
+++ b/src/libfsm/dfavm.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2008-2017 Shannon F. Stewman
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#ifndef FSM_DFAVM_H
+#define FSM_DFAVM_H
+
+enum dfavm_instr_bits {
+	// Stop the VM, mark match or failure
+	VM_OP_STOP   = 0,
+
+	// Start of each state: fetch next character.  Indicates
+	// match / fail if EOS.
+	VM_OP_FETCH  = 1,
+
+	// Branch to another state
+	VM_OP_BRANCH = 2,
+};
+
+enum dfavm_cmp_bits {
+	VM_CMP_ALWAYS = 0,
+	VM_CMP_LT     = 1,
+	VM_CMP_LE     = 2,
+	VM_CMP_GE     = 3,
+	VM_CMP_GT     = 4,
+	VM_CMP_EQ     = 5,
+	VM_CMP_NE     = 6,
+};
+
+enum dfavm_end_bits {
+	VM_END_FAIL = 0,
+	VM_END_SUCC = 1,
+};
+
+enum dfavm_dest_bits {
+	VM_DEST_NONE  = 0,
+	VM_DEST_SHORT = 1,  // 11-bit dest
+	VM_DEST_NEAR  = 2,  // 18-bit dest
+	VM_DEST_FAR   = 3,  // 32-bit dest
+};
+
+struct dfavm_op {
+	struct dfavm_op *next;
+	uint32_t count;
+	uint32_t offset;
+
+	uint32_t num_incoming; // number of branches to this instruction
+
+	enum dfavm_cmp_bits cmp;
+	enum dfavm_instr_bits instr;
+
+	union {
+		struct {
+			unsigned state;
+			enum dfavm_end_bits end_bits;
+		} fetch;
+
+		struct {
+			enum dfavm_end_bits end_bits;
+		} stop;
+
+		struct {
+			struct dfavm_op *dest_arg;
+			enum dfavm_dest_bits dest;
+			uint32_t dest_state;
+			int32_t  rel_dest;
+		} br;
+	} u;
+
+	unsigned char cmp_arg;
+	unsigned char num_encoded_bytes;
+	int in_trace;
+};
+
+struct dfavm_op_pool {
+	struct dfavm_op_pool *next;
+
+	unsigned int top;
+	struct dfavm_op ops[1024];
+};
+
+struct dfavm_assembler {
+	struct dfavm_op_pool *pool;
+	struct dfavm_op *freelist;
+
+	struct dfavm_op **ops;
+	struct dfavm_op *linked;
+
+	size_t nstates;
+	size_t start;
+
+	uint32_t nbytes;
+	uint32_t count;
+};
+
+enum dfavm_io_result {
+	DFAVM_IO_OK = 0,
+	DFAVM_IO_ERROR_WRITING,
+	DFAVM_IO_ERROR_READING,
+	DFAVM_IO_OUT_OF_MEMORY,
+	DFAVM_IO_BAD_HEADER,
+	DFAVM_IO_UNSUPPORTED_VERSION,
+	DFAVM_IO_SHORT_READ,
+};
+
+#endif /* FSM_DFAVM_H */

--- a/src/libfsm/dfavm.h
+++ b/src/libfsm/dfavm.h
@@ -140,6 +140,11 @@ enum dfavm_io_result {
 	DFAVM_IO_SHORT_READ,
 };
 
+struct dfavm_v1 {
+	unsigned char *ops;
+	uint32_t len;
+};
+
 enum dfavm_state {
 	VM_FAIL     = -1,
 	VM_MATCHING =  0,
@@ -153,8 +158,12 @@ struct vm_state {
 };
 
 struct fsm_dfavm {
-	unsigned char *ops;
-	uint32_t len;
+	uint8_t version_major;
+	uint8_t version_minor;
+
+	union {
+		struct dfavm_v1 v1;
+	} u;
 };
 
 #endif /* FSM_DFAVM_H */

--- a/src/libfsm/dfavm.h
+++ b/src/libfsm/dfavm.h
@@ -140,6 +140,18 @@ enum dfavm_io_result {
 	DFAVM_IO_SHORT_READ,
 };
 
+enum dfavm_state {
+	VM_FAIL     = -1,
+	VM_MATCHING =  0,
+	VM_SUCCESS  =  1,
+};
+
+struct vm_state {
+	uint32_t pc;
+	enum dfavm_state state;
+	int fetch_state;
+};
+
 struct fsm_dfavm {
 	unsigned char *ops;
 	uint32_t len;

--- a/src/libfsm/dfavm.h
+++ b/src/libfsm/dfavm.h
@@ -145,6 +145,27 @@ struct dfavm_v1 {
 	uint32_t len;
 };
 
+enum dfavm_vm_op_v2 {
+	// Stop the VM, mark match or failure
+	VM_V2_OP_STOP    = 0,
+
+	// Start of each state: fetch next character.  Indicates
+	// match / fail if EOS.
+	VM_V2_OP_FETCH   = 1,
+
+	// Branch to another state
+	VM_V2_OP_BRANCH  = 2,
+	VM_V2_OP_IBRANCH = 3,
+};
+
+struct dfavm_v2 {
+	uint32_t *abuf;
+	uint64_t alen;
+
+	uint32_t *ops;
+	uint32_t len;
+};
+
 enum dfavm_state {
 	VM_FAIL     = -1,
 	VM_MATCHING =  0,
@@ -163,6 +184,7 @@ struct fsm_dfavm {
 
 	union {
 		struct dfavm_v1 v1;
+		struct dfavm_v2 v2;
 	} u;
 };
 

--- a/src/libfsm/dfavm.h
+++ b/src/libfsm/dfavm.h
@@ -58,9 +58,9 @@ struct dfavm_op_ir {
 	 */
 	uint32_t index;
 
-	uint32_t offset;
-
 	uint32_t num_incoming; // number of branches to this instruction
+	int in_trace;
+	int cmp_arg;
 
 	enum dfavm_op_cmp cmp;
 	enum dfavm_op_instr instr;
@@ -77,15 +77,9 @@ struct dfavm_op_ir {
 
 		struct {
 			struct dfavm_op_ir *dest_arg;
-			enum dfavm_op_dest dest;
 			uint32_t dest_state;
-			int32_t  rel_dest;
 		} br;
 	} u;
-
-	int num_encoded_bytes;
-	int in_trace;
-	unsigned char cmp_arg;
 };
 
 struct dfavm_op_ir_pool {

--- a/src/libfsm/dfavm.h
+++ b/src/libfsm/dfavm.h
@@ -7,7 +7,7 @@
 #ifndef FSM_DFAVM_H
 #define FSM_DFAVM_H
 
-enum dfavm_instr_bits {
+enum dfavm_op_instr {
 	// Stop the VM, mark match or failure
 	VM_OP_STOP   = 0,
 
@@ -19,7 +19,7 @@ enum dfavm_instr_bits {
 	VM_OP_BRANCH = 2,
 };
 
-enum dfavm_cmp_bits {
+enum dfavm_op_cmp {
 	VM_CMP_ALWAYS = 0,
 	VM_CMP_LT     = 1,
 	VM_CMP_LE     = 2,
@@ -29,12 +29,12 @@ enum dfavm_cmp_bits {
 	VM_CMP_NE     = 6,
 };
 
-enum dfavm_end_bits {
+enum dfavm_op_end {
 	VM_END_FAIL = 0,
 	VM_END_SUCC = 1,
 };
 
-enum dfavm_dest_bits {
+enum dfavm_op_dest {
 	VM_DEST_NONE  = 0,
 	VM_DEST_SHORT = 1,  // 11-bit dest
 	VM_DEST_NEAR  = 2,  // 18-bit dest
@@ -48,22 +48,22 @@ struct dfavm_op {
 
 	uint32_t num_incoming; // number of branches to this instruction
 
-	enum dfavm_cmp_bits cmp;
-	enum dfavm_instr_bits instr;
+	enum dfavm_op_cmp cmp;
+	enum dfavm_op_instr instr;
 
 	union {
 		struct {
 			unsigned state;
-			enum dfavm_end_bits end_bits;
+			enum dfavm_op_end end_bits;
 		} fetch;
 
 		struct {
-			enum dfavm_end_bits end_bits;
+			enum dfavm_op_end end_bits;
 		} stop;
 
 		struct {
 			struct dfavm_op *dest_arg;
-			enum dfavm_dest_bits dest;
+			enum dfavm_op_dest dest;
 			uint32_t dest_state;
 			int32_t  rel_dest;
 		} br;

--- a/src/libfsm/dfavm.h
+++ b/src/libfsm/dfavm.h
@@ -140,4 +140,9 @@ enum dfavm_io_result {
 	DFAVM_IO_SHORT_READ,
 };
 
+struct fsm_dfavm {
+	unsigned char *ops;
+	uint32_t len;
+};
+
 #endif /* FSM_DFAVM_H */

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -101,6 +101,7 @@ closure_free # XXX: workaround for fsm
 fsm_mergeab
 
 fsm_vm_compile
+fsm_vm_compile_with_options
 fsm_vm_free
 fsm_vm_match_buffer
 fsm_vm_match_file

--- a/src/retest/Makefile
+++ b/src/retest/Makefile
@@ -2,18 +2,21 @@
 
 SRC += src/retest/main.c
 SRC += src/retest/reperf.c
+SRC += src/retest/cvtpcre.c
 
-.for src in ${SRC:Msrc/retest/main.c} ${SRC:Msrc/retest/reperf.c}
+.for src in ${SRC:Msrc/retest/main.c} ${SRC:Msrc/retest/reperf.c} ${SRC:Msrc/retest/cvtpcre.c}
 CFLAGS.${src} += -I src # XXX: for internal.h
 DFLAGS.${src} += -I src # XXX: for internal.h
 .endfor
 
 PROG += retest
 PROG += reperf
+PROG += cvtpcre
 
 .for lib in ${LIB:Mlibfsm} ${LIB:Mlibre}
 ${BUILD}/bin/retest: ${BUILD}/lib/${lib:R}.a
 ${BUILD}/bin/reperf: ${BUILD}/lib/${lib:R}.a
+${BUILD}/bin/cvtpcre: ${BUILD}/lib/${lib:R}.a
 .endfor
 
 .for src in ${SRC:Msrc/retest/main.c}
@@ -22,5 +25,9 @@ ${BUILD}/bin/retest: ${BUILD}/${src:R}.o
 
 .for src in ${SRC:Msrc/retest/reperf.c}
 ${BUILD}/bin/reperf: ${BUILD}/${src:R}.o
+.endfor
+
+.for src in ${SRC:Msrc/retest/cvtpcre.c}
+${BUILD}/bin/cvtpcre: ${BUILD}/${src:R}.o
 .endfor
 

--- a/src/retest/Makefile
+++ b/src/retest/Makefile
@@ -1,19 +1,26 @@
 .include "../../share/mk/top.mk"
 
 SRC += src/retest/main.c
+SRC += src/retest/reperf.c
 
-.for src in ${SRC:Msrc/retest/main.c}
+.for src in ${SRC:Msrc/retest/main.c} ${SRC:Msrc/retest/reperf.c}
 CFLAGS.${src} += -I src # XXX: for internal.h
 DFLAGS.${src} += -I src # XXX: for internal.h
 .endfor
 
 PROG += retest
+PROG += reperf
 
 .for lib in ${LIB:Mlibfsm} ${LIB:Mlibre}
 ${BUILD}/bin/retest: ${BUILD}/lib/${lib:R}.a
+${BUILD}/bin/reperf: ${BUILD}/lib/${lib:R}.a
 .endfor
 
-.for src in ${SRC:Msrc/retest/*.c}
+.for src in ${SRC:Msrc/retest/main.c}
 ${BUILD}/bin/retest: ${BUILD}/${src:R}.o
+.endfor
+
+.for src in ${SRC:Msrc/retest/reperf.c}
+${BUILD}/bin/reperf: ${BUILD}/${src:R}.o
 .endfor
 

--- a/src/retest/cvtpcre.c
+++ b/src/retest/cvtpcre.c
@@ -1,0 +1,252 @@
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <fsm/fsm.h>
+#include <fsm/options.h>
+
+#include <re/re.h>
+
+#include <adt/xalloc.h>
+
+#include <unistd.h>
+
+struct str {
+	char *s;
+	size_t len;
+	size_t cap;
+};
+
+static const struct str init_str;
+
+static void
+str_append(struct str *str, int ch)
+{
+	if (str->len+1 >= str->cap) {
+		size_t newcap;
+
+		if (str->cap < 16) {
+			newcap = 32;
+		} else if (str->cap < 1024) {
+			newcap = 2*str->cap;
+		} else {
+			newcap = str->cap + str->cap/2;
+		}
+
+		str->s = xrealloc(str->s, newcap);
+		str->cap = newcap;
+	}
+
+	str->s[str->len++] = ch;
+	str->s[str->len] = '\0';
+}
+
+static struct str *
+readline(FILE *f, struct str *str)
+{
+	int ch;
+
+	str->len = 0;
+
+	while (ch = getc(f), ch != EOF) {
+		str_append(str, ch);
+
+		if (ch == '\n') {
+			return str;
+		}
+	}
+
+	return (str->len > 0) ? str : NULL;
+}
+
+static int
+allws(const char *s)
+{
+	while (*s && isspace((unsigned char)*s)) {
+		s++;
+	}
+
+	return *s == '\0';
+}
+
+static char *
+lstrip(char *s)
+{
+	while (*s && isspace((unsigned char)*s)) {
+		s++;
+	}
+
+	return s;
+}
+
+static char *
+decode_escapes(char *s)
+{
+	char *b = s, *p = s;
+
+	while (*s) {
+		if (*s != '\\') {
+			*p++ = *s++;
+			continue;
+		}
+
+		s++;
+		if (*s == '\0') {
+			continue;
+		}
+
+		switch (s[0]) {
+		case 'a': 
+		case 'b':
+		case 'e':
+		case 'f':
+		case 'n':
+		case 'r':
+		case 't':
+		case 'x':
+		case '0': case '1': case '2': case '3': case '4':
+		case '5': case '6': case '7': case '8': case '9':
+		case '\\':
+			*p++ = '\\'; *p++ = s[0]; break;
+		default:
+			  *p++ = *s; break;
+		}
+
+		s++;
+	}
+
+	*p = '\0';
+	return b;
+}
+
+enum state {
+	ST_DEFAULT = 0,
+	ST_MATCHES = 1,
+	ST_NOTMATCHES = 2
+};
+
+int main(int argc, char **argv)
+{
+	struct str l;
+	enum state state;
+	size_t count, nparsed, linenum;
+	int re_ok = 0;
+	struct fsm_options opt;
+
+	(void)argc;
+	(void)argv;
+
+	l = init_str;
+	state = ST_DEFAULT;
+
+	opt.comments = 0;
+	opt.anonymous_states  = 1;
+	opt.consolidate_edges = 1;
+	opt.io = FSM_IO_GETC;
+
+	count   = 0;
+	nparsed = 0;
+	linenum = 0;
+
+	while (readline(stdin, &l) != NULL) {
+		char *s = l.s;
+		size_t n = l.len;
+		int reset = 0;
+
+		linenum++;
+
+		if (n > 0 && s[n-1] == '\n') {
+			s[n-1] = '\0';
+			n--;
+		}
+
+		switch (state) {
+		case ST_DEFAULT:
+			if (n > 1 && s[0] == '/' && s[n-1] == '/') {
+				static const struct re_err err_zero;
+				char *regexp;
+
+				struct fsm *fsm;
+				enum re_flags flags;
+				struct re_err comp_err;
+
+				s[n-1] = '\0';
+				s++;
+
+				regexp = xstrdup(s);
+
+				comp_err = err_zero;
+				flags = 0;
+
+				fsm = re_comp(RE_PCRE, fsm_sgetc, &s, &opt, flags, &comp_err);
+				re_ok = (fsm != NULL);
+				if (re_ok) {
+					fsm_free(fsm);
+					nparsed++;
+					if (count > 0) {
+						printf("\n");
+					}
+
+					printf("%s\n", regexp);
+				} else {
+					fprintf(stderr, "line %5zu: could not parse regexp /%s/: %s\n",
+						linenum, s, re_strerror(comp_err.e));
+				}
+
+				free(regexp);
+
+				state = ST_MATCHES;
+				count++;
+			}
+			break;
+
+		case ST_MATCHES:
+			if (n > 1 && s[0] == '\\' && s[1] == '=') {
+				state = ST_NOTMATCHES;
+			} else if (n == 0 || allws(s)) {
+				reset = 1;
+			} else if (n > 0 && s[0] == '/') {
+				fprintf(stderr, "state machine failure at line %zu: regexp before matches/notmatches ends\n", linenum);
+				reset = 1;
+			} else {
+				if (re_ok) {
+					printf("+%s\n", decode_escapes(lstrip(s)));
+				}
+			}
+			break;
+
+		case ST_NOTMATCHES:
+			if (n == 0 || allws(s)) {
+				reset = 1;
+			} else if (s[0] == '/') {
+				fprintf(stderr, "state machine failure at line %zu: regexp before matches/notmatches ends\n", linenum);
+				reset = 1;
+			} else {
+				if (re_ok) {
+					printf("-%s\n", decode_escapes(lstrip(s)));
+				}
+			}
+			break;
+		}
+
+		if (reset) {
+			state = ST_DEFAULT;
+			re_ok = 0;
+		}
+
+		if ((linenum % 500) == 0) {
+			fprintf(stderr, "line %5zu: %zu entries, %zu parsed correctly\n", linenum, count, nparsed);
+		}
+	}
+
+	if (ferror(stdin)) {
+		perror("reading from stdin");
+		exit(EXIT_FAILURE);
+	}
+
+	fprintf(stderr, "done.  %zu lines, %zu entries, %zu parsed correctly\n", linenum, count, nparsed);
+
+	return EXIT_SUCCESS;
+}
+

--- a/src/retest/main.c
+++ b/src/retest/main.c
@@ -717,7 +717,7 @@ main(int argc, char *argv[])
 	enum re_dialect dialect;
 	int max_test_errors;
 
-	int optlevel = 2;
+	int optlevel = 1;
 
 	/* note these defaults are the opposite than for fsm(1) */
 	opt.anonymous_states  = 1;
@@ -738,6 +738,7 @@ main(int argc, char *argv[])
 			case 'O':
 				optlevel = strtoul(optarg, NULL, 10);
 				break;
+
 			case 'L':
 				if (strcmp(optarg, "ir_pre") == 0) {
 					vm_opts.flags |= FSM_VM_COMPILE_PRINT_IR;
@@ -788,13 +789,13 @@ main(int argc, char *argv[])
 		argv += optind;
 	}
 
-	if (optlevel > 0) {
-		vm_opts.flags |= FSM_VM_COMPILE_OPTIM;
-	}
-
 	if (argc < 1) {
 		usage();
 		return EXIT_FAILURE;
+	}
+
+	if (optlevel > 0) {
+		vm_opts.flags |= FSM_VM_COMPILE_OPTIM;
 	}
 
 	{

--- a/src/retest/reperf.c
+++ b/src/retest/reperf.c
@@ -6,7 +6,7 @@
 
 #if __linux__
 /* apparently you need this for Linux, and it breaks macOS */
-#  define _POSIX_C_SOURCE 2
+#  define _POSIX_C_SOURCE 199309L
 #endif
 
 #include <unistd.h>

--- a/src/retest/reperf.c
+++ b/src/retest/reperf.c
@@ -4,8 +4,9 @@
  * See LICENCE for the full copyright terms.
  */
 
-#if 0
-#define _POSIX_C_SOURCE 2
+#if __linux__
+/* apparently you need this for Linux, and it breaks macOS */
+#  define _POSIX_C_SOURCE 2
 #endif
 
 #include <unistd.h>

--- a/src/retest/reperf.c
+++ b/src/retest/reperf.c
@@ -1,0 +1,771 @@
+/*
+ * Copyright 2019 Shannon F. Stewman
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#if 0
+#define _POSIX_C_SOURCE 2
+#endif
+
+#include <unistd.h>
+
+#include <assert.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <ctype.h>
+#include <time.h>
+
+#include <fsm/fsm.h>
+#include <fsm/bool.h>
+#include <fsm/pred.h>
+#include <fsm/print.h>
+#include <fsm/options.h>
+#include <fsm/vm.h>
+
+#include <re/re.h>
+
+#include <adt/xalloc.h>
+
+#include "libfsm/internal.h" /* XXX */
+#include "libre/print.h" /* XXX */
+#include "libre/class.h" /* XXX */
+#include "libre/ast.h" /* XXX */
+
+
+#define DEBUG_ESCAPES     0
+#define DEBUG_VM_FSM      0
+#define DEBUG_TEST_REGEXP 0
+
+/* reperf driver file
+ *
+ * Each line starts with an instruction and is followed by a space and then an
+ * argument.
+ *
+ * # <comment>			comment line.  ignored.
+ *
+ * - <test_name>		starts test named <name>.  resets all settings.
+ *
+ * D <dialect>			sets the regexp dialect
+ *
+ * M <regexp>			sets the regexp
+ *
+ * S <string>			if the previous line was not an 'S' line, then
+ * 				sets matching to against a string and sets the
+ *				string buffer to <string>.  if the previous line
+ *				was an 'S' line, appends a newline and <string>
+ *				to the string buffer.
+ *
+ * F <file>			sets matching against a file.  sets the file to
+ * 				<file>
+ *
+ * N <count>			match is run <count> times
+ *
+ * R <count>			expects <count> matches.  <count> can be zero.
+ *
+ * X [<subtest_name>]		executes current match.  if <subtest_name> is
+ * 				given, timing / correctness are recorded as
+ * 				<test_name>.<subtest_name>, otherwise
+ * 				<test_name>
+ *
+ * Lines ending with \ are continued to the next line.
+ */
+
+static struct fsm_options opt;
+
+struct str {
+	char *data;
+	size_t len;
+	size_t cap;
+};
+
+enum error_type {
+	ERROR_NONE = 0          ,
+	/* ERROR_BAD_RECORD_TYPE   , */
+	/* ERROR_ESCAPE_SEQUENCE   , */
+	ERROR_PARSING_REGEXP    ,
+	ERROR_DETERMINISING     ,
+	ERROR_COMPILING_BYTECODE,
+	ERROR_SHOULD_MATCH      ,
+	ERROR_SHOULD_NOT_MATCH  ,
+	ERROR_FILE_IO           ,
+	ERROR_CLOCK_ERROR
+};
+
+enum match_type {
+	MATCH_STRING = 0,
+	MATCH_FILE   = 1
+};
+
+struct perf_case {
+	struct str test_name;
+	struct str regexp;
+	struct str match;
+
+	size_t line;
+	int count;
+	int expected_matches;
+	enum re_dialect dialect;
+	enum match_type mt;
+};
+
+static struct str
+str_empty(void)
+{
+	static const struct str zero;
+	return zero;
+}
+
+static void
+str_init(struct str *s, size_t cap)
+{
+	s->data = xmalloc(cap);
+	s->len = 0;
+	s->cap = cap;
+}
+
+static void
+str_clear(struct str *s)
+{
+	s->len = 0;
+	if (s->cap > 0) {
+		s->data[0] = '\0';
+	}
+}
+
+static void
+str_append(struct str *s, const char *str)
+{
+	size_t len, newlen;
+
+	len = strlen(str);
+	newlen = s->len + len + 1;
+
+	if (newlen > s->cap) {
+		s->data = xrealloc(s->data, newlen);
+		s->cap = newlen;
+	}
+
+	memcpy(&s->data[s->len], str, len+1);
+	s->len += len;
+}
+
+static void
+str_set(struct str *s, const char *str)
+{
+	size_t len = strlen(str);
+	if (len + 1 > s->cap) {
+		size_t newcap = len+1;
+		s->data = xrealloc(s->data, newcap);
+		s->cap = newcap;
+	}
+
+	memcpy(s->data, str, len+1);
+	s->len = len;
+}
+
+static void
+str_addch(struct str *s, char ch) {
+	if (s->len+1 >= s->cap) {
+		size_t newcap;
+
+		if (s->cap < 16) {
+			newcap = 32;
+		} else if (s->cap < 256) {
+			newcap = s->cap * 2;
+		} else {
+			newcap = s->cap + s->cap/2;
+		}
+
+		s->data = xrealloc(s->data, newcap);
+		s->cap = newcap;
+	}
+
+	s->data[s->len++] = ch;
+	s->data[s->len] = '\0';
+}
+
+static void
+str_free(struct str *s)
+{
+	free(s->data);
+	s->data = NULL;
+	s->len = s->cap = 0;
+}
+
+static void
+rstrip(char *s, size_t *lenp)
+{
+	char *e = &s[*lenp-1];
+	while (e > s && isspace((unsigned char)(*e))) {
+		*e = '\0';
+		(*lenp)--;
+	}
+}
+
+static char *
+lstrip(char *s)
+{
+	while (isspace((unsigned char)(*s))) {
+		s++;
+	}
+
+	return s;
+}
+
+static enum re_dialect
+dialect_name(const char *name)
+{
+	size_t i;
+
+	struct {
+		const char *name;
+		enum re_dialect dialect;
+	} a[] = {
+		{ "like",    RE_LIKE    },
+		{ "literal", RE_LITERAL },
+		{ "glob",    RE_GLOB    },
+		{ "native",  RE_NATIVE  },
+		{ "pcre",    RE_PCRE    },
+		{ "sql",     RE_SQL     }
+	};
+
+	assert(name != NULL);
+
+	for (i = 0; i < sizeof a / sizeof *a; i++) {
+		if (0 == strcmp(a[i].name, name)) {
+			return a[i].dialect;
+		}
+	}
+
+	fprintf(stderr, "unrecognised regexp dialect \"%s\"; valid dialects are: ", name);
+
+	for (i = 0; i < sizeof a / sizeof *a; i++) {
+		fprintf(stderr, "%s%s",
+			a[i].name,
+			i + 1 < sizeof a / sizeof *a ? ", " : "\n");
+	}
+
+	exit(EXIT_FAILURE);
+}
+
+static void
+perf_case_reset(struct perf_case *c)
+{
+	str_clear(&c->test_name);
+	str_clear(&c->regexp);
+	str_clear(&c->match);
+
+	c->count     = 1;
+	c->dialect   = RE_NATIVE;
+	c->mt        = MATCH_STRING;
+	c->expected_matches = 1;
+}
+
+static void
+perf_case_init(struct perf_case *c)
+{
+	c->test_name = str_empty();
+	c->regexp    = str_empty();
+	c->match     = str_empty();
+
+	c->count     = 1;
+	c->dialect   = RE_NATIVE;
+	c->mt        = MATCH_STRING;
+
+	c->expected_matches = 1;
+}
+
+static enum error_type
+perf_case_run(struct perf_case *c, double *delta);
+
+static void
+perf_case_report(struct perf_case *c, enum error_type err, double runtime_secs);
+
+static int
+parse_perf_case(FILE *f)
+{
+	size_t line;
+	char buf[4096];
+	char *s;
+	char lastcmd;
+	struct perf_case c;
+	struct str *scont;
+	enum error_type err;
+	double delta;
+
+	scont = NULL;
+	line = 0;
+	lastcmd = 0;
+	perf_case_init(&c);
+
+	while (s = fgets(buf, sizeof buf, f), s != NULL) {
+		char last;
+		char *b;
+		size_t len;
+
+		line++;
+		len = strlen(s);
+
+		if (scont) {
+			struct str *sc = scont;
+			scont = NULL;
+
+			if (s[len-1] == '\n') {
+				s[--len] = '\0';
+			}
+
+			if (len == 0) {
+				continue;
+			}
+
+			if (s[len-1] == '\\') {
+				s[--len] = '\0';
+				scont = sc;
+			}
+
+			str_append(sc, s);
+
+			/* append line to string buffer */
+			continue;
+		}
+
+		last = lastcmd;
+		lastcmd = s[0];
+
+		if (len == 0) {
+			continue;
+		}
+
+		/* get rid of newline */
+		if (s[len-1] == '\n') {
+			s[len-1] = '\0';
+			len--;
+			if (len == 0) {
+				continue;
+			}
+		}
+
+		if (s[0] == '#') {
+			continue;
+		}
+
+		switch (s[0]) {
+		case '#':
+			/* comment, skip */
+			continue;
+
+		case '-':
+			/* strip trailing whitespace */
+			rstrip(s, &len);
+			str_set(&c.test_name, lstrip(&s[1]));
+			c.line = line;
+			break;
+
+		case 'D':
+			/* parse dialect */
+			rstrip(s, &len);
+			c.dialect = dialect_name(lstrip(&s[1]));
+			break;
+
+		case 'M':
+			b = &s[1];
+			if (*b == ' ') {
+				b++;
+			}
+			str_set(&c.regexp, b);
+			break;
+
+		case 'S':
+			b = &s[1];
+			if (*b == ' ') {
+				b++;
+			}
+
+			if (s[len-1] == '\\') {
+				s[len-1] = '\0';
+				len--;
+				scont = &c.match;
+			}
+
+			if (last != 'S') {
+				str_set(&c.match, b);
+			} else {
+				str_addch(&c.match, '\n');
+				str_append(&c.match, b);
+			}
+
+			c.mt = MATCH_STRING;
+			break;
+
+		case 'F':
+			rstrip(s, &len);
+			str_set(&c.match, lstrip(&s[1]));
+			c.mt = MATCH_FILE;
+			break;
+
+		case 'N':
+		case 'R':
+			rstrip(s, &len);
+			b = lstrip(&s[1]);
+
+			{
+				long n;
+				char *ep = NULL;
+				n = strtol(b, &ep, 10);
+				if (*b == '\0' || *ep != '\0') {
+					fprintf(stderr, "line %zu: invalid '%c' argument '%s'\n", line, s[0], b);
+					exit(EXIT_FAILURE);
+				}
+
+				if (s[0] == 'N') {
+					c.count = n;
+				} else {
+					c.expected_matches = n;
+				}
+			}
+			break;
+
+		case 'X':
+			delta = 0.0;
+			err = perf_case_run(&c, &delta);
+			perf_case_report(&c, err, delta);
+			perf_case_reset(&c);
+			break;
+
+		default:
+			fprintf(stderr, "line %zu: unknown command '%c': %s\n", line, s[0], s);
+			exit(EXIT_FAILURE);
+		}
+	}
+
+	return 0;
+}
+
+static enum error_type
+run_match(struct fsm_dfavm *vm, struct str contents, int niter, int num_matches)
+{
+	int iter;
+
+	for (iter=0; iter < niter; iter++) {
+		int ret;
+
+		ret = fsm_vm_match_buffer(vm, contents.data, contents.len);
+
+		/* XXX - at some point, match more than once! */
+		if (!!ret != !!num_matches) {
+			return (num_matches) ? ERROR_SHOULD_MATCH : ERROR_SHOULD_NOT_MATCH;
+		}
+	}
+
+	return ERROR_NONE;
+}
+
+static int
+read_file(const char *path, struct str *contents)
+{
+	char buf[4096];
+	FILE *f;
+	char *s;
+	size_t len, cap;
+
+	f = fopen(path, "r");
+	if (f == NULL) {
+		return -1;
+	}
+
+	s = contents->data;
+	cap = contents->cap;
+	len = 0;
+
+	for (;;) {
+		size_t n;
+		n = fread(buf, 1, sizeof buf, f);
+		if (n == 0) {
+			break;
+		}
+
+		if (len + n >= cap) {
+			size_t newcap = 2*cap;
+			if (newcap < len+n+1) {
+				newcap = len+n+1;
+			}
+
+			s = xrealloc(s, newcap);
+			cap = newcap;
+		}
+
+		memcpy(&s[len], buf, n);
+		len += n;
+	}
+
+	contents->data = s;
+	contents->len = len;
+	contents->cap = cap;
+
+	if (ferror(f)) {
+		return -1;
+	}
+
+	return 0;
+}
+
+static enum error_type
+perf_case_run(struct perf_case *c, double *delta)
+{
+	struct fsm_dfavm *vm;
+	struct fsm *fsm;
+	struct str contents;
+	struct timespec t0, t1;
+	enum error_type ret;
+
+	fsm = NULL;
+	vm  = NULL;
+	contents = str_empty();
+
+	/* XXX - fix this */
+	opt.comments = 0;
+
+	{
+		static const struct re_err err_zero;
+
+		struct re_err comp_err;
+		enum re_flags flags;
+		const char *re;
+
+		comp_err = err_zero;
+		flags = 0;
+		re = c->regexp.data;
+		fsm = re_comp(c->dialect, fsm_sgetc, &re, &opt, flags, &comp_err);
+		if (fsm == NULL) {
+			return ERROR_PARSING_REGEXP;
+		}
+	}
+
+	/* XXX - minimize or determinize? */
+	if (!fsm_determinise(fsm)) {
+		fsm_free(fsm);
+		return ERROR_DETERMINISING;
+	}
+
+#if DEBUG_VM_FSM
+	fprintf(stderr, "FSM:\n");
+	fsm_print_fsm(stderr, fsm);
+	fprintf(stderr, "---\n");
+	{
+		FILE *f = fopen("dump.fsm", "w");
+		fsm_print_fsm(f, fsm);
+		fclose(f);
+	}
+#endif /* DEBUG_VM_FSM */
+
+	vm = fsm_vm_compile(fsm);
+	if (vm == NULL) {
+		fsm_free(fsm);
+		return ERROR_COMPILING_BYTECODE;
+	}
+
+	fsm_free(fsm);
+
+	switch (c->mt) {
+	case MATCH_STRING:
+		contents = c->match;
+		break;
+
+	case MATCH_FILE:
+		contents = str_empty();
+		if (read_file(c->match.data, &contents) != 0) {
+			fsm_vm_free(vm);
+			str_free(&contents);
+			return ERROR_FILE_IO;
+		}
+	}
+
+	if (clock_gettime(CLOCK_MONOTONIC, &t0) != 0) {
+		fsm_vm_free(vm);
+		return ERROR_CLOCK_ERROR;
+	}
+
+	ret = run_match(vm, contents, c->count, c->expected_matches);
+	fsm_vm_free(vm);
+
+	if (c->mt == MATCH_FILE) {
+		str_free(&contents);
+	}
+
+	if (ret != ERROR_NONE) {
+		return ret;
+	}
+
+	if (clock_gettime(CLOCK_MONOTONIC, &t1) != 0) {
+		fsm_vm_free(vm);
+		return ERROR_CLOCK_ERROR;
+	}
+
+	/* report time difference */
+	{
+		double dsec = difftime(t1.tv_sec, t0.tv_sec);
+		double dns  = t1.tv_nsec - t0.tv_nsec;
+		*delta = dsec + dns * 1e-9;
+	}
+
+	return ERROR_NONE;
+}
+
+static void
+perf_case_report(struct perf_case *c, enum error_type err, double runtime_secs)
+{
+	printf("---[ %s ]---\n"
+		"line %zu\n"
+		"regexp /%s/\n",
+		c->test_name.data, c->line, c->regexp.data);
+
+	if (c->mt == MATCH_STRING) {
+		printf("matching STRING:\n%s\n", c->match.data);
+	} else {
+		printf("matching FILE %s\n", c->match.data);
+	}
+
+	switch (err) {
+	case ERROR_NONE:
+		printf("%d iterations took %.4f seconds, %.4g seconds/iteration\n",
+			c->count, runtime_secs, runtime_secs/c->count);
+		break;
+
+	/*
+	case ERROR_BAD_RECORD_TYPE:    fprintf(f, "bad record\n"); break;
+	case ERROR_ESCAPE_SEQUENCE:    fprintf(f, "bad escape sequence\n"); break;
+	*/
+
+	case ERROR_PARSING_REGEXP:
+		printf("ERROR: parsing regexp\n");
+		break;
+
+	case ERROR_DETERMINISING:
+		printf("ERROR: determinising regexp\n");
+		break;
+
+	case ERROR_COMPILING_BYTECODE:
+		printf("ERROR: compiling regexp\n");
+		break;
+
+	case ERROR_SHOULD_MATCH:
+		printf("ERROR: regexp should match but doesn't\n");
+		break;
+
+	case ERROR_SHOULD_NOT_MATCH:
+		printf("ERROR: regexp should not match but does\n");
+		break;
+
+	case ERROR_FILE_IO:
+		printf("ERROR: reading file: %s\n", strerror(errno));
+		break;
+
+	case ERROR_CLOCK_ERROR:
+		printf("ERROR: cannot retrieve clock value: %s\n", strerror(errno));
+		break;
+
+	default:
+		printf("ERROR: unknown error %d\n", (int)err);
+		break;
+	}
+
+	printf("\n");
+}
+
+static void
+usage(void)
+{
+	fprintf(stderr, "usage: reperf driverfile\n");
+	fprintf(stderr, "       reperf -\n");
+}
+
+static FILE *
+xopen(const char *s)
+{
+	FILE *f;
+
+	assert(s != NULL);
+
+	if (0 == strcmp(s, "-")) {
+		return stdin;
+	}
+
+	f = fopen(s, "r");
+	if (f == NULL) {
+		perror(s);
+		exit(EXIT_FAILURE);
+	}
+
+	return f;
+}
+
+enum parse_escape_result {
+	PARSE_OK = 0,
+	PARSE_INVALID_ESCAPE,
+	PARSE_INCOMPLETE_ESCAPE
+};
+
+int
+main(int argc, char *argv[])
+{
+	int i;
+	int pause;
+
+	(void)str_init;
+
+	/* note these defaults are the opposite than for fsm(1) */
+	opt.anonymous_states  = 1;
+	opt.consolidate_edges = 1;
+
+	opt.comments          = 1;
+	opt.io                = FSM_IO_GETC;
+
+	pause                 = 0;
+
+	{
+		int c;
+
+		while (c = getopt(argc, argv, "h" "p" "e:" ), c != -1) {
+			switch (c) {
+			case 'e': opt.prefix = optarg;     break;
+
+			case 'p': pause = 1; break;
+
+			case 'h':
+				usage();
+				return EXIT_SUCCESS;
+
+			case '?':
+			default:
+				usage();
+				return EXIT_FAILURE;
+			}
+		}
+
+		argc -= optind;
+		argv += optind;
+	}
+
+	if (argc < 1) {
+		usage();
+		return EXIT_FAILURE;
+	}
+
+	if (pause) {
+		char buf[128];
+		printf("paused\n");
+		fflush(stdout);
+		fgets(buf, sizeof buf, stdin);
+	}
+
+	for (i=0; i < argc; i++) {
+		FILE *f = xopen(argv[i]);
+		parse_perf_case(f);
+		fclose(f);
+	}
+
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This PR does a number of things, all kind of related:

1. Adds `reperf`: does performance testing for dfavm execution.
2. Adds `cvtpcre`: converts PCRE test suite files to something `retest` can run.
3. Improves dfavm opcodes: splits opcodes into "IR" level opcodes and "VM" level opcodes.  VM opcodes are meant to be encoded and executed.  IR opcodes are used to transform/optimize and emit other kinds of execution models, including C code generation.
4. Adds a fixed-encoding.  This seems to improve dfavm run time.