### PR TITLE
gengraph: Avoid syntax error from empty "ends:" list

### DIFF
--- a/fuzz/gengraph
+++ b/fuzz/gengraph
@@ -100,9 +100,12 @@ BEGIN {
 
     printf("\n")
     printf("start: %d;\n", start)
-    printf("end:")
-    for (n in ends) {
-        printf("%s%d", n > 0 ? "," : " ", ends[n])
+
+    if (length(ends) > 0) {
+	    printf("end:")
+	    for (n in ends) {
+		    printf("%s%d", n > 0 ? "," : " ", ends[n])
+	    }
+	    printf(";\n")
     }
-    printf(";\n")
 }

--- a/fuzz/gengraph
+++ b/fuzz/gengraph
@@ -101,11 +101,14 @@ BEGIN {
     printf("\n")
     printf("start: %d;\n", start)
 
-    if (length(ends) > 0) {
-	    printf("end:")
-	    for (n in ends) {
-		    printf("%s%d", n > 0 ? "," : " ", ends[n])
+    for (n in ends) {
+	    if (!printed_end) {	# first time only
+		    printf("end:")
+		    printed_end = 1
 	    }
+	    printf("%s%d", n > 0 ? "," : " ", ends[n])
+    }
+    if (printed_end) {
 	    printf(";\n")
     }
 }


### PR DESCRIPTION
Only emit the "ends:" when end state IDs are actually going to be printed.