### PR TITLE
Convert edge set ADT to a hash table.

### DIFF
--- a/include/adt/edgeset.h
+++ b/include/adt/edgeset.h
@@ -31,6 +31,10 @@ edge_set_add_state_set(struct edge_set **setp, const struct fsm_alloc *alloc,
 	unsigned char symbol, const struct state_set *state_set);
 
 int
+edge_set_find(const struct edge_set *set, unsigned char symbol,
+	struct fsm_edge *e);
+
+int
 edge_set_contains(const struct edge_set *set, unsigned char symbol);
 
 int

--- a/include/adt/edgeset.h
+++ b/include/adt/edgeset.h
@@ -20,7 +20,7 @@ struct edge_iter {
 };
 
 void
-edge_set_free(struct edge_set *set);
+edge_set_free(const struct fsm_alloc *a, struct edge_set *set);
 
 int
 edge_set_add(struct edge_set **set, const struct fsm_alloc *alloc,

--- a/include/adt/edgeset.h
+++ b/include/adt/edgeset.h
@@ -7,6 +7,8 @@
 #ifndef ADT_EDGESET_H
 #define ADT_EDGESET_H
 
+#include <stdint.h>
+
 struct bm;
 struct set;
 struct fsm_alloc;
@@ -17,6 +19,13 @@ struct state_set;
 struct edge_iter {
 	size_t i;
 	const struct edge_set *set;
+};
+
+struct edge_ordered_iter {
+	const struct edge_set *set;
+	size_t pos;
+	unsigned char symbol;
+	uint64_t symbols_used[4];
 };
 
 /* Opaque struct type for edge iterator,
@@ -83,14 +92,9 @@ int
 edge_set_empty(const struct edge_set *s);
 
 
-/* Allocate a new ordered edge_set iterator. */
-struct edge_ordered_iter *
-edge_set_ordered_iter_new(const struct fsm_alloc *alloc,
-    const struct edge_set *s);
-
-/* Free an ordered edge_set iterator. */
+/* Initialize a new ordered edge_set iterator. */
 void
-edge_set_ordered_iter_free(const struct fsm_alloc *alloc,
+edge_set_ordered_iter_reset(const struct edge_set *set,
     struct edge_ordered_iter *eoi);
 
 /* Get the next edge from an ordered iterator and return 1,

--- a/include/adt/edgeset.h
+++ b/include/adt/edgeset.h
@@ -19,6 +19,12 @@ struct edge_iter {
 	const struct edge_set *set;
 };
 
+/* Opaque struct type for edge iterator,
+ * which does extra processing upfront to iterate over
+ * edges in lexicographically ascending order; the
+ * edge_iter iterator is unordered. */
+struct edge_iter_ordered;
+
 void
 edge_set_free(const struct fsm_alloc *a, struct edge_set *set);
 
@@ -75,6 +81,22 @@ edge_set_replace_state(struct edge_set **setp, fsm_state_t old, fsm_state_t new)
 
 int
 edge_set_empty(const struct edge_set *s);
+
+
+/* Allocate a new ordered edge_set iterator. */
+struct edge_ordered_iter *
+edge_set_ordered_iter_new(const struct fsm_alloc *alloc,
+    const struct edge_set *s);
+
+/* Free an ordered edge_set iterator. */
+void
+edge_set_ordered_iter_free(const struct fsm_alloc *alloc,
+    struct edge_ordered_iter *eoi);
+
+/* Get the next edge from an ordered iterator and return 1,
+ * or return 0 when no more are available. */
+int
+edge_set_ordered_iter_next(struct edge_ordered_iter *eoi, struct fsm_edge *e);
 
 #endif
 

--- a/src/adt/edgeset.c
+++ b/src/adt/edgeset.c
@@ -25,7 +25,7 @@
 /*
  * Many edge sets only contain a single item, as is the case for state sets.
  * Likewise we avoid allocating for an edge set until it contains more than
- * a single item. As with state sets, the single tem is stored within the
+ * a single item. As with state sets, the single item is stored within the
  * directly in the edge set pointer value. I would draw the layout here,
  * but I'm not feeling very artistic today.
  */

--- a/src/adt/edgeset.c
+++ b/src/adt/edgeset.c
@@ -39,7 +39,6 @@
 #define IS_SINGLETON(ptr)               (((uintptr_t) (ptr)) & 0x1)
 
 struct edge_set {
-	const struct fsm_alloc *alloc;
 	struct fsm_edge *a;
 	size_t i;
 	size_t n;
@@ -61,7 +60,6 @@ edge_set_create(const struct fsm_alloc *a)
 		return NULL;
 	}
 
-	set->alloc = a;
 	set->i = 0;
 	set->n = SET_INITIAL;
 
@@ -69,7 +67,7 @@ edge_set_create(const struct fsm_alloc *a)
 }
 
 void
-edge_set_free(struct edge_set *set)
+edge_set_free(const struct fsm_alloc *alloc, struct edge_set *set)
 {
 	if (set == NULL) {
 		return;
@@ -81,8 +79,8 @@ edge_set_free(struct edge_set *set)
 
 	assert(set->a != NULL);
 
-	f_free(set->alloc, set->a);
-	f_free(set->alloc, set);
+	f_free(alloc, set->a);
+	f_free(alloc, set);
 }
 
 int
@@ -135,7 +133,7 @@ edge_set_add(struct edge_set **setp, const struct fsm_alloc *alloc,
 	if (set->i == set->n) {
 		struct fsm_edge *new;
 
-		new = f_realloc(set->alloc, set->a, (sizeof *set->a) * (set->n * 2));
+		new = f_realloc(alloc, set->a, (sizeof *set->a) * (set->n * 2));
 		if (new == NULL) {
 			return 0;
 		}

--- a/src/adt/edgeset.c
+++ b/src/adt/edgeset.c
@@ -20,15 +20,12 @@
 #include <adt/stateset.h>
 #include <adt/edgeset.h>
 
+/* This is a simple linear-probing hash table, keyed by the edge symbol.
+ * Since many edge sets only contain a single item, there is a special
+ * case to box the symbol and state ID boxed in the edge_set pointer.
+ * Otherwise, the hash table starts with SET_INITIAL buckets and grows
+ * as necessary. */
 #define SET_INITIAL 8
-
-/*
- * Many edge sets only contain a single item, as is the case for state sets.
- * Likewise we avoid allocating for an edge set until it contains more than
- * a single item. As with state sets, the single item is stored within the
- * directly in the edge set pointer value. I would draw the layout here,
- * but I'm not feeling very artistic today.
- */
 #define SINGLETON_MAX_STATE             ((~ (uintptr_t) 0U) >> (CHAR_BIT + 1))
 #define SINGLETON_ENCODE(symbol, state) ((void *) ( \
                                         	(((uintptr_t) (state)) << (CHAR_BIT + 1)) | \
@@ -38,10 +35,21 @@
 #define SINGLETON_DECODE_STATE(ptr)     ((fsm_state_t)   (((uintptr_t) (ptr)) >> (CHAR_BIT + 1)))
 #define IS_SINGLETON(ptr)               (((uintptr_t) (ptr)) & 0x1)
 
+/* Used to represent buckets that are not currently used;
+ * tombstone is for states that were removed (and can be replaced),
+ * but may be followed by other elements due to previous collisions. */
+#define BUCKET_UNUSED ((fsm_state_t)-1)
+#define BUCKET_TOMBSTONE ((fsm_state_t)-2)
+
+/* 32-bit approximation of the inverse golden ratio / UINT32_MAX:
+ * (sqrt(5) - 1)/2 -> 0.618, so 0.618 * 0xffffffff. See Knuth 6.4. */
+#define PHI32 0x9e3779b9
+
 struct edge_set {
-	struct fsm_edge *a;
-	size_t i;
-	size_t n;
+	struct fsm_edge *b;	/* buckets */
+	size_t count;
+	size_t ceil;
+
 };
 
 static struct edge_set *
@@ -54,14 +62,16 @@ edge_set_create(const struct fsm_alloc *a)
 		return NULL;
 	}
 
-	set->a = f_malloc(a, SET_INITIAL * sizeof *set->a);
-	if (set->a == NULL) {
+	set->b = f_malloc(a, SET_INITIAL * sizeof *set->b);
+	if (set->b == NULL) {
 		f_free(a, set);
 		return NULL;
 	}
+	memset(set->b, 0xff, SET_INITIAL * sizeof *set->b);
+	assert(set->b[0].state == BUCKET_UNUSED);
 
-	set->i = 0;
-	set->n = SET_INITIAL;
+	set->count = 0;
+	set->ceil = SET_INITIAL;
 
 	return set;
 }
@@ -77,10 +87,60 @@ edge_set_free(const struct fsm_alloc *alloc, struct edge_set *set)
 		return;
 	}
 
-	assert(set->a != NULL);
+	assert(set->b != NULL);
 
-	f_free(alloc, set->a);
+	f_free(alloc, set->b);
 	f_free(alloc, set);
+}
+
+static int
+grow_buckets(const struct fsm_alloc *alloc, struct edge_set *set)
+{
+	struct fsm_edge *nb, *ob = set->b; /* new and old buckets */
+	const size_t oceil = set->ceil;
+	const size_t nceil = 2 * oceil;
+	const size_t nmask = nceil - 1;
+	size_t o_i, n_i, added;
+
+	/* assumed to be a power of 2 */
+	assert((nceil & nmask) == 0);
+
+	nb = f_malloc(alloc, nceil * sizeof *nb);
+	if (nb == NULL) {
+		return 0;
+	}
+	memset(nb, 0xff, nceil * sizeof *nb);
+	assert(nb[0].state == BUCKET_UNUSED);
+
+	added = 0;
+	for (o_i = 0; o_i < oceil; o_i++) {
+		unsigned h;
+		const fsm_state_t bs = ob[o_i].state;
+		if (bs == BUCKET_UNUSED || bs == BUCKET_TOMBSTONE) {
+			continue;
+		}
+
+		h = PHI32 * ob[o_i].symbol;
+		for (n_i = 0; n_i < nceil; n_i++) {
+			const size_t b_i = (h + n_i) & nmask;
+			if (nb[b_i].state != BUCKET_UNUSED) {
+				assert(nb[b_i].state != BUCKET_TOMBSTONE);
+				continue;
+			}
+
+			nb[b_i].symbol = ob[o_i].symbol;
+			nb[b_i].state = ob[o_i].state;
+			added++;
+			break;
+		}
+	}
+	assert(added == set->count);
+
+	f_free(alloc, ob);
+
+	set->b = nb;
+	set->ceil = nceil;
+	return 1;
 }
 
 int
@@ -130,26 +190,35 @@ edge_set_add(struct edge_set **setp, const struct fsm_alloc *alloc,
 
 	set = *setp;
 
-	if (set->i == set->n) {
-		struct fsm_edge *new;
-
-		new = f_realloc(alloc, set->a, (sizeof *set->a) * (set->n * 2));
-		if (new == NULL) {
+	/* Grow buckets at 50% capacity */
+	if (set->count == set->ceil/2) {
+		if (!grow_buckets(alloc, set)) {
 			return 0;
 		}
-
-		set->a = new;
-		set->n *= 2;
 	}
 
-	set->a[set->i].symbol = symbol;
-	set->a[set->i].state  = state;
+	{
+		const size_t mask = set->ceil - 1;
+		const unsigned h = PHI32 * symbol;
+		size_t i;
+		for (i = 0; i < set->ceil; i++) {
+			const size_t b_i = (h + i) & mask;
+			const fsm_state_t bs = set->b[b_i].state;
+			if (bs != BUCKET_UNUSED && bs != BUCKET_TOMBSTONE) {
+				continue;
+			}
+			set->b[b_i].state = state;
+			set->b[b_i].symbol = symbol;
+			set->count++;
 
-	set->i++;
+			assert(edge_set_contains(set, symbol));
 
-	assert(edge_set_contains(set, symbol));
+			return 1;
+		}
 
-	return 1;
+		assert(!"unreachable");
+		return 0;
+	}
 }
 
 int
@@ -175,7 +244,6 @@ int
 edge_set_find(const struct edge_set *set, unsigned char symbol,
 	struct fsm_edge *e)
 {
-	size_t i;
 	assert(e != NULL);
 
 	if (edge_set_empty(set)) {
@@ -190,15 +258,26 @@ edge_set_find(const struct edge_set *set, unsigned char symbol,
 			e->state = SINGLETON_DECODE_STATE(set);
 			return 1;
 		}
-	}
-
-	for (i = 0; i < set->i; i++) {
-		if (set->a[i].symbol == symbol) {
-			memcpy(e, &set->a[i], sizeof(*e));
-			return 1;
+		return 0;
+	} else {
+		const size_t mask = set->ceil - 1;
+		const unsigned h = PHI32 * symbol;
+		size_t i;
+		for (i = 0; i < set->ceil; i++) {
+			const size_t b_i = (h + i) & mask;
+			const fsm_state_t bs = set->b[b_i].state;
+			if (bs == BUCKET_UNUSED) {
+				break;
+			} else if (bs == BUCKET_TOMBSTONE) {
+				continue; /* search past deleted */
+			} else if (set->b[b_i].symbol == symbol) {
+				memcpy(e, &set->b[b_i], sizeof *e);
+				return 1; /* found */
+			}
 		}
 	}
 
+	/* not found */
 	return 0;
 }
 
@@ -220,10 +299,10 @@ edge_set_hasnondeterminism(const struct edge_set *set, struct bm *bm)
 		return 0;
 	}
 
-	/* 
+	/*
 	 * Instances of struct fsm_edge aren't unique, and are not ordered.
 	 * The bitmap here is to identify duplicate symbols between structs.
-	 * 
+	 *
 	 * The same bitmap is shared between all states in an epsilon closure.
 	 */
 
@@ -236,12 +315,17 @@ edge_set_hasnondeterminism(const struct edge_set *set, struct bm *bm)
 		return 0;
 	}
 
-	for (i = 0; i < set->i; i++) {
-		if (bm_get(bm, set->a[i].symbol)) {
+	for (i = 0; i < set->ceil; i++) {
+		const fsm_state_t bs = set->b[i].state;
+		if (bs == BUCKET_UNUSED || bs == BUCKET_TOMBSTONE) {
+			continue; /* no element */
+		}
+
+		if (bm_get(bm, set->b[i].symbol)) {
 			return 1;
 		}
 
-		bm_set(bm, set->a[i].symbol);
+		bm_set(bm, set->b[i].symbol);
 	}
 
 	return 0;
@@ -251,46 +335,17 @@ int
 edge_set_transition(const struct edge_set *set, unsigned char symbol,
 	fsm_state_t *state)
 {
-	size_t i;
-#ifndef NDEBUG
-	struct bm bm;
-#endif
-
-	assert(state != NULL);
-
 	/*
 	 * This function is meaningful for DFA only; we require a DFA
 	 * by contract in order to identify a single destination state
 	 * for a given symbol.
 	 */
-#ifndef NDEBUG
-	bm_clear(&bm);
-	assert(!edge_set_hasnondeterminism(set, &bm));
-#endif
-
-	if (edge_set_empty(set)) {
+	struct fsm_edge e;
+	if (!edge_set_find(set, symbol, &e)) {
 		return 0;
 	}
-
-	if (IS_SINGLETON(set)) {
-		if (SINGLETON_DECODE_SYMBOL(set) == symbol) {
-			*state = SINGLETON_DECODE_STATE(set);
-			return 1;
-		}
-
-		return 0;
-	}
-
-	assert(set != NULL);
-
-	for (i = 0; i < set->i; i++) {
-		if (set->a[i].symbol == symbol) {
-			*state = set->a[i].state;
-			return 1;
-		}
-	}
-
-	return 0;
+	*state = e.state;
+	return 1;
 }
 
 size_t
@@ -304,9 +359,9 @@ edge_set_count(const struct edge_set *set)
 		return 1;
 	}
 
-	assert(set->a != NULL);
+	assert(set->b != NULL);
 
-	return set->i;
+	return set->count;
 }
 
 int
@@ -344,7 +399,6 @@ void
 edge_set_remove(struct edge_set **setp, unsigned char symbol)
 {
 	struct edge_set *set;
-	size_t i;
 
 	assert(setp != NULL);
 
@@ -359,17 +413,24 @@ edge_set_remove(struct edge_set **setp, unsigned char symbol)
 
 	if (edge_set_empty(set)) {
 		return;
-	}
-
-	i = 0;
-	while (i < set->i) {
-		if (set->a[i].symbol == symbol) {
-			if (i < set->i) {
-				memmove(&set->a[i], &set->a[i + 1], (set->i - i - 1) * (sizeof *set->a));
+	} else {
+		const size_t mask = set->ceil - 1;
+		const unsigned h = PHI32 * symbol;
+		size_t i;
+		for (i = 0; i < set->ceil; i++) {
+			const size_t b_i = (h + i) & mask;
+			const fsm_state_t bs = set->b[b_i].state;
+			if (bs == BUCKET_UNUSED) {
+				break; /* not found */
+			} else if (set->b[b_i].symbol == symbol) {
+				/* Set to a distinct marker for a deleted
+				 * entry; there may be entries past this
+				 * due to collisions that still need to
+				 * be checked. */
+				set->b[b_i].state = BUCKET_TOMBSTONE;
+				set->count--;
+				break;
 			}
-			set->i--;
-		} else {
-			i++;
 		}
 	}
 
@@ -383,6 +444,7 @@ edge_set_remove_state(struct edge_set **setp, fsm_state_t state)
 	size_t i;
 
 	assert(setp != NULL);
+	assert(state != BUCKET_UNUSED && state != BUCKET_TOMBSTONE);
 
 	if (IS_SINGLETON(*setp)) {
 		if (SINGLETON_DECODE_STATE(*setp) == state) {
@@ -397,15 +459,11 @@ edge_set_remove_state(struct edge_set **setp, fsm_state_t state)
 		return;
 	}
 
-	i = 0;
-	while (i < set->i) {
-		if (set->a[i].state == state) {
-			if (i < set->i) {
-				memmove(&set->a[i], &set->a[i + 1], (set->i - i - 1) * (sizeof *set->a));
-			}
-			set->i--;
-		} else {
-			i++;
+	for (i = 0; i < set->ceil; i++) {
+		if (set->b[i].state == state) {
+			set->b[i].state = BUCKET_TOMBSTONE;
+			set->count--;
+			break;
 		}
 	}
 }
@@ -415,7 +473,7 @@ edge_set_compact(struct edge_set **setp,
     fsm_state_remap_fun *remap, void *opaque)
 {
 	struct edge_set *set;
-	size_t i, removed, dst;
+	size_t i;
 
 	assert(setp != NULL);
 
@@ -439,27 +497,23 @@ edge_set_compact(struct edge_set **setp,
 	}
 
 	i = 0;
-	removed = 0;
-	dst = 0;
-	for (i = 0; i < set->i; i++) {
-		const fsm_state_t to = set->a[i].state;
-		const fsm_state_t new_to = remap(to, opaque);
+	for (i = 0; i < set->ceil; i++) {
+		const fsm_state_t to = set->b[i].state;
+		fsm_state_t new_to;
+		if (to == BUCKET_UNUSED || to == BUCKET_TOMBSTONE) {
+			continue;
+		}
+		new_to = remap(to, opaque);
 
 		if (new_to == FSM_STATE_REMAP_NO_STATE) { /* drop */
-			removed++;
+			set->b[i].state = BUCKET_TOMBSTONE;
+			set->count--;
 		} else {	/* keep */
-			if (dst < i) {
-				memcpy(&set->a[dst],
-				    &set->a[i],
-				    sizeof(set->a[i]));
-			}
-			set->a[dst].state = new_to;
-			dst++;
+			set->b[i].state = new_to;
 		}
 	}
 
-	set->i -= removed;
-	assert(set->i == dst);
+	/* todo: if set->count < set->ceil/2, shrink buckets */
 }
 
 void
@@ -492,15 +546,18 @@ edge_set_next(struct edge_iter *it, struct fsm_edge *e)
 		return 1;
 	}
 
-	if (it->i >= it->set->i) {
-		return 0;
+	while (it->i < it->set->ceil) {
+		const fsm_state_t bs = it->set->b[it->i].state;
+		if (bs == BUCKET_UNUSED || bs == BUCKET_TOMBSTONE) {
+			it->i++;
+			continue;
+		}
+		*e = it->set->b[it->i];
+		it->i++;
+		return 1;
 	}
 
-	*e = it->set->a[it->i];
-
-	it->i++;
-
-	return 1;
+	return 0;
 }
 
 void
@@ -531,8 +588,12 @@ edge_set_rebase(struct edge_set **setp, fsm_state_t base)
 		return;
 	}
 
-	for (i = 0; i < set->i; i++) {
-		set->a[i].state += base;
+	for (i = 0; i < set->ceil; i++) {
+		const fsm_state_t bs = set->b[i].state;
+		if (bs == BUCKET_UNUSED || bs == BUCKET_TOMBSTONE) {
+			continue;
+		}
+		set->b[i].state += base;
 	}
 }
 
@@ -543,6 +604,8 @@ edge_set_replace_state(struct edge_set **setp, fsm_state_t old, fsm_state_t new)
 	size_t i;
 
 	assert(setp != NULL);
+	assert(old != BUCKET_UNUSED);
+	assert(old != BUCKET_TOMBSTONE);
 
 	if (IS_SINGLETON(*setp)) {
 		if (SINGLETON_DECODE_STATE(*setp) == old) {
@@ -563,9 +626,9 @@ edge_set_replace_state(struct edge_set **setp, fsm_state_t old, fsm_state_t new)
 		return;
 	}
 
-	for (i = 0; i < set->i; i++) {
-		if (set->a[i].state == old) {
-			set->a[i].state = new;
+	for (i = 0; i < set->ceil; i++) {
+		if (set->b[i].state == old) {
+			set->b[i].state = new;
 		}
 	}
 }
@@ -581,6 +644,5 @@ edge_set_empty(const struct edge_set *set)
 		return 0;
 	}
 
-	return set->i == 0;
+	return set->count == 0;
 }
-

--- a/src/adt/edgeset.c
+++ b/src/adt/edgeset.c
@@ -172,27 +172,41 @@ edge_set_add_state_set(struct edge_set **setp, const struct fsm_alloc *alloc,
 }
 
 int
-edge_set_contains(const struct edge_set *set, unsigned char symbol)
+edge_set_find(const struct edge_set *set, unsigned char symbol,
+	struct fsm_edge *e)
 {
 	size_t i;
+	assert(e != NULL);
 
 	if (edge_set_empty(set)) {
 		return 0;
 	}
 
-	if (IS_SINGLETON(set)) {
-		return SINGLETON_DECODE_SYMBOL(set) == symbol;
-	}
-
 	assert(set != NULL);
+
+	if (IS_SINGLETON(set)) {
+		if (SINGLETON_DECODE_SYMBOL(set) == symbol) {
+			e->symbol = symbol;
+			e->state = SINGLETON_DECODE_STATE(set);
+			return 1;
+		}
+	}
 
 	for (i = 0; i < set->i; i++) {
 		if (set->a[i].symbol == symbol) {
+			memcpy(e, &set->a[i], sizeof(*e));
 			return 1;
 		}
 	}
 
 	return 0;
+}
+
+int
+edge_set_contains(const struct edge_set *set, unsigned char symbol)
+{
+	struct fsm_edge unused;
+	return edge_set_find(set, symbol, &unused);
 }
 
 int

--- a/src/libfsm/cost/legible.c
+++ b/src/libfsm/cost/legible.c
@@ -29,13 +29,11 @@ fsm_cost_legible(fsm_state_t from, fsm_state_t to, char c)
 	size_t i;
 
 	/*
-	 * Costs here approximate legibility; in particular needing an escape
-	 * sequence is seen as worth avoiding where possible.
- 	 *
-	 * Note that although not explicitly encoded here, for the same cost
-	 * (and assuming a suitable character set), lower character values
-	 * have precedence over higher (e.g. 'a' is preferable to 'z')
-	 * because of the traversal order for edges when searching the graph.
+	 * Costs here approximate legibility; in particular needing an
+	 * escape sequence is seen as worth avoiding where possible. Add
+	 * a base cost for the character class, and then the character
+	 * value itself as a tiebreaker, so lower character values have
+	 * precedence over higher (e.g. 'a' is preferable to 'z').
 	 */
 
 	struct {
@@ -60,7 +58,8 @@ fsm_cost_legible(fsm_state_t from, fsm_state_t to, char c)
 
 	for (i = 0; i < sizeof a / sizeof *a; i++) {
 		if (a[i].is(c)) {
-			return a[i].cost;
+			const unsigned char_class_cost = 1000 * a[i].cost;
+			return char_class_cost + (unsigned)c;
 		}
 	}
 

--- a/src/libfsm/fsm.c
+++ b/src/libfsm/fsm.c
@@ -30,7 +30,7 @@ free_contents(struct fsm *fsm)
 
 	for (i = 0; i < fsm->statecount; i++) {
 		state_set_free(fsm->states[i].epsilons);
-		edge_set_free(fsm->states[i].edges);
+		edge_set_free(fsm->opt->alloc, fsm->states[i].edges);
 	}
 
 	f_free(fsm->opt->alloc, fsm->states);

--- a/src/libfsm/print/api.c
+++ b/src/libfsm/print/api.c
@@ -131,7 +131,7 @@ fsm_print_api(FILE *f, const struct fsm *fsm_orig)
 
 	for (from = 0; from < fsm->statecount; from++) {
 		struct fsm_edge e;
-		struct edge_iter it;
+		struct edge_ordered_iter eoi;
 		struct state_iter jt;
 		fsm_state_t i, to;
 
@@ -144,7 +144,7 @@ fsm_print_api(FILE *f, const struct fsm *fsm_orig)
 				from, to);
 		}
 
-		for (edge_set_reset(fsm->states[from].edges, &it); edge_set_next(&it, &e); ) {
+		for (edge_set_ordered_iter_reset(fsm->states[from].edges, &eoi); edge_set_ordered_iter_next(&eoi, &e); ) {
 			bm_set(&a[e.state], e.symbol);
 		}
 

--- a/src/libfsm/print/dot.c
+++ b/src/libfsm/print/dot.c
@@ -29,6 +29,7 @@ singlestate(FILE *f, const struct fsm *fsm, fsm_state_t s)
 {
 	struct fsm_edge e;
 	struct edge_iter it;
+	struct edge_ordered_iter eoi;
 	struct state_set *unique;
 
 	assert(f != NULL);
@@ -64,7 +65,7 @@ singlestate(FILE *f, const struct fsm *fsm, fsm_state_t s)
 			}
 		}
 
-		for (edge_set_reset(fsm->states[s].edges, &it); edge_set_next(&it, &e); ) {
+		for (edge_set_ordered_iter_reset(fsm->states[s].edges, &eoi); edge_set_ordered_iter_next(&eoi, &e); ) {
 			fprintf(f, "\t%sS%-2u -> %sS%-2u [ label = <",
 				fsm->opt->prefix != NULL ? fsm->opt->prefix : "",
 				s,
@@ -97,7 +98,9 @@ singlestate(FILE *f, const struct fsm *fsm, fsm_state_t s)
 	 * To implement this, we loop through all unique states, rather than
 	 * looping through each edge.
 	 */
-	for (edge_set_reset(fsm->states[s].edges, &it); edge_set_next(&it, &e); ) {
+	for (edge_set_ordered_iter_reset(fsm->states[s].edges, &eoi); edge_set_ordered_iter_next(&eoi, &e); ) {
+
+
 		struct fsm_edge ne;
 		struct edge_iter kt;
 		struct bm bm;

--- a/src/libfsm/print/fsm.c
+++ b/src/libfsm/print/fsm.c
@@ -111,7 +111,7 @@ fsm_print_fsm(FILE *f, const struct fsm *fsm)
 
 	for (s = 0; s < fsm->statecount; s++) {
 		struct fsm_edge e;
-		struct edge_iter it;
+		struct edge_ordered_iter eoi;
 
 		{
 			struct state_iter jt;
@@ -132,7 +132,9 @@ fsm_print_fsm(FILE *f, const struct fsm *fsm)
 		}
 
 		assert(s < fsm->statecount);
-		for (edge_set_reset(fsm->states[s].edges, &it); edge_set_next(&it, &e); ) {
+
+		for (edge_set_ordered_iter_reset(fsm->states[s].edges, &eoi);
+		     edge_set_ordered_iter_next(&eoi, &e); ) {
 			assert(e.state < fsm->statecount);
 
 			fprintf(f, "%-2u -> %2u", s, e.state);

--- a/src/libfsm/print/ir.c
+++ b/src/libfsm/print/ir.c
@@ -77,13 +77,11 @@ make_groups(const struct fsm *fsm, fsm_state_t state,
 	assert(state < fsm->statecount);
 	assert(u != NULL);
 
-	/*
-	 * The first pass here populates ranges[] by collating consecutive symbols
-	 * which transition to the same FSM state. These ranges are constructed by
-	 * iterating over symbols, and so are populated in symbol order.
-	 * So several ranges may transition to the same state; these are grouped
-	 * in the second pass below.
-	 */
+	/* The first pass gathers ranges, and opportunistically combines
+	 * adjacent ranges with consecutive symbols which transition to
+	 * the same FSM state. Since the edges are stored unordered (in
+	 * a hash table), a follow-up pass sorts and then combines any
+	 * newly adjacent ranges to the same state. */
 
 	n = 0;          /* number of allocated ranges */
 	grp_ind = 0;    /* index of current working range */
@@ -106,12 +104,28 @@ make_groups(const struct fsm *fsm, fsm_state_t state,
 
 	assert(n > 0);
 
+	/* Sort and combine consecutive states. */
+	qsort(ranges, n, sizeof *ranges, range_cmp);
+	{
+		size_t src, dst = 0;
+		for (src = 1; src < n; src++) {
+			if (ranges[src].to == ranges[dst].to
+			    && ranges[src].start == ranges[dst].end + 1) {
+				ranges[dst].end = ranges[src].end;
+			} else {
+				assert(dst < src);
+				dst++;
+				memcpy(&ranges[dst], &ranges[src],
+				    sizeof(ranges[dst]));
+			}
+		}
+		n = dst + 1;
+	}
+
 	/*
-	 * Now ranges have been identified, the second pass below groups them
+	 * Now ranges have been identified, the next pass below groups them
 	 * together by their common destination states.
 	 */
-
-	qsort(ranges, n, sizeof *ranges, range_cmp);
 
 	groups = f_malloc(fsm->opt->alloc, sizeof *groups * n); /* worst case */
 	if (groups == NULL) {

--- a/src/libfsm/print/ir.c
+++ b/src/libfsm/print/ir.c
@@ -69,7 +69,7 @@ make_groups(const struct fsm *fsm, fsm_state_t state,
 	struct range ranges[FSM_SIGMA_COUNT]; /* worst case, one per symbol */
 	struct ir_group *groups;
 	struct fsm_edge e;
-	struct edge_iter it;
+	struct edge_ordered_iter eoi;
 	size_t i, j, k;
 	size_t grp_ind, n;
 
@@ -86,7 +86,7 @@ make_groups(const struct fsm *fsm, fsm_state_t state,
 	n = 0;          /* number of allocated ranges */
 	grp_ind = 0;    /* index of current working range */
 
-	for (edge_set_reset(fsm->states[state].edges, &it); edge_set_next(&it, &e); ) {
+	for (edge_set_ordered_iter_reset(fsm->states[state].edges, &eoi); edge_set_ordered_iter_next(&eoi, &e); ) {
 		if (have_mode && e.state == mode) {
 			continue;
 		}

--- a/src/libfsm/print/json.c
+++ b/src/libfsm/print/json.c
@@ -118,6 +118,7 @@ singlestate(FILE *f, const struct fsm *fsm, fsm_state_t s, int *notfirst)
 {
 	struct fsm_edge e;
 	struct edge_iter it;
+	struct edge_ordered_iter eoi;
 	struct state_set *unique;
 
 	assert(f != NULL);
@@ -134,7 +135,7 @@ singlestate(FILE *f, const struct fsm *fsm, fsm_state_t s, int *notfirst)
 			print_edge_epsilon(f, notfirst, s, st);
 		}
 
-		for (edge_set_reset(fsm->states[s].edges, &it); edge_set_next(&it, &e); ) {
+		for (edge_set_ordered_iter_reset(fsm->states[s].edges, &eoi); edge_set_ordered_iter_next(&eoi, &e); ) {
 			print_edge_symbol(f, notfirst, fsm->opt,
 				s, e.state, e.symbol);
 		}
@@ -160,7 +161,7 @@ singlestate(FILE *f, const struct fsm *fsm, fsm_state_t s, int *notfirst)
 	 * To implement this, we loop through all unique states, rather than
 	 * looping through each edge.
 	 */
-	for (edge_set_reset(fsm->states[s].edges, &it); edge_set_next(&it, &e); ) {
+	for (edge_set_ordered_iter_reset(fsm->states[s].edges, &eoi); edge_set_ordered_iter_next(&eoi, &e); ) {
 		struct fsm_edge ne;
 		struct edge_iter kt;
 		struct bm bm;

--- a/src/libfsm/reverse.c
+++ b/src/libfsm/reverse.c
@@ -250,7 +250,7 @@ fsm_reverse(struct fsm *fsm)
 
 		for (i = 0; i < fsm->statecount; i++) {
 			state_set_free(fsm->states[i].epsilons);
-			edge_set_free(fsm->states[i].edges);
+			edge_set_free(fsm->opt->alloc, fsm->states[i].edges);
 
 			fsm->states[i].epsilons = epsilons[i];
 			fsm->states[i].edges = edges[i];
@@ -271,7 +271,7 @@ error1:
 
 		for (i = 0; i < fsm->statecount; i++) {
 			state_set_free(fsm->states[i].epsilons);
-			edge_set_free(fsm->states[i].edges);
+			edge_set_free(fsm->opt->alloc, fsm->states[i].edges);
 
 			fsm->states[i].epsilons = epsilons[i];
 			fsm->states[i].edges = edges[i];

--- a/src/libfsm/state.c
+++ b/src/libfsm/state.c
@@ -125,7 +125,7 @@ fsm_removestate(struct fsm *fsm, fsm_state_t state)
 	}
 
 	state_set_free(fsm->states[state].epsilons);
-	edge_set_free(fsm->states[state].edges);
+	edge_set_free(fsm->opt->alloc, fsm->states[state].edges);
 
 	if (fsm_getstart(fsm, &start) && start == state) {
 		fsm_clearstart(fsm);


### PR DESCRIPTION
This converts the `edge_set` ADT to a hash table, because `fsm_minimise` will be spending a lot of time searching for individual edges by symbol. The existing uses based on iteration would not benefit from switching over -- they still need to check every edge. The `edge_set_contains` integrity assertions should become cheaper, though.

Also:

- Remove the `alloc` pointer from every individual edge state. It was passed in to all code paths anyway, so storing an extra copy per state just wastes memory.

- Fix the IR range combining -- the previous implementation assumed the edge set's edges were sorted by symbol. This isn't always true, though it has been true often enough by construction that tests were depending on it. Storing in hash table order exposed it. Now the IR ranges collected are sorted before combining.

- Add an ordered iterator (ordered by symbol), and update the printing code to use it.