### PR TITLE
Add property tests for edge_set and fsm_trim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ RE     ?= re
 BUILD  ?= build
 PREFIX ?= /usr/local
 
-.if make(fuzz)
+.if make(fuzz) || make(${BUILD}/theft/theft)
 PKG += libtheft
 .endif
 
@@ -73,7 +73,7 @@ SUBDIR += tests/hashset
 SUBDIR += tests/queue
 SUBDIR += tests/aho_corasick
 SUBDIR += tests
-.if make(fuzz)
+.if make(fuzz) || make(${BUILD}/theft/theft)
 SUBDIR += theft
 .endif
 SUBDIR += pc

--- a/include/adt/edgeset.h
+++ b/include/adt/edgeset.h
@@ -24,6 +24,7 @@ struct edge_iter {
 struct edge_ordered_iter {
 	const struct edge_set *set;
 	size_t pos;
+	size_t steps;
 	unsigned char symbol;
 	uint64_t symbols_used[4];
 };

--- a/include/adt/edgeset.h
+++ b/include/adt/edgeset.h
@@ -34,6 +34,11 @@ struct edge_ordered_iter {
  * edge_iter iterator is unordered. */
 struct edge_iter_ordered;
 
+/* Create an empty edge set.
+ * This currently returns a NULL pointer. */
+struct edge_set *
+edge_set_new(void);
+
 void
 edge_set_free(const struct fsm_alloc *a, struct edge_set *set);
 

--- a/include/adt/edgeset.h
+++ b/include/adt/edgeset.h
@@ -79,10 +79,10 @@ edge_set_remove_state(struct edge_set **set, fsm_state_t state);
 
 void
 edge_set_compact(struct edge_set **set,
-    fsm_state_remap_fun *remap, void *opaque);
+    fsm_state_remap_fun *remap, const void *opaque);
 
 void
-edge_set_reset(struct edge_set *set, struct edge_iter *it);
+edge_set_reset(const struct edge_set *set, struct edge_iter *it);
 
 int
 edge_set_next(struct edge_iter *it, struct fsm_edge *e);

--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -111,7 +111,7 @@ fsm_removestate(struct fsm *fsm, fsm_state_t state);
  * depends on the caller. */
 #define FSM_STATE_REMAP_NO_STATE ((fsm_state_t)-1)
 typedef fsm_state_t
-fsm_state_remap_fun(fsm_state_t id, void *opaque);
+fsm_state_remap_fun(fsm_state_t id, const void *opaque);
 
 /* Use the state passed in via opaque to determine whether
  * to keep state[id]. */

--- a/src/adt/edgeset.c
+++ b/src/adt/edgeset.c
@@ -53,6 +53,12 @@ struct edge_set {
 	size_t ceil;
 };
 
+struct edge_set *
+edge_set_new(void)
+{
+	return NULL;
+}
+
 static struct edge_set *
 edge_set_create(const struct fsm_alloc *a)
 {

--- a/src/adt/edgeset.c
+++ b/src/adt/edgeset.c
@@ -392,7 +392,7 @@ edge_set_copy(struct edge_set **dst, const struct fsm_alloc *alloc,
 		return 1;
 	}
 
-	for (edge_set_reset((void *) src, &jt); edge_set_next(&jt, &e); ) {
+	for (edge_set_reset(src, &jt); edge_set_next(&jt, &e); ) {
 		/* TODO: bulk add */
 		if (!edge_set_add(dst, alloc, e.symbol, e.state)) {
 			return 0;
@@ -477,7 +477,7 @@ edge_set_remove_state(struct edge_set **setp, fsm_state_t state)
 
 void
 edge_set_compact(struct edge_set **setp,
-    fsm_state_remap_fun *remap, void *opaque)
+    fsm_state_remap_fun *remap, const void *opaque)
 {
 	struct edge_set *set;
 	size_t i;
@@ -524,7 +524,7 @@ edge_set_compact(struct edge_set **setp,
 }
 
 void
-edge_set_reset(struct edge_set *set, struct edge_iter *it)
+edge_set_reset(const struct edge_set *set, struct edge_iter *it)
 {
 	it->i = 0;
 	it->set = set;

--- a/src/libfsm/state.c
+++ b/src/libfsm/state.c
@@ -153,7 +153,7 @@ fsm_removestate(struct fsm *fsm, fsm_state_t state)
 }
 
 static fsm_state_t
-mapping_cb(fsm_state_t id, void *opaque)
+mapping_cb(fsm_state_t id, const void *opaque)
 {
 	const fsm_state_t *mapping = opaque;
 	return mapping[id];

--- a/src/libfsm/trim.c
+++ b/src/libfsm/trim.c
@@ -152,15 +152,15 @@ mark_states(struct fsm *fsm, enum fsm_trim_mode mode)
 					goto cleanup;
 				}
 				fsm->states[next].visited = 1;
+			}
 
-				if (edges == NULL) {
-					continue;
-				}
-				if (!save_edge(fsm->opt->alloc,
-					&edge_count, &edge_ceil, &edges,
-					s_id, next)) {
-					goto cleanup;
-				}
+			if (edges == NULL) {
+				continue;
+			}
+			if (!save_edge(fsm->opt->alloc,
+				&edge_count, &edge_ceil, &edges,
+				s_id, next)) {
+				goto cleanup;
 			}
 		}
 
@@ -177,15 +177,15 @@ mark_states(struct fsm *fsm, enum fsm_trim_mode mode)
 					goto cleanup;
 				}
 				fsm->states[next].visited = 1;
+			}
 
-				if (edges == NULL) {
-					continue;
-				}
-				if (!save_edge(fsm->opt->alloc,
-					&edge_count, &edge_ceil, &edges,
-					s_id, next)) {
-					goto cleanup;
-				}
+			if (edges == NULL) {
+				continue;
+			}
+			if (!save_edge(fsm->opt->alloc,
+				&edge_count, &edge_ceil, &edges,
+				s_id, next)) {
+				goto cleanup;
 			}
 		}
 	}

--- a/theft/Makefile
+++ b/theft/Makefile
@@ -13,8 +13,10 @@ SRC += theft/fuzz_nfa.c
 SRC += theft/fuzz_re_parser.c
 SRC += theft/fuzz_re_parser_literal.c
 SRC += theft/fuzz_re_parser_pcre.c
+SRC += theft/fuzz_trim.c
 
 SRC += theft/type_info_adt_edge_set.c
+SRC += theft/type_info_dfa.c
 SRC += theft/type_info_fsm_literal.c
 SRC += theft/type_info_nfa.c
 SRC += theft/type_info_re.c

--- a/theft/Makefile
+++ b/theft/Makefile
@@ -42,7 +42,6 @@ PROPNAME.theft += union_literals
 CFLAGS.${src} += -D_POSIX_C_SOURCE=200809L
 CFLAGS.${src} += -std=c99
 .if ${CC:T:Mgcc} || ${CC:T:Mclang}
-CFLAGS.${src} += -Wdeclaration-after-statement
 .endif
 .endfor
 

--- a/theft/Makefile
+++ b/theft/Makefile
@@ -5,6 +5,7 @@ SRC += theft/buf.c
 SRC += theft/util.c
 SRC += theft/wrap.c
 
+SRC += theft/fuzz_adt_edge_set.c
 SRC += theft/fuzz_adt_priq.c
 SRC += theft/fuzz_adt_set.c
 SRC += theft/fuzz_literals.c
@@ -13,6 +14,7 @@ SRC += theft/fuzz_re_parser.c
 SRC += theft/fuzz_re_parser_literal.c
 SRC += theft/fuzz_re_parser_pcre.c
 
+SRC += theft/type_info_adt_edge_set.c
 SRC += theft/type_info_fsm_literal.c
 SRC += theft/type_info_nfa.c
 SRC += theft/type_info_re.c

--- a/theft/fuzz_adt_edge_set.c
+++ b/theft/fuzz_adt_edge_set.c
@@ -1,0 +1,702 @@
+/*
+ * Copyright 2020 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include "type_info_adt_edge_set.h"
+
+#include <adt/edgeset.h>
+#include <adt/stateset.h>
+#include <adt/xalloc.h>
+
+/* Currently needed for struct fsm_edge. */
+#include "../src/libfsm/internal.h"
+
+static enum theft_trial_res
+prop_model_check(struct theft *t, void *arg1);
+
+static bool
+prop_model_check_eval(const struct edge_set_op *op,
+    struct edge_set **e, struct edge_set_model *m);
+
+static bool
+prop_model_check_postcondition(const struct edge_set *es,
+    const struct edge_set_model *m);
+
+static fsm_state_t
+kept_rank(const uint64_t *kept, fsm_state_t i);
+
+static fsm_state_t
+kept_remap(fsm_state_t id, const void *opaque);
+
+/* Test the edge_set by evaluating a randomly generated
+ * series of operations, then comparing the result after
+ * each step with a simpler model implementation (which
+ * adds/removes/updates a dynamically resized array). */
+static bool
+test_edge_set_operations(theft_seed seed,
+    uintptr_t ceil_bits, uintptr_t symbol_bits, uintptr_t state_bits)
+{
+	enum theft_run_res res;
+
+	struct edge_set_ops_env ops_env = {
+		.tag = 'E',
+		.ceil_bits = (uint8_t)ceil_bits,
+		.symbol_bits = (uint8_t)symbol_bits,
+		.state_bits = (uint8_t)state_bits,
+	};
+
+	const char *gen_seed = getenv("GEN_SEED");
+
+	if (gen_seed != NULL) {
+		seed = strtoul(gen_seed, NULL, 0);
+		theft_generate(stderr, seed,
+		    &type_info_adt_edge_set_ops, &ops_env);
+		return true;
+	}
+
+	struct theft_run_config config = {
+		.name = __func__,
+		.prop1 = prop_model_check,
+		.type_info = { &type_info_adt_edge_set_ops, },
+		.hooks = {
+			.trial_pre = theft_hook_first_fail_halt,
+			.env = &ops_env,
+		},
+		.seed = seed,
+		.trials = 10000,
+		.fork = {
+			.enable = true,
+			.timeout = 1000,
+		},
+	};
+
+	res = theft_run(&config);
+	printf("%s: %s\n", __func__, theft_run_res_str(res));
+	return res == THEFT_RUN_PASS;
+}
+
+static enum theft_trial_res
+ops_model_check(const struct edge_set_ops *ops)
+{
+	enum theft_trial_res res = THEFT_TRIAL_FAIL;
+
+	const struct fsm_alloc *alloc = NULL; /* use defaults */
+
+	struct edge_set_model m = {
+		.count = 0,
+		.ceil = DEF_MODEL_CEIL,
+	};
+	m.edges = malloc(m.ceil * sizeof(m.edges[0]));
+	if (m.edges == NULL) { return THEFT_TRIAL_ERROR; }
+
+	struct edge_set *es = edge_set_new();
+
+	for (size_t op_i = 0; op_i < ops->count; op_i++) {
+		if (!prop_model_check_eval(&ops->ops[op_i], &es, &m)) {
+			goto cleanup;
+		}
+		if (!prop_model_check_postcondition(es, &m)) {
+			goto cleanup;
+		}
+	}
+
+	res = THEFT_TRIAL_PASS;
+cleanup:
+	edge_set_free(alloc, es);
+	free(m.edges);
+	return res;
+}
+
+static enum theft_trial_res
+prop_model_check(struct theft *t, void *arg1)
+{
+	(void)t;
+	struct edge_set_ops *ops = arg1;
+	return ops_model_check(ops);
+}
+
+static bool
+grow_model(struct edge_set_model *m)
+{
+	size_t nceil = 2*m->ceil;
+	assert(nceil > m->ceil);
+	struct model_edge *nedges = realloc(m->edges,
+	    nceil * sizeof(m->edges[0]));
+	if (nedges == NULL) { return false; }
+
+	m->ceil = nceil;
+	m->edges = nedges;
+	return true;
+}
+
+static bool
+prop_model_check_eval(const struct edge_set_op *op,
+    struct edge_set **es, struct edge_set_model *m)
+{
+	switch (op->t) {
+	case ESO_ADD:
+		if (m->count == m->ceil) {
+			if (!grow_model(m)) {
+				return false;
+			}
+		}
+
+		/* only add if not already present */
+		bool present = false;
+		for (size_t i = 0; i < m->count; i++) {
+			if (m->edges[i].symbol == op->u.add.symbol
+			    && m->edges[i].state == op->u.add.state) {
+				present = true;
+				break;
+			}
+		}
+
+		if (!present) {
+			m->edges[m->count].symbol = op->u.add.symbol;
+			m->edges[m->count].state = op->u.add.state;
+			m->count++;
+		}
+
+		if (!edge_set_add(es, NULL,
+			op->u.add.symbol, op->u.add.state)) {
+			return false;
+		}
+		break;
+
+	case ESO_ADD_STATE_SET:
+	{
+		/* grow model to fit entire state set */
+		while (m->count + op->u.add_state_set.state_count > m->ceil) {
+			if (!grow_model(m)) {
+				return false;
+			}
+		}
+
+		struct state_set *state_set = NULL;
+
+		for (size_t s_i = 0; s_i < op->u.add_state_set.state_count; s_i++) {
+			bool present = false;
+			const unsigned char symbol = op->u.add_state_set.symbol;
+			const fsm_state_t state = op->u.add_state_set.states[s_i];
+			for (size_t i = 0; i < m->count; i++) {
+				if (m->edges[i].symbol == symbol
+				    && m->edges[i].state == state) {
+					present = true;
+					break;
+				}
+			}
+
+			if (!present) {
+				m->edges[m->count].symbol = symbol;
+				m->edges[m->count].state = state;
+				m->count++;
+			}
+
+			if (!state_set_add(&state_set, NULL, state)) {
+				return false;
+			}
+		}
+
+		if (!edge_set_add_state_set(es, NULL,
+			op->u.add_state_set.symbol,
+			state_set)) {
+			return false;
+		}
+
+		state_set_free(state_set);
+		break;
+	}
+
+	case ESO_REMOVE:
+	{
+		/* remove all with same symbol */
+		size_t i = 0;
+		while (i < m->count) {
+			if (m->edges[i].symbol == op->u.remove.symbol) {
+				if (i < m->count - 1) {
+					memcpy(&m->edges[i],
+					    &m->edges[m->count - 1],
+					    sizeof(m->edges[i]));
+				}
+				m->count--;
+			} else {
+				i++;
+			}
+		}
+		edge_set_remove(es, op->u.remove.symbol);
+		break;
+	}
+
+	case ESO_REMOVE_STATE:
+	{
+		/* remove all instances of state */
+		size_t i = 0;
+		while (i < m->count) {
+			if (m->edges[i].state == op->u.remove_state.state) {
+				if (i < m->count - 1) {
+					memcpy(&m->edges[i],
+					    &m->edges[m->count - 1],
+					    sizeof(m->edges[i]));
+				}
+				m->count--;
+			} else {
+				i++;
+			}
+		}
+		edge_set_remove_state(es, op->u.remove_state.state);
+		break;
+	}
+
+	case ESO_REPLACE_STATE:
+	{
+		/* replace all instances of state */
+		for (size_t i = 0; i < m->count; i++) {
+			if (m->edges[i].state == op->u.replace_state.old) {
+				m->edges[i].state = op->u.replace_state.new;
+			}
+		}
+
+		/* if this introduced any duplicates, remove them */
+		size_t i = 0;
+		while (i < m->count) {
+			size_t removed = 0;
+			if (m->edges[i].state != op->u.replace_state.new) {
+				i++;
+				continue;
+			}
+			for (size_t j = i + 1; j < m->count; j++) {
+				if (m->edges[j].state == op->u.replace_state.new
+				    && m->edges[j].symbol == m->edges[i].symbol) {
+					if (j < m->count - 1) {
+						memcpy(&m->edges[j],
+						    &m->edges[m->count - 1],
+						    sizeof(m->edges[i]));
+					}
+					removed++;
+					m->count--;
+				}
+			}
+
+			if (removed == 0) {
+				i++;
+			}
+		}
+
+		edge_set_replace_state(es,
+		    op->u.replace_state.old,
+		    op->u.replace_state.new);
+		break;
+	}
+
+	case ESO_COMPACT:
+	{
+		size_t i = 0;
+		const uint64_t *kept = op->u.compact.kept;
+		while (i < m->count) {
+			fsm_state_t state = m->edges[i].state;
+			if (kept[state/64] & ((uint64_t)1 << (state & 63))) {
+				/* keep edge, but update state ID to rank */
+				fsm_state_t nstate = kept_rank(kept, state);
+				m->edges[i].state = nstate;
+				i++;
+			} else {
+				/* remove edge */
+				if (i < m->count - 1) {
+					memcpy(&m->edges[i],
+					    &m->edges[m->count - 1],
+					    sizeof(m->edges[i]));
+				}
+				m->count--;
+			}
+		}
+
+		/* By construction, this does not cover the case where
+		 * compaction produces duplicates. That's a misuse of
+		 * the function -- compaction should remove states and
+		 * shift IDs down, but not combine multiple edges that
+		 * were previously distinct. The function currently does
+		 * not detect and reject that. */
+		edge_set_compact(es,
+		    kept_remap, kept);
+
+		break;
+	}
+	case ESO_COPY:
+	{
+		struct edge_set *dst = NULL;
+		if (!edge_set_copy(&dst, NULL, *es)) {
+			return false;
+		}
+		edge_set_free(NULL, *es);
+		*es = dst;
+
+		/* no impact on model */
+		break;
+	}
+	default:
+		assert(!"match fail");
+		return false;
+	}
+
+	return true;
+}
+
+/* Count how many 1 bits there are in the bit-set before s.
+ * This corresponds to how many states before it were kept, so
+ * its new ID no longer counts the states that were removed.
+ *
+ * This is kind of expensive and could be precomputed to block
+ * boundaries, but it's test code. */
+static fsm_state_t
+kept_rank(const uint64_t *kept, fsm_state_t s)
+{
+	fsm_state_t res = 0;
+	assert(s < (64 * MAX_KEPT));
+
+	for (size_t i = 0; i < s; i++) {
+		if (kept[i/64] & ((uint64_t)1 << (i&63))) {
+			res++;
+		}
+	}
+	return res;
+}
+
+/* A state's new ID is nothing, if not kept, otherwise it's
+ * the new rank (number of kept states preceding it). */
+static fsm_state_t
+kept_remap(fsm_state_t id, const void *opaque)
+{
+	const uint64_t *kept = opaque;
+	if (kept[id/64] & ((uint64_t)1 << (id&63))) {
+		return kept_rank(kept, id);
+	} else {
+		return FSM_STATE_REMAP_NO_STATE;
+	}
+}
+
+static bool
+prop_model_check_postcondition(const struct edge_set *es,
+    const struct edge_set_model *m) {
+
+	/* same count and empty/non-empty state*/
+	const size_t es_count = edge_set_count(es);
+
+#define POSTCONDITION_LOG_COUNTS 0
+	if (POSTCONDITION_LOG_COUNTS) {
+		fprintf(stderr, "-- postcondition: es_count %zu, model_count %zu\n",
+		    es_count, m->count);
+	}
+
+	if (es_count != m->count) {
+		fprintf(stderr, "-- fail: count mismatch: %zu (es) vs %zu (model)\n",
+		    edge_set_count(es), m->count);
+		return false;
+	}
+	if (edge_set_empty(es) != (m->count == 0)) {
+		fprintf(stderr, "-- fail: edge_set_empty disagrees with model\n");
+		return false;
+	}
+
+	struct fsm_edge e;
+	struct edge_iter ei;
+
+	/* every edge in m should be in es */
+	for (size_t i = 0; i < m->count; i++) {
+		bool found = false;
+
+		/* There can be multiple edges associated with the same
+		 * symbol (to different states), so if `edge_set_find`
+		 * gets a different state, it isn't necessarily a
+		 * mismatch. `edge_set_find` should be used with DFAs.
+		 * In this case we need to iterate. */
+		for (edge_set_reset(es, &ei);
+		     edge_set_next(&ei, &e); ) {
+			if (e.symbol == m->edges[i].symbol
+			    && e.state == m->edges[i].state) {
+				found = true;
+				break;
+			}
+		}
+
+		if (!found) {
+			fprintf(stderr, "-- fail: matching edge for symbol 0x%x, state %d not found\n",
+			    m->edges[i].symbol, m->edges[i].state);
+			return false;
+		}
+
+		if (!edge_set_find(es, m->edges[i].symbol, &e)) {
+			fprintf(stderr, "-- fail: edge for symbol 0x%x not found\n",
+			    m->edges[i].symbol);
+			return false;
+		}
+	}
+
+	/* unordered iteration has same count */
+	size_t count = 0;
+	for (edge_set_reset(es, &ei);
+	     edge_set_next(&ei, &e); ) {
+		count++;
+	}
+	if (count != m->count) {
+		fprintf(stderr, "-- fail: unordered iter count mismatch: exp %zu, got %zu\n",
+		    m->count, count);
+		return false;
+	}
+
+	/* ordered iteration has same count */
+	count = 0;
+	struct edge_ordered_iter eoi;
+	for (edge_set_ordered_iter_reset(es, &eoi);
+	     edge_set_ordered_iter_next(&eoi, &e); ) {
+		count++;
+	}
+	if (count != m->count) {
+		fprintf(stderr, "-- fail: unordered iter count mismatch: exp %zu, got %zu\n",
+		    m->count, count);
+		return false;
+	}
+
+	return true;
+}
+
+static bool
+regression0(theft_seed unused)
+{
+	(void)unused;
+	struct edge_set_op op_list[] = {
+		{		/* add once */
+			.t = ESO_ADD,
+			.u.add = { .symbol = 0, .state = 0, },
+		},
+		{		/* redundant add */
+			.t = ESO_ADD,
+			.u.add = { .symbol = 0, .state = 0, },
+		},
+		{		/* remove */
+			.t = ESO_REMOVE,
+			.u.remove = { .symbol = 0, },
+		},
+		{		/* redundant remove */
+			.t = ESO_REMOVE,
+			.u.add = { .symbol = 0, },
+		},
+		{		/* add back */
+			.t = ESO_ADD,
+			.u.add = { .symbol = 0, .state = 0, },
+		},
+	};
+	struct edge_set_ops ops = {
+		.count = sizeof(op_list)/sizeof(op_list[0]),
+		.ops = op_list,
+	};
+
+	enum theft_trial_res res = ops_model_check(&ops);
+	return res == THEFT_TRIAL_PASS;
+}
+
+static bool
+regression1(theft_seed unused)
+{
+	(void)unused;
+	struct edge_set_op op_list[] = {
+		{
+			.t = ESO_ADD,
+			.u.add = { .symbol = 0, .state = 1, },
+		},
+		{
+			.t = ESO_ADD,
+			.u.add = { .symbol = 0, .state = 0, },
+		},
+		{
+			.t = ESO_REMOVE,
+			.u.remove = { .symbol = 0, },
+		},
+	};
+	struct edge_set_ops ops = {
+		.count = sizeof(op_list)/sizeof(op_list[0]),
+		.ops = op_list,
+	};
+
+	enum theft_trial_res res = ops_model_check(&ops);
+	return res == THEFT_TRIAL_PASS;
+}
+
+static bool
+regression2(theft_seed unused)
+{
+	(void)unused;
+	struct edge_set_op op_list[] = {
+		{
+			.t = ESO_ADD,
+			.u.add = { .symbol = 0, .state = 32, },
+		},
+		{
+			.t = ESO_ADD,
+			.u.add = { .symbol = 0, .state = 0, },
+		},
+		{
+			.t = ESO_REMOVE_STATE,
+			.u.remove_state = { .state = 32, },
+		},
+		{
+			.t = ESO_ADD,
+			.u.add = { .symbol = 0, .state = 0, },
+		},
+	};
+	struct edge_set_ops ops = {
+		.count = sizeof(op_list)/sizeof(op_list[0]),
+		.ops = op_list,
+	};
+
+	enum theft_trial_res res = ops_model_check(&ops);
+	return res == THEFT_TRIAL_PASS;
+}
+
+static bool
+regression3(theft_seed unused)
+{
+	(void)unused;
+
+	/* edge_set_add_state_set could previously be used
+	 * to sneak in duplicate edges. */
+	struct edge_set_op op_list[] = {
+		{
+			.t = ESO_ADD_STATE_SET,
+			.u.add_state_set = {
+				.symbol = 0x00,
+				.state_count = 2,
+				.states = { 0, 13 },
+			},
+		},
+		{
+			.t = ESO_REPLACE_STATE,
+			.u.replace_state = {
+				.old = 0,
+				.new = 13,
+			},
+		},
+		{
+			.t = ESO_COPY
+		},
+	};
+	struct edge_set_ops ops = {
+		.count = sizeof(op_list)/sizeof(op_list[0]),
+		.ops = op_list,
+	};
+
+	enum theft_trial_res res = ops_model_check(&ops);
+	return res == THEFT_TRIAL_PASS;
+}
+
+static bool
+regression4(theft_seed unused)
+{
+	(void)unused;
+
+	/* A series of calls to edge_set_add and edge_set_compact could
+	 * fill the hash table with entries and tombstones without growing,
+	 * which caused ordered iteration to get stuck in an infinite loop,
+	 * or add to trigger an assert (because it didn't replace the first
+	 * tombstone after wrapping the table). */
+	struct edge_set_op op_list[] = {
+		{
+			.t = ESO_ADD,
+			.u.add = {
+				.symbol = 0x1,
+				.state = 0,
+			},
+		},
+		{
+			.t = ESO_ADD,
+			.u.add = {
+				.symbol = 0x0,
+				.state = 0,
+			},
+		},
+		{
+			.t = ESO_ADD,
+			.u.add = {
+				.symbol = 0x0,
+				.state = 1,
+			},
+		},
+		{
+			.t = ESO_ADD,
+			.u.add = {
+				.symbol = 0x0,
+				.state = 2,
+			},
+		},
+
+		{
+			.t = ESO_COMPACT,
+			.u.compact.kept = { 0xc },
+		},
+
+		{
+			.t = ESO_ADD,
+			.u.add = {
+				.symbol = 0x5,
+				.state = 0,
+			},
+		},
+
+		{
+			.t = ESO_ADD,
+			.u.add = {
+				.symbol = 0x4,
+				.state = 0,
+			},
+		},
+
+		{
+			.t = ESO_ADD,
+			.u.add = {
+				.symbol = 0x3,
+				.state = 0,
+			},
+		},
+
+		{
+			.t = ESO_COMPACT,
+			.u.compact.kept = { 0x0 },
+		},
+
+		{
+			.t = ESO_ADD,
+			.u.add = {
+				.symbol = 0x7,
+				.state = 0,
+			},
+		},
+		{
+			.t = ESO_ADD,
+			.u.add = {
+				.symbol = 0x0,
+				.state = 0,
+			},
+		},
+	};
+	struct edge_set_ops ops = {
+		.count = sizeof(op_list)/sizeof(op_list[0]),
+		.ops = op_list,
+	};
+
+	enum theft_trial_res res = ops_model_check(&ops);
+	return res == THEFT_TRIAL_PASS;
+}
+
+void
+register_test_adt_edge_set(void)
+{
+	reg_test3("adt_edge_set_operations", test_edge_set_operations,
+	    10, 6, 6);
+
+	reg_test("adt_edge_set_regression0", regression0);
+	reg_test("adt_edge_set_regression1", regression1);
+	reg_test("adt_edge_set_regression2", regression2);
+	reg_test("adt_edge_set_regression3", regression3);
+	reg_test("adt_edge_set_regression4", regression4);
+}

--- a/theft/fuzz_literals.c
+++ b/theft/fuzz_literals.c
@@ -15,8 +15,8 @@ add_literal(struct fsm *fsm, const uint8_t *string, size_t size, intptr_t id);
 static bool
 check_literal(struct fsm *fsm, struct fsm_literal_scen *scen, intptr_t id);
 static void
-carryopaque_cb(const fsm_state_t *set, size_t count,
-	struct fsm *fsm, fsm_state_t state);
+carryopaque_cb(struct fsm *src_fsm, const fsm_state_t *set, size_t count,
+	struct fsm *dst_fsm, fsm_state_t state);
 
 static const struct fsm_options opt = {
 	.anonymous_states  = 1,
@@ -189,8 +189,8 @@ check_literal(struct fsm *fsm, struct fsm_literal_scen *scen, intptr_t id)
 }
 
 static void
-carryopaque_cb(const fsm_state_t *set, size_t count,
-	struct fsm *fsm, fsm_state_t state)
+carryopaque_cb(struct fsm *src_fsm, const fsm_state_t *set, size_t count,
+	struct fsm *dst_fsm, fsm_state_t state)
 {
 	const intptr_t NONE = -1;
 	intptr_t first_id;
@@ -198,20 +198,20 @@ carryopaque_cb(const fsm_state_t *set, size_t count,
 	intptr_t other;
 	size_t i;
 
-	if (!fsm_isend(fsm, state)) {
+	if (!fsm_isend(dst_fsm, state)) {
 		return;
 	}
 
-	assert(fsm_getopaque(fsm, state) == NULL);
+	assert(fsm_getopaque(dst_fsm, state) == NULL);
 
 	/* Get the first id */
 	first_id = NONE;
 
 	for (first_i = 0; first_i < count; first_i++) {
 		/* Get first udata */
-		if (fsm_isend(fsm, set[first_i])) {
-			first_id = (intptr_t) fsm_getopaque(fsm, set[first_i]);
-			fsm_setopaque(fsm, state, (void *) first_id);
+		if (fsm_isend(dst_fsm, set[first_i])) {
+			first_id = (intptr_t) fsm_getopaque(dst_fsm, set[first_i]);
+			fsm_setopaque(dst_fsm, state, (void *) first_id);
 			break;
 		}
 	}
@@ -222,18 +222,18 @@ carryopaque_cb(const fsm_state_t *set, size_t count,
 			continue;
 		}
 
-		if (!fsm_isend(fsm, set[i])) {
+		if (!fsm_isend(dst_fsm, set[i])) {
 			continue;
 		}
 
-		assert(fsm_getopaque(fsm, set[i]) != NULL);
-		other = (intptr_t) fsm_getopaque(fsm, set[i]);
+		assert(fsm_getopaque(dst_fsm, set[i]) != NULL);
+		other = (intptr_t) fsm_getopaque(dst_fsm, set[i]);
 	}
 
 	if (first_id != NONE && other == NONE) {
-		fsm_setopaque(fsm, state, (void *) first_id);
+		fsm_setopaque(dst_fsm, state, (void *) first_id);
 	} else if (first_id == NONE && other != NONE) {
-		fsm_setopaque(fsm, state, (void *) other);
+		fsm_setopaque(dst_fsm, state, (void *) other);
 	} else if (first_id != other) {
 		printf("CONFLICT\n");
 	}

--- a/theft/fuzz_literals.c
+++ b/theft/fuzz_literals.c
@@ -198,6 +198,8 @@ carryopaque_cb(struct fsm *src_fsm, const fsm_state_t *set, size_t count,
 	intptr_t other;
 	size_t i;
 
+	(void)src_fsm;
+
 	if (!fsm_isend(dst_fsm, state)) {
 		return;
 	}

--- a/theft/fuzz_nfa.c
+++ b/theft/fuzz_nfa.c
@@ -250,7 +250,7 @@ apply_ops(struct test_env *env, struct nfa_spec *nfa_spec,
 			break;
 
 		case NFA_OP_TRIM:
-			if (!fsm_trim(nfa)) {
+			if (!fsm_trim(nfa, FSM_TRIM_START_AND_END_REACHABLE)) {
 				if (verbosity > 0) {
 					fprintf(stdout, "FAIL: trim\n");
 				}
@@ -259,7 +259,7 @@ apply_ops(struct test_env *env, struct nfa_spec *nfa_spec,
 			break;
 
 		case NFA_OP_DOUBLE_REVERSE:
-			if (!fsm_trim(nfa)) {
+			if (!fsm_trim(nfa, FSM_TRIM_START_AND_END_REACHABLE)) {
 				if (verbosity > 0) {
 					fprintf(stdout, "FAIL: first reverse's trim\n");
 				}
@@ -273,7 +273,7 @@ apply_ops(struct test_env *env, struct nfa_spec *nfa_spec,
 			}
 			PRINT_FSM("REVERSE");
 
-			if (!fsm_trim(nfa)) {
+			if (!fsm_trim(nfa, FSM_TRIM_START_AND_END_REACHABLE)) {
 				if (verbosity > 0) {
 					fprintf(stdout, "FAIL: second reverse's trim\n");
 				}

--- a/theft/fuzz_trim.c
+++ b/theft/fuzz_trim.c
@@ -1,0 +1,303 @@
+/*
+ * Copyright 2020 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include "type_info_dfa.h"
+
+#include <adt/queue.h>
+
+static enum theft_trial_res
+check_trimming_matches_reachability(const struct dfa_spec *spec);
+
+static enum theft_trial_res
+prop_trimming_matches_reachability(struct theft *t, void *arg1);
+
+static bool
+count_expected_live(const struct dfa_spec *spec,
+    fsm_state_t start_state, size_t *exp);
+
+static bool
+test_dfa_trimming(theft_seed seed,
+    uintptr_t state_ceil_bits,
+    uintptr_t symbol_ceil_bits,
+    uintptr_t end_bits)
+{
+	enum theft_run_res res;
+
+	struct dfa_spec_env env = {
+		.tag = 'D',
+		.state_ceil_bits = state_ceil_bits,
+		.symbol_ceil_bits = symbol_ceil_bits,
+		.end_bits = end_bits,
+	};
+
+	const char *gen_seed = getenv("GEN_SEED");
+
+	if (gen_seed != NULL) {
+		seed = strtoul(gen_seed, NULL, 0);
+		theft_generate(stderr, seed,
+		    &type_info_dfa, (void *)&env);
+		return true;
+	}
+
+	struct theft_run_config config = {
+		.name = __func__,
+		.prop1 = prop_trimming_matches_reachability,
+		.type_info = { &type_info_dfa, },
+		.hooks = {
+			.trial_pre = theft_hook_first_fail_halt,
+			.env = (void *)&env,
+		},
+		.seed = seed,
+		.trials = 10000,
+		.fork = {
+			.enable = true,
+			.timeout = 1000,
+		},
+	};
+
+	res = theft_run(&config);
+	printf("%s: %s\n", __func__, theft_run_res_str(res));
+	return res == THEFT_RUN_PASS;
+}
+
+static enum theft_trial_res
+prop_trimming_matches_reachability(struct theft *t, void *arg1)
+{
+	(void)t;
+	const struct dfa_spec *spec = arg1;
+	return check_trimming_matches_reachability(spec);
+}
+
+static enum theft_trial_res
+check_trimming_matches_reachability(const struct dfa_spec *spec)
+{
+	/* For an arbitrary DFA, the number of states after
+	 * trimming should match the expected count given what
+	 * states are on a path between the start state and
+	 * any end state -- no more, no less. */
+	struct fsm *fsm = fsm_new(NULL);
+	if (fsm == NULL) {
+		fprintf(stderr, "-- ERROR: fsm_new\n");
+		return THEFT_TRIAL_ERROR;
+	}
+
+	if (!fsm_addstate_bulk(fsm, spec->state_count)) {
+		fprintf(stderr, "-- ERROR: fsm_addstate_bulk\n");
+		return THEFT_TRIAL_ERROR;
+	}
+
+	size_t expected_pre_states = 0;
+
+	if (spec->start < spec->state_count) {
+		fsm_setstart(fsm, spec->start);
+	}
+
+	for (size_t s_i = 0; s_i < spec->state_count; s_i++) {
+		const fsm_state_t state_id = (fsm_state_t)s_i;
+		const struct dfa_spec_state *s = &spec->states[s_i];
+		if (!s->used) { continue; }
+		expected_pre_states++;
+
+		if (s->end) {
+			fsm_setend(fsm, state_id, 1);
+		}
+
+		for (size_t e_i = 0; e_i < s->edge_count; e_i++) {
+			const fsm_state_t to = s->edges[e_i].state;
+			const unsigned char symbol = s->edges[e_i].symbol;
+			if (!fsm_addedge_literal(fsm,
+				state_id, to, symbol)) {
+				fprintf(stderr, "-- ERROR: fsm_addedge_literal\n");
+				return THEFT_TRIAL_ERROR;
+			}
+		}
+	}
+
+	if (!fsm_all(fsm, fsm_isdfa)) {
+		fprintf(stderr, "-- FAIL: all is_dfa\n");
+		return THEFT_TRIAL_FAIL;
+	}
+
+	const size_t pre_states = fsm_countstates(fsm);
+	if (pre_states != expected_pre_states) {
+		fprintf(stderr, "-- FAIL: pre_states: exp %zu, got %zu\n",
+		    expected_pre_states, pre_states);
+		return THEFT_TRIAL_FAIL;
+	}
+
+	size_t expected_post_states;
+	if (!count_expected_live(spec, spec->start, &expected_post_states)) {
+		fprintf(stderr, "-- ERROR: count_expected_live alloc\n");
+		return THEFT_TRIAL_ERROR;
+	}
+
+	long trim_res = fsm_trim(fsm, FSM_TRIM_START_AND_END_REACHABLE);
+	if (trim_res < 0) {
+		fprintf(stderr, "-- FAIL: trim_res %ld\n", trim_res);
+		return THEFT_TRIAL_FAIL;
+	}
+
+	const size_t post_states = fsm_countstates(fsm);
+	if (post_states != expected_post_states) {
+		fprintf(stderr, "-- FAIL: post_states: exp %zu, got %zu\n",
+		    expected_post_states, post_states);
+		return THEFT_TRIAL_FAIL;
+	}
+
+	fsm_free(fsm);
+	return THEFT_TRIAL_PASS;
+}
+
+static bool
+enqueue_reachable(const struct dfa_spec *spec, struct queue *q,
+    uint64_t *seen, fsm_state_t state)
+{
+	if (BITSET_CHECK(seen, state)) { return true; }
+	if (!queue_push(q, state)) { return false; }
+	BITSET_SET(seen, state);
+
+	const struct dfa_spec_state *s = &spec->states[state];
+	assert(s->used);
+
+	for (size_t i = 0; i < s->edge_count; i++) {
+		const fsm_state_t to = s->edges[i].state;
+		if (BITSET_CHECK(seen, to)) { continue; }
+		if (!enqueue_reachable(spec, q, seen, to)) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+static bool
+calc_reaches_end_by_fixpoint(const struct dfa_spec *spec,
+    uint64_t *reaches_end)
+{
+	/* A state reaches an end if it's an end, or one of its
+	 * edges transitively reaches an end. */
+	bool changed;
+	do {
+		changed = false;
+		for (size_t s_i = 0; s_i < spec->state_count; s_i++) {
+			const struct dfa_spec_state *s = &spec->states[s_i];
+			if (!s->used) { continue; }
+
+			if (s->end) {
+				if (!BITSET_CHECK(reaches_end, s_i)) {
+					changed = true;
+					BITSET_SET(reaches_end, s_i);
+				}
+				continue;
+			}
+
+			for (size_t i = 0; i < s->edge_count; i++) {
+				const fsm_state_t to = s->edges[i].state;
+				if (BITSET_CHECK(reaches_end, to)) {
+					if (!BITSET_CHECK(reaches_end, s_i)) {
+						changed = true;
+						BITSET_SET(reaches_end, s_i);
+					}
+				}
+			}
+		}
+	} while (changed);
+	return true;
+}
+
+static bool
+count_expected_live(const struct dfa_spec *spec, fsm_state_t start_state,
+	size_t *exp)
+{
+	bool res = false;
+	uint64_t *seen = NULL;
+	uint64_t *reaches_end = NULL;
+	size_t exp_count = 0;
+	struct queue *q = NULL;
+
+	if (spec->state_count == 0) {
+		*exp = 0;
+		return true;
+	}
+
+	q = queue_new(NULL, spec->state_count);
+	if (q == NULL) {
+		fprintf(stderr, "cleanup %d\n", __LINE__);
+		goto cleanup;
+	}
+
+	seen = calloc(spec->state_count/64 + 1, sizeof(seen[0]));
+	if (seen == NULL) { goto cleanup; }
+
+	reaches_end = calloc(spec->state_count/64 + 1, sizeof(reaches_end[0]));
+	if (reaches_end == NULL) { goto cleanup; }
+
+	if (!enqueue_reachable(spec, q, seen, start_state)) {
+		fprintf(stderr, "-- ERROR: enqueue_reachable\n");
+		goto cleanup;
+	}
+
+	if (!calc_reaches_end_by_fixpoint(spec, reaches_end)) {
+		fprintf(stderr, "-- ERROR: calc_reaches_end_by_fixpoint\n");
+		goto cleanup;
+	}
+
+	fsm_state_t s;
+	while (queue_pop(q, &s)) {
+		if (BITSET_CHECK(reaches_end, s)) {
+			exp_count++;
+		}
+	}
+
+	res = true;
+	*exp = exp_count;
+
+cleanup:
+	if (seen != NULL) { free(seen); }
+	if (reaches_end != NULL) { free(reaches_end); }
+	if (q != NULL) { queue_free(q); }
+
+	return res;
+}
+
+#define RUN_SPEC(STATES, START)					 \
+	struct dfa_spec spec = {				 \
+		.state_count = sizeof(STATES)/sizeof(STATES[0]), \
+		.start = START,					 \
+		.states = STATES,				 \
+	};							 \
+	return (check_trimming_matches_reachability(&spec)	 \
+	    == THEFT_TRIAL_PASS)
+
+static bool
+dfa_trim_reg0(theft_seed seed)
+{
+	(void)seed;
+	struct dfa_spec_state states[] = {
+		[0] = { .used = true,
+			.edge_count = 1,
+			.edges = { { .symbol = 0, .state = 2 } },
+		},
+		[1] = { .used = true,
+			.edge_count = 1,
+			.edges = { { .symbol = 0, .state = 0 } },
+		},
+		[2] = { .used = true, .end = true,
+			.edge_count = 1,
+			.edges = { { .symbol = 0, .state = 1 } },
+		},
+	};
+	RUN_SPEC(states, 0);
+}
+
+void
+register_test_trim(void)
+{
+	reg_test("dfa_trimming_regression0", dfa_trim_reg0);
+
+	reg_test3("dfa_trimming", test_dfa_trimming,
+	    0, 0, 0);
+}

--- a/theft/main.c
+++ b/theft/main.c
@@ -22,7 +22,9 @@
 
 enum test_type {
 	TEST0,
-	TEST1
+	TEST1,
+	TEST2,
+	TEST3
 };
 
 struct test_link {
@@ -37,6 +39,17 @@ struct test_link {
 			test_fun1 *fun;
 			uintptr_t arg;
 		} test1;
+		struct {
+			test_fun2 *fun;
+			uintptr_t arg0;
+			uintptr_t arg1;
+		} test2;
+		struct {
+			test_fun3 *fun;
+			uintptr_t arg0;
+			uintptr_t arg1;
+			uintptr_t arg2;
+		} test3;
 	} u;
 };
 
@@ -134,6 +147,50 @@ reg_test1(const char *name, test_fun1 *test, uintptr_t arg)
 	state.tests = link;
 }
 
+void
+reg_test2(const char *name, test_fun2 *test,
+    uintptr_t arg0, uintptr_t arg1)
+{
+	struct test_link *link;
+
+	link = xmalloc(sizeof *link);
+
+	*link = (struct test_link) {
+		.next = state.tests,
+		.name = name,
+		.type = TEST2,
+		.u.test2 = {
+			.fun = test,
+			.arg0 = arg0,
+			.arg1 = arg1,
+		},
+	};
+
+	state.tests = link;
+}
+
+void reg_test3(const char *name, test_fun3 *test,
+    uintptr_t arg0, uintptr_t arg1, uintptr_t arg2)
+{
+	struct test_link *link;
+
+	link = xmalloc(sizeof *link);
+
+	*link = (struct test_link) {
+		.next = state.tests,
+		.name = name,
+		.type = TEST3,
+		.u.test3 = {
+			.fun = test,
+			.arg0 = arg0,
+			.arg1 = arg1,
+			.arg2 = arg2,
+		},
+	};
+
+	state.tests = link;
+}
+
 int
 test_get_verbosity(void)
 {
@@ -178,6 +235,7 @@ main(int argc, char **argv)
 		 }
 	}
 
+	register_test_adt_edge_set();
 	register_test_literals();
 	register_test_re();
 	register_test_adt_priq();
@@ -216,8 +274,17 @@ main(int argc, char **argv)
 
 		pass = false;
 		switch (link->type) {
-		case TEST0: pass = link->u.test0.fun(seed);                    break;
-		case TEST1: pass = link->u.test1.fun(seed, link->u.test1.arg); break;
+		case TEST0: pass = link->u.test0.fun(seed);
+			break;
+		case TEST1: pass = link->u.test1.fun(seed,
+		    link->u.test1.arg);
+			break;
+		case TEST2: pass = link->u.test2.fun(seed,
+		    link->u.test2.arg0, link->u.test2.arg1);
+			break;
+		case TEST3: pass = link->u.test3.fun(seed,
+		    link->u.test3.arg0, link->u.test3.arg1, link->u.test3.arg2);
+			break;
 
 		default:
 			assert(false);

--- a/theft/main.c
+++ b/theft/main.c
@@ -63,8 +63,8 @@ usage(const char *exec_name)
 		"  -v:		   increase verbosity\n"
 		"  -l:		   list tests by name\n"
 		"  -f:		   halt after first failure\n"
-		"  -n <STRING>:  only run tests STRING in the name\n"
-		"  -s <SEED>:	  fuzz from the given seed\n",
+		"  -n <STRING>:    only run tests with STRING in the name\n"
+		"  -s <SEED>:	   fuzz from the given seed\n",
 		exec_name);
 	exit(1);
 }

--- a/theft/main.c
+++ b/theft/main.c
@@ -241,6 +241,7 @@ main(int argc, char **argv)
 	register_test_adt_priq();
 	register_test_adt_set();
 	register_test_nfa();
+	register_test_trim();
 
 	for (link = state.tests; link; link = link->next) {
 		bool hit, pass;

--- a/theft/theft_libfsm.h
+++ b/theft/theft_libfsm.h
@@ -52,9 +52,18 @@ void hexdump(FILE *f, const uint8_t *buf, size_t size);
 
 typedef bool test_fun(theft_seed);
 typedef bool test_fun1(theft_seed, uintptr_t arg);
+typedef bool test_fun2(theft_seed,
+    uintptr_t arg0, uintptr_t arg1);
+typedef bool test_fun3(theft_seed,
+    uintptr_t arg0, uintptr_t arg1, uintptr_t arg2);
 
 void reg_test(const char *name, test_fun *test);
-void reg_test1(const char *name, test_fun1 *test, uintptr_t arg);
+void reg_test1(const char *name, test_fun1 *test,
+    uintptr_t arg);
+void reg_test2(const char *name, test_fun2 *test,
+    uintptr_t arg0, uintptr_t arg1);
+void reg_test3(const char *name, test_fun3 *test,
+    uintptr_t arg0, uintptr_t arg1, uintptr_t arg2);
 
 /* Register tests within a module. */
 void register_test_literals(void);
@@ -62,6 +71,7 @@ void register_test_re(void);
 void register_test_adt_priq(void);
 void register_test_adt_set(void);
 void register_test_nfa(void);
+void register_test_adt_edge_set(void);
 
 int test_get_verbosity(void);
 

--- a/theft/theft_libfsm.h
+++ b/theft/theft_libfsm.h
@@ -72,6 +72,7 @@ void register_test_adt_priq(void);
 void register_test_adt_set(void);
 void register_test_nfa(void);
 void register_test_adt_edge_set(void);
+void register_test_trim(void);
 
 int test_get_verbosity(void);
 
@@ -127,3 +128,6 @@ wrap_re_comp(enum re_dialect dialect, const struct string_pair *pair,
 	} while(0)
 
 #endif
+
+#define BITSET_CHECK(SET, BIT) (SET[BIT/64] & ((uint64_t)1 << (BIT & 63)))
+#define BITSET_SET(SET, BIT) (SET[BIT/64] |= ((uint64_t)1 << (BIT & 63)))

--- a/theft/type_info_adt_edge_set.c
+++ b/theft/type_info_adt_edge_set.c
@@ -1,0 +1,156 @@
+#include "type_info_adt_edge_set.h"
+
+#include <ctype.h>
+#include <inttypes.h>
+
+static enum theft_alloc_res
+edge_set_ops_alloc(struct theft *t, void *penv, void **output)
+{
+	(void)penv;
+	const struct edge_set_ops_env *env = theft_hook_get_env(t);
+
+#define GET_BITS(FIELD, DEF) (uint8_t)(env-> FIELD ? env -> FIELD : DEF)
+	assert(env->tag == 'E');
+	const uint8_t ceil_bits = GET_BITS(ceil_bits, DEF_CEIL_BITS);
+	const uint8_t symbol_bits = GET_BITS(symbol_bits, DEF_SYMBOL_BITS);
+	const uint8_t state_bits = GET_BITS(state_bits, DEF_STATE_BITS);
+
+	const size_t ceil = theft_random_bits(t, ceil_bits);
+
+	struct edge_set_ops *res = malloc(sizeof(*res));
+	if (res == NULL) { return THEFT_ALLOC_ERROR; }
+	memset(res, 0x00, sizeof(*res));
+
+	const size_t alloc_size = ceil * sizeof(res->ops[0]);
+	res->ops = malloc(alloc_size);
+	if (res == NULL) { return THEFT_ALLOC_ERROR; }
+	memset(res->ops, 0x00, alloc_size);
+
+	for (size_t op_i = 0; op_i < ceil; op_i++) {
+		struct edge_set_op *op = &res->ops[res->count];
+		memset(op, 0x00, sizeof(*op));
+
+		op->t = theft_random_choice(t, ESO_TYPE_COUNT);
+		switch (op->t) {
+		case ESO_ADD:
+			op->u.add.symbol = theft_random_bits(t, symbol_bits);
+			op->u.add.state = theft_random_bits(t, state_bits);
+			break;
+		case ESO_ADD_STATE_SET:
+			op->u.add_state_set.symbol = theft_random_bits(t, symbol_bits);
+			op->u.add_state_set.state_count = theft_random_choice(t, MAX_STATE_SET);
+			for (size_t i = 0; i < MAX_STATE_SET; i++) {
+				op->u.add_state_set.states[i] = theft_random_bits(t, state_bits);
+			}
+			break;
+		case ESO_REMOVE:
+			op->u.remove.symbol = theft_random_bits(t, symbol_bits);
+			break;
+		case ESO_REMOVE_STATE:
+			op->u.remove_state.state = theft_random_bits(t, state_bits);
+			break;
+		case ESO_REPLACE_STATE:
+			op->u.replace_state.old = theft_random_bits(t, state_bits);
+			op->u.replace_state.new = theft_random_bits(t, state_bits);
+			break;
+		case ESO_COMPACT:
+			for (size_t i = 0; i < MAX_KEPT; i++) {
+				op->u.compact.kept[i] = theft_random_bits(t, 64);
+			}
+			break;
+		case ESO_COPY:
+			break;	/* no arguments */
+		default:
+			assert(!"match fail");
+			return THEFT_ALLOC_ERROR;
+		}
+
+		/* small odds of randomly discarding result,
+		 * which will increase during shrinking */
+		const bool keep = theft_random_bits(t, 3) > 0;
+		if (keep) { res->count++; }
+	}
+
+	*output = res;
+	return THEFT_ALLOC_OK;
+}
+
+static void
+edge_set_ops_free(void *instance, void *env)
+{
+	struct edge_set_ops *ops = instance;
+	free(ops->ops);
+	free(ops);
+	(void)env;
+}
+
+static void
+edge_set_ops_print
+(FILE *f, const void *instance, void *env)
+{
+	(void)env;
+	const struct edge_set_ops *ops = instance;
+	fprintf(f, "== edge_set_ops#%p(%zu):\n",
+	    (void *)ops, ops->count);
+
+	for (size_t op_i = 0; op_i < ops->count; op_i++) {
+		const struct edge_set_op *op = &ops->ops[op_i];
+		fprintf(f, "  - %zu: ", op_i);
+		switch (op->t) {
+		case ESO_ADD:
+			fprintf(f, "ADD 0x%x (%c) -> %d\n",
+			    op->u.add.symbol,
+			    isprint(op->u.add.symbol) ? op->u.add.symbol : '.',
+			    op->u.add.state);
+			break;
+		case ESO_ADD_STATE_SET:
+			fprintf(f, "ADD_STATE_SET: 0x%x (%c) -> [",
+			    op->u.add_state_set.symbol,
+			    isprint(op->u.add_state_set.symbol)
+			    ? op->u.add_state_set.symbol : '.');
+			for (size_t i = 0; i < op->u.add_state_set.state_count; i++) {
+				fprintf(f, "%s%d",
+				    i > 0 ? ", " : "",
+				    op->u.add_state_set.states[i]);
+			}
+			fprintf(f, "]\n");
+			break;
+		case ESO_REMOVE:
+			fprintf(f, "REMOVE 0x%x (%c)\n",
+			    op->u.remove.symbol,
+			    isprint(op->u.remove.symbol) ? op->u.remove.symbol : '.');
+			break;
+		case ESO_REMOVE_STATE:
+			fprintf(f, "REMOVE_STATE %d\n",
+			    op->u.remove_state.state);
+			break;
+		case ESO_REPLACE_STATE:
+			fprintf(f, "REPLACE_STATE %d -> %d\n",
+			    op->u.replace_state.old,
+			    op->u.replace_state.new);
+			break;
+		case ESO_COMPACT:
+			fprintf(f, "COMPACT: ");
+			for (size_t i = 0; i < MAX_KEPT; i++) {
+				fprintf(f, "%016"PRIx64"",
+				    op->u.compact.kept[i]);
+			}
+			fprintf(f, "\n");
+			break;
+		case ESO_COPY:
+			fprintf(f, "COPY\n");
+			break;
+		default:
+			assert(!"match fail");
+		}
+	}
+}
+
+const struct theft_type_info type_info_adt_edge_set_ops = {
+	.alloc = edge_set_ops_alloc,
+	.free  = edge_set_ops_free,
+	.print = edge_set_ops_print,
+	.autoshrink_config = {
+		.enable = true,
+	}
+};

--- a/theft/type_info_adt_edge_set.h
+++ b/theft/type_info_adt_edge_set.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#ifndef TYPE_INFO_ADT_EDGE_SET_H
+#define TYPE_INFO_ADT_EDGE_SET_H
+
+#include "theft_libfsm.h"
+
+#define MAX_STATE_SET 13
+#define MAX_KEPT 8
+#define DEF_MODEL_CEIL 8
+
+#define DEF_CEIL_BITS 10
+#define DEF_SYMBOL_BITS 6
+#define DEF_STATE_BITS 6
+struct edge_set_ops_env {
+	char tag;
+	uint8_t ceil_bits;
+	uint8_t symbol_bits;
+	uint8_t state_bits;
+};
+
+struct edge_set_ops {
+	size_t count;
+	struct edge_set_op {
+		enum edge_set_op_type {
+			ESO_ADD,
+			ESO_ADD_STATE_SET,
+			ESO_REMOVE,
+			ESO_REMOVE_STATE,
+			ESO_REPLACE_STATE,
+			ESO_COMPACT,
+			ESO_COPY,
+			ESO_TYPE_COUNT,
+		} t;
+		union {
+			struct eso_add {
+				unsigned char symbol;
+				fsm_state_t state;
+			} add;
+			struct eso_add_state_set {
+				unsigned char symbol;
+				unsigned char state_count;
+				fsm_state_t states[MAX_STATE_SET];
+			} add_state_set;
+			struct eso_remove {
+				unsigned char symbol;
+			} remove;
+			struct eso_remove_state {
+				fsm_state_t state;
+			} remove_state;
+			struct eso_replace_state {
+				fsm_state_t old;
+				fsm_state_t new;
+			} replace_state;
+			struct eso_compact {
+				uint64_t kept[MAX_KEPT];
+			} compact;
+		} u;
+	} *ops;
+};
+
+struct edge_set_model {
+	size_t count;
+	size_t ceil;
+	struct model_edge {
+		unsigned char symbol;
+		fsm_state_t state;
+	} *edges;
+};
+
+extern const struct theft_type_info type_info_adt_edge_set_ops;
+
+#endif

--- a/theft/type_info_dfa.c
+++ b/theft/type_info_dfa.c
@@ -1,0 +1,157 @@
+#include "type_info_dfa.h"
+
+static enum theft_alloc_res
+dfa_alloc(struct theft *t, void *unused_env, void **output)
+{
+	(void)unused_env;
+	const struct dfa_spec_env *env = theft_hook_get_env(t);
+	assert(env->tag == 'D');
+	const uint8_t state_ceil_bits = (env->state_ceil_bits
+	    ? env->state_ceil_bits : DEF_STATE_CEIL_BITS);
+	const uint8_t symbol_ceil_bits = (env->symbol_ceil_bits
+	    ? env->symbol_ceil_bits : DEF_SYMBOL_CEIL_BITS);
+	const uint8_t end_bits = (env->end_bits
+	    ? env->end_bits : DEF_END_BITS);
+
+	if (end_bits >= 64) {
+		return THEFT_ALLOC_ERROR;
+	}
+
+	const size_t state_count = theft_random_bits(t, state_ceil_bits);
+
+	bool has_start = false;
+	struct dfa_spec *res = NULL;
+	res = calloc(1, sizeof(*res));
+	if (res == NULL) { return THEFT_ALLOC_ERROR; }
+
+	res->states = calloc(state_count, sizeof(res->states[0]));
+	if (res->states == NULL) {
+		free(res);
+		return THEFT_ALLOC_ERROR;
+	}
+
+	const uint64_t end_value = (1ULL << end_bits) - 1;
+
+	res->state_count = 0;
+	for (size_t s_i = 0; s_i < state_count; s_i++) {
+		struct dfa_spec_state *s = &res->states[res->state_count];
+		memset(s, 0x00, sizeof(*s));
+
+		for (size_t i = 0; i < MAX_EDGES; i++) {
+			struct dfa_spec_edge *e = &s->edges[s->edge_count];
+			e->symbol = theft_random_bits(t, symbol_ceil_bits);
+			e->state = theft_random_bits(t, state_ceil_bits);
+
+			if (theft_random_bits(t, 3) > 0) {
+				s->edge_count++; /* keep it */
+			}
+		}
+
+		/* If the max value is drawn, mark it as an end state. */
+		if (theft_random_bits(t, end_bits) == end_value) {
+			s->end = true;
+		}
+
+		/* As this shrinks towards 0, states get discarded,
+		 * but their contents still generate -- this keeps
+		 * the DFA from changing dramatically during shrinking
+		 * due to sudden misalignment of the random bits. */
+		if (theft_random_bits(t, 3) > 0) {
+			s->used = true;
+			if (!has_start) {
+				res->start = res->state_count;
+				has_start = true;
+			}
+			res->state_count++; /* keep it */
+		}
+	}
+
+	/* second pass: remove any edges pointing to nonexistent states
+	 * or using symbols that already appear on the same state */
+	for (size_t s_i = 0; s_i < state_count; s_i++) {
+		struct dfa_spec_state *s = &res->states[s_i];
+		if (!s->used) { continue; }
+
+		uint64_t symbol_seen[4] = { 0 };
+
+		struct dfa_spec_edge {
+			unsigned char symbol;
+			fsm_state_t state;
+		} dst[MAX_EDGES] = { 0 };
+
+		/* filter, only keep valid edges */
+		size_t e_dst = 0;
+		for (size_t e_src = 0; e_src < s->edge_count; e_src++) {
+			bool keep;
+
+			const fsm_state_t to = s->edges[e_src].state;
+			const unsigned char symbol = s->edges[e_src].symbol;
+
+			if (to >= res->state_count || !res->states[to].used) {
+				keep = false; /* unused state */
+			} else if (BITSET_CHECK(symbol_seen, symbol)) {
+				keep = false; /* symbol already in use */
+			} else {
+				keep = true;
+				BITSET_SET(symbol_seen, symbol);
+			}
+
+			if (keep) {
+				memcpy(&dst[e_dst],
+				    &s->edges[e_src], sizeof(*dst));
+			        e_dst++;
+			}
+		}
+		memset(s->edges, 0x00, MAX_EDGES * sizeof(*s->edges));
+		memcpy(&s->edges[0], &dst[0],
+		    e_dst * sizeof(dst[0]));
+		s->edge_count = e_dst;
+	}
+
+	*output = res;
+	return THEFT_ALLOC_OK;
+}
+
+static void
+dfa_free(void *instance, void *env)
+{
+	(void)env;
+	struct dfa_spec *dfa = instance;
+	free(dfa->states);
+	free(dfa);
+}
+
+static void
+dfa_print(FILE *f, const void *instance, void *env)
+{
+	(void)env;
+	const struct dfa_spec *dfa = instance;
+	fprintf(f, "=== DFA#%p:\n", (void *)dfa);
+	for (size_t s_i = 0; s_i < dfa->state_count; s_i++) {
+		const struct dfa_spec_state *s = &dfa->states[s_i];
+		if (!s->used) { continue; }
+		fprintf(f, " -- state[%zu], %u edge%s",
+		    s_i, s->edge_count,
+		    s->edge_count == 1 ? "" : "s");
+		if (s_i == dfa->start) {
+			fprintf(f, ", start");
+		}
+		if (s->end) {
+			fprintf(f, ", end");
+		}
+		fprintf(f, ":\n");
+		for (size_t e_i = 0; e_i < s->edge_count; e_i++) {
+			fprintf(f, "    -- %zu: 0x%x -> %u\n",
+			    e_i, s->edges[e_i].symbol, s->edges[e_i].state);
+		}
+	}
+}
+
+const struct theft_type_info type_info_dfa = {
+	.alloc = dfa_alloc,
+	.free  = dfa_free,
+	.print = dfa_print,
+	.autoshrink_config = {
+		.enable = true,
+	}
+};

--- a/theft/type_info_dfa.h
+++ b/theft/type_info_dfa.h
@@ -1,0 +1,41 @@
+#ifndef TYPE_INFO_DFA_H
+#define TYPE_INFO_DFA_H
+
+#include "theft_libfsm.h"
+
+#define MAX_EDGES 16
+
+#define DEF_SYMBOL_CEIL_BITS 6
+#define DEF_STATE_CEIL_BITS 6
+#define DEF_END_BITS 3 		/* 1/8 chance of beind an end */
+
+struct dfa_spec_env {
+	char tag;		/* 'D' */
+	uint8_t state_ceil_bits;
+	uint8_t symbol_ceil_bits;
+	uint8_t end_bits;	/* 1:n chance of being an end */
+};
+
+/* Spec for a random DFA. If an edge refers to a state
+ * >= state_count or a state where !dfa->states[id].used,
+ * then the edge is ignored. Limiting the variety of symbols
+ * and/or states chan produce a variety of sparser or denser
+ * DFAs. */
+struct dfa_spec {
+	size_t state_count;
+	size_t start;
+	struct dfa_spec_state {
+		/* This flag is a foothold for shrinking. */
+		bool used;
+		bool end;
+		uint8_t edge_count;
+		struct dfa_spec_edge {
+			unsigned char symbol;
+			fsm_state_t state;
+		} edges[MAX_EDGES];
+	} *states;
+};
+
+extern const struct theft_type_info type_info_dfa;
+
+#endif

--- a/theft/util.c
+++ b/theft/util.c
@@ -110,12 +110,6 @@ delta_msec(const struct timeval *pre, const struct timeval *post)
 size_t *
 gen_permutation_vector(size_t length, uint32_t seed)
 {
-	static const unsigned long primes[] = {
-		11, 101, 1009, 10007,
-		100003, 1000003, 10000019, 100000007, 1000000007,
-		1538461, 1865471, 17471, 2147483647 /* 2**32 - 1 */
-	};
-
 	size_t *res;
 	uint32_t mod;
 	uint32_t ceil;
@@ -143,7 +137,7 @@ gen_permutation_vector(size_t length, uint32_t seed)
 
 	state = seed & ((1LLU << 29) - 1);
 	a = (4 * state) + 1;
-	c = primes[(state * 16451) % sizeof primes / sizeof *primes];
+	c = 2147483647;		/* (2 ** 31) - 1 */
 
 	offset = 0;
 	mask = mod - 1;


### PR DESCRIPTION
This adds some new property tests, fixed bugs found by them, and also does some misc. cleanup:

- Update some existing property tests to reflect interface changes. These tests aren't part of the default build, so the broken build went unnoticed.
- Reformat the property test CLI's usage message.
- Fix a parameter for the LCG, used for shuffling input data.
- Make `fsm_state_remap_fun`s opaque argument `const`.
- Fix an unused argument warning.
- Remove a warning in the makefile; the property tests are `-std=c99`.
- Add conditionally controlled logging for `fsm_trim`.
- Fix incremental rebuilding of the `build/theft/theft` target.
- Add a property test for edge_set operations, add several regression tests for bugs found, fix them. 
- Add a property test for trimming, a regression test for its minimal failing case, and fix the bug.

I am still working on property testing `fsm_minimise`, but that work should probably go in a later PR to avoid excessively large merge conflicts. Some of the other existing property tests need further attention, but at the moment I'm focusing on testing that will support `fsm_minimise`. I will address those later. In particular, the `nfa_minimise...` test is broken because `fsm_minimise` rejects NFAs now, and the `adt_set` tests are pointing out that the set does not actually compare sets with elements reordered as equal. (Since nothing currently relies on that, we are probably just going to remove `set_cmp`.)

The fix for the bug in `fsm_trim` is the same as in PR #229, except it does not have the XXX start state hack; the tests all pass without it.