### PR TITLE
Fixes a few bugs in the new fsm_trim() code

### DIFF
--- a/src/libfsm/trim.c
+++ b/src/libfsm/trim.c
@@ -133,10 +133,13 @@ mark_states(struct fsm *fsm, enum fsm_trim_mode mode)
 					goto cleanup;
 				}
 				fsm->states[next].visited = 1;
+			}
 
-				if (edges == NULL) {
-					continue;
-				}
+			/* have to add all edges whether we've already visited
+			 * them or not to ensure that all possible backward
+			 * paths are present in the edge list.
+			 */
+			if (edges != NULL) {
 				if (!save_edge(fsm->opt->alloc,
 					&edge_count, &edge_ceil, &edges,
 					s_id, next)) {
@@ -153,10 +156,13 @@ mark_states(struct fsm *fsm, enum fsm_trim_mode mode)
 					goto cleanup;
 				}
 				fsm->states[next].visited = 1;
+			}
 
-				if (edges == NULL) {
-					continue;
-				}
+			/* have to add all edges whether we've already visited
+			 * them or not to ensure that all possible backward
+			 * paths are present in the edge list.
+			 */
+			if (edges != NULL) {
 				if (!save_edge(fsm->opt->alloc,
 					&edge_count, &edge_ceil, &edges,
 					s_id, next)) {

--- a/src/libfsm/trim.c
+++ b/src/libfsm/trim.c
@@ -343,6 +343,17 @@ fsm_trim(struct fsm *fsm, enum fsm_trim_mode mode)
 		goto cleanup;
 	}
 
+	{
+		/* - XXX -
+		 * this is a hack to make sure that we leave at least the start state.
+		 * otherwise a bunch of tests break...
+		 */
+		fsm_state_t start;
+		if (fsm_getstart(fsm, &start)) {
+			fsm->states[start].visited = 1;
+		}
+	}
+
 	/*
 	 * Remove all states which are unreachable from the start state
 	 * or have no path to an end state. These are a trailing suffix


### PR DESCRIPTION
While trying to use the new `fsm_trim()`, I encountered a few problems:

1. `fsm_trim` is too efficient; it trims away the whole graph when there are no accepting states.  This breaks a number of tests.  For now, I've added a hack that avoids trimming the starting state.  This fixes the tests that rely on that behavior.

2. `fsm_trim` wasn't collecting all edges in the forward pass.  If the destination of an edge had already been visited, that edge would be omitted.  This can result in backward paths being omitted, which can cause states to be trimmed on the reverse pass.

One example is in `tests/minimise/in11.fsm`, whose graph is:
![min-in11](https://user-images.githubusercontent.com/2184720/89248328-770c3980-d5dd-11ea-80a3-9e2e2f26f128.png)

Running

```./build/bin/fsm -t trim -p -l dot tests/minimise/in11.fsm | dot -Tpng``` 

on the `main` branch produces:
![min-in11-t](https://user-images.githubusercontent.com/2184720/89248373-94410800-d5dd-11ea-850e-eb9834da8270.png)

This PR fixes the behavior, and avoids trimming the states.
