### PR TITLE
Number states in fsm output

### DIFF
--- a/man/fsm.5/fsm.5.xml
+++ b/man/fsm.5/fsm.5.xml
@@ -57,6 +57,8 @@ Edges are one of the following kinds of transition:
 
 Examples:
 
+0; 1; 2; 3; # declarations to force numbering in order
+
 0 -> 1;       # illegal (0 is reserved)
 1 -> 2;       # epsilon
 2 -> 3 "";    # illegal (empty label)

--- a/src/fsm/parser.c
+++ b/src/fsm/parser.c
@@ -87,11 +87,11 @@
 /* BEGINNING OF FUNCTION DECLARATIONS */
 
 static void p_label(fsm, lex_state, act_state, char *);
-static void p_edges(fsm, lex_state, act_state);
-static void p_edges_C_Cedge(fsm, lex_state, act_state);
+static void p_items(fsm, lex_state, act_state);
 static void p_xstart(fsm, lex_state, act_state);
 static void p_xend(fsm, lex_state, act_state);
-static void p_58(fsm, lex_state, act_state);
+static void p_61(fsm, lex_state, act_state);
+static void p_63(fsm, lex_state, act_state, string *);
 extern void p_fsm(fsm, lex_state, act_state);
 static void p_xend_C_Cend_Hids(fsm, lex_state, act_state);
 static void p_xend_C_Cend_Hid(fsm, lex_state, act_state);
@@ -254,53 +254,24 @@ ZL0:;
 }
 
 static void
-p_edges(fsm fsm, lex_state lex_state, act_state act_state)
+p_items(fsm fsm, lex_state lex_state, act_state act_state)
 {
-ZL2_edges:;
+ZL2_items:;
 	switch (CURRENT_TERMINAL) {
 	case (TOK_IDENT):
 		{
-			p_edges_C_Cedge (fsm, lex_state, act_state);
-			/* BEGINNING OF INLINE: edges */
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			} else {
-				goto ZL2_edges;
-			}
-			/* END OF INLINE: edges */
-		}
-		/*UNREACHED*/
-	case (ERROR_TERMINAL):
-		return;
-	default:
-		break;
-	}
-	return;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-}
-
-static void
-p_edges_C_Cedge(fsm fsm, lex_state lex_state, act_state act_state)
-{
-	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-		return;
-	}
-	{
-		string ZIa;
-		string ZIb;
-		state ZIx;
-		state ZIy;
-
-		/* BEGINNING OF INLINE: id */
-		{
+			/* BEGINNING OF INLINE: 48 */
 			{
-				switch (CURRENT_TERMINAL) {
-				case (TOK_IDENT):
-					/* BEGINNING OF EXTRACT: IDENT */
+				{
+					string ZIa;
+
+					/* BEGINNING OF INLINE: id */
 					{
+						{
+							switch (CURRENT_TERMINAL) {
+							case (TOK_IDENT):
+								/* BEGINNING OF EXTRACT: IDENT */
+								{
 #line 186 "src/fsm/parser.act"
 
 		ZIa = xstrdup(lex_state->buf.a);
@@ -309,241 +280,34 @@ p_edges_C_Cedge(fsm fsm, lex_state lex_state, act_state act_state)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 313 "src/fsm/parser.c"
+#line 284 "src/fsm/parser.c"
+								}
+								/* END OF EXTRACT: IDENT */
+								break;
+							default:
+								goto ZL1;
+							}
+							ADVANCE_LEXER;
+						}
 					}
-					/* END OF EXTRACT: IDENT */
-					break;
-				default:
-					goto ZL1;
-				}
-				ADVANCE_LEXER;
-			}
-		}
-		/* END OF INLINE: id */
-		switch (CURRENT_TERMINAL) {
-		case (TOK_TO):
-			break;
-		default:
-			goto ZL1;
-		}
-		ADVANCE_LEXER;
-		/* BEGINNING OF INLINE: id */
-		{
-			{
-				switch (CURRENT_TERMINAL) {
-				case (TOK_IDENT):
-					/* BEGINNING OF EXTRACT: IDENT */
-					{
-#line 186 "src/fsm/parser.act"
-
-		ZIb = xstrdup(lex_state->buf.a);
-		if (ZIb == NULL) {
-			perror("xstrdup");
-			exit(EXIT_FAILURE);
-		}
-	
-#line 346 "src/fsm/parser.c"
-					}
-					/* END OF EXTRACT: IDENT */
-					break;
-				default:
-					goto ZL1;
-				}
-				ADVANCE_LEXER;
-			}
-		}
-		/* END OF INLINE: id */
-		/* BEGINNING OF ACTION: add-state */
-		{
-#line 198 "src/fsm/parser.act"
-
-		struct act_statelist *p;
-
-		assert((ZIa) != NULL);
-
-		for (p = act_state->sl; p != NULL; p = p->next) {
-			assert(p->id != NULL);
-
-			if (0 == strcmp(p->id, (ZIa))) {
-				(ZIx) = p->state;
-				break;
-			}
-		}
-
-		if (p == NULL) {
-			struct act_statelist *new;
-
-			new = malloc(sizeof *new);
-			if (new == NULL) {
-				perror("malloc");
-				exit(EXIT_FAILURE);
-			}
-
-			new->id = xstrdup((ZIa));
-			if (new->id == NULL) {
-				perror("xstrdup");
-				exit(EXIT_FAILURE);
-			}
-
-			if (!fsm_addstate(fsm, &(ZIx))) {
-				perror("fsm_addstate");
-				exit(EXIT_FAILURE);
-			}
-
-			new->state = (ZIx);
-
-			new->next = act_state->sl;
-			act_state->sl = new;
-		}
-	
-#line 400 "src/fsm/parser.c"
-		}
-		/* END OF ACTION: add-state */
-		/* BEGINNING OF ACTION: add-state */
-		{
-#line 198 "src/fsm/parser.act"
-
-		struct act_statelist *p;
-
-		assert((ZIb) != NULL);
-
-		for (p = act_state->sl; p != NULL; p = p->next) {
-			assert(p->id != NULL);
-
-			if (0 == strcmp(p->id, (ZIb))) {
-				(ZIy) = p->state;
-				break;
-			}
-		}
-
-		if (p == NULL) {
-			struct act_statelist *new;
-
-			new = malloc(sizeof *new);
-			if (new == NULL) {
-				perror("malloc");
-				exit(EXIT_FAILURE);
-			}
-
-			new->id = xstrdup((ZIb));
-			if (new->id == NULL) {
-				perror("xstrdup");
-				exit(EXIT_FAILURE);
-			}
-
-			if (!fsm_addstate(fsm, &(ZIy))) {
-				perror("fsm_addstate");
-				exit(EXIT_FAILURE);
-			}
-
-			new->state = (ZIy);
-
-			new->next = act_state->sl;
-			act_state->sl = new;
-		}
-	
-#line 446 "src/fsm/parser.c"
-		}
-		/* END OF ACTION: add-state */
-		/* BEGINNING OF ACTION: free */
-		{
-#line 245 "src/fsm/parser.act"
-
-		free((ZIa));
-	
-#line 455 "src/fsm/parser.c"
-		}
-		/* END OF ACTION: free */
-		/* BEGINNING OF ACTION: free */
-		{
-#line 245 "src/fsm/parser.act"
-
-		free((ZIb));
-	
-#line 464 "src/fsm/parser.c"
-		}
-		/* END OF ACTION: free */
-		/* BEGINNING OF INLINE: 44 */
-		{
-			switch (CURRENT_TERMINAL) {
-			case (TOK_ANY):
-				{
-					ADVANCE_LEXER;
-					/* BEGINNING OF ACTION: add-edge-any */
-					{
-#line 270 "src/fsm/parser.act"
-
-		if (!fsm_addedge_any(fsm, (ZIx), (ZIy))) {
-			perror("fsm_addedge_any");
-			exit(EXIT_FAILURE);
-		}
-	
-#line 482 "src/fsm/parser.c"
-					}
-					/* END OF ACTION: add-edge-any */
-				}
-				break;
-			case (TOK_ESC): case (TOK_OCT): case (TOK_HEX): case (TOK_CHAR):
-				{
-					char ZIc;
-
-					p_label (fsm, lex_state, act_state, &ZIc);
+					/* END OF INLINE: id */
+					p_63 (fsm, lex_state, act_state, &ZIa);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
-						goto ZL5;
+						goto ZL1;
 					}
-					/* BEGINNING OF ACTION: add-edge-literal */
-					{
-#line 263 "src/fsm/parser.act"
-
-		if (!fsm_addedge_literal(fsm, (ZIx), (ZIy), (ZIc))) {
-			perror("fsm_addedge_literal");
-			exit(EXIT_FAILURE);
-		}
-	
-#line 505 "src/fsm/parser.c"
-					}
-					/* END OF ACTION: add-edge-literal */
 				}
-				break;
-			default:
-				{
-					/* BEGINNING OF ACTION: add-edge-epsilon */
-					{
-#line 277 "src/fsm/parser.act"
-
-		if (!fsm_addedge_epsilon(fsm, (ZIx), (ZIy))) {
-			perror("fsm_addedge_epsilon");
-			exit(EXIT_FAILURE);
-		}
-	
-#line 521 "src/fsm/parser.c"
-					}
-					/* END OF ACTION: add-edge-epsilon */
-				}
-				break;
 			}
-			goto ZL4;
-		ZL5:;
-			{
-				/* BEGINNING OF ACTION: err-expected-trans */
-				{
-#line 290 "src/fsm/parser.act"
-
-		err_expected(lex_state, "transition");
-	
-#line 536 "src/fsm/parser.c"
-				}
-				/* END OF ACTION: err-expected-trans */
-			}
-		ZL4:;
+			/* END OF INLINE: 48 */
+			/* BEGINNING OF INLINE: items */
+			goto ZL2_items;
+			/* END OF INLINE: items */
 		}
-		/* END OF INLINE: 44 */
-		p_58 (fsm, lex_state, act_state);
-		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-			RESTORE_LEXER;
-			goto ZL1;
-		}
+		/*UNREACHED*/
+	case (ERROR_TERMINAL):
+		return;
+	default:
+		break;
 	}
 	return;
 ZL1:;
@@ -560,7 +324,7 @@ p_xstart(fsm fsm, lex_state lex_state, act_state act_state)
 			string ZIn;
 			state ZIs;
 
-			/* BEGINNING OF INLINE: 47 */
+			/* BEGINNING OF INLINE: 50 */
 			{
 				{
 					switch (CURRENT_TERMINAL) {
@@ -580,13 +344,13 @@ p_xstart(fsm fsm, lex_state lex_state, act_state act_state)
 
 		err_expected(lex_state, "'start:'");
 	
-#line 584 "src/fsm/parser.c"
+#line 348 "src/fsm/parser.c"
 					}
 					/* END OF ACTION: err-expected-start */
 				}
 			ZL2:;
 			}
-			/* END OF INLINE: 47 */
+			/* END OF INLINE: 50 */
 			/* BEGINNING OF INLINE: id */
 			{
 				{
@@ -602,7 +366,7 @@ p_xstart(fsm fsm, lex_state lex_state, act_state act_state)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 606 "src/fsm/parser.c"
+#line 370 "src/fsm/parser.c"
 						}
 						/* END OF EXTRACT: IDENT */
 						break;
@@ -613,7 +377,7 @@ p_xstart(fsm fsm, lex_state lex_state, act_state act_state)
 				}
 			}
 			/* END OF INLINE: id */
-			p_58 (fsm, lex_state, act_state);
+			p_61 (fsm, lex_state, act_state);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -661,7 +425,7 @@ p_xstart(fsm fsm, lex_state lex_state, act_state act_state)
 			act_state->sl = new;
 		}
 	
-#line 665 "src/fsm/parser.c"
+#line 429 "src/fsm/parser.c"
 			}
 			/* END OF ACTION: add-state */
 			/* BEGINNING OF ACTION: mark-start */
@@ -670,7 +434,7 @@ p_xstart(fsm fsm, lex_state lex_state, act_state act_state)
 
 		fsm_setstart(fsm, (ZIs));
 	
-#line 674 "src/fsm/parser.c"
+#line 438 "src/fsm/parser.c"
 			}
 			/* END OF ACTION: mark-start */
 			/* BEGINNING OF ACTION: free */
@@ -679,7 +443,7 @@ p_xstart(fsm fsm, lex_state lex_state, act_state act_state)
 
 		free((ZIn));
 	
-#line 683 "src/fsm/parser.c"
+#line 447 "src/fsm/parser.c"
 			}
 			/* END OF ACTION: free */
 		}
@@ -701,7 +465,7 @@ p_xend(fsm fsm, lex_state lex_state, act_state act_state)
 	switch (CURRENT_TERMINAL) {
 	case (TOK_END):
 		{
-			/* BEGINNING OF INLINE: 57 */
+			/* BEGINNING OF INLINE: 60 */
 			{
 				{
 					switch (CURRENT_TERMINAL) {
@@ -721,15 +485,15 @@ p_xend(fsm fsm, lex_state lex_state, act_state act_state)
 
 		err_expected(lex_state, "'end:'");
 	
-#line 725 "src/fsm/parser.c"
+#line 489 "src/fsm/parser.c"
 					}
 					/* END OF ACTION: err-expected-end */
 				}
 			ZL2:;
 			}
-			/* END OF INLINE: 57 */
+			/* END OF INLINE: 60 */
 			p_xend_C_Cend_Hids (fsm, lex_state, act_state);
-			p_58 (fsm, lex_state, act_state);
+			p_61 (fsm, lex_state, act_state);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -748,7 +512,7 @@ ZL1:;
 }
 
 static void
-p_58(fsm fsm, lex_state lex_state, act_state act_state)
+p_61(fsm fsm, lex_state lex_state, act_state act_state)
 {
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 		return;
@@ -771,10 +535,317 @@ ZL1:;
 
 		err_expected(lex_state, "';'");
 	
-#line 775 "src/fsm/parser.c"
+#line 539 "src/fsm/parser.c"
 		}
 		/* END OF ACTION: err-expected-sep */
 	}
+}
+
+static void
+p_63(fsm fsm, lex_state lex_state, act_state act_state, string *ZIa)
+{
+	switch (CURRENT_TERMINAL) {
+	case (TOK_TO):
+		{
+			string ZIb;
+			state ZIx;
+			state ZIy;
+
+			ADVANCE_LEXER;
+			/* BEGINNING OF INLINE: id */
+			{
+				{
+					switch (CURRENT_TERMINAL) {
+					case (TOK_IDENT):
+						/* BEGINNING OF EXTRACT: IDENT */
+						{
+#line 186 "src/fsm/parser.act"
+
+		ZIb = xstrdup(lex_state->buf.a);
+		if (ZIb == NULL) {
+			perror("xstrdup");
+			exit(EXIT_FAILURE);
+		}
+	
+#line 571 "src/fsm/parser.c"
+						}
+						/* END OF EXTRACT: IDENT */
+						break;
+					default:
+						goto ZL1;
+					}
+					ADVANCE_LEXER;
+				}
+			}
+			/* END OF INLINE: id */
+			/* BEGINNING OF ACTION: add-state */
+			{
+#line 198 "src/fsm/parser.act"
+
+		struct act_statelist *p;
+
+		assert((*ZIa) != NULL);
+
+		for (p = act_state->sl; p != NULL; p = p->next) {
+			assert(p->id != NULL);
+
+			if (0 == strcmp(p->id, (*ZIa))) {
+				(ZIx) = p->state;
+				break;
+			}
+		}
+
+		if (p == NULL) {
+			struct act_statelist *new;
+
+			new = malloc(sizeof *new);
+			if (new == NULL) {
+				perror("malloc");
+				exit(EXIT_FAILURE);
+			}
+
+			new->id = xstrdup((*ZIa));
+			if (new->id == NULL) {
+				perror("xstrdup");
+				exit(EXIT_FAILURE);
+			}
+
+			if (!fsm_addstate(fsm, &(ZIx))) {
+				perror("fsm_addstate");
+				exit(EXIT_FAILURE);
+			}
+
+			new->state = (ZIx);
+
+			new->next = act_state->sl;
+			act_state->sl = new;
+		}
+	
+#line 625 "src/fsm/parser.c"
+			}
+			/* END OF ACTION: add-state */
+			/* BEGINNING OF ACTION: add-state */
+			{
+#line 198 "src/fsm/parser.act"
+
+		struct act_statelist *p;
+
+		assert((ZIb) != NULL);
+
+		for (p = act_state->sl; p != NULL; p = p->next) {
+			assert(p->id != NULL);
+
+			if (0 == strcmp(p->id, (ZIb))) {
+				(ZIy) = p->state;
+				break;
+			}
+		}
+
+		if (p == NULL) {
+			struct act_statelist *new;
+
+			new = malloc(sizeof *new);
+			if (new == NULL) {
+				perror("malloc");
+				exit(EXIT_FAILURE);
+			}
+
+			new->id = xstrdup((ZIb));
+			if (new->id == NULL) {
+				perror("xstrdup");
+				exit(EXIT_FAILURE);
+			}
+
+			if (!fsm_addstate(fsm, &(ZIy))) {
+				perror("fsm_addstate");
+				exit(EXIT_FAILURE);
+			}
+
+			new->state = (ZIy);
+
+			new->next = act_state->sl;
+			act_state->sl = new;
+		}
+	
+#line 671 "src/fsm/parser.c"
+			}
+			/* END OF ACTION: add-state */
+			/* BEGINNING OF ACTION: free */
+			{
+#line 245 "src/fsm/parser.act"
+
+		free((*ZIa));
+	
+#line 680 "src/fsm/parser.c"
+			}
+			/* END OF ACTION: free */
+			/* BEGINNING OF ACTION: free */
+			{
+#line 245 "src/fsm/parser.act"
+
+		free((ZIb));
+	
+#line 689 "src/fsm/parser.c"
+			}
+			/* END OF ACTION: free */
+			/* BEGINNING OF INLINE: 42 */
+			{
+				switch (CURRENT_TERMINAL) {
+				case (TOK_ANY):
+					{
+						ADVANCE_LEXER;
+						/* BEGINNING OF ACTION: add-edge-any */
+						{
+#line 270 "src/fsm/parser.act"
+
+		if (!fsm_addedge_any(fsm, (ZIx), (ZIy))) {
+			perror("fsm_addedge_any");
+			exit(EXIT_FAILURE);
+		}
+	
+#line 707 "src/fsm/parser.c"
+						}
+						/* END OF ACTION: add-edge-any */
+					}
+					break;
+				case (TOK_ESC): case (TOK_OCT): case (TOK_HEX): case (TOK_CHAR):
+					{
+						char ZIc;
+
+						p_label (fsm, lex_state, act_state, &ZIc);
+						if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+							RESTORE_LEXER;
+							goto ZL4;
+						}
+						/* BEGINNING OF ACTION: add-edge-literal */
+						{
+#line 263 "src/fsm/parser.act"
+
+		if (!fsm_addedge_literal(fsm, (ZIx), (ZIy), (ZIc))) {
+			perror("fsm_addedge_literal");
+			exit(EXIT_FAILURE);
+		}
+	
+#line 730 "src/fsm/parser.c"
+						}
+						/* END OF ACTION: add-edge-literal */
+					}
+					break;
+				default:
+					{
+						/* BEGINNING OF ACTION: add-edge-epsilon */
+						{
+#line 277 "src/fsm/parser.act"
+
+		if (!fsm_addedge_epsilon(fsm, (ZIx), (ZIy))) {
+			perror("fsm_addedge_epsilon");
+			exit(EXIT_FAILURE);
+		}
+	
+#line 746 "src/fsm/parser.c"
+						}
+						/* END OF ACTION: add-edge-epsilon */
+					}
+					break;
+				}
+				goto ZL3;
+			ZL4:;
+				{
+					/* BEGINNING OF ACTION: err-expected-trans */
+					{
+#line 290 "src/fsm/parser.act"
+
+		err_expected(lex_state, "transition");
+	
+#line 761 "src/fsm/parser.c"
+					}
+					/* END OF ACTION: err-expected-trans */
+				}
+			ZL3:;
+			}
+			/* END OF INLINE: 42 */
+			p_61 (fsm, lex_state, act_state);
+			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+				RESTORE_LEXER;
+				goto ZL1;
+			}
+		}
+		break;
+	case (TOK_SEP):
+		{
+			state ZI45;
+
+			/* BEGINNING OF ACTION: add-state */
+			{
+#line 198 "src/fsm/parser.act"
+
+		struct act_statelist *p;
+
+		assert((*ZIa) != NULL);
+
+		for (p = act_state->sl; p != NULL; p = p->next) {
+			assert(p->id != NULL);
+
+			if (0 == strcmp(p->id, (*ZIa))) {
+				(ZI45) = p->state;
+				break;
+			}
+		}
+
+		if (p == NULL) {
+			struct act_statelist *new;
+
+			new = malloc(sizeof *new);
+			if (new == NULL) {
+				perror("malloc");
+				exit(EXIT_FAILURE);
+			}
+
+			new->id = xstrdup((*ZIa));
+			if (new->id == NULL) {
+				perror("xstrdup");
+				exit(EXIT_FAILURE);
+			}
+
+			if (!fsm_addstate(fsm, &(ZI45))) {
+				perror("fsm_addstate");
+				exit(EXIT_FAILURE);
+			}
+
+			new->state = (ZI45);
+
+			new->next = act_state->sl;
+			act_state->sl = new;
+		}
+	
+#line 822 "src/fsm/parser.c"
+			}
+			/* END OF ACTION: add-state */
+			/* BEGINNING OF ACTION: free */
+			{
+#line 245 "src/fsm/parser.act"
+
+		free((*ZIa));
+	
+#line 831 "src/fsm/parser.c"
+			}
+			/* END OF ACTION: free */
+			p_61 (fsm, lex_state, act_state);
+			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+				RESTORE_LEXER;
+				goto ZL1;
+			}
+		}
+		break;
+	case (ERROR_TERMINAL):
+		return;
+	default:
+		goto ZL1;
+	}
+	return;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
 }
 
 void
@@ -784,7 +855,7 @@ p_fsm(fsm fsm, lex_state lex_state, act_state act_state)
 		return;
 	}
 	{
-		p_edges (fsm, lex_state, act_state);
+		p_items (fsm, lex_state, act_state);
 		p_xstart (fsm, lex_state, act_state);
 		p_xend (fsm, lex_state, act_state);
 		switch (CURRENT_TERMINAL) {
@@ -813,7 +884,7 @@ p_fsm(fsm fsm, lex_state lex_state, act_state act_state)
 			free(p);
 		}
 	
-#line 817 "src/fsm/parser.c"
+#line 888 "src/fsm/parser.c"
 		}
 		/* END OF ACTION: free-statelist */
 	}
@@ -827,7 +898,7 @@ ZL1:;
 		err(lex_state, "Syntax error");
 		exit(EXIT_FAILURE);
 	
-#line 831 "src/fsm/parser.c"
+#line 902 "src/fsm/parser.c"
 		}
 		/* END OF ACTION: err-syntax */
 	}
@@ -842,12 +913,12 @@ p_xend_C_Cend_Hids(fsm fsm, lex_state lex_state, act_state act_state)
 ZL2_xend_C_Cend_Hids:;
 	{
 		p_xend_C_Cend_Hid (fsm, lex_state, act_state);
-		/* BEGINNING OF INLINE: 55 */
+		/* BEGINNING OF INLINE: 58 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_COMMA):
 				{
-					/* BEGINNING OF INLINE: 56 */
+					/* BEGINNING OF INLINE: 59 */
 					{
 						{
 							switch (CURRENT_TERMINAL) {
@@ -867,13 +938,13 @@ ZL2_xend_C_Cend_Hids:;
 
 		err_expected(lex_state, "','");
 	
-#line 871 "src/fsm/parser.c"
+#line 942 "src/fsm/parser.c"
 							}
 							/* END OF ACTION: err-expected-comma */
 						}
 					ZL4:;
 					}
-					/* END OF INLINE: 56 */
+					/* END OF INLINE: 59 */
 					/* BEGINNING OF INLINE: xend::end-ids */
 					goto ZL2_xend_C_Cend_Hids;
 					/* END OF INLINE: xend::end-ids */
@@ -886,7 +957,7 @@ ZL2_xend_C_Cend_Hids:;
 				break;
 			}
 		}
-		/* END OF INLINE: 55 */
+		/* END OF INLINE: 58 */
 	}
 	return;
 ZL1:;
@@ -919,7 +990,7 @@ p_xend_C_Cend_Hid(fsm fsm, lex_state lex_state, act_state act_state)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 923 "src/fsm/parser.c"
+#line 994 "src/fsm/parser.c"
 					}
 					/* END OF EXTRACT: IDENT */
 					break;
@@ -973,7 +1044,7 @@ p_xend_C_Cend_Hid(fsm fsm, lex_state lex_state, act_state act_state)
 			act_state->sl = new;
 		}
 	
-#line 977 "src/fsm/parser.c"
+#line 1048 "src/fsm/parser.c"
 		}
 		/* END OF ACTION: add-state */
 		/* BEGINNING OF ACTION: mark-end */
@@ -982,7 +1053,7 @@ p_xend_C_Cend_Hid(fsm fsm, lex_state lex_state, act_state act_state)
 
 		fsm_setend(fsm, (ZIs), 1);
 	
-#line 986 "src/fsm/parser.c"
+#line 1057 "src/fsm/parser.c"
 		}
 		/* END OF ACTION: mark-end */
 		/* BEGINNING OF ACTION: free */
@@ -991,7 +1062,7 @@ p_xend_C_Cend_Hid(fsm fsm, lex_state lex_state, act_state act_state)
 
 		free((ZIn));
 	
-#line 995 "src/fsm/parser.c"
+#line 1066 "src/fsm/parser.c"
 		}
 		/* END OF ACTION: free */
 	}
@@ -1054,6 +1125,6 @@ ZL1:;
 		return new;
 	}
 
-#line 1058 "src/fsm/parser.c"
+#line 1129 "src/fsm/parser.c"
 
 /* END OF FILE */

--- a/src/fsm/parser.sid
+++ b/src/fsm/parser.sid
@@ -68,41 +68,64 @@
 		n = IDENT;
 	};
 
-	edges [
+	edge = {
+		a = id;
+		TO;
+		b = id;
 
-		edge = {
-			a = id;
-			TO;
-			b = id;
+		x = <add-state>(a);
+		y = <add-state>(b);
 
-			x = <add-state>(a);
-			y = <add-state>(b);
+		<free>(a);
+		<free>(b);
 
-			<free>(a);
-			<free>(b);
-
-			{
-				c = label;
-				<add-edge-literal>(x, y, c);
-			||
-				ANY;
-				<add-edge-any>(x, y);
-			||
-				<add-edge-epsilon>(x, y);
-			##
-				<err-expected-trans>;
-			};
-
-			{
-				SEP;
-			##
-				<err-expected-sep>;
-			};
+		{
+			c = label;
+			<add-edge-literal>(x, y, c);
+		||
+			ANY;
+			<add-edge-any>(x, y);
+		||
+			<add-edge-epsilon>(x, y);
+		##
+			<err-expected-trans>;
 		};
 
-	] = {
-		edges;
-		edge;
+		{
+			SEP;
+		##
+			<err-expected-sep>;
+		};
+	};
+
+	/*
+	 * Declaration for a single state, just as a way to force ordering
+	 * when states are created. This is a workaround for the .fsm syntax
+	 * being so terrible, and that state labels aren't numeric, but the
+	 * .fsm format is expected to maintain the same numbering when parsing
+	 * its own output.
+	 */
+	decl = {
+		a = id;
+
+		! = <add-state>(a);
+
+		<free>(a);
+
+		{
+			SEP;
+		##
+			<err-expected-sep>;
+		};
+	};
+
+	items = {
+		items;
+		{
+			edge;
+		||
+			decl;
+		};
 	||
 		$;
 	};
@@ -176,7 +199,7 @@
 	};
 
 	fsm = {
-		edges;
+		items;
 		xstart;
 		xend;
 

--- a/src/libfsm/print/fsm.c
+++ b/src/libfsm/print/fsm.c
@@ -95,6 +95,20 @@ fsm_print_fsm(FILE *f, const struct fsm *fsm)
 	assert(f != NULL);
 	assert(fsm != NULL);
 
+	if (!fsm->opt->anonymous_states) {
+		/*
+		 * States are output in order here so as to force ordering when
+		 * parsing the .fsm format and creating new states. This ensures
+		 * that the new states (numbered in order) match the numbering here.
+		 */
+		for (s = 0; s < fsm->statecount; s++) {
+			fprintf(f, "%u;%s", s,
+				s + 1 < fsm->statecount ? " " : "\n");
+		}
+
+		fprintf(f, "\n");
+	}
+
 	for (s = 0; s < fsm->statecount; s++) {
 		struct fsm_edge e;
 		struct edge_iter it;


### PR DESCRIPTION
Add .fsm syntax to allow declarations for states.

This provides a way to force numbering for states when parsing. Currently the labels are not numeric, and so states are numbered internally in their creation order. This is confusing when using .fsm as an intermediate format for serialisation in a pipeline, where one would expect the output to match the input.

This is enabled by default, and can be disabled with `-a` (for anonymous states):
```
; ./build/bin/fsm -pc examples/fsm/a.fsm
0; 1; 2; 3; 4; 5; 6;

0  ->  1 "a"; # e.g. "a"
1  ->  2 "b"; # e.g. "ab"
...
```
vs:
```
; ./build/bin/fsm -apc examples/fsm/a.fsm
0  ->  1 "a"; # e.g. "a"
1  ->  2 "b"; # e.g. "ab"
1  ->  6 "g"; # e.g. "ag"
1  ->  1 "x"; # e.g. "a"
... 
```