### PR TITLE
Add VM style C code generation

### DIFF
--- a/include/fsm/print.h
+++ b/include/fsm/print.h
@@ -22,6 +22,7 @@ struct fsm;
  *  fsm_print_ir     - Codegen IR as Dot
  *  fsm_print_irjson - Codegen IR as JSON
  *  fsm_print_json   - JavaScript Object Notation
+ *  fsm_print_vmc    - ISO C90 code, VM style
  *
  * The output options may be NULL, indicating to use defaults.
  *
@@ -38,6 +39,7 @@ fsm_print fsm_print_fsm;
 fsm_print fsm_print_ir;
 fsm_print fsm_print_irjson;
 fsm_print fsm_print_json;
+fsm_print fsm_print_vmc;
 
 #endif
 

--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -160,7 +160,8 @@ print_name(const char *name)
 		{ "dot",  fsm_print_dot  },
 		{ "fsm",  fsm_print_fsm  },
 		{ "ir",   fsm_print_ir   },
-		{ "json", fsm_print_json }
+		{ "json", fsm_print_json },
+		{ "vmc",  fsm_print_vmc  }
 	};
 
 	assert(name != NULL);

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -34,6 +34,7 @@ fsm_print_fsm
 fsm_print_ir
 fsm_print_irjson
 fsm_print_json
+fsm_print_vmc
 
 # <fsm/fsm.h>
 fsm_clone

--- a/src/libfsm/print/Makefile
+++ b/src/libfsm/print/Makefile
@@ -8,6 +8,12 @@ SRC += src/libfsm/print/ir.c
 SRC += src/libfsm/print/irdot.c
 SRC += src/libfsm/print/irjson.c
 SRC += src/libfsm/print/json.c
+SRC += src/libfsm/print/vmc.c
+
+.for src in ${SRC:Msrc/libfsm/print/vmc.c}
+CFLAGS.${src} += -std=c99 # XXX: for ir.h
+DFLAGS.${src} += -std=c99 # XXX: for ir.h
+.endfor
 
 .for src in ${SRC:Msrc/libfsm/print/*.c}
 CFLAGS.${src} += -I src # XXX: for internal.h

--- a/src/libfsm/print/vmc.c
+++ b/src/libfsm/print/vmc.c
@@ -1,0 +1,287 @@
+/*
+ * Copyright 2008-2020 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <string.h>
+#include <stdint.h>
+#include <errno.h>
+#include <stdio.h>
+
+#include <print/esc.h>
+
+#include <adt/set.h>
+
+#include <fsm/fsm.h>
+#include <fsm/pred.h>
+#include <fsm/walk.h>
+#include <fsm/print.h>
+#include <fsm/options.h>
+#include <fsm/vm.h>
+
+#include "libfsm/internal.h"
+
+#include "libfsm/vm/vm.h"
+
+#include "ir.h"
+
+static int
+leaf(FILE *f, const void *state_opaque, const void *leaf_opaque)
+{
+	assert(f != NULL);
+	assert(leaf_opaque == NULL);
+
+	(void) state_opaque;
+	(void) leaf_opaque;
+
+	/* XXX: this should be FSM_UNKNOWN or something non-EOF,
+	 * maybe user defined */
+	fprintf(f, "return TOK_UNKNOWN;");
+
+	return 0;
+}
+
+static const char *
+cmp_operator(int cmp)
+{
+	switch (cmp) {
+	case VM_CMP_LT: return "<";
+	case VM_CMP_LE: return "<=";
+	case VM_CMP_EQ: return "==";
+	case VM_CMP_GE: return ">=";
+	case VM_CMP_GT: return ">";
+	case VM_CMP_NE: return "!=";
+
+	case VM_CMP_ALWAYS:
+	default:
+		assert("unreached");
+		return NULL;
+	}
+}
+
+static void
+print_label(FILE *f, const struct dfavm_op_ir *op)
+{
+	fprintf(f, "l%lu:", (unsigned long) op->index);
+}
+
+static void
+print_cond(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt)
+{
+	if (op->cmp == VM_CMP_ALWAYS) {
+		return;
+	}
+
+	fprintf(f, "if (c %s ", cmp_operator(op->cmp));
+	c_escputcharlit(f, opt, op->cmp_arg);
+	fprintf(f, ") ");
+}
+
+static void
+print_stop(FILE *f, const struct dfavm_op_ir *op)
+{
+	fprintf(f, "goto %s;", op->u.stop.end_bits == VM_END_FAIL ? "fail" : "match");
+}
+
+static void
+print_branch(FILE *f, const struct dfavm_op_ir *op)
+{
+	fprintf(f, "goto l%lu;", (unsigned long) op->u.br.dest_arg->index);
+}
+
+static void
+print_fetch(FILE *f, const struct fsm_options *opt)
+{
+	switch (opt->io) {
+	case FSM_IO_GETC:
+		fprintf(f, "if (c = fsm_getc(opaque), c == EOF) ");
+		break;
+
+	case FSM_IO_STR:
+		fprintf(f, "if (c = *p++, c == '\\0') ");
+		break;
+
+	case FSM_IO_PAIR:
+		fprintf(f, "if (c = *p++, p == e) ");
+		break;
+	}
+}
+
+/* TODO: eventually to be non-static */
+static int
+fsm_print_cfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
+	const char *cp,
+	int (*leaf)(FILE *, const void *state_opaque, const void *leaf_opaque),
+	const void *leaf_opaque)
+{
+	static const struct dfavm_assembler_ir zero;
+	struct dfavm_assembler_ir a;
+	struct dfavm_op_ir *op;
+
+	static const struct fsm_vm_compile_opts vm_opts = { FSM_VM_COMPILE_DEFAULT_FLAGS, FSM_VM_COMPILE_VM_V1, NULL };
+
+	assert(f != NULL);
+	assert(ir != NULL);
+	assert(opt != NULL);
+	assert(cp != NULL);
+
+	a = zero;
+
+	/* TODO: we don't currently have .opaque information attached to struct dfavm_op_ir.
+	 * We'll need that in order to be able to use the leaf callback here. */
+	(void) leaf;
+	(void) leaf_opaque;
+
+	/* TODO: we'll need to heed cp for e.g. lx's codegen */
+	(void) cp;
+
+	if (!dfavm_compile_ir(&a, ir, vm_opts)) {
+		return -1;
+	}
+
+	/*
+	 * We only output labels for ops which are branched to. This gives
+	 * gaps in the sequence for ops which don't need a label.
+	 * So here we renumber just the ones we use.
+	 */
+	{
+		uint32_t l;
+
+		l = 0;
+
+		for (op = a.linked; op != NULL; op = op->next) {
+			if (op->num_incoming > 0) {
+				op->index = l++;
+			}
+		}
+	}
+
+	for (op = a.linked; op != NULL; op = op->next) {
+		if (op->num_incoming > 0) {
+			print_label(f, op);
+			fprintf(f, "\n");
+		}
+
+		fprintf(f, "\t");
+
+		switch (op->instr) {
+		case VM_OP_STOP:
+			print_cond(f, op, opt);
+			print_stop(f, op);
+			break;
+
+		case VM_OP_FETCH:
+			print_fetch(f, opt);
+			print_stop(f, op);
+			break;
+
+		case VM_OP_BRANCH:
+			print_cond(f, op, opt);
+			print_branch(f, op);
+			break;
+
+		default:
+			assert(!"unreached");
+			break;
+		}
+
+		fprintf(f, "\n");
+	}
+
+	dfavm_opasm_finalize_op(&a);
+
+	return 0;
+}
+
+static void
+fsm_print_c_complete(FILE *f, const struct ir *ir, const struct fsm_options *opt)
+{
+	const char *cp;
+
+	assert(f != NULL);
+	assert(ir != NULL);
+	assert(opt != NULL);
+
+	(void) fsm_print_cfrag(f, ir, opt, cp,
+		opt->leaf != NULL ? opt->leaf : leaf, opt->leaf_opaque);
+
+	fprintf(f, "\n");
+
+	fprintf(f, "match:\n");
+	fprintf(f, "\treturn 0x1;\n"); /* TODO: eventually switch on state here */
+
+	fprintf(f, "fail:\n");
+	fprintf(f, "\treturn -1;\n");
+}
+
+void
+fsm_print_vmc(FILE *f, const struct fsm *fsm)
+{
+	struct ir *ir;
+	const char *prefix;
+
+	assert(f != NULL);
+	assert(fsm != NULL);
+	assert(fsm->opt != NULL);
+
+	ir = make_ir(fsm);
+	if (ir == NULL) {
+		return;
+	}
+
+	/* henceforth, no function should be passed struct fsm *, only the ir and options */
+
+	if (fsm->opt->prefix != NULL) {
+		prefix = fsm->opt->prefix;
+	} else {
+		prefix = "fsm_";
+	}
+
+	if (fsm->opt->fragment) {
+		fsm_print_c_complete(f, ir, fsm->opt);
+		return;
+	}
+
+	fprintf(f, "\n");
+
+	fprintf(f, "int\n%smain", prefix);
+
+	switch (fsm->opt->io) {
+	case FSM_IO_GETC:
+		fprintf(f, "(int (*fsm_getc)(void *opaque), void *opaque)\n");
+		fprintf(f, "{\n");
+		fprintf(f, "\tint c;\n");
+		fprintf(f, "\n");
+		break;
+
+	case FSM_IO_STR:
+		fprintf(f, "(const char *s)\n");
+		fprintf(f, "{\n");
+		fprintf(f, "\tconst char *p;\n");
+		fprintf(f, "\tint c;\n");
+		fprintf(f, "\n");
+		fprintf(f, "\tp = s;\n");
+		fprintf(f, "\n");
+		break;
+
+	case FSM_IO_PAIR:
+		fprintf(f, "(const char *b, const char *e)\n");
+		fprintf(f, "{\n");
+		fprintf(f, "\tconst char *p;\n");
+		fprintf(f, "\tint c;\n");
+		fprintf(f, "\n");
+		fprintf(f, "\tp = b;\n");
+		fprintf(f, "\n");
+		break;
+	}
+
+	fsm_print_c_complete(f, ir, fsm->opt);
+
+	fprintf(f, "}\n");
+	fprintf(f, "\n");
+
+	free_ir(fsm, ir);
+}
+

--- a/src/libfsm/vm/vm.h
+++ b/src/libfsm/vm/vm.h
@@ -20,6 +20,7 @@
 #define DFAVM_MAGIC "DFAVM$"
 
 struct ir;
+struct ir_state;
 struct fsm_vm_compile_opts;
 struct dfavm_op_ir_pool;
 
@@ -73,6 +74,8 @@ struct dfavm_op_ir {
 	 * entering the operation.
 	 */
 	uint32_t index;
+
+	const struct ir_state *ir_state; // for void *opaque
 
 	uint32_t num_incoming; // number of branches to this instruction
 	int in_trace;

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -895,7 +895,7 @@ main(int argc, char *argv[])
 		/* TODO: print examples in comments for end states;
 		 * patterns in comments for the whole FSM */
 
-		if (print_fsm == fsm_print_c) {
+		if (print_fsm == fsm_print_c || print_fsm == fsm_print_vmc) {
 			opt.endleaf = endleaf_c;
 		} else if (print_fsm == fsm_print_dot) {
 			opt.endleaf = patterns ? endleaf_dot : NULL;

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -111,6 +111,7 @@ print_name(const char *name,
 		{ "ir",     fsm_print_ir,     NULL  },
 		{ "irjson", fsm_print_irjson, NULL  },
 		{ "json",   fsm_print_json,   NULL  },
+		{ "vmc",    fsm_print_vmc,    NULL  },
 
 		{ "tree",   NULL, ast_print_tree },
 		{ "abnf",   NULL, ast_print_abnf },

--- a/src/retest/Makefile
+++ b/src/retest/Makefile
@@ -9,6 +9,15 @@ CFLAGS.${src} += -I src # XXX: for internal.h
 DFLAGS.${src} += -I src # XXX: for internal.h
 .endfor
 
+.for src in ${SRC:Msrc/retest/reperf.c}
+CFLAGS.${src} += -std=c99
+DFLAGS.${src} += -std=c99
+.endfor
+
+.if ${SYSTEM} == Linux
+LFLAGS.reperf += -ldl
+.endif
+
 PROG += retest
 PROG += reperf
 PROG += cvtpcre


### PR DESCRIPTION
This PR introduces a new kind of C code generation for libfsm. This is generated from the VM IR opcodes introduced in https://github.com/katef/libfsm/pull/201

This style of code generation walks the list of opcodes and emits them essentially verbatim, transliterated to C:
```
; ./build/bin/re -k str -pl vmc '^ab+c?.?$'
int
fsm_main(const char *s)
{
        const char *p;
        int c;

        p = s;

        if (c = *p++, c == '\0') return -1;
        if (c != 'a') return -1;
        if (c = *p++, c == '\0') return -1;
        if (c != 'b') return -1;
l0: /* e.g. "ab" */
        if (c = *p++, c == '\0') return 0x1; /* "^ab+c?.?$" */
        if (c == 'b') goto l0;
        if (c == 'c') goto l2;
l1: /* e.g. "aba" */
        if (c = *p++, c == '\0') return 0x1; /* "^ab+c?.?$" */
        return -1;
l2: /* e.g. "abc" */
        if (c = *p++, c == '\0') return 0x1; /* "^ab+c?.?$" */
        goto l1;
}
```

The idea here is that this might eventually serve as a model for generating assembly.

I had also hoped that this might be friendlier to the instruction cache. I haven't profiled this, but benchmarking with reperf shows that execution time is essentially indistinguishable from the older switch-style generated code. clang was slightly slower than gcc, but not by much.

Also worth noting, the v2 bytecode interpreter runs only about 2.5x slower than the generated code. I think that's excellent.

This produces much shorter output for the same regexp:
```
; ./build/bin/re -r pcre -bpl c '(?:[a-zA-Z0-9]+ ){0,10}fish' | wc -l
4204
; ./build/bin/re -r pcre -bpl vmc '(?:[a-zA-Z0-9]+ ){0,10}fish' | wc -l
728
```

I've called this `-l vmc` for the moment, and I haven't updated documentation etc, because I expect to replace the older `-l c` eventually. I don't see a reason to keep both, except perhaps as an example for how to implement the switch style codegen if it suits a particular language.

I haven't updated lx to use this yet, because lx has some corner case where it emits a special state as an entry point. That needs dealing with somehow.