### PR TITLE
trim: Add argument for trimming start or start+end reachable states.

### DIFF
--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -253,13 +253,19 @@ fsm_mergestates(struct fsm *fsm, fsm_state_t a, fsm_state_t b,
 /*
  * Trim away "dead" states. More formally, this recursively removes
  * unreachable states (i.e. those in a subgraph which is disjoint from
- * the state state's connected component), and non-end states which
- * do not have a path to an end state.
+ * the state state's connected component), and optionally non-end
+ * states which do not have a path to an end state.
  *
  * Returns how many states were removed, or -1 on error.
  */
-int
-fsm_trim(struct fsm *fsm);
+enum fsm_trim_mode {
+	/* Remove states unreachable from the start state. */
+	FSM_TRIM_START_REACHABLE,
+	/* Also remove states without a path to an end state. */
+	FSM_TRIM_START_AND_END_REACHABLE
+};
+long
+fsm_trim(struct fsm *fsm, enum fsm_trim_mode mode);
 
 /*
  * Produce a short legible string that matches up to a goal state.

--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -254,7 +254,7 @@ fsm_mergestates(struct fsm *fsm, fsm_state_t a, fsm_state_t b,
  * Trim away "dead" states. More formally, this recursively removes
  * unreachable states (i.e. those in a subgraph which is disjoint from
  * the state state's connected component), and optionally non-end
- * states which do not have a path to an end state.
+ * states that do not have a path to an end state.
  *
  * Returns how many states were removed, or -1 on error.
  */

--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -490,7 +490,9 @@ main(int argc, char *argv[])
 		case OP_REVERSE:     r = fsm_reverse(q);      break;
 		case OP_DETERMINISE: r = fsm_determinise(q);  break;
 		case OP_GLUSHKOVISE: r = fsm_glushkovise(q);  break;
-		case OP_TRIM:        r = fsm_trim(q);         break;
+		case OP_TRIM:        r = fsm_trim(q,
+			FSM_TRIM_START_AND_END_REACHABLE);
+			break;
 
 		case OP_CONCAT:      q = fsm_concat(a, b);    break;
 		case OP_UNION:       q = fsm_union(a, b);     break;

--- a/src/libfsm/complement.c
+++ b/src/libfsm/complement.c
@@ -39,7 +39,7 @@ fsm_complement(struct fsm *fsm)
 		fsm_setend(fsm, i, !fsm_isend(fsm, i));
 	}
 
-	if (!fsm_trim(fsm)) {
+	if (fsm_trim(fsm, FSM_TRIM_START_REACHABLE) < 0) {
 		return 0;
 	}
 

--- a/src/libfsm/trim.c
+++ b/src/libfsm/trim.c
@@ -14,198 +14,332 @@
 #include <adt/set.h>
 #include <adt/edgeset.h>
 #include <adt/stateset.h>
+#include <adt/queue.h>
 
 #include "internal.h"
 
-enum mark_flags {
-	MARK_UNVISITED = 0x00,
-	MARK_ENQUEUED = 0x01,
-	MARK_PROCESSING = 0x02,
-	MARK_REACHES_END = 0x04,
-	MARK_DONE = 0x08
+#define DEF_EDGES_CEIL 8
+#define DEF_ENDS_CEIL 8
+
+struct edge {
+	fsm_state_t from;
+	fsm_state_t to;
 };
 
 static int
-mark_states(struct fsm *fsm,
-	unsigned char *marks)
+grow_ends(const struct fsm_alloc *alloc, size_t *ceil, fsm_state_t **ends);
+
+static int
+save_edge(const struct fsm_alloc *alloc,
+    size_t *count, size_t *ceil, struct edge **edges,
+    fsm_state_t from, fsm_state_t to);
+
+static int
+cmp_edges_by_to(const void *pa, const void *pb)
 {
-	/* Mark all states that are reachable from the start state and
-	 * that are either ends or have edge(s) which lead to an edge
-	 * state (directly or transitively).
+	const struct edge *a = (const struct edge *)pa;
+	const struct edge *b = (const struct edge *)pb;
+
+	return a->to < b->to ? -1
+	    : a->to > b->to ? 1
+	    : a->from < b->from ? -1
+	    : a->from > b->from ? 1
+	    : 0;
+}
+
+static int
+mark_states(struct fsm *fsm, enum fsm_trim_mode mode)
+{
+	/* Use a queue to walk breath-first over all states reachable
+	 * from the start state. Note all end states. Collect all the
+	 * edges, then sort them by the note they lead to, to convert it
+	 * to a reverse edge index. Then, enqueue all the end states,
+	 * and again use the queue to walk the graph breadth-first, but
+	 * this time iterating bottom-up from the end states, and mark
+	 * all reachable states (on fsm_state.visited).
 	 *
-	 * This uses a heap-allocated stack, because a recursive call
-	 * could overrun the call stack for sufficiently large and
-	 * deeply nested automata, and each recursive call only needs
-	 * the state ID and the flags in marks[]. This slightly
-	 * complicates what would otherwise be a pretty simple recursive
-	 * algorithm with memoization. */
-	const unsigned state_count = fsm_countstates(fsm);
+	 * This marks all states which are both reachable from the start
+	 * state and have a path to an end state. */
+	int res = 0;
+	fsm_state_t start, s_id;
+	struct queue *q = NULL;
 
-	/* Basic stack: Empty when i == 0, top at i - 1. */
-	fsm_state_t *stack = NULL;
-	size_t stack_i = 0;
-	size_t stack_ceil;
+	struct edge *edges = NULL;
+	size_t edge_count = 0, edge_ceil = DEF_EDGES_CEIL;
 
-	fsm_state_t start;
+	fsm_state_t *ends = NULL;
+	size_t end_count = 0, end_ceil = DEF_ENDS_CEIL;
+	const size_t state_count = fsm->statecount;
+
+	size_t *offsets = NULL;
+
 	if (!fsm_getstart(fsm, &start)) {
-		return 1;
+		return 1;	/* nothing is reachable */
 	}
 
-	stack_ceil = state_count + 1;
-	if (stack_ceil == 0) {
-		stack_ceil = 1;
-	}
-	stack = f_malloc(fsm->opt->alloc,
-	    stack_ceil * sizeof(stack[0]));
-	if (stack == NULL) {
-		return 0;
+	q = queue_new(fsm->opt->alloc, state_count);
+	if (q == NULL) {
+		goto cleanup;
 	}
 
-	stack[stack_i] = start;
-	stack_i++;
-	marks[start] |= MARK_ENQUEUED;
+	if (mode == FSM_TRIM_START_AND_END_REACHABLE) {
+		edges = f_malloc(fsm->opt->alloc,
+		    edge_ceil * sizeof(edges[0]));
+		if (edges == NULL) {
+			goto cleanup;
+		}
 
-	while (stack_i > 0) {
-		fsm_state_t s = stack[stack_i - 1];
-		struct fsm_edge e;
-		struct edge_iter edge_iter;
-		struct state_iter state_iter;
-		fsm_state_t epsilon_s;
-
-		if (!(marks[s] & MARK_PROCESSING)) {
-			/* First pass: Note that processing has started,
-			 * stack other reachable states, note if this is
-			 * an end state. */
-			marks[s] |= MARK_PROCESSING;
-
-			if (fsm_isend(fsm, s)) {
-				marks[s] |= MARK_REACHES_END;
-			}
-
-			for (state_set_reset(fsm->states[s].epsilons, &state_iter); state_set_next(&state_iter, &epsilon_s); ) {
-				if (marks[epsilon_s] & MARK_PROCESSING) {
-					continue; /* already being processed */
-				}
-
-				if (stack_i == stack_ceil) {
-					size_t nceil = 2*stack_ceil;
-					fsm_state_t *nstack = f_realloc(fsm->opt->alloc,
-					    stack, nceil * sizeof(stack[0]));
-					assert(!"unreachable");
-					if (stack == NULL) {
-						f_free(fsm->opt->alloc, stack);
-						return 0;
-					}
-					stack_ceil = nceil;
-					stack = nstack;
-				}
-
-				if (!(marks[epsilon_s] & MARK_ENQUEUED)) {
-					stack[stack_i] = epsilon_s;
-					stack_i++;
-					marks[epsilon_s] |= MARK_ENQUEUED;
-				}
-			}
-
-			for (edge_set_reset(fsm->states[s].edges, &edge_iter); edge_set_next(&edge_iter, &e); ) {
-				if (marks[e.state] & MARK_PROCESSING) {
-					continue;
-				}
-
-				if (stack_i == stack_ceil) {
-					size_t nceil = 2*stack_ceil;
-					fsm_state_t *nstack = f_realloc(fsm->opt->alloc,
-					    stack, nceil * sizeof(stack[0]));
-					assert(!"unreachable");
-					if (stack == NULL) {
-						f_free(fsm->opt->alloc, stack);
-						return 0;
-					}
-					stack_ceil = nceil;
-					stack = nstack;
-				}
-
-				if (!(marks[e.state] & MARK_ENQUEUED)) {
-					stack[stack_i] = e.state;
-					stack_i++;
-					marks[e.state] |= MARK_ENQUEUED;
-				}
-			}
-		} else if (!(marks[s] & MARK_DONE)) {
-			/* Second pass: Mark the state as reaching an
-			 * end if any of its reachable nodes do, mark
-			 * processing as done. Terminate iteration once
-			 * the END flag is set. */
-			for (state_set_reset(fsm->states[s].epsilons, &state_iter);
-			     state_set_next(&state_iter, &epsilon_s); ) {
-				if (marks[s] & MARK_REACHES_END) {
-					break;
-				}
-				if (marks[epsilon_s] & MARK_REACHES_END) {
-					marks[s] |= MARK_REACHES_END;
-				}
-			}
-
-			for (edge_set_reset(fsm->states[s].edges, &edge_iter);
-			     edge_set_next(&edge_iter, &e); ) {
-				if (marks[s] & MARK_REACHES_END) {
-					break;
-				}
-				if (marks[e.state] & MARK_REACHES_END) {
-					marks[s] |= MARK_REACHES_END;
-				}
-			}
-
-			marks[s] |= MARK_DONE;
-			stack_i--;
-		} else {
-			assert(!"unreachable");
+		ends = f_malloc(fsm->opt->alloc,
+		    end_ceil * sizeof(ends[0]));
+		if (ends == NULL) {
+			goto cleanup;
 		}
 	}
 
-	f_free(fsm->opt->alloc, stack);
+	fsm->states[start].visited = 1;
+	if (!queue_push(q, start)) {
+		goto cleanup;
+	}
+	assert(start < state_count);
 
+	/* Breadth-first walk, mark states reachable from start and (if
+	 * checking whether states can reach end states later) also
+	 * collect edges & end states. */
+	while (queue_pop(q, &s_id)) {
+		fsm_state_t next;
+		struct fsm_edge e;
+		struct edge_iter edge_iter;
+		struct state_iter state_iter;
+
+		assert(s_id < state_count);
+		assert(fsm->states[s_id].visited);
+
+		if (ends && fsm_isend(fsm, s_id)) {
+			if (end_count == end_ceil) {
+				if (!grow_ends(fsm->opt->alloc,
+					&end_ceil, &ends)) {
+					goto cleanup;
+				}
+			}
+			ends[end_count] = s_id;
+			end_count++;
+		}
+
+		for (state_set_reset(fsm->states[s_id].epsilons, &state_iter);
+		     state_set_next(&state_iter, &next); ) {
+			assert(next < state_count);
+			if (!fsm->states[next].visited) {
+				if (!queue_push(q, next)) {
+					goto cleanup;
+				}
+				fsm->states[next].visited = 1;
+
+				if (edges == NULL) {
+					continue;
+				}
+				if (!save_edge(fsm->opt->alloc,
+					&edge_count, &edge_ceil, &edges,
+					s_id, next)) {
+					goto cleanup;
+				}
+			}
+		}
+
+		for (edge_set_reset(fsm->states[s_id].edges, &edge_iter);
+		     edge_set_next(&edge_iter, &e); ) {
+			next = e.state;
+			if (!fsm->states[next].visited) {
+				if (!queue_push(q, next)) {
+					goto cleanup;
+				}
+				fsm->states[next].visited = 1;
+
+				if (edges == NULL) {
+					continue;
+				}
+				if (!save_edge(fsm->opt->alloc,
+					&edge_count, &edge_ceil, &edges,
+					s_id, next)) {
+					goto cleanup;
+				}
+			}
+		}
+	}
+
+	/* Only tracking reachability from start, so we're done. */
+	if (mode == FSM_TRIM_START_REACHABLE) {
+		queue_free(q);
+		return 1;
+	}
+
+	/* Clear mark for second pass. */
+	for (s_id = 0; s_id < state_count; s_id++) {
+		fsm->states[s_id].visited = 0;
+	}
+
+	/* Sort edges by state they lead to, inverting the index. */
+	qsort(edges, edge_count, sizeof(edges[0]), cmp_edges_by_to);
+
+	/* Reuse the existing queue for a second breadth-first walk.
+	 * This assumes the queue can be reused once empty; if the
+	 * implementation changes, it may need to reset the queue or
+	 * construct a new one.
+	 *
+	 * Initialize the queue with the end states. */
+	{
+		size_t e_i;
+		for (e_i = 0; e_i < end_count; e_i++) {
+			const fsm_state_t end_id = ends[e_i];
+			assert(end_id < state_count);
+			if (!queue_push(q, end_id)) {
+				goto cleanup;
+			}
+			fsm->states[end_id].visited = 1;
+		}
+
+		/* The ends are no longer needed. */
+		f_free(fsm->opt->alloc, ends);
+		ends = NULL;
+	}
+
+	if (edge_count == 0) {	/* done */
+		res = 1;
+		goto cleanup;
+	}
+
+	/* Build the offset table into the edge index, so we
+	 * can map from s_id to the consecutive edges leading
+	 * to it with random access.
+	 *
+	 * offsets[s_id] contains the offset of the first edge after
+	 * s_id, so that offsets[s_id - 1] can be used as the starting
+	 * offset, or 0 when s_id is 0. Since states may not appear in
+	 * the table, any case where offsets[i] == 0 is set to
+	 * offsets[i - 1], to represent zero entries. */
+	{
+		size_t i;
+		const fsm_state_t max_to = edges[edge_count - 1].to;
+		offsets = f_calloc(fsm->opt->alloc,
+		    (max_to + 1), sizeof(offsets[0]));
+		if (offsets == NULL) {
+			goto cleanup;
+		}
+
+		for (i = 0; i < edge_count; i++) {
+			const fsm_state_t to = edges[i].to;
+			offsets[to] = i + 1;
+		}
+
+		for (i = 0; i <= max_to; i++) { /* fill in gaps */
+			if (i > 0 && offsets[i] == 0) {
+				offsets[i] = offsets[i - 1];
+			}
+		}
+		assert(offsets[max_to] == edge_count);
+	}
+
+
+	/* Walk breadth-first from ends and mark reachable states. */
+	while (queue_pop(q, &s_id)) {
+		size_t base, limit, e_i;
+		assert(fsm->states[s_id].visited);
+
+		base = (s_id == 0 ? 0 : offsets[s_id - 1]);
+		limit = offsets[s_id];
+		for (e_i = base; e_i < limit; e_i++) {
+			const fsm_state_t from = edges[e_i].from;
+			assert(from < state_count);
+			if (!fsm->states[from].visited) {
+				fsm->states[from].visited = 1;
+				if (!queue_push(q, from)) {
+					goto cleanup;
+				}
+			}
+		}
+	}
+
+
+	/* All start- and end-reachable states are now marked. */
+	res = 1;
+
+cleanup:
+	if (edges != NULL) { f_free(fsm->opt->alloc, edges); }
+	if (ends != NULL) { f_free(fsm->opt->alloc, ends); }
+	if (offsets != NULL) { f_free(fsm->opt->alloc, offsets); }
+	if (q != NULL) { queue_free(q); }
+
+	return res;
+}
+
+static int
+grow_ends(const struct fsm_alloc *alloc, size_t *ceil, fsm_state_t **ends)
+{
+	const size_t nceil = 2 * (*ceil);
+	fsm_state_t *nends = f_realloc(alloc,
+	    *ends, nceil * sizeof((*ends)[0]));
+	if (nends == NULL) {
+		return 0;
+	}
+	*ceil = nceil;
+	*ends = nends;
+	return 1;
+}
+
+static int
+save_edge(const struct fsm_alloc *alloc,
+    size_t *count, size_t *ceil, struct edge **edges,
+    fsm_state_t from, fsm_state_t to)
+{
+	struct edge *e;
+	if (*count == *ceil) {
+		const size_t nceil = 2 * (*ceil);
+		struct edge *nedges = f_realloc(alloc,
+		    *edges, nceil * sizeof((*edges)[0]));
+		if (nedges == NULL) {
+			return 0;
+		}
+		*ceil = nceil;
+		*edges = nedges;
+	}
+
+	e = &(*edges)[*count];
+	e->from = from;
+	e->to = to;
+	(*count)++;
 	return 1;
 }
 
 static int
 marks_filter_cb(fsm_state_t id, void *opaque)
 {
-	const unsigned char *marks = opaque;
-	return marks[id] & MARK_REACHES_END;
+	const struct fsm *fsm = opaque;
+	assert(id < fsm->statecount);
+	return fsm->states[id].visited;
 }
 
 long
-sweep_states(struct fsm *fsm,
-	unsigned char *marks)
+sweep_states(struct fsm *fsm)
 {
 	size_t swept;
 
 	assert(fsm != NULL);
 
-	if (!fsm_compact_states(fsm, marks_filter_cb, marks, &swept)) {
+	if (!fsm_compact_states(fsm, marks_filter_cb, fsm, &swept)) {
 		return -1;
 	}
 
 	return (long)swept;
 }
 
-int
-fsm_trim(struct fsm *fsm)
+long
+fsm_trim(struct fsm *fsm, enum fsm_trim_mode mode)
 {
 	long ret;
 	unsigned char *marks = NULL;
+	fsm_state_t i;
 	assert(fsm != NULL);
 
-	/* Strictly speaking, this only needs 4 bits per state,
-	 * but using a full byte makes the addressing easier. */
-	marks = f_calloc(fsm->opt->alloc,
-	    fsm->statecount, sizeof(marks[0]));
-	if (marks == NULL) {
-		goto cleanup;
-	}
-
-	if (!mark_states(fsm, marks)) {
+	if (!mark_states(fsm, mode)) {
 		goto cleanup;
 	}
 
@@ -217,15 +351,19 @@ fsm_trim(struct fsm *fsm)
 	 * sweep_states returns a negative value on error, otherwise it returns
 	 * the number of states swept.
 	 */
-	ret = sweep_states(fsm, marks);
+	ret = sweep_states(fsm);
 
-	f_free(fsm->opt->alloc, marks);
+	/* Clear the marks on remaining states, since .visited is
+	 * only meaningful within a single operation. */
+	for (i = 0; i < fsm->statecount; i++) {
+		fsm->states[i].visited = 0;
+	}
 
 	if (ret < 0) {
 		return ret;
 	}
 
-	return 1;
+	return ret;
 
 cleanup:
 	if (marks != NULL) {


### PR DESCRIPTION
The previous change to `fsm_trim` broke some internal assumptions
about how trimming works. fsm_complement calls `fsm_trim`, but
should only trim states that are unreachable from the start -- it
can produce states without a path to end states, but those should
still be kept.

The new implementation of `fsm_trim` merged in c6e07f3e had some flaws.
In an attempt to avoid constructing a reverse edge index (but also avoid
repeatedly checking linked states) it added edge cases where certain
graph traversal orders could cause states to be incorrectly trimmed.
Work on another branch made this bug more visible, because it switches
the edge_set ADT to a hash table and traverses the graph in hash table
order. Adding an edge could resize the table and lead to a very
different graph walk ordering.

This discards that approach and replaces it with something more
conventional -- use a queue to do a breadth-first walk from the start
state, collect end states and edges, invert the edge collection so it
can be used as a reverse edge index, and then do another breadth-first
walk from the end states marking reachable states.

Update the callers to `fsm_trim` so that they have the new argument,
and also match the interface as described -- now it actually does
return how many states were removed, or -1 on error.

With these changes, all tests are again passing.