### PR TITLE
apt-get update for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,9 @@ jobs:
         submodules: recursive
 
     - name: dependencies
-      run: sudo apt-get install pmake bmake pcregrep
+      run: |
+        sudo apt-get update
+        sudo apt-get install pmake bmake pcregrep
 
     - name: make
       run: ${{ matrix.make }} -r -j 2 PKGCONF=pkg-config CC=${{ matrix.cc }}


### PR DESCRIPTION
CI started failing because pcregrep_8.4.3-1 is no longer available. Here I've added `apt-get update` first, because we don't depend on any particular version.

Writing yaml is always total guesswork for me.