### PR TITLE
Makefile fixup to move test summary to after the build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,8 @@ STAGE_BUILD := ${STAGE_BUILD:Nbin/cvtpcre}
 .include <install.mk>
 .include <clean.mk>
 
-test:: .EXEC
+.if make(test)
+.END::
 	grep FAIL ${BUILD}/tests/*/res*; [ $$? -ne 0 ]
+.endif
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ RE     ?= re
 BUILD  ?= build
 PREFIX ?= /usr/local
 
-.if !empty(.TARGETS:Mfuzz)
+.if make(fuzz)
 PKG += libtheft
 .endif
 
@@ -73,7 +73,7 @@ SUBDIR += tests/hashset
 SUBDIR += tests/queue
 SUBDIR += tests/aho_corasick
 SUBDIR += tests
-.if !empty(.TARGETS:Mfuzz)
+.if make(fuzz)
 SUBDIR += theft
 .endif
 SUBDIR += pc

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,6 @@ STAGE_BUILD := ${STAGE_BUILD:Nbin/cvtpcre}
 .include <install.mk>
 .include <clean.mk>
 
-test::
+test:: .EXEC
 	grep FAIL ${BUILD}/tests/*/res*; [ $$? -ne 0 ]
 


### PR DESCRIPTION
A couple of makefile-related fixups here. The significant one is that the grep to summarise test failures is now under `.END` (meaning that it runs last), which forces it to be after each test has run.

This should fix the issue for CI, where -j parallelism caused this to accidentally run before the tests had executed, which is why we saw no failures when things should fail.