### PR TITLE
Graphviz rendering for blocks of VM ops

### DIFF
--- a/include/fsm/print.h
+++ b/include/fsm/print.h
@@ -23,6 +23,7 @@ struct fsm;
  *  fsm_print_irjson - Codegen IR as JSON
  *  fsm_print_json   - JavaScript Object Notation
  *  fsm_print_vmc    - ISO C90 code, VM style
+ *  fsm_print_vmdot  - Graphviz Dot format, showing VM opcodes
  *  fsm_print_sh     - Shell script (bash dialect)
  *  fsm_print_go     - Go code
  *
@@ -42,6 +43,7 @@ fsm_print fsm_print_ir;
 fsm_print fsm_print_irjson;
 fsm_print fsm_print_json;
 fsm_print fsm_print_vmc;
+fsm_print fsm_print_vmdot;
 fsm_print fsm_print_vmasm;
 fsm_print fsm_print_vmasm_amd64_att;  /* output amd64 assembler in AT&T format */
 fsm_print fsm_print_vmasm_amd64_nasm; /* output amd64 assembler in NASM format */

--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -155,21 +155,21 @@ print_name(const char *name)
 		const char *name;
 		fsm_print *f;
 	} a[] = {
-		{ "api",  fsm_print_api  },
-		{ "c",    fsm_print_c    },
-		{ "dot",  fsm_print_dot  },
-		{ "fsm",  fsm_print_fsm  },
-		{ "ir",   fsm_print_ir   },
-		{ "json", fsm_print_json },
-		{ "vmc",  fsm_print_vmc  },
+		{ "api",   fsm_print_api   },
+		{ "c",     fsm_print_c     },
+		{ "dot",   fsm_print_dot   },
+		{ "fsm",   fsm_print_fsm   },
+		{ "ir",    fsm_print_ir    },
+		{ "json",  fsm_print_json  },
+		{ "vmc",   fsm_print_vmc   },
+		{ "vmdot", fsm_print_vmdot },
+		{ "sh",    fsm_print_sh    },
+		{ "go",    fsm_print_go    },
 
-		{ "amd64",  fsm_print_vmasm                },
+		{ "amd64",      fsm_print_vmasm            },
 		{ "amd64_att",  fsm_print_vmasm_amd64_att  },
 		{ "amd64_nasm", fsm_print_vmasm_amd64_nasm },
-		{ "amd64_go", fsm_print_vmasm_amd64_go },
-
-		{ "sh",   fsm_print_sh   },
-		{ "go",   fsm_print_go   }
+		{ "amd64_go",   fsm_print_vmasm_amd64_go   }
 	};
 
 	assert(name != NULL);

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -35,6 +35,7 @@ fsm_print_ir
 fsm_print_irjson
 fsm_print_json
 fsm_print_vmc
+fsm_print_vmdot
 fsm_print_vmasm
 fsm_print_vmasm_amd64_att
 fsm_print_vmasm_amd64_nasm

--- a/src/libfsm/print/Makefile
+++ b/src/libfsm/print/Makefile
@@ -8,12 +8,13 @@ SRC += src/libfsm/print/ir.c
 SRC += src/libfsm/print/irdot.c
 SRC += src/libfsm/print/irjson.c
 SRC += src/libfsm/print/json.c
-SRC += src/libfsm/print/vmc.c
-SRC += src/libfsm/print/vmasm.c
 SRC += src/libfsm/print/sh.c
 SRC += src/libfsm/print/go.c
+SRC += src/libfsm/print/vmc.c
+SRC += src/libfsm/print/vmdot.c
+SRC += src/libfsm/print/vmasm.c
 
-.for src in ${SRC:Msrc/libfsm/print/vmc.c} ${SRC:Msrc/libfsm/print/sh.c} ${SRC:Msrc/libfsm/print/go.c} ${SRC:Msrc/libfsm/print/vmasm.c}
+.for src in ${SRC:Msrc/libfsm/print/vmc.c} ${SRC:Msrc/libfsm/print/sh.c} ${SRC:Msrc/libfsm/print/go.c} ${SRC:Msrc/libfsm/print/vmasm.c} ${SRC:Msrc/libfsm/print/vmdot.c}
 CFLAGS.${src} += -std=c99 # XXX: for ir.h
 DFLAGS.${src} += -std=c99 # XXX: for ir.h
 .endfor

--- a/src/libfsm/print/vmdot.c
+++ b/src/libfsm/print/vmdot.c
@@ -128,7 +128,11 @@ fsm_print_nodes(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 			fprintf(f, "\t\t<table border='0' cellborder='1' cellpadding='6' cellspacing='0'>\n");
 
 			fprintf(f, "\t\t<tr>\n");
-			fprintf(f, "\t\t\t<td><b>L%u</b></td>\n", block++);
+			if (op == a->linked) {
+				fprintf(f, "\t\t\t<td><b>L-</b></td>\n");
+			} else {
+				fprintf(f, "\t\t\t<td><b>L%u</b></td>\n", block++);
+			}
 			fprintf(f, "\t\t\t<td><b>State</b></td>\n");
 			fprintf(f, "\t\t\t<td><b>Cond</b></td>\n");
 			fprintf(f, "\t\t\t<td align='left'><b>Op</b></td>\n");

--- a/src/libfsm/print/vmdot.c
+++ b/src/libfsm/print/vmdot.c
@@ -1,0 +1,344 @@
+/*
+ * Copyright 2008-2020 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <string.h>
+#include <stdint.h>
+#include <errno.h>
+#include <stdio.h>
+
+#include <print/esc.h>
+
+#include <adt/set.h>
+
+#include <fsm/fsm.h>
+#include <fsm/pred.h>
+#include <fsm/walk.h>
+#include <fsm/print.h>
+#include <fsm/options.h>
+#include <fsm/vm.h>
+
+#include "libfsm/internal.h"
+
+#include "libfsm/vm/vm.h"
+
+#include "ir.h"
+
+static unsigned int
+ir_indexof(const struct ir *ir, const struct ir_state *cs)
+{
+	assert(ir != NULL);
+	assert(cs != NULL);
+
+	return cs - &ir->states[0];
+}
+
+static const char *
+cmp_operator(int cmp)
+{
+	switch (cmp) {
+	case VM_CMP_LT: return "&lt;";
+	case VM_CMP_LE: return "&le;";
+	case VM_CMP_EQ: return "=";
+	case VM_CMP_GE: return "&ge;";
+	case VM_CMP_GT: return "&gt;";
+	case VM_CMP_NE: return "&ne;";
+
+	case VM_CMP_ALWAYS:
+	default:
+		assert("unreached");
+		return NULL;
+	}
+}
+
+static int
+op_can_fallthrough(const struct dfavm_op_ir *op)
+{
+	if (op->instr == VM_OP_STOP && op->cmp == VM_CMP_ALWAYS) {
+		return 0;
+	}
+
+	if (op->instr == VM_OP_BRANCH && op->cmp == VM_CMP_ALWAYS) {
+		return 0;
+	}
+
+	return 1;
+}
+
+static void
+print_cond(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt)
+{
+	if (op->cmp == VM_CMP_ALWAYS) {
+		fprintf(f, "always");
+		return;
+	}
+
+	fprintf(f, "%s '", cmp_operator(op->cmp));
+	dot_escputc_html(f, opt, op->cmp_arg);
+	fprintf(f, "'");
+}
+
+static void
+print_end(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt,
+	enum dfavm_op_end end_bits, const struct ir *ir)
+{
+	if (end_bits == VM_END_FAIL) {
+		fprintf(f, "fail");
+		return;
+	}
+
+	if (opt->endleaf != NULL) {
+		opt->endleaf(f, op->ir_state->opaque, opt->endleaf_opaque);
+	} else {
+		fprintf(f, "ret %lu", (unsigned long) (op->ir_state - ir->states));
+	}
+}
+
+static void
+print_branch(FILE *f, const struct dfavm_op_ir *op)
+{
+	fprintf(f, "branch #%lu", (unsigned long) op->u.br.dest_arg->index);
+}
+
+static void
+fsm_print_nodes(FILE *f, const struct ir *ir, const struct fsm_options *opt,
+	const struct dfavm_assembler_ir *a)
+{
+	const struct dfavm_op_ir *op;
+	const struct ir_state *ir_state;
+	unsigned block;
+
+	block = 0;
+
+	ir_state = NULL;
+
+	for (op = a->linked; op != NULL; op = op->next) {
+		if (op->num_incoming > 0 || op == a->linked) {
+			if (op != a->linked) {
+				fprintf(f, "\t\t</table>\n");
+				fprintf(f, "\t> ];\n");
+			}
+
+			fprintf(f, "\n");
+
+			fprintf(f, "\tS%lu [ label=<\n", (unsigned long) op->index);
+			fprintf(f, "\t\t<table border='0' cellborder='1' cellpadding='6' cellspacing='0'>\n");
+
+			fprintf(f, "\t\t<tr>\n");
+			fprintf(f, "\t\t\t<td><b>L%u</b></td>\n", block++);
+			fprintf(f, "\t\t\t<td><b>State</b></td>\n");
+			fprintf(f, "\t\t\t<td><b>Cond</b></td>\n");
+			fprintf(f, "\t\t\t<td align='left'><b>Op</b></td>\n");
+			fprintf(f, "\t\t</tr>\n");
+		}
+
+		if (ir_state != op->ir_state || op->num_incoming > 0) {
+			if (op->ir_state->example != NULL) {
+				fprintf(f, "\t\t<tr>\n");
+				fprintf(f, "\t\t\t<td colspan='4' align='left'>");
+				fprintf(f, "e.g. <font face='mono'>\"");
+				escputs(f, opt, dot_escputc_html, op->ir_state->example);
+				fprintf(f, "\"</font>");
+				fprintf(f, "</td>\n");
+				fprintf(f, "\t\t</tr>\n");
+			}
+
+			ir_state = op->ir_state;
+		}
+
+		fprintf(f, "\t\t<tr>\n");
+
+		fprintf(f, "\t\t\t<td align='right' port='i%lu'>", (unsigned long) op->index);
+		fprintf(f, "#%lu", (unsigned long) op->index);
+		fprintf(f, "</td>\n");
+
+		fprintf(f, "\t\t\t<td>");
+		fprintf(f, op->ir_state->isend ? "(S%u)" : "S%u", ir_indexof(ir, op->ir_state));
+		fprintf(f, "</td>\n");
+
+		switch (op->instr) {
+		case VM_OP_STOP:
+			fprintf(f, "\t\t\t<td>");
+			print_cond(f, op, opt);
+			fprintf(f, "</td>\n");
+			fprintf(f, "\t\t\t<td align='left' port='b%u'>", op->index);
+			print_end(f, op, opt, op->u.stop.end_bits, ir);
+			fprintf(f, "</td>\n");
+			break;
+
+		case VM_OP_FETCH:
+			fprintf(f, "\t\t\t<td>fetch</td>\n");
+			fprintf(f, "\t\t\t<td align='left' port='b%u'>", op->index);
+			print_end(f, op, opt, op->u.fetch.end_bits, ir);
+			fprintf(f, "</td>\n");
+			break;
+
+		case VM_OP_BRANCH:
+			fprintf(f, "\t\t\t<td>");
+			print_cond(f, op, opt);
+			fprintf(f, "</td>\n");
+			fprintf(f, "\t\t\t<td align='left' port='b%u'>", op->index);
+			print_branch(f, op);
+			fprintf(f, "</td>\n");
+			break;
+
+		default:
+			assert(!"unreached");
+			break;
+		}
+
+		fprintf(f, "\t\t</tr>\n");
+	}
+
+	fprintf(f, "\t\t</table>\n");
+	fprintf(f, "\t> ];\n");
+}
+
+static void
+fsm_print_edges(FILE *f, const struct ir *ir, const struct fsm_options *opt,
+	const struct dfavm_assembler_ir *a)
+{
+	const struct dfavm_op_ir *op;
+	unsigned long block;
+	int can_fallthrough;
+
+	(void) ir;
+	(void) opt;
+
+	can_fallthrough = 1;
+
+	for (op = a->linked; op != NULL; op = op->next) {
+		if (op->num_incoming > 0 || op == a->linked) {
+			if (op != a->linked && can_fallthrough) {
+				fprintf(f, "\t");
+				fprintf(f, "S%lu:s -> S%lu:n [ style = bold ]; /* fallthrough */",
+					(unsigned long) block,
+					(unsigned long) op->index);
+				fprintf(f, "\n");
+			}
+
+			block = op->index;
+		}
+
+		can_fallthrough = op_can_fallthrough(op);
+
+		if (op->instr != VM_OP_BRANCH) {
+			continue;
+		}
+
+		fprintf(f, "\t");
+
+		/*
+		 * The instructions have been sorted by the VM optimisation somewhat,
+		 * similar to a topological sort. We're taking advantage of that here
+		 * by placing backward edges on the left, forward edges on the right.
+		 * This helps give some visual consistency to the layout.
+		 */
+		if (op->u.br.dest_arg->index > block) {
+			/* branch to a later block */
+			fprintf(f, "S%lu:b%lu:e -> S%lu;",
+				(unsigned long) block,
+				(unsigned long) op->index,
+				(unsigned long) op->u.br.dest_arg->index);
+		} else if (op->u.br.dest_arg->index < block) {
+			/* branch to an earlier block */
+			fprintf(f, "S%lu:i%lu:w -> S%lu;",
+				(unsigned long) block,
+				(unsigned long) op->index,
+				(unsigned long) op->u.br.dest_arg->index);
+		} else {
+			/* relative branch within the same block, entry on the east */
+			/* XXX: would like to make these edges shorter, but I don't know how */
+			fprintf(f, "S%lu:b%lu:e -> S%lu:b%lu:e [ constraint = false ]; /* relative */",
+				(unsigned long) block,
+				(unsigned long) op->index,
+				(unsigned long) block,
+				(unsigned long) op->u.br.dest_arg->index);
+		}
+
+		fprintf(f, "\n");
+	}
+}
+
+/* TODO: eventually to be non-static */
+static int
+fsm_print_vmdotfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt)
+{
+	static const struct dfavm_assembler_ir zero;
+	struct dfavm_assembler_ir a;
+
+	static const struct fsm_vm_compile_opts vm_opts = { FSM_VM_COMPILE_DEFAULT_FLAGS, FSM_VM_COMPILE_VM_V1, NULL };
+
+	assert(f != NULL);
+	assert(ir != NULL);
+	assert(opt != NULL);
+
+	a = zero;
+
+	if (!dfavm_compile_ir(&a, ir, vm_opts)) {
+		return -1;
+	}
+
+	fsm_print_nodes(f, ir, opt, &a);
+	fprintf(f, "\n");
+
+	fsm_print_edges(f, ir, opt, &a);
+
+	dfavm_opasm_finalize_op(&a);
+
+	return 0;
+}
+
+void
+fsm_print_vmdot(FILE *f, const struct fsm *fsm)
+{
+	struct ir *ir;
+	const char *prefix;
+
+	assert(f != NULL);
+	assert(fsm != NULL);
+	assert(fsm->opt != NULL);
+
+	ir = make_ir(fsm);
+	if (ir == NULL) {
+		return;
+	}
+
+	/* henceforth, no function should be passed struct fsm *, only the ir and options */
+
+	if (fsm->opt->prefix != NULL) {
+		prefix = fsm->opt->prefix;
+	} else {
+		prefix = "fsm_";
+	}
+
+	if (fsm->opt->fragment) {
+		fsm_print_vmdotfrag(f, ir, fsm->opt);
+		return;
+	}
+
+	fprintf(f, "\n");
+
+	fprintf(f, "digraph G {\n");
+
+	fprintf(f, "\tnode [ shape = plaintext ];\n");
+	fprintf(f, "\trankdir = TB;\n");
+	fprintf(f, "\tnodesep = 0.5;\n");
+	fprintf(f, "\troot = S0;\n");
+
+	fprintf(f, "\t{ start; S0; rank= same }\n");
+
+	fprintf(f, "\tstart [ shape = none, label = \"\" ];\n");
+	fprintf(f, "\tstart -> S0:i0:w [ style = bold ];\n");
+
+	fsm_print_vmdotfrag(f, ir, fsm->opt);
+
+	fprintf(f, "}\n");
+	fprintf(f, "\n");
+
+	free_ir(fsm, ir);
+}
+

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -104,22 +104,22 @@ print_name(const char *name,
 		fsm_print *print_fsm;
 		ast_print *print_ast;
 	} a[] = {
-		{ "api",    fsm_print_api,    NULL  },
-		{ "c",      fsm_print_c,      NULL  },
-		{ "dot",    fsm_print_dot,    NULL  },
-		{ "fsm",    fsm_print_fsm,    NULL  },
-		{ "ir",     fsm_print_ir,     NULL  },
-		{ "irjson", fsm_print_irjson, NULL  },
-		{ "json",   fsm_print_json,   NULL  },
-		{ "vmc",    fsm_print_vmc,    NULL  },
+		{ "api",    fsm_print_api,    NULL },
+		{ "c",      fsm_print_c,      NULL },
+		{ "dot",    fsm_print_dot,    NULL },
+		{ "fsm",    fsm_print_fsm,    NULL },
+		{ "ir",     fsm_print_ir,     NULL },
+		{ "irjson", fsm_print_irjson, NULL },
+		{ "json",   fsm_print_json,   NULL },
+		{ "vmc",    fsm_print_vmc,    NULL },
+		{ "vmdot",  fsm_print_vmdot,  NULL },
+		{ "sh",     fsm_print_sh,     NULL },
+		{ "go",     fsm_print_go,     NULL },
 
 		{ "amd64",      fsm_print_vmasm,            NULL },
 		{ "amd64_att",  fsm_print_vmasm_amd64_att,  NULL },
 		{ "amd64_nasm", fsm_print_vmasm_amd64_nasm, NULL },
-		{ "amd64_go", fsm_print_vmasm_amd64_go, NULL },
-
-		{ "sh",     fsm_print_sh,     NULL  },
-		{ "go",     fsm_print_go,     NULL  },
+		{ "amd64_go",   fsm_print_vmasm_amd64_go,   NULL },
 
 		{ "tree",   NULL, ast_print_tree },
 		{ "abnf",   NULL, ast_print_abnf },
@@ -908,7 +908,7 @@ main(int argc, char *argv[])
 
 		if (print_fsm == fsm_print_c || print_fsm == fsm_print_vmc) {
 			opt.endleaf = endleaf_c;
-		} else if (print_fsm == fsm_print_dot) {
+		} else if (print_fsm == fsm_print_dot || print_fsm == fsm_print_vmdot) {
 			opt.endleaf = patterns ? endleaf_dot : NULL;
 		} else if (print_fsm == fsm_print_json) {
 			opt.endleaf = patterns ? endleaf_json : NULL;


### PR DESCRIPTION
Here's rendering to graphviz for blocks of VM ops, showing the graph formed by branches between blocks, and relatively within a block.

Blocks are numbered uniquely top-left as `L*`; these correspond to the labels for gotos in the generated code.

Ops are numbered in the leftmost column.

Corresponding DFA (actually IR) states are shown in the second column; accepting states are indicated like `(S0)`. Examples are shown whenever this state changes (as can be seen in block `L3` below).

Bold arrows indicate fallthrough, non-bold for explicit branching. Branches always go to the top of a block, although the incoming arrows between blocks are drawn connecting wherever is convenient to keep the layout simple (for example, the branch from `L3` to `L1` resumes execution at instruction `#3`, not `#4`).

Fetch instructions are draw as if they're a condition (and their argument executes when a fetch fails), because that's convenient for rendering.

Here's a regexp that illustratrates most of the interesting situations:
```
; ./build/bin/re -bpl vmdot '(.ab?c)+es$|[0-9]f*' | dot
```
![image](https://user-images.githubusercontent.com/1371085/86522040-01118880-be0d-11ea-97ff-c30deedfb282.png)

This (hopefully!) corresponds to the generated code for the same regexp:
```c
; ./build/bin/re -k str -bpl vmc '(.ab?c)+es$|[0-9]f*' 

int
fsm_main(const char *s)
{
        const char *p;
        int c;

        p = s;

        if (c = (unsigned char) *p++, c == '\0') return -1;
        if (c <= '/') goto l0;
        if (c <= '9') goto l3;

l0: /* e.g. "a" */
        if (c = (unsigned char) *p++, c == '\0') return -1;
        if (c != 'a') return -1;

l1: /* e.g. "aa" */
        if (c = (unsigned char) *p++, c == '\0') return -1;
        if (c == 'b') goto l5;
        if (c != 'c') return -1;

l2: /* e.g. "aac" */
        if (c = (unsigned char) *p++, c == '\0') return -1;
        if (c != 'e') goto l0;
        if (c = (unsigned char) *p++, c == '\0') return -1;
        if (c == 'a') goto l1;
        if (c != 's') return -1;
        if (c = (unsigned char) *p++, c == '\0') return 0x1; /* "(.ab?c)+es$|[0-9]f*" */
        return -1;

l3: /* e.g. "0" */
        if (c = (unsigned char) *p++, c == '\0') return 0x1; /* "(.ab?c)+es$|[0-9]f*" */
        if (c == 'a') goto l1;
        if (c != 'f') return -1;

l4: /* e.g. "0f" */
        if (c = (unsigned char) *p++, c == '\0') return 0x1; /* "(.ab?c)+es$|[0-9]f*" */
        if (c != 'f') return -1;
        goto l4;

l5: /* e.g. "aab" */
        if (c = (unsigned char) *p++, c == '\0') return -1;
        if (c != 'c') return -1;
        goto l2;
}
```