### PR TITLE
Code generation to sh

### DIFF
--- a/include/fsm/print.h
+++ b/include/fsm/print.h
@@ -40,6 +40,7 @@ fsm_print fsm_print_ir;
 fsm_print fsm_print_irjson;
 fsm_print fsm_print_json;
 fsm_print fsm_print_vmc;
+fsm_print fsm_print_sh;
 
 #endif
 

--- a/man/fsm.1/fsm.1.xml
+++ b/man/fsm.1/fsm.1.xml
@@ -48,6 +48,7 @@
 	<!ENTITY fsm.lit  "<literal>fsm</literal>">
 	<!ENTITY ir.lit   "<literal>ir</literal>">
 	<!ENTITY json.lit "<literal>json</literal>">
+	<!ENTITY sh.lit   "<literal>sh</literal>">
 ]>
 
 <refentry>

--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -161,7 +161,8 @@ print_name(const char *name)
 		{ "fsm",  fsm_print_fsm  },
 		{ "ir",   fsm_print_ir   },
 		{ "json", fsm_print_json },
-		{ "vmc",  fsm_print_vmc  }
+		{ "vmc",  fsm_print_vmc  },
+		{ "sh",   fsm_print_sh   }
 	};
 
 	assert(name != NULL);

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -35,6 +35,7 @@ fsm_print_ir
 fsm_print_irjson
 fsm_print_json
 fsm_print_vmc
+fsm_print_sh
 
 # <fsm/fsm.h>
 fsm_clone

--- a/src/libfsm/print/Makefile
+++ b/src/libfsm/print/Makefile
@@ -9,8 +9,9 @@ SRC += src/libfsm/print/irdot.c
 SRC += src/libfsm/print/irjson.c
 SRC += src/libfsm/print/json.c
 SRC += src/libfsm/print/vmc.c
+SRC += src/libfsm/print/sh.c
 
-.for src in ${SRC:Msrc/libfsm/print/vmc.c}
+.for src in ${SRC:Msrc/libfsm/print/vmc.c} ${SRC:Msrc/libfsm/print/sh.c}
 CFLAGS.${src} += -std=c99 # XXX: for ir.h
 DFLAGS.${src} += -std=c99 # XXX: for ir.h
 .endfor

--- a/src/libfsm/print/sh.c
+++ b/src/libfsm/print/sh.c
@@ -73,7 +73,7 @@ print_cond(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt)
 	}
 
 	fprintf(f, "[ $(ord \"$c\") %s ", cmp_operator(op->cmp));
-	fprintf(f, "%hhu", (unsigned char) op->cmp_arg);
+	fprintf(f, "%3hhu", (unsigned char) op->cmp_arg);
 	fprintf(f, " ] && ");
 }
 

--- a/src/libfsm/print/sh.c
+++ b/src/libfsm/print/sh.c
@@ -50,6 +50,12 @@ print_label(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt
 {
 	fprintf(f, "l%lu)", (unsigned long) op->index);
 
+	/*
+	 * The example strings here are just for human-readable comments;
+	 * double quoted strings in sh do not support numeric escapes for
+	 * arbitrary characters, and nobody can read $'...' style strings.
+	 * So I'm just using C-style strings here because it's simple enough.
+	 */
 	if (op->ir_state->example != NULL) {
 		fprintf(f, " # e.g. \"");
 		escputs(f, opt, c_escputc_str, op->ir_state->example);

--- a/src/libfsm/print/sh.c
+++ b/src/libfsm/print/sh.c
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2008-2020 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <string.h>
+#include <stdint.h>
+#include <errno.h>
+#include <stdio.h>
+
+#include <print/esc.h>
+
+#include <adt/set.h>
+
+#include <fsm/fsm.h>
+#include <fsm/pred.h>
+#include <fsm/walk.h>
+#include <fsm/print.h>
+#include <fsm/options.h>
+#include <fsm/vm.h>
+
+#include "libfsm/internal.h"
+
+#include "libfsm/vm/vm.h"
+
+#include "ir.h"
+
+static const char *
+cmp_operator(int cmp)
+{
+	switch (cmp) {
+	case VM_CMP_LT: return "-lt";
+	case VM_CMP_LE: return "-le";
+	case VM_CMP_EQ: return "-eq";
+	case VM_CMP_GE: return "-ge";
+	case VM_CMP_GT: return "-gt";
+	case VM_CMP_NE: return "-ne";
+
+	case VM_CMP_ALWAYS:
+	default:
+		assert("unreached");
+		return NULL;
+	}
+}
+
+static void
+print_label(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt)
+{
+	fprintf(f, "l%lu)", (unsigned long) op->index);
+
+	if (op->ir_state->example != NULL) {
+		fprintf(f, " # e.g. \"");
+		escputs(f, opt, c_escputc_str, op->ir_state->example);
+		fprintf(f, "\"");
+	}
+}
+
+static void
+print_cond(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt)
+{
+	(void) opt;
+
+	if (op->cmp == VM_CMP_ALWAYS) {
+		return;
+	}
+
+	fprintf(f, "[ $(ord \"$c\") %s ", cmp_operator(op->cmp));
+	fprintf(f, "%hu", (unsigned char) op->cmp_arg);
+	fprintf(f, " ] && ");
+}
+
+static void
+print_end(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt,
+	enum dfavm_op_end end_bits, const struct ir *ir)
+{
+	if (end_bits == VM_END_FAIL) {
+		fprintf(f, "fail");
+		return;
+	}
+
+	if (opt->endleaf != NULL) {
+		opt->endleaf(f, op->ir_state->opaque, opt->endleaf_opaque);
+	} else {
+		fprintf(f, "matched %lu", (unsigned long) (op->ir_state - ir->states));
+	}
+}
+
+static void
+print_branch(FILE *f, const struct dfavm_op_ir *op)
+{
+	fprintf(f, "{ l=l%lu; continue; }", (unsigned long) op->u.br.dest_arg->index);
+}
+
+static void
+print_fetch(FILE *f, const struct fsm_options *opt)
+{
+	(void) opt;
+
+	fprintf(f, "read -n 1 c || ");
+}
+
+static int
+fsm_print_shfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt)
+{
+	static const struct dfavm_assembler_ir zero;
+	struct dfavm_assembler_ir a;
+	struct dfavm_op_ir *op;
+
+	static const struct fsm_vm_compile_opts vm_opts = { FSM_VM_COMPILE_DEFAULT_FLAGS, FSM_VM_COMPILE_VM_V1, NULL };
+
+	assert(f != NULL);
+	assert(ir != NULL);
+	assert(opt != NULL);
+
+	a = zero;
+
+	if (!dfavm_compile_ir(&a, ir, vm_opts)) {
+		return -1;
+	}
+
+	/*
+	 * We only output labels for ops which are branched to. This gives
+	 * gaps in the sequence for ops which don't need a label.
+	 * So here we renumber just the ones we use.
+	 */
+	{
+		uint32_t l;
+
+		l = 0;
+
+		for (op = a.linked; op != NULL; op = op->next) {
+			if (op->num_incoming > 0) {
+				op->index = l++;
+			}
+		}
+	}
+
+	fprintf(f, "ord() { printf %%d \"'$1\"; }\n");
+	fprintf(f, "fail() { echo fail; exit 1; }\n");
+	fprintf(f, "matched() { echo match; exit 0; }\n");
+	fprintf(f, "\n");
+
+	fprintf(f, "l=start\n");
+	fprintf(f, "\n");
+
+	fprintf(f, "while true; do\n");
+	fprintf(f, "\tcase $l in\n");
+	fprintf(f, "\tstart)\n");
+
+	for (op = a.linked; op != NULL; op = op->next) {
+		if (op->num_incoming > 0) {
+			if (op != a.linked) {
+				fprintf(f, "\t\t;&\n");
+			}
+
+			fprintf(f, "\t");
+			print_label(f, op, opt);
+			fprintf(f, "\n");
+		}
+
+		fprintf(f, "\t\t");
+
+		switch (op->instr) {
+		case VM_OP_STOP:
+			print_cond(f, op, opt);
+			print_end(f, op, opt, op->u.stop.end_bits, ir);
+			break;
+
+		case VM_OP_FETCH:
+			print_fetch(f, opt);
+			print_end(f, op, opt, op->u.fetch.end_bits, ir);
+			break;
+
+		case VM_OP_BRANCH:
+			print_cond(f, op, opt);
+			print_branch(f, op);
+			break;
+
+		default:
+			assert(!"unreached");
+			break;
+		}
+
+		fprintf(f, "\n");
+	}
+
+	fprintf(f, "\t\t;;\n");
+	fprintf(f, "\tesac\n");
+	fprintf(f, "done\n");
+
+	dfavm_opasm_finalize_op(&a);
+
+	return 0;
+}
+
+void
+fsm_print_sh(FILE *f, const struct fsm *fsm)
+{
+	struct ir *ir;
+
+	assert(f != NULL);
+	assert(fsm != NULL);
+	assert(fsm->opt != NULL);
+
+	ir = make_ir(fsm);
+	if (ir == NULL) {
+		return;
+	}
+
+	if (fsm->opt->io != FSM_IO_STR) {
+		fprintf(stderr, "unsupported IO API\n");
+		exit(EXIT_FAILURE);
+	}
+
+	(void) fsm_print_shfrag(f, ir, fsm->opt);
+
+	free_ir(fsm, ir);
+}
+

--- a/src/libfsm/print/sh.c
+++ b/src/libfsm/print/sh.c
@@ -67,7 +67,7 @@ print_cond(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt)
 	}
 
 	fprintf(f, "[ $(ord \"$c\") %s ", cmp_operator(op->cmp));
-	fprintf(f, "%hu", (unsigned char) op->cmp_arg);
+	fprintf(f, "%hhu", (unsigned char) op->cmp_arg);
 	fprintf(f, " ] && ");
 }
 

--- a/src/re/Makefile
+++ b/src/re/Makefile
@@ -17,3 +17,7 @@ ${BUILD}/bin/re: ${BUILD}/lib/${lib:R}.a
 ${BUILD}/bin/re: ${BUILD}/${src:R}.o
 .endfor
 
+# smoke test for sh codegen
+test:: ${BUILD}/bin/re
+	echo -n abcd | bash -c "`./build/bin/re -pl sh -k str -br glob 'a?c*d'`"
+	

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -112,6 +112,7 @@ print_name(const char *name,
 		{ "irjson", fsm_print_irjson, NULL  },
 		{ "json",   fsm_print_json,   NULL  },
 		{ "vmc",    fsm_print_vmc,    NULL  },
+		{ "sh",     fsm_print_sh,     NULL  },
 
 		{ "tree",   NULL, ast_print_tree },
 		{ "abnf",   NULL, ast_print_abnf },


### PR DESCRIPTION
This is really terrible. Now you can compile your regular expressions to shell scripts.

The generated code looks like this:
```sh
; ./build/bin/re -k str -pl sh '^ab+c?.?[a-z]{2,3}$'
ord() { printf %d "'$1"; }
fail() { echo fail; exit 1; }
matched() { echo match; exit 0; }

l=start

while true; do
	case $l in
	start)
		read -n 1 c || fail
		[ $(ord "$c") -ne 97 ] && fail
		read -n 1 c || fail
		[ $(ord "$c") -ne 98 ] && fail
		read -n 1 c || fail
		[ $(ord "$c") -le 96 ] && { l=l0; continue; }
		[ $(ord "$c") -eq 97 ] && { l=l4; continue; }
		[ $(ord "$c") -eq 98 ] && { l=l6; continue; }
		[ $(ord "$c") -eq 99 ] && { l=l8; continue; }
		[ $(ord "$c") -le 122 ] && { l=l4; continue; }
		;&
	l0) # e.g. "abA"
		read -n 1 c || fail
		[ $(ord "$c") -le 96 ] && fail
		[ $(ord "$c") -gt 122 ] && fail
		;&
	l1) # e.g. "abAa"
		read -n 1 c || fail
		[ $(ord "$c") -le 96 ] && fail
		[ $(ord "$c") -gt 122 ] && fail
		;&
	l2) # e.g. "abaaa"
		read -n 1 c || matched 9
		[ $(ord "$c") -le 96 ] && fail
		[ $(ord "$c") -gt 122 ] && fail
		;&
	l3) # e.g. "abaaaa"
		read -n 1 c || matched 10
		fail
		;&
	l4) # e.g. "aba"
		read -n 1 c || fail
		[ $(ord "$c") -le 96 ] && fail
		[ $(ord "$c") -gt 122 ] && fail
		;&
	l5) # e.g. "abaa"
		read -n 1 c || matched 8
		[ $(ord "$c") -le 96 ] && fail
		[ $(ord "$c") -le 122 ] && { l=l2; continue; }
		fail
		;&
	l6) # e.g. "abb"
		read -n 1 c || fail
		[ $(ord "$c") -le 96 ] && { l=l0; continue; }
		[ $(ord "$c") -eq 97 ] && { l=l7; continue; }
		[ $(ord "$c") -eq 98 ] && { l=l9; continue; }
		[ $(ord "$c") -eq 99 ] && { l=l10; continue; }
		[ $(ord "$c") -gt 122 ] && { l=l0; continue; }
		;&
	l7) # e.g. "abca"
		read -n 1 c || matched 7
		[ $(ord "$c") -le 96 ] && fail
		[ $(ord "$c") -le 122 ] && { l=l5; continue; }
		fail
		;&
	l8) # e.g. "abc"
		read -n 1 c || fail
		[ $(ord "$c") -le 96 ] && { l=l0; continue; }
		[ $(ord "$c") -le 122 ] && { l=l7; continue; }
		{ l=l0; continue; }
		;&
	l9) # e.g. "abbb"
		read -n 1 c || matched 11
		[ $(ord "$c") -le 96 ] && { l=l0; continue; }
		[ $(ord "$c") -eq 97 ] && { l=l7; continue; }
		[ $(ord "$c") -eq 98 ] && { l=l9; continue; }
		[ $(ord "$c") -eq 99 ] && { l=l10; continue; }
		[ $(ord "$c") -le 122 ] && { l=l7; continue; }
		{ l=l0; continue; }
		;&
	l10) # e.g. "abbc"
		read -n 1 c || matched 12
		[ $(ord "$c") -le 96 ] && { l=l0; continue; }
		[ $(ord "$c") -le 122 ] && { l=l7; continue; }
		{ l=l0; continue; }
		;;
	esac
done
```