### PR TITLE
Remove `AST_EXPR_ANY`

### DIFF
--- a/src/libre/ast.c
+++ b/src/libre/ast.c
@@ -83,7 +83,6 @@ ast_expr_free(struct ast_expr *n)
 	case AST_EXPR_EMPTY:
 	case AST_EXPR_LITERAL:
 	case AST_EXPR_CODEPOINT:
-	case AST_EXPR_ANY:
 	case AST_EXPR_FLAGS:
 	case AST_EXPR_ANCHOR:
 	case AST_EXPR_RANGE:
@@ -255,9 +254,6 @@ ast_expr_cmp(const struct ast_expr *a, const struct ast_expr *b)
 		if (a->u.codepoint.u < b->u.codepoint.u) { return -1; }
 		if (a->u.codepoint.u > b->u.codepoint.u) { return +1; }
 
-		return 0;
-
-	case AST_EXPR_ANY:
 		return 0;
 
 	case AST_EXPR_REPEAT:
@@ -493,21 +489,6 @@ ast_make_expr_codepoint(uint32_t u)
 
 	res->type = AST_EXPR_CODEPOINT;
 	res->u.codepoint.u = u;
-
-	return res;
-}
-
-struct ast_expr *
-ast_make_expr_any(void)
-{
-	struct ast_expr *res;
-
-	res = calloc(1, sizeof *res);
-	if (res == NULL) {
-		return NULL;
-	}
-
-	res->type = AST_EXPR_ANY;
 
 	return res;
 }

--- a/src/libre/ast.h
+++ b/src/libre/ast.h
@@ -25,7 +25,6 @@ enum ast_expr_type {
 	AST_EXPR_ALT,
 	AST_EXPR_LITERAL,
 	AST_EXPR_CODEPOINT,
-	AST_EXPR_ANY,
 	AST_EXPR_REPEAT,
 	AST_EXPR_GROUP,
 	AST_EXPR_FLAGS,
@@ -229,9 +228,6 @@ ast_make_expr_literal(char c);
 
 struct ast_expr *
 ast_make_expr_codepoint(uint32_t u);
-
-struct ast_expr *
-ast_make_expr_any(void);
 
 struct ast_expr *
 ast_make_expr_repeat(struct ast_expr *e, struct ast_count count);

--- a/src/libre/ast_analysis.c
+++ b/src/libre/ast_analysis.c
@@ -66,7 +66,6 @@ analysis_iter(struct analysis_env *env, struct ast_expr *n)
 
 	case AST_EXPR_LITERAL:
 	case AST_EXPR_CODEPOINT:
-	case AST_EXPR_ANY:
 	case AST_EXPR_RANGE:
 		/* no special handling */
 		break;
@@ -175,7 +174,6 @@ always_consumes_input(const struct ast_expr *n, int thud)
 	switch (n->type) {
 	case AST_EXPR_LITERAL:
 	case AST_EXPR_CODEPOINT:
-	case AST_EXPR_ANY:
 	case AST_EXPR_RANGE:
 		return 1;
 
@@ -300,7 +298,6 @@ analysis_iter_anchoring(struct anchoring_env *env, struct ast_expr *n)
 
 	case AST_EXPR_LITERAL:
 	case AST_EXPR_CODEPOINT:
-	case AST_EXPR_ANY:
 	case AST_EXPR_RANGE:
 		if (!is_nullable(n)) {
 			env->past_any_consuming = 1;
@@ -480,7 +477,6 @@ assign_firsts(struct ast_expr *n)
 
 	case AST_EXPR_LITERAL:
 	case AST_EXPR_CODEPOINT:
-	case AST_EXPR_ANY:
 	case AST_EXPR_RANGE:
 		set_flags(n, AST_FLAG_FIRST);
 		break;
@@ -554,7 +550,6 @@ assign_lasts(struct ast_expr *n)
 
 	case AST_EXPR_LITERAL:
 	case AST_EXPR_CODEPOINT:
-	case AST_EXPR_ANY:
 	case AST_EXPR_RANGE:
 		set_flags(n, AST_FLAG_LAST);
 		break;

--- a/src/libre/ast_compile.c
+++ b/src/libre/ast_compile.c
@@ -389,7 +389,6 @@ decide_linking(struct comp_env *env,
 	case AST_EXPR_SUBTRACT:
 	case AST_EXPR_LITERAL:
 	case AST_EXPR_CODEPOINT:
-	case AST_EXPR_ANY:
 
 	case AST_EXPR_CONCAT:
 	case AST_EXPR_ALT:
@@ -847,10 +846,6 @@ comp_iter(struct comp_env *env,
 		break;
 	}
 
-	case AST_EXPR_ANY:
-		ANY(x, y);
-		break;
-
 	case AST_EXPR_REPEAT:
 		/*
 		 * REPEAT breaks out into its own function, because
@@ -947,6 +942,13 @@ comp_iter(struct comp_env *env,
 		}
 
 		assert(n->u.range.from.u.literal.c <= n->u.range.to.u.literal.c);
+
+		if (n->u.range.from.u.literal.c == 0x00 &&
+			n->u.range.to.u.literal.c == 0xff)
+		{
+			ANY(x, y);
+			break;
+		}
 
 		for (i = n->u.range.from.u.literal.c; i <= n->u.range.to.u.literal.c; i++) {
 			LITERAL(x, y, i);

--- a/src/libre/ast_rewrite.c
+++ b/src/libre/ast_rewrite.c
@@ -609,7 +609,6 @@ rewrite(struct ast_expr *n, enum re_flags flags)
 
 	case AST_EXPR_LITERAL:
 	case AST_EXPR_CODEPOINT:
-	case AST_EXPR_ANY:
 		return 1;
 
 	case AST_EXPR_REPEAT:

--- a/src/libre/dialect/glob/parser.c
+++ b/src/libre/dialect/glob/parser.c
@@ -244,7 +244,7 @@ ZL2_list_Hof_Hatoms:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 823 "src/libre/parser.act"
+#line 824 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
@@ -286,14 +286,15 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-any */
 			{
-#line 689 "src/libre/parser.act"
+#line 690 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_any();
+		/* TODO: or the unicode equivalent */
+		(ZIe) = ast_make_expr_named(&class_any);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 297 "src/libre/dialect/glob/parser.c"
+#line 298 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: ast-make-any */
 		}
@@ -316,7 +317,7 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 320 "src/libre/dialect/glob/parser.c"
+#line 321 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
@@ -329,7 +330,7 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			goto ZL1;
 		}
 	
-#line 333 "src/libre/dialect/glob/parser.c"
+#line 334 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -342,14 +343,15 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-any */
 			{
-#line 689 "src/libre/parser.act"
+#line 690 "src/libre/parser.act"
 
-		(ZIg) = ast_make_expr_any();
+		/* TODO: or the unicode equivalent */
+		(ZIg) = ast_make_expr_named(&class_any);
 		if ((ZIg) == NULL) {
 			goto ZL1;
 		}
 	
-#line 353 "src/libre/dialect/glob/parser.c"
+#line 355 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: ast-make-any */
 			/* BEGINNING OF ACTION: count-zero-or-more */
@@ -358,12 +360,12 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 362 "src/libre/dialect/glob/parser.c"
+#line 364 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 			/* BEGINNING OF ACTION: ast-make-piece */
 			{
-#line 696 "src/libre/parser.act"
+#line 697 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZIe) = ast_make_expr_empty();
@@ -377,7 +379,7 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			goto ZL1;
 		}
 	
-#line 381 "src/libre/dialect/glob/parser.c"
+#line 383 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: ast-make-piece */
 		}
@@ -399,19 +401,20 @@ ZL1:;
 		}
 		goto ZL2;
 	
-#line 403 "src/libre/dialect/glob/parser.c"
+#line 405 "src/libre/dialect/glob/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-any */
 		{
-#line 689 "src/libre/parser.act"
+#line 690 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_any();
+		/* TODO: or the unicode equivalent */
+		(ZIe) = ast_make_expr_named(&class_any);
 		if ((ZIe) == NULL) {
 			goto ZL2;
 		}
 	
-#line 415 "src/libre/dialect/glob/parser.c"
+#line 418 "src/libre/dialect/glob/parser.c"
 		}
 		/* END OF ACTION: ast-make-any */
 	}
@@ -446,7 +449,7 @@ p_re__glob(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 			goto ZL1;
 		}
 	
-#line 450 "src/libre/dialect/glob/parser.c"
+#line 453 "src/libre/dialect/glob/parser.c"
 					}
 					/* END OF ACTION: ast-make-concat */
 					p_list_Hof_Hatoms (flags, lex_state, act_state, err, ZInode);
@@ -467,7 +470,7 @@ p_re__glob(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 			goto ZL1;
 		}
 	
-#line 471 "src/libre/dialect/glob/parser.c"
+#line 474 "src/libre/dialect/glob/parser.c"
 					}
 					/* END OF ACTION: ast-make-empty */
 				}
@@ -498,7 +501,7 @@ p_re__glob(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 		}
 		goto ZL1;
 	
-#line 502 "src/libre/dialect/glob/parser.c"
+#line 505 "src/libre/dialect/glob/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
@@ -516,7 +519,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 976 "src/libre/parser.act"
+#line 977 "src/libre/parser.act"
 
 
 	static int
@@ -659,6 +662,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 663 "src/libre/dialect/glob/parser.c"
+#line 666 "src/libre/dialect/glob/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/glob/parser.c
+++ b/src/libre/dialect/glob/parser.c
@@ -244,7 +244,7 @@ ZL2_list_Hof_Hatoms:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 824 "src/libre/parser.act"
+#line 821 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
@@ -283,20 +283,31 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 	switch (CURRENT_TERMINAL) {
 	case (TOK_ANY):
 		{
+			t_ast__class__id ZIa;
+
 			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: ast-make-any */
+			/* BEGINNING OF ACTION: class-any */
 			{
-#line 690 "src/libre/parser.act"
+#line 574 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
-		(ZIe) = ast_make_expr_named(&class_any);
+		(ZIa) = &class_any;
+	
+#line 297 "src/libre/dialect/glob/parser.c"
+			}
+			/* END OF ACTION: class-any */
+			/* BEGINNING OF ACTION: ast-make-named */
+			{
+#line 814 "src/libre/parser.act"
+
+		(ZIe) = ast_make_expr_named((ZIa));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 298 "src/libre/dialect/glob/parser.c"
+#line 309 "src/libre/dialect/glob/parser.c"
 			}
-			/* END OF ACTION: ast-make-any */
+			/* END OF ACTION: ast-make-named */
 		}
 		break;
 	case (TOK_CHAR):
@@ -317,55 +328,65 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 321 "src/libre/dialect/glob/parser.c"
+#line 332 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 678 "src/libre/parser.act"
+#line 683 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_literal((ZIc));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 334 "src/libre/dialect/glob/parser.c"
+#line 345 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
 		break;
 	case (TOK_MANY):
 		{
+			t_ast__class__id ZIa;
 			t_ast__expr ZIg;
 			t_ast__count ZIc;
 
 			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: ast-make-any */
+			/* BEGINNING OF ACTION: class-any */
 			{
-#line 690 "src/libre/parser.act"
+#line 574 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
-		(ZIg) = ast_make_expr_named(&class_any);
+		(ZIa) = &class_any;
+	
+#line 364 "src/libre/dialect/glob/parser.c"
+			}
+			/* END OF ACTION: class-any */
+			/* BEGINNING OF ACTION: ast-make-named */
+			{
+#line 814 "src/libre/parser.act"
+
+		(ZIg) = ast_make_expr_named((ZIa));
 		if ((ZIg) == NULL) {
 			goto ZL1;
 		}
 	
-#line 355 "src/libre/dialect/glob/parser.c"
+#line 376 "src/libre/dialect/glob/parser.c"
 			}
-			/* END OF ACTION: ast-make-any */
+			/* END OF ACTION: ast-make-named */
 			/* BEGINNING OF ACTION: count-zero-or-more */
 			{
-#line 590 "src/libre/parser.act"
+#line 595 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 364 "src/libre/dialect/glob/parser.c"
+#line 385 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 			/* BEGINNING OF ACTION: ast-make-piece */
 			{
-#line 697 "src/libre/parser.act"
+#line 694 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZIe) = ast_make_expr_empty();
@@ -379,7 +400,7 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			goto ZL1;
 		}
 	
-#line 383 "src/libre/dialect/glob/parser.c"
+#line 404 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: ast-make-piece */
 		}
@@ -401,22 +422,21 @@ ZL1:;
 		}
 		goto ZL2;
 	
-#line 405 "src/libre/dialect/glob/parser.c"
+#line 426 "src/libre/dialect/glob/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
-		/* BEGINNING OF ACTION: ast-make-any */
+		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 690 "src/libre/parser.act"
+#line 662 "src/libre/parser.act"
 
-		/* TODO: or the unicode equivalent */
-		(ZIe) = ast_make_expr_named(&class_any);
+		(ZIe) = ast_make_expr_empty();
 		if ((ZIe) == NULL) {
 			goto ZL2;
 		}
 	
-#line 418 "src/libre/dialect/glob/parser.c"
+#line 438 "src/libre/dialect/glob/parser.c"
 		}
-		/* END OF ACTION: ast-make-any */
+		/* END OF ACTION: ast-make-empty */
 	}
 	goto ZL0;
 ZL2:;
@@ -442,14 +462,14 @@ p_re__glob(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 				{
 					/* BEGINNING OF ACTION: ast-make-concat */
 					{
-#line 664 "src/libre/parser.act"
+#line 669 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_concat();
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 453 "src/libre/dialect/glob/parser.c"
+#line 473 "src/libre/dialect/glob/parser.c"
 					}
 					/* END OF ACTION: ast-make-concat */
 					p_list_Hof_Hatoms (flags, lex_state, act_state, err, ZInode);
@@ -463,14 +483,14 @@ p_re__glob(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 				{
 					/* BEGINNING OF ACTION: ast-make-empty */
 					{
-#line 657 "src/libre/parser.act"
+#line 662 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty();
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 474 "src/libre/dialect/glob/parser.c"
+#line 494 "src/libre/dialect/glob/parser.c"
 					}
 					/* END OF ACTION: ast-make-empty */
 				}
@@ -501,7 +521,7 @@ p_re__glob(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 		}
 		goto ZL1;
 	
-#line 505 "src/libre/dialect/glob/parser.c"
+#line 525 "src/libre/dialect/glob/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
@@ -519,7 +539,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 977 "src/libre/parser.act"
+#line 974 "src/libre/parser.act"
 
 
 	static int
@@ -662,6 +682,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 666 "src/libre/dialect/glob/parser.c"
+#line 686 "src/libre/dialect/glob/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/glob/parser.h
+++ b/src/libre/dialect/glob/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__glob(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 979 "src/libre/parser.act"
+#line 976 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/glob/parser.h"

--- a/src/libre/dialect/glob/parser.h
+++ b/src/libre/dialect/glob/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__glob(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 978 "src/libre/parser.act"
+#line 979 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/glob/parser.h"

--- a/src/libre/dialect/glob/parser.sid
+++ b/src/libre/dialect/glob/parser.sid
@@ -13,7 +13,7 @@
 	!err;
 	ast_expr;
 	ast_count;
-	!ast_class_id;
+	ast_class_id;
 	!endpoint;
 
 %terminals%
@@ -81,7 +81,6 @@
 	<ast-make-literal>:       (:char)                  -> (:ast_expr);
 	<ast-make-concat>:        ()                       -> (:ast_expr);
 	!<ast-make-alt>:          ()                       -> (:ast_expr);
-	<ast-make-any>:           ()                       -> (:ast_expr);
 	<ast-make-piece>:         (:ast_expr, :ast_count)  -> (:ast_expr);
 	!<ast-make-group>:        (:ast_expr)              -> (:ast_expr);
 	!<ast-make-re-flags>:     (:re_flags, :re_flags)   -> (:ast_expr);
@@ -90,7 +89,7 @@
 	!<ast-make-subtract>:     (:ast_expr, :ast_expr)   -> (:ast_expr); 
 	!<ast-make-invert>:       (:ast_expr)              -> (:ast_expr); 
 	!<ast-make-range>:        (:endpoint, :pos, :endpoint, :pos) -> (:ast_expr);
-	!<ast-make-named>:        (:ast_class_id)          -> (:ast_expr);
+	<ast-make-named>:         (:ast_class_id)          -> (:ast_expr);
 
 	<ast-add-concat>: (:ast_expr, :ast_expr) -> ();
 	!<ast-add-alt>:   (:ast_expr, :ast_expr) -> ();
@@ -112,6 +111,8 @@
 	!<mark-count>: (:pos, :pos) -> ();
 	!<mark-expr>: (:ast_expr, :pos, :pos) -> ();
 
+	<class-any>: () -> (:ast_class_id);
+
 	list-of-atoms: (cat :ast_expr) -> () [
 
 		atom: () -> (e :ast_expr) = {
@@ -119,15 +120,17 @@
 			e = <ast-make-literal>(c);
 		||
 			ANY;
-			e = <ast-make-any>;
+			a = <class-any>;
+			e = <ast-make-named>(a);
 		||
 			MANY;
-			g = <ast-make-any>;
+			a = <class-any>;
+			g = <ast-make-named>(a);
 			c = <count-zero-or-more>;
 			e = <ast-make-piece>(g, c);
 		##
 			<err-expected-atom>;
-			e = <ast-make-any>;
+			e = <ast-make-empty>;
 		};
 
 	] = {

--- a/src/libre/dialect/like/parser.c
+++ b/src/libre/dialect/like/parser.c
@@ -244,7 +244,7 @@ ZL2_list_Hof_Hatoms:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 824 "src/libre/parser.act"
+#line 821 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
@@ -283,27 +283,38 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 	switch (CURRENT_TERMINAL) {
 	case (TOK_ANY):
 		{
+			t_ast__class__id ZIa;
+
 			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: ast-make-any */
+			/* BEGINNING OF ACTION: class-any */
 			{
-#line 690 "src/libre/parser.act"
+#line 574 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
-		(ZIe) = ast_make_expr_named(&class_any);
+		(ZIa) = &class_any;
+	
+#line 297 "src/libre/dialect/like/parser.c"
+			}
+			/* END OF ACTION: class-any */
+			/* BEGINNING OF ACTION: ast-make-named */
+			{
+#line 814 "src/libre/parser.act"
+
+		(ZIe) = ast_make_expr_named((ZIa));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 298 "src/libre/dialect/like/parser.c"
+#line 309 "src/libre/dialect/like/parser.c"
 			}
-			/* END OF ACTION: ast-make-any */
+			/* END OF ACTION: ast-make-named */
 		}
 		break;
 	case (TOK_CHAR):
 		{
 			t_char ZIc;
-			t_pos ZI95;
 			t_pos ZI96;
+			t_pos ZI97;
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
@@ -312,60 +323,70 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI95 = lex_state->lx.start;
-		ZI96   = lex_state->lx.end;
+		ZI96 = lex_state->lx.start;
+		ZI97   = lex_state->lx.end;
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 321 "src/libre/dialect/like/parser.c"
+#line 332 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 678 "src/libre/parser.act"
+#line 683 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_literal((ZIc));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 334 "src/libre/dialect/like/parser.c"
+#line 345 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
 		break;
 	case (TOK_MANY):
 		{
+			t_ast__class__id ZIa;
 			t_ast__expr ZIg;
 			t_ast__count ZIc;
 
 			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: ast-make-any */
+			/* BEGINNING OF ACTION: class-any */
 			{
-#line 690 "src/libre/parser.act"
+#line 574 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
-		(ZIg) = ast_make_expr_named(&class_any);
+		(ZIa) = &class_any;
+	
+#line 364 "src/libre/dialect/like/parser.c"
+			}
+			/* END OF ACTION: class-any */
+			/* BEGINNING OF ACTION: ast-make-named */
+			{
+#line 814 "src/libre/parser.act"
+
+		(ZIg) = ast_make_expr_named((ZIa));
 		if ((ZIg) == NULL) {
 			goto ZL1;
 		}
 	
-#line 355 "src/libre/dialect/like/parser.c"
+#line 376 "src/libre/dialect/like/parser.c"
 			}
-			/* END OF ACTION: ast-make-any */
+			/* END OF ACTION: ast-make-named */
 			/* BEGINNING OF ACTION: count-zero-or-more */
 			{
-#line 590 "src/libre/parser.act"
+#line 595 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 364 "src/libre/dialect/like/parser.c"
+#line 385 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 			/* BEGINNING OF ACTION: ast-make-piece */
 			{
-#line 697 "src/libre/parser.act"
+#line 694 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZIe) = ast_make_expr_empty();
@@ -379,7 +400,7 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			goto ZL1;
 		}
 	
-#line 383 "src/libre/dialect/like/parser.c"
+#line 404 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: ast-make-piece */
 		}
@@ -401,22 +422,21 @@ ZL1:;
 		}
 		goto ZL2;
 	
-#line 405 "src/libre/dialect/like/parser.c"
+#line 426 "src/libre/dialect/like/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
-		/* BEGINNING OF ACTION: ast-make-any */
+		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 690 "src/libre/parser.act"
+#line 662 "src/libre/parser.act"
 
-		/* TODO: or the unicode equivalent */
-		(ZIe) = ast_make_expr_named(&class_any);
+		(ZIe) = ast_make_expr_empty();
 		if ((ZIe) == NULL) {
 			goto ZL2;
 		}
 	
-#line 418 "src/libre/dialect/like/parser.c"
+#line 438 "src/libre/dialect/like/parser.c"
 		}
-		/* END OF ACTION: ast-make-any */
+		/* END OF ACTION: ast-make-empty */
 	}
 	goto ZL0;
 ZL2:;
@@ -442,14 +462,14 @@ p_re__like(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 				{
 					/* BEGINNING OF ACTION: ast-make-concat */
 					{
-#line 664 "src/libre/parser.act"
+#line 669 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_concat();
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 453 "src/libre/dialect/like/parser.c"
+#line 473 "src/libre/dialect/like/parser.c"
 					}
 					/* END OF ACTION: ast-make-concat */
 					p_list_Hof_Hatoms (flags, lex_state, act_state, err, ZInode);
@@ -463,14 +483,14 @@ p_re__like(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 				{
 					/* BEGINNING OF ACTION: ast-make-empty */
 					{
-#line 657 "src/libre/parser.act"
+#line 662 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty();
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 474 "src/libre/dialect/like/parser.c"
+#line 494 "src/libre/dialect/like/parser.c"
 					}
 					/* END OF ACTION: ast-make-empty */
 				}
@@ -501,7 +521,7 @@ p_re__like(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 		}
 		goto ZL1;
 	
-#line 505 "src/libre/dialect/like/parser.c"
+#line 525 "src/libre/dialect/like/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
@@ -519,7 +539,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 977 "src/libre/parser.act"
+#line 974 "src/libre/parser.act"
 
 
 	static int
@@ -662,6 +682,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 666 "src/libre/dialect/like/parser.c"
+#line 686 "src/libre/dialect/like/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/like/parser.c
+++ b/src/libre/dialect/like/parser.c
@@ -244,7 +244,7 @@ ZL2_list_Hof_Hatoms:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 823 "src/libre/parser.act"
+#line 824 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
@@ -286,14 +286,15 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-any */
 			{
-#line 689 "src/libre/parser.act"
+#line 690 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_any();
+		/* TODO: or the unicode equivalent */
+		(ZIe) = ast_make_expr_named(&class_any);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 297 "src/libre/dialect/like/parser.c"
+#line 298 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: ast-make-any */
 		}
@@ -316,7 +317,7 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 320 "src/libre/dialect/like/parser.c"
+#line 321 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
@@ -329,7 +330,7 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			goto ZL1;
 		}
 	
-#line 333 "src/libre/dialect/like/parser.c"
+#line 334 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -342,14 +343,15 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-any */
 			{
-#line 689 "src/libre/parser.act"
+#line 690 "src/libre/parser.act"
 
-		(ZIg) = ast_make_expr_any();
+		/* TODO: or the unicode equivalent */
+		(ZIg) = ast_make_expr_named(&class_any);
 		if ((ZIg) == NULL) {
 			goto ZL1;
 		}
 	
-#line 353 "src/libre/dialect/like/parser.c"
+#line 355 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: ast-make-any */
 			/* BEGINNING OF ACTION: count-zero-or-more */
@@ -358,12 +360,12 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 362 "src/libre/dialect/like/parser.c"
+#line 364 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 			/* BEGINNING OF ACTION: ast-make-piece */
 			{
-#line 696 "src/libre/parser.act"
+#line 697 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZIe) = ast_make_expr_empty();
@@ -377,7 +379,7 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			goto ZL1;
 		}
 	
-#line 381 "src/libre/dialect/like/parser.c"
+#line 383 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: ast-make-piece */
 		}
@@ -399,19 +401,20 @@ ZL1:;
 		}
 		goto ZL2;
 	
-#line 403 "src/libre/dialect/like/parser.c"
+#line 405 "src/libre/dialect/like/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-any */
 		{
-#line 689 "src/libre/parser.act"
+#line 690 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_any();
+		/* TODO: or the unicode equivalent */
+		(ZIe) = ast_make_expr_named(&class_any);
 		if ((ZIe) == NULL) {
 			goto ZL2;
 		}
 	
-#line 415 "src/libre/dialect/like/parser.c"
+#line 418 "src/libre/dialect/like/parser.c"
 		}
 		/* END OF ACTION: ast-make-any */
 	}
@@ -446,7 +449,7 @@ p_re__like(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 			goto ZL1;
 		}
 	
-#line 450 "src/libre/dialect/like/parser.c"
+#line 453 "src/libre/dialect/like/parser.c"
 					}
 					/* END OF ACTION: ast-make-concat */
 					p_list_Hof_Hatoms (flags, lex_state, act_state, err, ZInode);
@@ -467,7 +470,7 @@ p_re__like(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 			goto ZL1;
 		}
 	
-#line 471 "src/libre/dialect/like/parser.c"
+#line 474 "src/libre/dialect/like/parser.c"
 					}
 					/* END OF ACTION: ast-make-empty */
 				}
@@ -498,7 +501,7 @@ p_re__like(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 		}
 		goto ZL1;
 	
-#line 502 "src/libre/dialect/like/parser.c"
+#line 505 "src/libre/dialect/like/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
@@ -516,7 +519,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 976 "src/libre/parser.act"
+#line 977 "src/libre/parser.act"
 
 
 	static int
@@ -659,6 +662,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 663 "src/libre/dialect/like/parser.c"
+#line 666 "src/libre/dialect/like/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/like/parser.h
+++ b/src/libre/dialect/like/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__like(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 978 "src/libre/parser.act"
+#line 979 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/like/parser.h"

--- a/src/libre/dialect/like/parser.h
+++ b/src/libre/dialect/like/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__like(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 979 "src/libre/parser.act"
+#line 976 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/like/parser.h"

--- a/src/libre/dialect/like/parser.sid
+++ b/src/libre/dialect/like/parser.sid
@@ -13,7 +13,7 @@
 	!err;
 	ast_expr;
 	ast_count;
-	!ast_class_id;
+	ast_class_id;
 	!endpoint;
 
 %terminals%
@@ -81,7 +81,6 @@
 	<ast-make-literal>:       (:char)                  -> (:ast_expr);
 	<ast-make-concat>:        ()                       -> (:ast_expr);
 	!<ast-make-alt>:          ()                       -> (:ast_expr);
-	<ast-make-any>:           ()                       -> (:ast_expr);
 	<ast-make-piece>:         (:ast_expr, :ast_count)  -> (:ast_expr);
 	!<ast-make-group>:        (:ast_expr)              -> (:ast_expr);
 	!<ast-make-re-flags>:     (:re_flags, :re_flags)   -> (:ast_expr);
@@ -90,7 +89,7 @@
 	!<ast-make-subtract>:     (:ast_expr, :ast_expr)   -> (:ast_expr); 
 	!<ast-make-invert>:       (:ast_expr)              -> (:ast_expr); 
 	!<ast-make-range>:        (:endpoint, :pos, :endpoint, :pos) -> (:ast_expr);
-	!<ast-make-named>:        (:ast_class_id) -> (:ast_expr);
+	<ast-make-named>:         (:ast_class_id) -> (:ast_expr);
 
 	<ast-add-concat>: (:ast_expr, :ast_expr) -> ();
 	!<ast-add-alt>:   (:ast_expr, :ast_expr) -> ();
@@ -112,14 +111,18 @@
 	!<mark-count>: (:pos, :pos) -> ();
 	!<mark-expr>: (:ast_expr, :pos, :pos) -> ();
 
+	<class-any>: () -> (:ast_class_id);
+
 	list-of-atoms: (cat :ast_expr) -> () [
 
 		atom: () -> (e :ast_expr) = {
 			ANY;
-			e = <ast-make-any>;
+			a = <class-any>;
+			e = <ast-make-named>(a);
 		||
 			MANY;
-			g = <ast-make-any>;
+			a = <class-any>;
+			g = <ast-make-named>(a);
 			c = <count-zero-or-more>;
 			e = <ast-make-piece>(g, c);
 		||
@@ -127,7 +130,7 @@
 			e = <ast-make-literal>(c);
 		##
 			<err-expected-atom>;
-			e = <ast-make-any>;
+			e = <ast-make-empty>;
 		};
 
 	] = {

--- a/src/libre/dialect/literal/parser.c
+++ b/src/libre/dialect/literal/parser.c
@@ -244,7 +244,7 @@ ZL2_list_Hof_Hatoms:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 824 "src/libre/parser.act"
+#line 821 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
@@ -291,7 +291,7 @@ p_re__literal(flags flags, lex_state lex_state, act_state act_state, err err, t_
 				{
 					/* BEGINNING OF ACTION: ast-make-concat */
 					{
-#line 664 "src/libre/parser.act"
+#line 669 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_concat();
 		if ((ZInode) == NULL) {
@@ -312,7 +312,7 @@ p_re__literal(flags flags, lex_state lex_state, act_state act_state, err err, t_
 				{
 					/* BEGINNING OF ACTION: ast-make-empty */
 					{
-#line 657 "src/libre/parser.act"
+#line 662 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty();
 		if ((ZInode) == NULL) {
@@ -403,7 +403,7 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-make-literal */
 		{
-#line 678 "src/libre/parser.act"
+#line 683 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_literal((ZIc));
 		if ((ZInode) == NULL) {
@@ -429,19 +429,18 @@ ZL1:;
 #line 430 "src/libre/dialect/literal/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
-		/* BEGINNING OF ACTION: ast-make-any */
+		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 690 "src/libre/parser.act"
+#line 662 "src/libre/parser.act"
 
-		/* TODO: or the unicode equivalent */
-		(ZInode) = ast_make_expr_named(&class_any);
+		(ZInode) = ast_make_expr_empty();
 		if ((ZInode) == NULL) {
 			goto ZL2;
 		}
 	
-#line 443 "src/libre/dialect/literal/parser.c"
+#line 442 "src/libre/dialect/literal/parser.c"
 		}
-		/* END OF ACTION: ast-make-any */
+		/* END OF ACTION: ast-make-empty */
 	}
 	goto ZL0;
 ZL2:;
@@ -453,7 +452,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 977 "src/libre/parser.act"
+#line 974 "src/libre/parser.act"
 
 
 	static int
@@ -596,6 +595,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 600 "src/libre/dialect/literal/parser.c"
+#line 599 "src/libre/dialect/literal/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/literal/parser.c
+++ b/src/libre/dialect/literal/parser.c
@@ -244,7 +244,7 @@ ZL2_list_Hof_Hatoms:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 823 "src/libre/parser.act"
+#line 824 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
@@ -431,14 +431,15 @@ ZL1:;
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-any */
 		{
-#line 689 "src/libre/parser.act"
+#line 690 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_any();
+		/* TODO: or the unicode equivalent */
+		(ZInode) = ast_make_expr_named(&class_any);
 		if ((ZInode) == NULL) {
 			goto ZL2;
 		}
 	
-#line 442 "src/libre/dialect/literal/parser.c"
+#line 443 "src/libre/dialect/literal/parser.c"
 		}
 		/* END OF ACTION: ast-make-any */
 	}
@@ -452,7 +453,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 976 "src/libre/parser.act"
+#line 977 "src/libre/parser.act"
 
 
 	static int
@@ -595,6 +596,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 599 "src/libre/dialect/literal/parser.c"
+#line 600 "src/libre/dialect/literal/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/literal/parser.h
+++ b/src/libre/dialect/literal/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__literal(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 978 "src/libre/parser.act"
+#line 979 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/literal/parser.h"

--- a/src/libre/dialect/literal/parser.h
+++ b/src/libre/dialect/literal/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__literal(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 979 "src/libre/parser.act"
+#line 976 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/literal/parser.h"

--- a/src/libre/dialect/literal/parser.sid
+++ b/src/libre/dialect/literal/parser.sid
@@ -81,7 +81,6 @@
 	<ast-make-literal>:       (:char)                  -> (:ast_expr);
 	<ast-make-concat>:        ()                       -> (:ast_expr);
 	!<ast-make-alt>:          ()                       -> (:ast_expr);
-	<ast-make-any>:           ()                       -> (:ast_expr);
 	!<ast-make-piece>:        (:ast_expr, :ast_count)  -> (:ast_expr);
 	!<ast-make-group>:        (:ast_expr)              -> (:ast_expr);
 	!<ast-make-re-flags>:     (:re_flags, :re_flags)   -> (:ast_expr);
@@ -112,6 +111,8 @@
 	!<mark-count>: (:pos, :pos) -> ();
 	!<mark-expr>: (:ast_expr, :pos, :pos) -> ();
 
+	!<class-any>: () -> (:ast_class_id);
+
 	list-of-atoms: (cat :ast_expr) -> () [
 
 		atom: () -> (node :ast_expr) = {
@@ -119,7 +120,7 @@
 			node = <ast-make-literal>(c);
 		##
 			<err-expected-atom>;
-			node = <ast-make-any>;
+			node = <ast-make-empty>;
 		};
 
 	] = {

--- a/src/libre/dialect/native/parser.c
+++ b/src/libre/dialect/native/parser.c
@@ -260,7 +260,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead(flags flags, lex_state lex_state, act_
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-invert */
 			{
-#line 773 "src/libre/parser.act"
+#line 774 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -334,7 +334,7 @@ ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 				}
 				/* BEGINNING OF ACTION: ast-add-alt */
 				{
-#line 829 "src/libre/parser.act"
+#line 830 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIclass), (ZInode))) {
 			goto ZL4;
@@ -403,7 +403,7 @@ ZL2_expr_C_Clist_Hof_Hpieces:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 823 "src/libre/parser.act"
+#line 824 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
@@ -1008,7 +1008,7 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 		}
 		/* BEGINNING OF ACTION: ast-make-piece */
 		{
-#line 696 "src/libre/parser.act"
+#line 697 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZInode) = ast_make_expr_empty();
@@ -1490,7 +1490,7 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			/* END OF ACTION: ast-range-distinct */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 786 "src/libre/parser.act"
+#line 787 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -1721,7 +1721,7 @@ ZL2_expr_C_Clist_Hof_Halts:;
 		}
 		/* BEGINNING OF ACTION: ast-add-alt */
 		{
-#line 829 "src/libre/parser.act"
+#line 830 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIalts), (ZIa))) {
 			goto ZL1;
@@ -1934,14 +1934,15 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-any */
 			{
-#line 689 "src/libre/parser.act"
+#line 690 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_any();
+		/* TODO: or the unicode equivalent */
+		(ZIe) = ast_make_expr_named(&class_any);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1945 "src/libre/dialect/native/parser.c"
+#line 1946 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-any */
 		}
@@ -1951,14 +1952,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-anchor-end */
 			{
-#line 731 "src/libre/parser.act"
+#line 732 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_anchor(AST_ANCHOR_END);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1962 "src/libre/dialect/native/parser.c"
+#line 1963 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-end */
 		}
@@ -1975,14 +1976,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			}
 			/* BEGINNING OF ACTION: ast-make-group */
 			{
-#line 710 "src/libre/parser.act"
+#line 711 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_group((ZIg));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1986 "src/libre/dialect/native/parser.c"
+#line 1987 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-group */
 			switch (CURRENT_TERMINAL) {
@@ -1999,14 +2000,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-anchor-start */
 			{
-#line 724 "src/libre/parser.act"
+#line 725 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_anchor(AST_ANCHOR_START);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2010 "src/libre/dialect/native/parser.c"
+#line 2011 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-start */
 		}
@@ -2046,19 +2047,20 @@ ZL1:;
 		}
 		goto ZL2;
 	
-#line 2050 "src/libre/dialect/native/parser.c"
+#line 2051 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-any */
 		{
-#line 689 "src/libre/parser.act"
+#line 690 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_any();
+		/* TODO: or the unicode equivalent */
+		(ZIe) = ast_make_expr_named(&class_any);
 		if ((ZIe) == NULL) {
 			goto ZL2;
 		}
 	
-#line 2062 "src/libre/dialect/native/parser.c"
+#line 2064 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-make-any */
 	}
@@ -2098,7 +2100,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed(flags flags, lex_state lex_state, act
 		ZI145 = lex_state->lx.start;
 		ZI146   = lex_state->lx.end;
 	
-#line 2102 "src/libre/dialect/native/parser.c"
+#line 2104 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			break;
@@ -2108,14 +2110,14 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed(flags flags, lex_state lex_state, act
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-make-named */
 		{
-#line 816 "src/libre/parser.act"
+#line 817 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_named((ZIid));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2119 "src/libre/dialect/native/parser.c"
+#line 2121 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-make-named */
 	}
@@ -2145,7 +2147,7 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 			goto ZL1;
 		}
 	
-#line 2149 "src/libre/dialect/native/parser.c"
+#line 2151 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-make-concat */
 		p_expr_C_Clist_Hof_Hpieces (flags, lex_state, act_state, err, ZInode);
@@ -2164,7 +2166,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 976 "src/libre/parser.act"
+#line 977 "src/libre/parser.act"
 
 
 	static int
@@ -2307,6 +2309,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 2311 "src/libre/dialect/native/parser.c"
+#line 2313 "src/libre/dialect/native/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/native/parser.c
+++ b/src/libre/dialect/native/parser.c
@@ -260,7 +260,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead(flags flags, lex_state lex_state, act_
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-invert */
 			{
-#line 774 "src/libre/parser.act"
+#line 771 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -334,7 +334,7 @@ ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 				}
 				/* BEGINNING OF ACTION: ast-add-alt */
 				{
-#line 830 "src/libre/parser.act"
+#line 827 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIclass), (ZInode))) {
 			goto ZL4;
@@ -403,7 +403,7 @@ ZL2_expr_C_Clist_Hof_Hpieces:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 824 "src/libre/parser.act"
+#line 821 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
@@ -620,7 +620,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		/* END OF INLINE: 92 */
 		/* BEGINNING OF ACTION: ast-make-literal */
 		{
-#line 678 "src/libre/parser.act"
+#line 683 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_literal((ZIc));
 		if ((ZInode) == NULL) {
@@ -887,7 +887,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-make-alt */
 		{
-#line 671 "src/libre/parser.act"
+#line 676 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt();
 		if ((ZInode) == NULL) {
@@ -1008,7 +1008,7 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 		}
 		/* BEGINNING OF ACTION: ast-make-piece */
 		{
-#line 697 "src/libre/parser.act"
+#line 694 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZInode) = ast_make_expr_empty();
@@ -1046,7 +1046,7 @@ p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__ex
 		{
 			/* BEGINNING OF ACTION: ast-make-alt */
 			{
-#line 671 "src/libre/parser.act"
+#line 676 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt();
 		if ((ZInode) == NULL) {
@@ -1067,7 +1067,7 @@ p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__ex
 		{
 			/* BEGINNING OF ACTION: ast-make-empty */
 			{
-#line 657 "src/libre/parser.act"
+#line 662 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty();
 		if ((ZInode) == NULL) {
@@ -1099,7 +1099,7 @@ ZL1:;
 		/* END OF ACTION: err-expected-alts */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 657 "src/libre/parser.act"
+#line 662 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty();
 		if ((ZInode) == NULL) {
@@ -1187,7 +1187,7 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		{
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 678 "src/libre/parser.act"
+#line 683 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_literal((*ZI209));
 		if ((ZInode) == NULL) {
@@ -1208,7 +1208,7 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 626 "src/libre/parser.act"
+#line 631 "src/libre/parser.act"
 
 		(ZIa).type = AST_ENDPOINT_LITERAL;
 		(ZIa).u.literal.c = (*ZI209);
@@ -1448,7 +1448,7 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			/* END OF INLINE: 133 */
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 626 "src/libre/parser.act"
+#line 631 "src/libre/parser.act"
 
 		(ZIz).type = AST_ENDPOINT_LITERAL;
 		(ZIz).u.literal.c = (ZIcz);
@@ -1468,7 +1468,7 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-range-distinct */
 			{
-#line 638 "src/libre/parser.act"
+#line 643 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -1490,7 +1490,7 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			/* END OF ACTION: ast-range-distinct */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 787 "src/libre/parser.act"
+#line 784 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -1573,7 +1573,7 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 608 "src/libre/parser.act"
+#line 613 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -1666,7 +1666,7 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 608 "src/libre/parser.act"
+#line 613 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -1721,7 +1721,7 @@ ZL2_expr_C_Clist_Hof_Halts:;
 		}
 		/* BEGINNING OF ACTION: ast-add-alt */
 		{
-#line 830 "src/libre/parser.act"
+#line 827 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIalts), (ZIa))) {
 			goto ZL1;
@@ -1837,7 +1837,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-zero-or-one */
 			{
-#line 598 "src/libre/parser.act"
+#line 603 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, 1, NULL);
 	
@@ -1851,7 +1851,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-one-or-more */
 			{
-#line 594 "src/libre/parser.act"
+#line 599 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
@@ -1865,7 +1865,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-zero-or-more */
 			{
-#line 590 "src/libre/parser.act"
+#line 595 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
@@ -1878,7 +1878,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 		{
 			/* BEGINNING OF ACTION: count-one */
 			{
-#line 602 "src/libre/parser.act"
+#line 607 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
@@ -1907,7 +1907,7 @@ ZL1:;
 		/* END OF ACTION: err-expected-count */
 		/* BEGINNING OF ACTION: count-one */
 		{
-#line 602 "src/libre/parser.act"
+#line 607 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
@@ -1931,20 +1931,31 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 	switch (CURRENT_TERMINAL) {
 	case (TOK_ANY):
 		{
+			t_ast__class__id ZIa;
+
 			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: ast-make-any */
+			/* BEGINNING OF ACTION: class-any */
 			{
-#line 690 "src/libre/parser.act"
+#line 574 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
-		(ZIe) = ast_make_expr_named(&class_any);
+		(ZIa) = &class_any;
+	
+#line 1945 "src/libre/dialect/native/parser.c"
+			}
+			/* END OF ACTION: class-any */
+			/* BEGINNING OF ACTION: ast-make-named */
+			{
+#line 814 "src/libre/parser.act"
+
+		(ZIe) = ast_make_expr_named((ZIa));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1946 "src/libre/dialect/native/parser.c"
+#line 1957 "src/libre/dialect/native/parser.c"
 			}
-			/* END OF ACTION: ast-make-any */
+			/* END OF ACTION: ast-make-named */
 		}
 		break;
 	case (TOK_END):
@@ -1952,14 +1963,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-anchor-end */
 			{
-#line 732 "src/libre/parser.act"
+#line 729 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_anchor(AST_ANCHOR_END);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1963 "src/libre/dialect/native/parser.c"
+#line 1974 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-end */
 		}
@@ -1976,14 +1987,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			}
 			/* BEGINNING OF ACTION: ast-make-group */
 			{
-#line 711 "src/libre/parser.act"
+#line 708 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_group((ZIg));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1987 "src/libre/dialect/native/parser.c"
+#line 1998 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-group */
 			switch (CURRENT_TERMINAL) {
@@ -2000,14 +2011,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-anchor-start */
 			{
-#line 725 "src/libre/parser.act"
+#line 722 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_anchor(AST_ANCHOR_START);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2011 "src/libre/dialect/native/parser.c"
+#line 2022 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-start */
 		}
@@ -2047,22 +2058,21 @@ ZL1:;
 		}
 		goto ZL2;
 	
-#line 2051 "src/libre/dialect/native/parser.c"
+#line 2062 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
-		/* BEGINNING OF ACTION: ast-make-any */
+		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 690 "src/libre/parser.act"
+#line 662 "src/libre/parser.act"
 
-		/* TODO: or the unicode equivalent */
-		(ZIe) = ast_make_expr_named(&class_any);
+		(ZIe) = ast_make_expr_empty();
 		if ((ZIe) == NULL) {
 			goto ZL2;
 		}
 	
-#line 2064 "src/libre/dialect/native/parser.c"
+#line 2074 "src/libre/dialect/native/parser.c"
 		}
-		/* END OF ACTION: ast-make-any */
+		/* END OF ACTION: ast-make-empty */
 	}
 	goto ZL0;
 ZL2:;
@@ -2100,7 +2110,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed(flags flags, lex_state lex_state, act
 		ZI145 = lex_state->lx.start;
 		ZI146   = lex_state->lx.end;
 	
-#line 2104 "src/libre/dialect/native/parser.c"
+#line 2114 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			break;
@@ -2110,14 +2120,14 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed(flags flags, lex_state lex_state, act
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-make-named */
 		{
-#line 817 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_named((ZIid));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2121 "src/libre/dialect/native/parser.c"
+#line 2131 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-make-named */
 	}
@@ -2140,14 +2150,14 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 	{
 		/* BEGINNING OF ACTION: ast-make-concat */
 		{
-#line 664 "src/libre/parser.act"
+#line 669 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_concat();
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2151 "src/libre/dialect/native/parser.c"
+#line 2161 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-make-concat */
 		p_expr_C_Clist_Hof_Hpieces (flags, lex_state, act_state, err, ZInode);
@@ -2166,7 +2176,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 977 "src/libre/parser.act"
+#line 974 "src/libre/parser.act"
 
 
 	static int
@@ -2309,6 +2319,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 2313 "src/libre/dialect/native/parser.c"
+#line 2323 "src/libre/dialect/native/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/native/parser.h
+++ b/src/libre/dialect/native/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__native(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 979 "src/libre/parser.act"
+#line 976 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/native/parser.h"

--- a/src/libre/dialect/native/parser.h
+++ b/src/libre/dialect/native/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__native(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 978 "src/libre/parser.act"
+#line 979 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/native/parser.h"

--- a/src/libre/dialect/native/parser.sid
+++ b/src/libre/dialect/native/parser.sid
@@ -86,7 +86,6 @@
 	<ast-make-literal>:      (:char)                  -> (:ast_expr);
 	<ast-make-concat>:       ()                       -> (:ast_expr);
 	<ast-make-alt>:          ()                       -> (:ast_expr);
-	<ast-make-any>:          ()                       -> (:ast_expr);
 	<ast-make-piece>:        (:ast_expr, :ast_count)  -> (:ast_expr);
 	<ast-make-group>:        (:ast_expr)              -> (:ast_expr);
 	!<ast-make-re-flags>:    (:re_flags, :re_flags)   -> (:ast_expr);
@@ -118,6 +117,8 @@
 	<mark-range>: (:pos, :pos) -> ();
 	<mark-count>: (:pos, :pos) -> ();
 	<mark-expr>: (:ast_expr, :pos, :pos) -> ();
+
+	<class-any>: () -> (:ast_class_id);
 
 	expr: () -> (node :ast_expr) [
 
@@ -252,7 +253,8 @@
 				e = <ast-make-anchor-end>;
 			||
 				ANY;
-				e = <ast-make-any>;
+				a = <class-any>;
+				e = <ast-make-named>(a);
 			||
 				e = literal;
 			||
@@ -264,7 +266,7 @@
 				CLOSESUB;
 			##
 				<err-expected-atom>;
-				e = <ast-make-any>;
+				e = <ast-make-empty>;
 			};
 
 			count: () -> (c :ast_count) = {

--- a/src/libre/dialect/pcre/parser.c
+++ b/src/libre/dialect/pcre/parser.c
@@ -274,7 +274,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead(flags flags, lex_state lex_state, act_
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-invert */
 			{
-#line 773 "src/libre/parser.act"
+#line 774 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -631,7 +631,7 @@ p_269(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 		{
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 816 "src/libre/parser.act"
+#line 817 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_named((*ZI266));
 		if ((ZInode) == NULL) {
@@ -677,7 +677,7 @@ p_269(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 786 "src/libre/parser.act"
+#line 787 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -746,7 +746,7 @@ ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 				}
 				/* BEGINNING OF ACTION: ast-add-alt */
 				{
-#line 829 "src/libre/parser.act"
+#line 830 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIclass), (ZInode))) {
 			goto ZL4;
@@ -896,7 +896,7 @@ p_289(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 786 "src/libre/parser.act"
+#line 787 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -1044,7 +1044,7 @@ ZL2_expr_C_Clist_Hof_Hpieces:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 823 "src/libre/parser.act"
+#line 824 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
@@ -1066,7 +1066,7 @@ ZL2_expr_C_Clist_Hof_Hpieces:;
 					goto ZL2_expr_C_Clist_Hof_Hpieces;
 					/* END OF INLINE: expr::list-of-pieces */
 				}
-				/* UNREACHED */
+				/*UNREACHED*/
 			default:
 				break;
 			}
@@ -1931,7 +1931,7 @@ p_177(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 						}
 						/* BEGINNING OF ACTION: ast-make-range */
 						{
-#line 786 "src/libre/parser.act"
+#line 787 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -1974,7 +1974,7 @@ p_177(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			/* END OF INLINE: 179 */
 			/* BEGINNING OF ACTION: ast-add-alt */
 			{
-#line 829 "src/libre/parser.act"
+#line 830 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((*ZItmp), (ZInode1))) {
 			goto ZL1;
@@ -2109,7 +2109,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 					}
 					/* BEGINNING OF ACTION: ast-add-alt */
 					{
-#line 829 "src/libre/parser.act"
+#line 830 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZItmp), (ZInode1))) {
 			goto ZL1;
@@ -2155,7 +2155,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 					ZItmp = ZInode;
 					/* BEGINNING OF ACTION: ast-make-invert */
 					{
-#line 773 "src/libre/parser.act"
+#line 774 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -2235,7 +2235,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 					ZItmp = ZInode;
 					/* BEGINNING OF ACTION: ast-make-invert */
 					{
-#line 773 "src/libre/parser.act"
+#line 774 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -2292,7 +2292,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 					}
 					/* BEGINNING OF ACTION: ast-add-alt */
 					{
-#line 829 "src/libre/parser.act"
+#line 830 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZItmp), (ZInode1))) {
 			goto ZL1;
@@ -2505,7 +2505,7 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 					/* END OF ACTION: count-one */
 					/* BEGINNING OF ACTION: ast-make-piece */
 					{
-#line 696 "src/libre/parser.act"
+#line 697 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZInode) = ast_make_expr_empty();
@@ -2673,7 +2673,7 @@ p_194(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 786 "src/libre/parser.act"
+#line 787 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -2745,7 +2745,7 @@ ZL2_198:;
 							}
 							/* BEGINNING OF ACTION: ast-add-alt */
 							{
-#line 829 "src/libre/parser.act"
+#line 830 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((*ZItmp), (ZInode))) {
 			goto ZL5;
@@ -2778,11 +2778,11 @@ ZL2_198:;
 					goto ZL2_198;
 					/* END OF INLINE: 198 */
 				}
-				/* UNREACHED */
+				/*UNREACHED*/
 			}
 			/* END OF INLINE: expr::character-class::list-of-class-terms */
 		}
-		/* UNREACHED */
+		/*UNREACHED*/
 	case (ERROR_TERMINAL):
 		return;
 	default:
@@ -2886,7 +2886,7 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 				ADVANCE_LEXER;
 				/* BEGINNING OF ACTION: ast-make-re-flags */
 				{
-#line 717 "src/libre/parser.act"
+#line 718 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_re_flags((ZIpos), (ZIneg));
 		if ((ZInode) == NULL) {
@@ -2955,7 +2955,7 @@ p_expr_C_Cpiece_C_Clist_Hof_Hcounts(flags flags, lex_state lex_state, act_state 
 		}
 		/* BEGINNING OF ACTION: ast-make-piece */
 		{
-#line 696 "src/libre/parser.act"
+#line 697 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZInode) = ast_make_expr_empty();
@@ -3085,7 +3085,7 @@ p_class_Hnamed(flags flags, lex_state lex_state, act_state act_state, err err, t
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-make-named */
 		{
-#line 816 "src/libre/parser.act"
+#line 817 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_named((ZIid));
 		if ((ZInode) == NULL) {
@@ -3123,7 +3123,7 @@ ZL2_expr_C_Clist_Hof_Halts:;
 		}
 		/* BEGINNING OF ACTION: ast-add-alt */
 		{
-#line 829 "src/libre/parser.act"
+#line 830 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIalts), (ZIa))) {
 			goto ZL1;
@@ -3142,7 +3142,7 @@ ZL2_expr_C_Clist_Hof_Halts:;
 					goto ZL2_expr_C_Clist_Hof_Halts;
 					/* END OF INLINE: expr::list-of-alts */
 				}
-				/* UNREACHED */
+				/*UNREACHED*/
 			default:
 				break;
 			}
@@ -3384,14 +3384,15 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-any */
 			{
-#line 689 "src/libre/parser.act"
+#line 690 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_any();
+		/* TODO: or the unicode equivalent */
+		(ZIe) = ast_make_expr_named(&class_any);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3395 "src/libre/dialect/pcre/parser.c"
+#line 3396 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-any */
 		}
@@ -3420,7 +3421,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 		ZI226 = lex_state->lx.start;
 		ZI227   = lex_state->lx.end;
 	
-#line 3424 "src/libre/dialect/pcre/parser.c"
+#line 3425 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: CONTROL */
 			ADVANCE_LEXER;
@@ -3433,7 +3434,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 		}
 		goto ZL1;
 	
-#line 3437 "src/libre/dialect/pcre/parser.c"
+#line 3438 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: err-unsupported */
 			/* BEGINNING OF ACTION: ast-make-empty */
@@ -3445,7 +3446,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 3449 "src/libre/dialect/pcre/parser.c"
+#line 3450 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-empty */
 		}
@@ -3455,14 +3456,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-anchor-end */
 			{
-#line 731 "src/libre/parser.act"
+#line 732 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_anchor(AST_ANCHOR_END);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3466 "src/libre/dialect/pcre/parser.c"
+#line 3467 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-end */
 		}
@@ -3479,14 +3480,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			}
 			/* BEGINNING OF ACTION: ast-make-group */
 			{
-#line 710 "src/libre/parser.act"
+#line 711 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_group((ZIg));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3490 "src/libre/dialect/pcre/parser.c"
+#line 3491 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-group */
 			switch (CURRENT_TERMINAL) {
@@ -3519,14 +3520,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-anchor-start */
 			{
-#line 724 "src/libre/parser.act"
+#line 725 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_anchor(AST_ANCHOR_START);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3530 "src/libre/dialect/pcre/parser.c"
+#line 3531 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-start */
 		}
@@ -3585,19 +3586,20 @@ ZL1:;
 		}
 		goto ZL2;
 	
-#line 3589 "src/libre/dialect/pcre/parser.c"
+#line 3590 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-any */
 		{
-#line 689 "src/libre/parser.act"
+#line 690 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_any();
+		/* TODO: or the unicode equivalent */
+		(ZIe) = ast_make_expr_named(&class_any);
 		if ((ZIe) == NULL) {
 			goto ZL2;
 		}
 	
-#line 3601 "src/libre/dialect/pcre/parser.c"
+#line 3603 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-any */
 	}
@@ -3630,7 +3632,7 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 			goto ZL1;
 		}
 	
-#line 3634 "src/libre/dialect/pcre/parser.c"
+#line 3636 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-concat */
 			p_expr_C_Clist_Hof_Hpieces (flags, lex_state, act_state, err, ZInode);
@@ -3651,7 +3653,7 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 			goto ZL1;
 		}
 	
-#line 3655 "src/libre/dialect/pcre/parser.c"
+#line 3657 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-empty */
 		}
@@ -3694,18 +3696,18 @@ p_expr_C_Ctype(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL1;
 		}
 	
-#line 3698 "src/libre/dialect/pcre/parser.c"
+#line 3700 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-alt */
 		/* BEGINNING OF ACTION: ast-add-alt */
 		{
-#line 829 "src/libre/parser.act"
+#line 830 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZInode), (ZIclass))) {
 			goto ZL1;
 		}
 	
-#line 3709 "src/libre/dialect/pcre/parser.c"
+#line 3711 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-add-alt */
 		/* BEGINNING OF ACTION: mark-expr */
@@ -3725,7 +3727,7 @@ p_expr_C_Ctype(flags flags, lex_state lex_state, act_state act_state, err err, t
 		(ZInode)->u.class.end   = ast_end;
 */
 	
-#line 3729 "src/libre/dialect/pcre/parser.c"
+#line 3731 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: mark-expr */
 	}
@@ -3739,7 +3741,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 976 "src/libre/parser.act"
+#line 977 "src/libre/parser.act"
 
 
 	static int
@@ -3882,6 +3884,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 3886 "src/libre/dialect/pcre/parser.c"
+#line 3888 "src/libre/dialect/pcre/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/pcre/parser.c
+++ b/src/libre/dialect/pcre/parser.c
@@ -274,7 +274,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead(flags flags, lex_state lex_state, act_
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-invert */
 			{
-#line 774 "src/libre/parser.act"
+#line 771 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -350,7 +350,7 @@ p_expr_C_Cflags_C_Cflag__set(flags flags, lex_state lex_state, act_state act_sta
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: re-flag-union */
 			{
-#line 582 "src/libre/parser.act"
+#line 587 "src/libre/parser.act"
 
 		(ZIo) = (ZIi) | (ZIc);
 	
@@ -602,7 +602,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 		/* END OF INLINE: 136 */
 		/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 		{
-#line 626 "src/libre/parser.act"
+#line 631 "src/libre/parser.act"
 
 		(ZIr).type = AST_ENDPOINT_LITERAL;
 		(ZIr).u.literal.c = (ZIc);
@@ -631,7 +631,7 @@ p_269(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 		{
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 817 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_named((*ZI266));
 		if ((ZInode) == NULL) {
@@ -651,7 +651,7 @@ p_269(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-class */
 			{
-#line 631 "src/libre/parser.act"
+#line 636 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_NAMED;
 		(ZIlower).u.named.class = (*ZI266);
@@ -677,7 +677,7 @@ p_269(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 787 "src/libre/parser.act"
+#line 784 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -746,7 +746,7 @@ ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 				}
 				/* BEGINNING OF ACTION: ast-add-alt */
 				{
-#line 830 "src/libre/parser.act"
+#line 827 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIclass), (ZInode))) {
 			goto ZL4;
@@ -850,7 +850,7 @@ p_289(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		{
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 678 "src/libre/parser.act"
+#line 683 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_literal((*ZI286));
 		if ((ZInode) == NULL) {
@@ -870,7 +870,7 @@ p_289(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 626 "src/libre/parser.act"
+#line 631 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_LITERAL;
 		(ZIlower).u.literal.c = (*ZI286);
@@ -896,7 +896,7 @@ p_289(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 787 "src/libre/parser.act"
+#line 784 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -953,14 +953,14 @@ p_292(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CLOSECOUNT):
 		{
-			t_pos ZI233;
+			t_pos ZI234;
 			t_pos ZIend;
 
 			/* BEGINNING OF EXTRACT: CLOSECOUNT */
 			{
 #line 278 "src/libre/parser.act"
 
-		ZI233 = lex_state->lx.start;
+		ZI234 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
 #line 967 "src/libre/dialect/pcre/parser.c"
@@ -979,7 +979,7 @@ p_292(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 608 "src/libre/parser.act"
+#line 613 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -1044,7 +1044,7 @@ ZL2_expr_C_Clist_Hof_Hpieces:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 824 "src/libre/parser.act"
+#line 821 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
@@ -1087,7 +1087,7 @@ p_293(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CLOSECOUNT):
 		{
-			t_pos ZI238;
+			t_pos ZI239;
 			t_pos ZIend;
 			t_unsigned ZIn;
 
@@ -1095,7 +1095,7 @@ p_293(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			{
 #line 278 "src/libre/parser.act"
 
-		ZI238 = lex_state->lx.start;
+		ZI239 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
 #line 1102 "src/libre/dialect/pcre/parser.c"
@@ -1114,7 +1114,7 @@ p_293(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-unbounded */
 			{
-#line 586 "src/libre/parser.act"
+#line 591 "src/libre/parser.act"
 
 		(ZIn) = AST_COUNT_UNBOUNDED;
 	
@@ -1123,7 +1123,7 @@ p_293(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			/* END OF ACTION: count-unbounded */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 608 "src/libre/parser.act"
+#line 613 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -1151,7 +1151,7 @@ p_293(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 	case (TOK_COUNT):
 		{
 			t_unsigned ZIn;
-			t_pos ZI236;
+			t_pos ZI237;
 			t_pos ZIend;
 
 			/* BEGINNING OF EXTRACT: COUNT */
@@ -1186,7 +1186,7 @@ p_293(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 				{
 #line 278 "src/libre/parser.act"
 
-		ZI236 = lex_state->lx.start;
+		ZI237 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
 #line 1193 "src/libre/dialect/pcre/parser.c"
@@ -1209,7 +1209,7 @@ p_293(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 608 "src/libre/parser.act"
+#line 613 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -1455,7 +1455,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		/* END OF INLINE: 94 */
 		/* BEGINNING OF ACTION: ast-make-literal */
 		{
-#line 678 "src/libre/parser.act"
+#line 683 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_literal((ZIc));
 		if ((ZInode) == NULL) {
@@ -1710,7 +1710,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 678 "src/libre/parser.act"
+#line 683 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_literal((ZIc));
 		if ((ZInode) == NULL) {
@@ -1832,7 +1832,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hclass(flags fl
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-range-endpoint-class */
 		{
-#line 631 "src/libre/parser.act"
+#line 636 "src/libre/parser.act"
 
 		(ZIr).type = AST_ENDPOINT_NAMED;
 		(ZIr).u.named.class = (ZIid);
@@ -1881,7 +1881,7 @@ p_177(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 					{
 						/* BEGINNING OF ACTION: ast-make-literal */
 						{
-#line 678 "src/libre/parser.act"
+#line 683 "src/libre/parser.act"
 
 		(ZInode1) = ast_make_expr_literal((ZIc));
 		if ((ZInode1) == NULL) {
@@ -1904,7 +1904,7 @@ p_177(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 
 						/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 						{
-#line 626 "src/libre/parser.act"
+#line 631 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_LITERAL;
 		(ZIlower).u.literal.c = (ZIc);
@@ -1931,7 +1931,7 @@ p_177(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 						}
 						/* BEGINNING OF ACTION: ast-make-range */
 						{
-#line 787 "src/libre/parser.act"
+#line 784 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -1974,7 +1974,7 @@ p_177(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			/* END OF INLINE: 179 */
 			/* BEGINNING OF ACTION: ast-add-alt */
 			{
-#line 830 "src/libre/parser.act"
+#line 827 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((*ZItmp), (ZInode1))) {
 			goto ZL1;
@@ -2044,7 +2044,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-alt */
 					{
-#line 671 "src/libre/parser.act"
+#line 676 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt();
 		if ((ZInode) == NULL) {
@@ -2082,7 +2082,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-alt */
 					{
-#line 671 "src/libre/parser.act"
+#line 676 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt();
 		if ((ZInode) == NULL) {
@@ -2095,7 +2095,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 					ZItmp = ZInode;
 					/* BEGINNING OF ACTION: make-literal-cbrak */
 					{
-#line 685 "src/libre/parser.act"
+#line 690 "src/libre/parser.act"
 
 		(ZIcbrak) = ']';
 	
@@ -2109,7 +2109,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 					}
 					/* BEGINNING OF ACTION: ast-add-alt */
 					{
-#line 830 "src/libre/parser.act"
+#line 827 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZItmp), (ZInode1))) {
 			goto ZL1;
@@ -2142,7 +2142,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-alt */
 					{
-#line 671 "src/libre/parser.act"
+#line 676 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt();
 		if ((ZInode) == NULL) {
@@ -2155,7 +2155,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 					ZItmp = ZInode;
 					/* BEGINNING OF ACTION: ast-make-invert */
 					{
-#line 774 "src/libre/parser.act"
+#line 771 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -2222,7 +2222,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-alt */
 					{
-#line 671 "src/libre/parser.act"
+#line 676 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt();
 		if ((ZInode) == NULL) {
@@ -2235,7 +2235,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 					ZItmp = ZInode;
 					/* BEGINNING OF ACTION: ast-make-invert */
 					{
-#line 774 "src/libre/parser.act"
+#line 771 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -2278,7 +2278,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 					/* END OF ACTION: ast-make-invert */
 					/* BEGINNING OF ACTION: make-literal-cbrak */
 					{
-#line 685 "src/libre/parser.act"
+#line 690 "src/libre/parser.act"
 
 		(ZIcbrak) = ']';
 	
@@ -2292,7 +2292,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 					}
 					/* BEGINNING OF ACTION: ast-add-alt */
 					{
-#line 830 "src/libre/parser.act"
+#line 827 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZItmp), (ZInode1))) {
 			goto ZL1;
@@ -2429,7 +2429,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_Hend(flags flags, lex_state lex_st
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 					{
-#line 626 "src/libre/parser.act"
+#line 631 "src/libre/parser.act"
 
 		(ZIr).type = AST_ENDPOINT_LITERAL;
 		(ZIr).u.literal.c = (ZIc);
@@ -2478,7 +2478,7 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 		t_ast__expr ZIe;
 
 		p_expr_C_Cpiece_C_Catom (flags, lex_state, act_state, err, &ZIe);
-		/* BEGINNING OF INLINE: 242 */
+		/* BEGINNING OF INLINE: 243 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_OPT): case (TOK_PLUS): case (TOK_STAR): case (TOK_OPENCOUNT):
@@ -2496,7 +2496,7 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 
 					/* BEGINNING OF ACTION: count-one */
 					{
-#line 602 "src/libre/parser.act"
+#line 607 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
@@ -2505,7 +2505,7 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 					/* END OF ACTION: count-one */
 					/* BEGINNING OF ACTION: ast-make-piece */
 					{
-#line 697 "src/libre/parser.act"
+#line 694 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZInode) = ast_make_expr_empty();
@@ -2529,7 +2529,7 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 242 */
+		/* END OF INLINE: 243 */
 	}
 	goto ZL0;
 ZL1:;
@@ -2550,7 +2550,7 @@ p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__ex
 	{
 		/* BEGINNING OF ACTION: ast-make-alt */
 		{
-#line 671 "src/libre/parser.act"
+#line 676 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt();
 		if ((ZInode) == NULL) {
@@ -2583,7 +2583,7 @@ ZL1:;
 		/* END OF ACTION: err-expected-alts */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 657 "src/libre/parser.act"
+#line 662 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty();
 		if ((ZInode) == NULL) {
@@ -2612,7 +2612,7 @@ p_194(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 		{
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 678 "src/libre/parser.act"
+#line 683 "src/libre/parser.act"
 
 		(ZInode1) = ast_make_expr_literal((*ZIcbrak));
 		if ((ZInode1) == NULL) {
@@ -2636,7 +2636,7 @@ p_194(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 626 "src/libre/parser.act"
+#line 631 "src/libre/parser.act"
 
 		(ZIr).type = AST_ENDPOINT_LITERAL;
 		(ZIr).u.literal.c = (*ZIcbrak);
@@ -2663,7 +2663,7 @@ p_194(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 			}
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 626 "src/libre/parser.act"
+#line 631 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_LITERAL;
 		(ZIlower).u.literal.c = (*ZIcbrak);
@@ -2673,7 +2673,7 @@ p_194(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 787 "src/libre/parser.act"
+#line 784 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -2745,7 +2745,7 @@ ZL2_198:;
 							}
 							/* BEGINNING OF ACTION: ast-add-alt */
 							{
-#line 830 "src/libre/parser.act"
+#line 827 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((*ZItmp), (ZInode))) {
 			goto ZL5;
@@ -2817,7 +2817,7 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: re-flag-none */
 		{
-#line 578 "src/libre/parser.act"
+#line 583 "src/libre/parser.act"
 
 		(ZIempty__pos) = RE_FLAGS_NONE;
 	
@@ -2826,7 +2826,7 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 		/* END OF ACTION: re-flag-none */
 		/* BEGINNING OF ACTION: re-flag-none */
 		{
-#line 578 "src/libre/parser.act"
+#line 583 "src/libre/parser.act"
 
 		(ZIempty__neg) = RE_FLAGS_NONE;
 	
@@ -2886,7 +2886,7 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 				ADVANCE_LEXER;
 				/* BEGINNING OF ACTION: ast-make-re-flags */
 				{
-#line 718 "src/libre/parser.act"
+#line 715 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_re_flags((ZIpos), (ZIneg));
 		if ((ZInode) == NULL) {
@@ -2914,7 +2914,7 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 				/* END OF ACTION: err-expected-closeflags */
 				/* BEGINNING OF ACTION: ast-make-empty */
 				{
-#line 657 "src/libre/parser.act"
+#line 662 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty();
 		if ((ZInode) == NULL) {
@@ -2955,7 +2955,7 @@ p_expr_C_Cpiece_C_Clist_Hof_Hcounts(flags flags, lex_state lex_state, act_state 
 		}
 		/* BEGINNING OF ACTION: ast-make-piece */
 		{
-#line 697 "src/libre/parser.act"
+#line 694 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZInode) = ast_make_expr_empty();
@@ -2972,7 +2972,7 @@ p_expr_C_Cpiece_C_Clist_Hof_Hcounts(flags flags, lex_state lex_state, act_state 
 #line 2973 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-piece */
-		/* BEGINNING OF INLINE: 241 */
+		/* BEGINNING OF INLINE: 242 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_OPT): case (TOK_PLUS): case (TOK_STAR): case (TOK_OPENCOUNT):
@@ -2988,7 +2988,7 @@ p_expr_C_Cpiece_C_Clist_Hof_Hcounts(flags flags, lex_state lex_state, act_state 
 				break;
 			}
 		}
-		/* END OF INLINE: 241 */
+		/* END OF INLINE: 242 */
 	}
 	goto ZL0;
 ZL1:;
@@ -3085,7 +3085,7 @@ p_class_Hnamed(flags flags, lex_state lex_state, act_state act_state, err err, t
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-make-named */
 		{
-#line 817 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_named((ZIid));
 		if ((ZInode) == NULL) {
@@ -3123,7 +3123,7 @@ ZL2_expr_C_Clist_Hof_Halts:;
 		}
 		/* BEGINNING OF ACTION: ast-add-alt */
 		{
-#line 830 "src/libre/parser.act"
+#line 827 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIalts), (ZIa))) {
 			goto ZL1;
@@ -3239,7 +3239,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-zero-or-one */
 			{
-#line 598 "src/libre/parser.act"
+#line 603 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, 1, NULL);
 	
@@ -3253,7 +3253,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-one-or-more */
 			{
-#line 594 "src/libre/parser.act"
+#line 599 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
@@ -3267,7 +3267,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-zero-or-more */
 			{
-#line 590 "src/libre/parser.act"
+#line 595 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
@@ -3298,7 +3298,7 @@ ZL1:;
 		/* END OF ACTION: err-expected-count */
 		/* BEGINNING OF ACTION: count-one */
 		{
-#line 602 "src/libre/parser.act"
+#line 607 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
@@ -3381,27 +3381,38 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 	switch (CURRENT_TERMINAL) {
 	case (TOK_ANY):
 		{
+			t_ast__class__id ZIa;
+
 			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: ast-make-any */
+			/* BEGINNING OF ACTION: class-any */
 			{
-#line 690 "src/libre/parser.act"
+#line 574 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
-		(ZIe) = ast_make_expr_named(&class_any);
+		(ZIa) = &class_any;
+	
+#line 3395 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: class-any */
+			/* BEGINNING OF ACTION: ast-make-named */
+			{
+#line 814 "src/libre/parser.act"
+
+		(ZIe) = ast_make_expr_named((ZIa));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3396 "src/libre/dialect/pcre/parser.c"
+#line 3407 "src/libre/dialect/pcre/parser.c"
 			}
-			/* END OF ACTION: ast-make-any */
+			/* END OF ACTION: ast-make-named */
 		}
 		break;
 	case (TOK_CONTROL):
 		{
-			t_char ZI225;
-			t_pos ZI226;
+			t_char ZI226;
 			t_pos ZI227;
+			t_pos ZI228;
 
 			/* BEGINNING OF EXTRACT: CONTROL */
 			{
@@ -3412,16 +3423,16 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 		assert(lex_state->buf.a[2] != '\0');
 		assert(lex_state->buf.a[3] == '\0');
 
-		ZI225 = lex_state->buf.a[2];
-		if ((unsigned char) ZI225 > 127) {
+		ZI226 = lex_state->buf.a[2];
+		if ((unsigned char) ZI226 > 127) {
 			goto ZL1;
 		}
-		ZI225 = (((toupper((unsigned char)ZI225)) - 64) % 128 + 128) % 128;
+		ZI226 = (((toupper((unsigned char)ZI226)) - 64) % 128 + 128) % 128;
 
-		ZI226 = lex_state->lx.start;
-		ZI227   = lex_state->lx.end;
+		ZI227 = lex_state->lx.start;
+		ZI228   = lex_state->lx.end;
 	
-#line 3425 "src/libre/dialect/pcre/parser.c"
+#line 3436 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: CONTROL */
 			ADVANCE_LEXER;
@@ -3434,19 +3445,19 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 		}
 		goto ZL1;
 	
-#line 3438 "src/libre/dialect/pcre/parser.c"
+#line 3449 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: err-unsupported */
 			/* BEGINNING OF ACTION: ast-make-empty */
 			{
-#line 657 "src/libre/parser.act"
+#line 662 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_empty();
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3450 "src/libre/dialect/pcre/parser.c"
+#line 3461 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-empty */
 		}
@@ -3456,14 +3467,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-anchor-end */
 			{
-#line 732 "src/libre/parser.act"
+#line 729 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_anchor(AST_ANCHOR_END);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3467 "src/libre/dialect/pcre/parser.c"
+#line 3478 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-end */
 		}
@@ -3480,14 +3491,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			}
 			/* BEGINNING OF ACTION: ast-make-group */
 			{
-#line 711 "src/libre/parser.act"
+#line 708 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_group((ZIg));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3491 "src/libre/dialect/pcre/parser.c"
+#line 3502 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-group */
 			switch (CURRENT_TERMINAL) {
@@ -3520,14 +3531,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-anchor-start */
 			{
-#line 725 "src/libre/parser.act"
+#line 722 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_anchor(AST_ANCHOR_START);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3531 "src/libre/dialect/pcre/parser.c"
+#line 3542 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-start */
 		}
@@ -3586,22 +3597,21 @@ ZL1:;
 		}
 		goto ZL2;
 	
-#line 3590 "src/libre/dialect/pcre/parser.c"
+#line 3601 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
-		/* BEGINNING OF ACTION: ast-make-any */
+		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 690 "src/libre/parser.act"
+#line 662 "src/libre/parser.act"
 
-		/* TODO: or the unicode equivalent */
-		(ZIe) = ast_make_expr_named(&class_any);
+		(ZIe) = ast_make_expr_empty();
 		if ((ZIe) == NULL) {
 			goto ZL2;
 		}
 	
-#line 3603 "src/libre/dialect/pcre/parser.c"
+#line 3613 "src/libre/dialect/pcre/parser.c"
 		}
-		/* END OF ACTION: ast-make-any */
+		/* END OF ACTION: ast-make-empty */
 	}
 	goto ZL0;
 ZL2:;
@@ -3625,14 +3635,14 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 		{
 			/* BEGINNING OF ACTION: ast-make-concat */
 			{
-#line 664 "src/libre/parser.act"
+#line 669 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_concat();
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3636 "src/libre/dialect/pcre/parser.c"
+#line 3646 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-concat */
 			p_expr_C_Clist_Hof_Hpieces (flags, lex_state, act_state, err, ZInode);
@@ -3646,14 +3656,14 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 		{
 			/* BEGINNING OF ACTION: ast-make-empty */
 			{
-#line 657 "src/libre/parser.act"
+#line 662 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty();
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3657 "src/libre/dialect/pcre/parser.c"
+#line 3667 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-empty */
 		}
@@ -3689,25 +3699,25 @@ p_expr_C_Ctype(flags flags, lex_state lex_state, act_state act_state, err err, t
 		}
 		/* BEGINNING OF ACTION: ast-make-alt */
 		{
-#line 671 "src/libre/parser.act"
+#line 676 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt();
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3700 "src/libre/dialect/pcre/parser.c"
+#line 3710 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-alt */
 		/* BEGINNING OF ACTION: ast-add-alt */
 		{
-#line 830 "src/libre/parser.act"
+#line 827 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZInode), (ZIclass))) {
 			goto ZL1;
 		}
 	
-#line 3711 "src/libre/dialect/pcre/parser.c"
+#line 3721 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-add-alt */
 		/* BEGINNING OF ACTION: mark-expr */
@@ -3727,7 +3737,7 @@ p_expr_C_Ctype(flags flags, lex_state lex_state, act_state act_state, err err, t
 		(ZInode)->u.class.end   = ast_end;
 */
 	
-#line 3731 "src/libre/dialect/pcre/parser.c"
+#line 3741 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: mark-expr */
 	}
@@ -3741,7 +3751,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 977 "src/libre/parser.act"
+#line 974 "src/libre/parser.act"
 
 
 	static int
@@ -3884,6 +3894,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 3888 "src/libre/dialect/pcre/parser.c"
+#line 3898 "src/libre/dialect/pcre/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/pcre/parser.h
+++ b/src/libre/dialect/pcre/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__pcre(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 979 "src/libre/parser.act"
+#line 976 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/pcre/parser.h"

--- a/src/libre/dialect/pcre/parser.h
+++ b/src/libre/dialect/pcre/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__pcre(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 978 "src/libre/parser.act"
+#line 979 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/pcre/parser.h"

--- a/src/libre/dialect/pcre/parser.sid
+++ b/src/libre/dialect/pcre/parser.sid
@@ -92,7 +92,6 @@
 	<ast-make-literal>:      (:char)                  -> (:ast_expr);
 	<ast-make-concat>:       ()                       -> (:ast_expr);
 	<ast-make-alt>:          ()                       -> (:ast_expr);
-	<ast-make-any>:          ()                       -> (:ast_expr);
 	<ast-make-piece>:        (:ast_expr, :ast_count)  -> (:ast_expr);
 	<ast-make-group>:        (:ast_expr)              -> (:ast_expr);
 	<ast-make-re-flags>:     (:re_flags, :re_flags)   -> (:ast_expr);
@@ -122,6 +121,8 @@
 	<mark-range>: (:pos, :pos) -> ();
 	<mark-count>: (:pos, :pos) -> ();
 	<mark-expr>: (:ast_expr, :pos, :pos) -> ();
+
+	<class-any>: () -> (:ast_class_id);
 
 	expr: () -> (node :ast_expr) [
 		literal: () -> (node :ast_expr) = {
@@ -445,7 +446,8 @@
 				e = <ast-make-anchor-end>;
 			||
 				ANY;
-				e = <ast-make-any>;
+				a = <class-any>;
+				e = <ast-make-named>(a);
 			||
 				e = literal;
 			||
@@ -469,7 +471,7 @@
 				CLOSE;
 			##
 				<err-expected-atom>;
-				e = <ast-make-any>;
+				e = <ast-make-empty>;
 			};
 
 			count: () -> (c :ast_count) = {

--- a/src/libre/dialect/sql/parser.c
+++ b/src/libre/dialect/sql/parser.c
@@ -299,7 +299,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead(flags flags, lex_state lex_state, act_
 			/* END OF ACTION: ast-make-literal */
 			/* BEGINNING OF ACTION: ast-add-alt */
 			{
-#line 829 "src/libre/parser.act"
+#line 830 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((*ZIclass), (ZInode))) {
 			goto ZL1;
@@ -400,7 +400,7 @@ ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 				}
 				/* BEGINNING OF ACTION: ast-add-alt */
 				{
-#line 829 "src/libre/parser.act"
+#line 830 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIclass), (ZInode))) {
 			goto ZL4;
@@ -476,7 +476,7 @@ ZL2_expr_C_Clist_Hof_Hpieces:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 823 "src/libre/parser.act"
+#line 824 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
@@ -803,7 +803,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 					/* END OF ACTION: mark-expr */
 					/* BEGINNING OF ACTION: ast-make-subtract */
 					{
-#line 738 "src/libre/parser.act"
+#line 739 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_subtract((ZIclass), (ZImask));
 		if ((ZInode) == NULL) {
@@ -898,7 +898,7 @@ p_189(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			/* END OF ACTION: ast-make-literal */
 			/* BEGINNING OF ACTION: ast-add-alt */
 			{
-#line 829 "src/libre/parser.act"
+#line 830 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((*ZIclass), (ZInode))) {
 			goto ZL1;
@@ -909,7 +909,7 @@ p_189(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			/* END OF ACTION: ast-add-alt */
 			/* BEGINNING OF ACTION: ast-make-invert */
 			{
-#line 773 "src/libre/parser.act"
+#line 774 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -956,7 +956,7 @@ p_189(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 		{
 			/* BEGINNING OF ACTION: ast-make-invert */
 			{
-#line 773 "src/libre/parser.act"
+#line 774 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -1028,7 +1028,7 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 		}
 		/* BEGINNING OF ACTION: ast-make-piece */
 		{
-#line 696 "src/libre/parser.act"
+#line 697 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZInode) = ast_make_expr_empty();
@@ -1153,7 +1153,7 @@ p_193(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 786 "src/libre/parser.act"
+#line 787 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -1447,7 +1447,7 @@ ZL2_expr_C_Clist_Hof_Halts:;
 		}
 		/* BEGINNING OF ACTION: ast-add-alt */
 		{
-#line 829 "src/libre/parser.act"
+#line 830 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIalts), (ZIa))) {
 			goto ZL1;
@@ -1660,14 +1660,15 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-any */
 			{
-#line 689 "src/libre/parser.act"
+#line 690 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_any();
+		/* TODO: or the unicode equivalent */
+		(ZIe) = ast_make_expr_named(&class_any);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1671 "src/libre/dialect/sql/parser.c"
+#line 1672 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-any */
 		}
@@ -1690,7 +1691,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 
 		ZIa = lex_state->buf.a[0];
 	
-#line 1694 "src/libre/dialect/sql/parser.c"
+#line 1695 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
@@ -1703,7 +1704,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 1707 "src/libre/dialect/sql/parser.c"
+#line 1708 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -1716,14 +1717,15 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-any */
 			{
-#line 689 "src/libre/parser.act"
+#line 690 "src/libre/parser.act"
 
-		(ZIg) = ast_make_expr_any();
+		/* TODO: or the unicode equivalent */
+		(ZIg) = ast_make_expr_named(&class_any);
 		if ((ZIg) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1727 "src/libre/dialect/sql/parser.c"
+#line 1729 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-any */
 			/* BEGINNING OF ACTION: count-zero-or-more */
@@ -1732,12 +1734,12 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 1736 "src/libre/dialect/sql/parser.c"
+#line 1738 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 			/* BEGINNING OF ACTION: ast-make-piece */
 			{
-#line 696 "src/libre/parser.act"
+#line 697 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZIe) = ast_make_expr_empty();
@@ -1751,7 +1753,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 1755 "src/libre/dialect/sql/parser.c"
+#line 1757 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-piece */
 		}
@@ -1768,14 +1770,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			}
 			/* BEGINNING OF ACTION: ast-make-group */
 			{
-#line 710 "src/libre/parser.act"
+#line 711 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_group((ZIg));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1779 "src/libre/dialect/sql/parser.c"
+#line 1781 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-group */
 			switch (CURRENT_TERMINAL) {
@@ -1813,19 +1815,20 @@ ZL1:;
 		}
 		goto ZL2;
 	
-#line 1817 "src/libre/dialect/sql/parser.c"
+#line 1819 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-any */
 		{
-#line 689 "src/libre/parser.act"
+#line 690 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_any();
+		/* TODO: or the unicode equivalent */
+		(ZIe) = ast_make_expr_named(&class_any);
 		if ((ZIe) == NULL) {
 			goto ZL2;
 		}
 	
-#line 1829 "src/libre/dialect/sql/parser.c"
+#line 1832 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-any */
 	}
@@ -1865,7 +1868,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed(flags flags, lex_state lex_state, act
 		ZI111 = lex_state->lx.start;
 		ZI112   = lex_state->lx.end;
 	
-#line 1869 "src/libre/dialect/sql/parser.c"
+#line 1872 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			break;
@@ -1875,14 +1878,14 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed(flags flags, lex_state lex_state, act
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-make-named */
 		{
-#line 816 "src/libre/parser.act"
+#line 817 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_named((ZIid));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1886 "src/libre/dialect/sql/parser.c"
+#line 1889 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-named */
 	}
@@ -1912,7 +1915,7 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 			goto ZL1;
 		}
 	
-#line 1916 "src/libre/dialect/sql/parser.c"
+#line 1919 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-concat */
 			p_expr_C_Clist_Hof_Hpieces (flags, lex_state, act_state, err, ZInode);
@@ -1933,7 +1936,7 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 			goto ZL1;
 		}
 	
-#line 1937 "src/libre/dialect/sql/parser.c"
+#line 1940 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-empty */
 		}
@@ -1951,7 +1954,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 976 "src/libre/parser.act"
+#line 977 "src/libre/parser.act"
 
 
 	static int
@@ -2094,6 +2097,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 2098 "src/libre/dialect/sql/parser.c"
+#line 2101 "src/libre/dialect/sql/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/sql/parser.c
+++ b/src/libre/dialect/sql/parser.c
@@ -287,7 +287,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead(flags flags, lex_state lex_state, act_
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 678 "src/libre/parser.act"
+#line 683 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_literal((ZIc));
 		if ((ZInode) == NULL) {
@@ -299,7 +299,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead(flags flags, lex_state lex_state, act_
 			/* END OF ACTION: ast-make-literal */
 			/* BEGINNING OF ACTION: ast-add-alt */
 			{
-#line 830 "src/libre/parser.act"
+#line 827 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((*ZIclass), (ZInode))) {
 			goto ZL1;
@@ -400,7 +400,7 @@ ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 				}
 				/* BEGINNING OF ACTION: ast-add-alt */
 				{
-#line 830 "src/libre/parser.act"
+#line 827 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIclass), (ZInode))) {
 			goto ZL4;
@@ -476,7 +476,7 @@ ZL2_expr_C_Clist_Hof_Hpieces:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 824 "src/libre/parser.act"
+#line 821 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
@@ -598,7 +598,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-make-alt */
 		{
-#line 671 "src/libre/parser.act"
+#line 676 "src/libre/parser.act"
 
 		(ZIclass) = ast_make_expr_alt();
 		if ((ZIclass) == NULL) {
@@ -685,7 +685,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-alt */
 					{
-#line 671 "src/libre/parser.act"
+#line 676 "src/libre/parser.act"
 
 		(ZImask) = ast_make_expr_alt();
 		if ((ZImask) == NULL) {
@@ -803,7 +803,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 					/* END OF ACTION: mark-expr */
 					/* BEGINNING OF ACTION: ast-make-subtract */
 					{
-#line 739 "src/libre/parser.act"
+#line 736 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_subtract((ZIclass), (ZImask));
 		if ((ZInode) == NULL) {
@@ -838,7 +838,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 				/* END OF ACTION: err-expected-closegroup */
 				/* BEGINNING OF ACTION: ast-make-empty */
 				{
-#line 657 "src/libre/parser.act"
+#line 662 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty();
 		if ((ZInode) == NULL) {
@@ -886,7 +886,7 @@ p_189(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 678 "src/libre/parser.act"
+#line 683 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_literal((ZIc));
 		if ((ZInode) == NULL) {
@@ -898,7 +898,7 @@ p_189(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			/* END OF ACTION: ast-make-literal */
 			/* BEGINNING OF ACTION: ast-add-alt */
 			{
-#line 830 "src/libre/parser.act"
+#line 827 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((*ZIclass), (ZInode))) {
 			goto ZL1;
@@ -909,7 +909,7 @@ p_189(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			/* END OF ACTION: ast-add-alt */
 			/* BEGINNING OF ACTION: ast-make-invert */
 			{
-#line 774 "src/libre/parser.act"
+#line 771 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -956,7 +956,7 @@ p_189(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 		{
 			/* BEGINNING OF ACTION: ast-make-invert */
 			{
-#line 774 "src/libre/parser.act"
+#line 771 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -1028,7 +1028,7 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 		}
 		/* BEGINNING OF ACTION: ast-make-piece */
 		{
-#line 697 "src/libre/parser.act"
+#line 694 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZInode) = ast_make_expr_empty();
@@ -1064,7 +1064,7 @@ p_193(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		{
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 678 "src/libre/parser.act"
+#line 683 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_literal((*ZI190));
 		if ((ZInode) == NULL) {
@@ -1089,7 +1089,7 @@ p_193(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 626 "src/libre/parser.act"
+#line 631 "src/libre/parser.act"
 
 		(ZIa).type = AST_ENDPOINT_LITERAL;
 		(ZIa).u.literal.c = (*ZI190);
@@ -1133,7 +1133,7 @@ p_193(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 626 "src/libre/parser.act"
+#line 631 "src/libre/parser.act"
 
 		(ZIz).type = AST_ENDPOINT_LITERAL;
 		(ZIz).u.literal.c = (ZIcz);
@@ -1153,7 +1153,7 @@ p_193(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 787 "src/libre/parser.act"
+#line 784 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -1213,7 +1213,7 @@ p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__ex
 	{
 		/* BEGINNING OF ACTION: ast-make-alt */
 		{
-#line 671 "src/libre/parser.act"
+#line 676 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt();
 		if ((ZInode) == NULL) {
@@ -1246,7 +1246,7 @@ ZL1:;
 		/* END OF ACTION: err-expected-alts */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 657 "src/libre/parser.act"
+#line 662 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty();
 		if ((ZInode) == NULL) {
@@ -1299,7 +1299,7 @@ p_196(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI1
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 608 "src/libre/parser.act"
+#line 613 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -1392,7 +1392,7 @@ p_196(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI1
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 608 "src/libre/parser.act"
+#line 613 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -1447,7 +1447,7 @@ ZL2_expr_C_Clist_Hof_Halts:;
 		}
 		/* BEGINNING OF ACTION: ast-add-alt */
 		{
-#line 830 "src/libre/parser.act"
+#line 827 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIalts), (ZIa))) {
 			goto ZL1;
@@ -1563,7 +1563,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-zero-or-one */
 			{
-#line 598 "src/libre/parser.act"
+#line 603 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, 1, NULL);
 	
@@ -1577,7 +1577,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-one-or-more */
 			{
-#line 594 "src/libre/parser.act"
+#line 599 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
@@ -1591,7 +1591,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-zero-or-more */
 			{
-#line 590 "src/libre/parser.act"
+#line 595 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
@@ -1604,7 +1604,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 		{
 			/* BEGINNING OF ACTION: count-one */
 			{
-#line 602 "src/libre/parser.act"
+#line 607 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
@@ -1633,7 +1633,7 @@ ZL1:;
 		/* END OF ACTION: err-expected-count */
 		/* BEGINNING OF ACTION: count-one */
 		{
-#line 602 "src/libre/parser.act"
+#line 607 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
@@ -1657,20 +1657,31 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 	switch (CURRENT_TERMINAL) {
 	case (TOK_ANY):
 		{
+			t_ast__class__id ZIa;
+
 			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: ast-make-any */
+			/* BEGINNING OF ACTION: class-any */
 			{
-#line 690 "src/libre/parser.act"
+#line 574 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
-		(ZIe) = ast_make_expr_named(&class_any);
+		(ZIa) = &class_any;
+	
+#line 1671 "src/libre/dialect/sql/parser.c"
+			}
+			/* END OF ACTION: class-any */
+			/* BEGINNING OF ACTION: ast-make-named */
+			{
+#line 814 "src/libre/parser.act"
+
+		(ZIe) = ast_make_expr_named((ZIa));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1672 "src/libre/dialect/sql/parser.c"
+#line 1683 "src/libre/dialect/sql/parser.c"
 			}
-			/* END OF ACTION: ast-make-any */
+			/* END OF ACTION: ast-make-named */
 		}
 		break;
 	case (TOK_CHAR):
@@ -1691,55 +1702,65 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 
 		ZIa = lex_state->buf.a[0];
 	
-#line 1695 "src/libre/dialect/sql/parser.c"
+#line 1706 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 678 "src/libre/parser.act"
+#line 683 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_literal((ZIa));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1708 "src/libre/dialect/sql/parser.c"
+#line 1719 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
 		break;
 	case (TOK_MANY):
 		{
+			t_ast__class__id ZIa;
 			t_ast__expr ZIg;
 			t_ast__count ZIc;
 
 			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: ast-make-any */
+			/* BEGINNING OF ACTION: class-any */
 			{
-#line 690 "src/libre/parser.act"
+#line 574 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
-		(ZIg) = ast_make_expr_named(&class_any);
+		(ZIa) = &class_any;
+	
+#line 1738 "src/libre/dialect/sql/parser.c"
+			}
+			/* END OF ACTION: class-any */
+			/* BEGINNING OF ACTION: ast-make-named */
+			{
+#line 814 "src/libre/parser.act"
+
+		(ZIg) = ast_make_expr_named((ZIa));
 		if ((ZIg) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1729 "src/libre/dialect/sql/parser.c"
+#line 1750 "src/libre/dialect/sql/parser.c"
 			}
-			/* END OF ACTION: ast-make-any */
+			/* END OF ACTION: ast-make-named */
 			/* BEGINNING OF ACTION: count-zero-or-more */
 			{
-#line 590 "src/libre/parser.act"
+#line 595 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 1738 "src/libre/dialect/sql/parser.c"
+#line 1759 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 			/* BEGINNING OF ACTION: ast-make-piece */
 			{
-#line 697 "src/libre/parser.act"
+#line 694 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZIe) = ast_make_expr_empty();
@@ -1753,7 +1774,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 1757 "src/libre/dialect/sql/parser.c"
+#line 1778 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-piece */
 		}
@@ -1770,14 +1791,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			}
 			/* BEGINNING OF ACTION: ast-make-group */
 			{
-#line 711 "src/libre/parser.act"
+#line 708 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_group((ZIg));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1781 "src/libre/dialect/sql/parser.c"
+#line 1802 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-group */
 			switch (CURRENT_TERMINAL) {
@@ -1815,22 +1836,21 @@ ZL1:;
 		}
 		goto ZL2;
 	
-#line 1819 "src/libre/dialect/sql/parser.c"
+#line 1840 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
-		/* BEGINNING OF ACTION: ast-make-any */
+		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 690 "src/libre/parser.act"
+#line 662 "src/libre/parser.act"
 
-		/* TODO: or the unicode equivalent */
-		(ZIe) = ast_make_expr_named(&class_any);
+		(ZIe) = ast_make_expr_empty();
 		if ((ZIe) == NULL) {
 			goto ZL2;
 		}
 	
-#line 1832 "src/libre/dialect/sql/parser.c"
+#line 1852 "src/libre/dialect/sql/parser.c"
 		}
-		/* END OF ACTION: ast-make-any */
+		/* END OF ACTION: ast-make-empty */
 	}
 	goto ZL0;
 ZL2:;
@@ -1868,7 +1888,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed(flags flags, lex_state lex_state, act
 		ZI111 = lex_state->lx.start;
 		ZI112   = lex_state->lx.end;
 	
-#line 1872 "src/libre/dialect/sql/parser.c"
+#line 1892 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			break;
@@ -1878,14 +1898,14 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed(flags flags, lex_state lex_state, act
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-make-named */
 		{
-#line 817 "src/libre/parser.act"
+#line 814 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_named((ZIid));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1889 "src/libre/dialect/sql/parser.c"
+#line 1909 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-named */
 	}
@@ -1908,14 +1928,14 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 		{
 			/* BEGINNING OF ACTION: ast-make-concat */
 			{
-#line 664 "src/libre/parser.act"
+#line 669 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_concat();
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1919 "src/libre/dialect/sql/parser.c"
+#line 1939 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-concat */
 			p_expr_C_Clist_Hof_Hpieces (flags, lex_state, act_state, err, ZInode);
@@ -1929,14 +1949,14 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 		{
 			/* BEGINNING OF ACTION: ast-make-empty */
 			{
-#line 657 "src/libre/parser.act"
+#line 662 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty();
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1940 "src/libre/dialect/sql/parser.c"
+#line 1960 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-empty */
 		}
@@ -1954,7 +1974,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 977 "src/libre/parser.act"
+#line 974 "src/libre/parser.act"
 
 
 	static int
@@ -2097,6 +2117,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 2101 "src/libre/dialect/sql/parser.c"
+#line 2121 "src/libre/dialect/sql/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/sql/parser.h
+++ b/src/libre/dialect/sql/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__sql(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 978 "src/libre/parser.act"
+#line 979 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/sql/parser.h"

--- a/src/libre/dialect/sql/parser.h
+++ b/src/libre/dialect/sql/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__sql(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 979 "src/libre/parser.act"
+#line 976 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/sql/parser.h"

--- a/src/libre/dialect/sql/parser.sid
+++ b/src/libre/dialect/sql/parser.sid
@@ -92,7 +92,6 @@
 	<ast-make-literal>:       (:char)                  -> (:ast_expr);
 	<ast-make-concat>:        ()                       -> (:ast_expr);
 	<ast-make-alt>:           ()                       -> (:ast_expr);
-	<ast-make-any>:           ()                       -> (:ast_expr);
 	<ast-make-piece>:         (:ast_expr, :ast_count)  -> (:ast_expr);
 	<ast-make-group>:         (:ast_expr)              -> (:ast_expr);
 	!<ast-make-re-flags>:     (:re_flags, :re_flags)   -> (:ast_expr);
@@ -122,6 +121,8 @@
 	<mark-range>: (:pos, :pos) -> ();
 	<mark-count>: (:pos, :pos) -> ();
 	<mark-expr>: (:ast_expr, :pos, :pos) -> ();
+
+	<class-any>: () -> (:ast_class_id);
 
 	expr: () -> (node :ast_expr) [
 
@@ -291,10 +292,12 @@
 
 			atom: () -> (e :ast_expr) = {
 				ANY;
-				e = <ast-make-any>;
+				a = <class-any>;
+				e = <ast-make-named>(a);
 			||
 				MANY;
-				g = <ast-make-any>;
+				a = <class-any>;
+				g = <ast-make-named>(a);
 				c = <count-zero-or-more>;
 				e = <ast-make-piece>(g, c);
 			||
@@ -309,7 +312,7 @@
 				CLOSESUB;
 			##
 				<err-expected-atom>;
-				e = <ast-make-any>;
+				e = <ast-make-empty>;
 			};
 
 			count: () -> (c :ast_count) = {

--- a/src/libre/parser.act
+++ b/src/libre/parser.act
@@ -686,7 +686,8 @@
 	@};
 
 	<ast-make-any>: () -> (node :ast_expr) = @{
-		@node = ast_make_expr_any();
+		/* TODO: or the unicode equivalent */
+		@node = ast_make_expr_named(&class_any);
 		if (@node == NULL) {
 			@!;
 		}

--- a/src/libre/parser.act
+++ b/src/libre/parser.act
@@ -569,6 +569,11 @@
 */
 	@};
 
+	<class-any>: () -> (c :ast_class_id) = @{
+		/* TODO: or the unicode equivalent */
+		@c = &class_any;
+	@};
+
 
 	/*
 	 * AST construction
@@ -683,14 +688,6 @@
 
 	<make-literal-cbrak>: () -> (c :char) = @{
 		@c = ']';
-	@};
-
-	<ast-make-any>: () -> (node :ast_expr) = @{
-		/* TODO: or the unicode equivalent */
-		@node = ast_make_expr_named(&class_any);
-		if (@node == NULL) {
-			@!;
-		}
 	@};
 
 	<ast-make-piece>: (e :ast_expr, c :ast_count) -> (node :ast_expr) = @{

--- a/src/libre/print/dot.c
+++ b/src/libre/print/dot.c
@@ -107,10 +107,6 @@ pp_iter(FILE *f, const struct fsm_options *opt,
 			(unsigned long) n->u.codepoint.u);
 		break; 
 
-	case AST_EXPR_ANY:
-		fprintf(f, "\tn%p [ label = <ANY> ];\n", (void *) n);
-		break;
-
 	case AST_EXPR_REPEAT:
 		fprintf(f, "\tn%p [ label = <REPEAT|&#x7b;", (void *) n);
 		fprintf_count(f, n->u.repeat.min);

--- a/src/libre/print/pcre.c
+++ b/src/libre/print/pcre.c
@@ -26,11 +26,14 @@ atomic(struct ast_expr *n)
 	switch (n->type) {
 	case AST_EXPR_EMPTY:
 	case AST_EXPR_LITERAL:
-	case AST_EXPR_ANY:
 	case AST_EXPR_REPEAT:
 	case AST_EXPR_GROUP:
 	case AST_EXPR_TOMBSTONE:
 		return 1;
+
+	case AST_EXPR_RANGE:
+		return (n->u.range.from.u.literal.c == 0x00 &&
+			n->u.range.to.u.literal.c == 0xff);
 
 	case AST_EXPR_FLAGS:
 		return 0; /* XXX */
@@ -113,10 +116,6 @@ pp_iter(FILE *f, const struct fsm_options *opt, struct ast_expr *n)
 		fprintf(f, "\\x{%lX}", (unsigned long) n->u.codepoint.u);
 		break;
 
-	case AST_EXPR_ANY:
-		fprintf(f, ".");
-		break;
-
 	case AST_EXPR_REPEAT: {
 		size_t i;
 
@@ -188,6 +187,13 @@ pp_iter(FILE *f, const struct fsm_options *opt, struct ast_expr *n)
 		break;
 
 	case AST_EXPR_RANGE:
+		if (n->u.range.from.u.literal.c == 0x00 &&
+			n->u.range.to.u.literal.c == 0xff)
+		{
+			fprintf(f, ".");
+			break;
+		}
+
 		fprintf(f, "[");
 		print_endpoint(f, opt, &n->u.range.from);
 		fprintf(f, "-");

--- a/src/libre/print/tree.c
+++ b/src/libre/print/tree.c
@@ -145,10 +145,6 @@ pp_iter(FILE *f, const struct fsm_options *opt, size_t indent, struct ast_expr *
 		fprintf(f, "CODEPOINT U+%lX\n", (unsigned long) n->u.codepoint.u);
 		break;
 
-	case AST_EXPR_ANY:
-		fprintf(f, "ANY:\n");
-		break;
-
 	case AST_EXPR_REPEAT:
 		fprintf(f, "REPEAT {");
 		fprintf_count(f, n->u.repeat.min);


### PR DESCRIPTION
There's no need to have a special AST node for this any more; I'm now constructing this as `AST_EXPR_RANGE` of `0x00`-`0xff` instead