### PR TITLE
Add invariant: `fsm_minimise` should only be called with DFAs.

### DIFF
--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -278,7 +278,7 @@ fsm_complete(struct fsm *fsm,
 	int (*predicate)(const struct fsm *, fsm_state_t));
 
 /*
- * Minimize an FSM to its canonical form.
+ * Minimize a DFA to its canonical form.
  *
  * Returns false on error; see errno.
  */

--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -482,13 +482,19 @@ main(int argc, char *argv[])
 		case OP_REVERSE:     r = fsm_reverse(q);      break;
 		case OP_DETERMINISE: r = fsm_determinise(q);  break;
 		case OP_GLUSHKOVISE: r = fsm_glushkovise(q);  break;
-		case OP_MINIMISE:    r = fsm_minimise(q);     break;
 		case OP_TRIM:        r = fsm_trim(q);         break;
 
 		case OP_CONCAT:      q = fsm_concat(a, b);    break;
 		case OP_UNION:       q = fsm_union(a, b);     break;
 		case OP_INTERSECT:   q = fsm_intersect(a, b); break;
 		case OP_SUBTRACT:    q = fsm_subtract(a, b);  break;
+
+		case OP_MINIMISE:
+			r = fsm_determinise(q);
+			if (r == 1) {
+				r = fsm_minimise(q);
+			}
+			break;
 
 		case OP_EQUAL:
 			r = fsm_equal(a, b);

--- a/src/libfsm/minimise.c
+++ b/src/libfsm/minimise.c
@@ -23,6 +23,9 @@ fsm_minimise(struct fsm *fsm)
 
 	assert(fsm != NULL);
 
+	/* This should only be called with a DFA. */
+	assert(fsm_all(fsm, fsm_isdfa));
+
 	/*
 	 * Brzozowski's algorithm.
 	 */

--- a/src/lx/main.c
+++ b/src/lx/main.c
@@ -494,6 +494,12 @@ zone_minimise(void *arg)
 			assert(m->fsm != NULL);
 
 			if (!keep_nfa) {
+				if (!fsm_determinise(m->fsm)) {
+					pthread_mutex_lock(&zmtx);
+					zerror = errno;
+					pthread_mutex_unlock(&zmtx);
+					return "fsm_minimise";
+				}
 				if (!fsm_minimise(m->fsm)) {
 					pthread_mutex_lock(&zmtx);
 					zerror = errno;

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -693,6 +693,10 @@ main(int argc, char *argv[])
 			}
 
 			if (!keep_nfa) {
+				if (!fsm_determinise(new)) {
+					perror("fsm_determinise");
+					return EXIT_FAILURE;
+				}
 				if (!fsm_minimise(new)) {
 					perror("fsm_minimise");
 					return EXIT_FAILURE;
@@ -836,17 +840,16 @@ main(int argc, char *argv[])
 		opt.carryopaque = carryopaque;
 
 		/*
-		 * Minimise only when we don't need to keep the end state information
-		 * separated per regexp. Otherwise, convert to a DFA.
-		 */
+		 * Convert to a DFA, then minimise unless we need to keep the end
+		 * state information separated per regexp. */
+		if (!fsm_determinise(fsm)) {
+			perror("fsm_determinise");
+			return EXIT_FAILURE;
+		}
+
 		if (!patterns && !example && print_fsm != fsm_print_c) {
 			if (!fsm_minimise(fsm)) {
 				perror("fsm_minimise");
-				return EXIT_FAILURE;
-			}
-		} else {
-			if (!fsm_determinise(fsm)) {
-				perror("fsm_determinise");
 				return EXIT_FAILURE;
 			}
 		}


### PR DESCRIPTION
This invariant needs to be in place before switching to the new minimization algorithm.

I feel a bit apprehensive about adding a big invariant like this after the fact, but Brzozowski's algorithm is calling `fsm_determinise` internally anyway, albeit after reversing.