### PR TITLE
`fsm_minimise`: Add property test, switch to Moore's algorithm (with a couple optimizations)

### DIFF
--- a/src/adt/edgeset.c
+++ b/src/adt/edgeset.c
@@ -520,7 +520,6 @@ edge_set_compact(struct edge_set **setp,
 		if (new_id == FSM_STATE_REMAP_NO_STATE) {
 			*setp = NULL;
 		} else {
-			assert(new_id <= s);
 			*setp = SINGLETON_ENCODE(symbol, new_id);
 		}
 		return;

--- a/src/libfsm/Makefile
+++ b/src/libfsm/Makefile
@@ -2,6 +2,7 @@
 
 SRC += src/libfsm/collate.c
 SRC += src/libfsm/complete.c
+SRC += src/libfsm/consolidate.c
 SRC += src/libfsm/clone.c
 SRC += src/libfsm/closure.c
 SRC += src/libfsm/edge.c

--- a/src/libfsm/consolidate.c
+++ b/src/libfsm/consolidate.c
@@ -29,7 +29,7 @@ struct mapping_closure {
 };
 
 static fsm_state_t
-mapping_cb(fsm_state_t id, void *opaque)
+mapping_cb(fsm_state_t id, const void *opaque)
 {
 	const struct mapping_closure *closure = opaque;
 	assert(id < closure->count);

--- a/src/libfsm/consolidate.c
+++ b/src/libfsm/consolidate.c
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2020 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+/* fsm consolidate -> take an FSM and a mapping, produce a new FSM with combined states */
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include <fsm/fsm.h>
+#include <fsm/pred.h>
+#include <fsm/walk.h>
+
+#include <adt/alloc.h>
+#include <adt/set.h>
+#include <adt/edgeset.h>
+#include <adt/stateset.h>
+#include <adt/hashset.h>
+#include <adt/mappinghashset.h>
+
+#include "internal.h"
+
+struct mapping_closure {
+	size_t count;
+	const fsm_state_t *mapping;
+};
+
+static fsm_state_t
+mapping_cb(fsm_state_t id, void *opaque)
+{
+	const struct mapping_closure *closure = opaque;
+	assert(id < closure->count);
+	return closure->mapping[id];
+}
+
+struct fsm *
+fsm_consolidate(struct fsm *src,
+    const fsm_state_t *mapping, size_t mapping_count)
+{
+	struct fsm *dst;
+	fsm_state_t src_i;
+	uint64_t *seen = NULL;
+	struct mapping_closure closure;
+
+	assert(src != NULL);
+	assert(src->opt != NULL);
+
+	dst = fsm_new(src->opt);
+	if (dst == NULL) {
+		goto cleanup;
+	}
+
+	if (!fsm_addstate_bulk(dst, mapping_count)) {
+		goto cleanup;
+	}
+	assert(dst->statecount == mapping_count);
+
+	seen = f_calloc(src->opt->alloc,
+	    mapping_count/64 + 1, sizeof(seen[0]));
+	if (seen == NULL) {
+		goto cleanup;
+	}
+
+#define DST_SEEN(I) (seen[I/64] & ((uint64_t)1 << (I&63)))
+#define SET_DST_SEEN(I) (seen[I/64] |= ((uint64_t)1 << (I&63)))
+
+	/* map N states to M states, where N >= M.
+	 * if it's the first time state[M] is seen,
+	 * then copy it verbatim, otherwise only
+	 * carryopaque. */
+
+	closure.count = mapping_count;
+	closure.mapping = mapping;
+
+	for (src_i = 0; src_i < mapping_count; src_i++) {
+		fprintf(stderr, "mapping[%u]: %u\n",
+		    src_i, mapping[src_i]);
+	}
+
+	for (src_i = 0; src_i < mapping_count; src_i++) {
+		const fsm_state_t dst_i = mapping[src_i];
+
+		if (!DST_SEEN(dst_i)) {
+			SET_DST_SEEN(dst_i);
+
+			dst->states[dst_i].opaque = src->states[src_i].opaque;
+
+			if (!state_set_copy(&dst->states[dst_i].epsilons,
+				dst->opt->alloc, src->states[src_i].epsilons)) {
+				goto cleanup;
+			}
+			/* FIXME compact mapping! */
+
+			if (!edge_set_copy(&dst->states[dst_i].edges,
+				dst->opt->alloc,
+				src->states[src_i].edges)) {
+				goto cleanup;
+			}
+			/* FIXME compact mapping! */
+			edge_set_compact(&dst->states[dst_i].edges,
+			    mapping_cb, &closure);
+
+			if (fsm_isend(src, src_i)) {
+				fsm_setend(dst, dst_i, 1);
+			}
+		} else {
+			assert(fsm_isend(dst, dst_i) == fsm_isend(src, src_i));
+
+			/* src->opt->carryopaque(src,  */
+			/* TODO carry opaque */
+			/* can we do a pairwise carry? */
+		}
+	}
+
+	{
+		fsm_state_t src_start, dst_start;
+		if (fsm_getstart(src, &src_start)) {
+			assert(src_start < mapping_count);
+			dst_start = mapping[src_start];
+			fsm_setstart(dst, dst_start);
+		}
+	}
+
+	f_free(src->opt->alloc, seen);
+
+	return dst;
+
+cleanup:
+
+	if (seen != NULL) { f_free(src->opt->alloc, seen); }
+	return NULL;
+}

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -125,6 +125,7 @@ f_malloc(const struct fsm_alloc *a, size_t sz);
  */
 void *
 f_calloc(const struct fsm_alloc *a, size_t n, size_t sz);
+
 /*
  * Internal realloc function that invokes realloc(3) by default, or a user-provided
  * realloc function to re-allocate memory to the specified size and perform

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -134,5 +134,10 @@ f_calloc(const struct fsm_alloc *a, size_t n, size_t sz);
 void *
 f_realloc(const struct fsm_alloc *a, void *p, size_t sz);
 
-#endif
+/* Take a source fsm and a state mapping, produce a new
+ * fsm where states may be consolidated. */
+struct fsm *
+fsm_consolidate(struct fsm *src,
+    const fsm_state_t *mapping, size_t mapping_count);
 
+#endif

--- a/src/libfsm/minimise.c
+++ b/src/libfsm/minimise.c
@@ -1183,7 +1183,7 @@ min_exmoore(const struct fsm *fsm,
 	if (minimized_state_count != NULL) {
 		*minimized_state_count = ec_count - ec_offset;
 #if DUMP_MAPPINGS
-		for (i = 0; i < *minimized_state_count; i++) {
+		for (i = 0; i < fsm->statecount; i++) {
 			fprintf(stderr, "# exmoore_mapping[%lu]: %u\n",
 			    i, mapping[i]);
 		}

--- a/src/libfsm/minimise.c
+++ b/src/libfsm/minimise.c
@@ -193,7 +193,7 @@ fsm_minimise(struct fsm *fsm)
 	/* This should only be called with a DFA. */
 	assert(fsm_all(fsm, fsm_isdfa));
 
-	if (!fsm_trim(fsm)) {
+	if (fsm_trim(fsm, FSM_TRIM_START_AND_END_REACHABLE) < 0) {
 		return 0;
 	}
 
@@ -280,7 +280,7 @@ cleanup:
 	/* This should only be called with a DFA. */
 	assert(fsm_all(fsm, fsm_isdfa));
 
-	if (!fsm_trim(fsm)) {
+	if (fsm_trim(fsm, FSM_TRIM_START_AND_END_REACHABLE) < 0) {
 		return 0;
 	}
 
@@ -1134,6 +1134,7 @@ min_exmoore(const struct fsm *fsm,
 						exmoore_update_ec(&env, ec_src);
 						exmoore_update_ec(&env, nsrc);
 
+						assert(done_ec_offset > 0);
 						done_ec_offset--;
 
 						/* The src EC just got swapped with another,
@@ -1146,7 +1147,6 @@ min_exmoore(const struct fsm *fsm,
 					changed = 1;
 					ec_count++;
 
-					assert(done_ec_offset >= 0);
 					assert(done_ec_offset <= ec_count);
 				}
 

--- a/src/libfsm/minimise.c
+++ b/src/libfsm/minimise.c
@@ -41,7 +41,7 @@ fsm_minimise(struct fsm *fsm)
 	int r = 0;
 	struct fsm *dst = NULL;
 
-	unsigned char labels[256];
+	unsigned char labels[FSM_SIGMA_COUNT];
 	size_t label_count, orig_states, minimised_states;
 	fsm_state_t *mapping = NULL;
 

--- a/src/libfsm/minimise.c
+++ b/src/libfsm/minimise.c
@@ -476,8 +476,9 @@ update_ec_links(struct min_env *env, fsm_state_t ec_dst)
 	fsm_state_t cur = env->ecs[ec_dst];
 
 	assert(cur != NO_ID);
+	cur = MASK_EC_HEAD(cur);
+
 	while (cur != NO_ID) {
-		cur = MASK_EC_HEAD(cur);
 		env->state_ecs[cur] = ec_dst;
 		cur = env->jump[cur];
 		count++;

--- a/src/libfsm/minimise.c
+++ b/src/libfsm/minimise.c
@@ -7,30 +7,196 @@
 #include <assert.h>
 #include <stddef.h>
 #include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include <stdio.h>
 
 #include <fsm/fsm.h>
 #include <fsm/pred.h>
 #include <fsm/walk.h>
+#include <fsm/alloc.h>
 
+#include <adt/edgeset.h>
+#include <adt/queue.h>
 #include <adt/set.h>
 
 #include "internal.h"
 
+#define MIN_ALT 1
+#define DUMP_MAPPINGS 0
+#define DUMP_STEPS 1
+#define DUMP_TIME 1
+
+#define NAIVE_DUMP_TABLE 0
+#define NAIVE_LOG_PARTITION 0
+
+#define MOORE_DUMP_INIT 0
+#define MOORE_DUMP_ECS 0
+#define MOORE_LOG_PARTITION 0
+
+#define EXMOORE_DUMP_INIT 0
+#define EXMOORE_DUMP_ECS 0
+#define EXMOORE_LOG_PARTITION 0
+
+#define DO_HOPCROFT 0
+#define HOPCROFT_DUMP_INIT 0
+#define HOPCROFT_DUMP_ECS 0
+#define HOPCROFT_LOG_STACK 0
+#define HOPCROFT_LOG_PARTITION 0
+#define HOPCROFT_LOG_FREELIST 0
+#define HOPCROFT_LOG_INDEX 0
+#define HOPCROFT_USE_LABEL_INDEX 0
+
+#define EXPENSIVE_INTEGRITY_CHECKS 0
+
+#if DUMP_TIME
+#include <sys/time.h>
+#endif
+
+#if MIN_ALT
+#include "minimise_internal.h"
+#else
+static int
+min_brz(struct fsm *fsm, size_t *minimized_state_count);
+#endif
+
 int
 fsm_minimise(struct fsm *fsm)
 {
-	int r;
+#if MIN_ALT
+	int r = 0;
+	size_t states_before, states_naive,
+	    states_moore, states_exmoore,
+	    states_hopcroft, states_brz;
+	fsm_state_t *mapping = NULL;
+	const struct fsm_alloc *alloc = fsm->opt ? fsm->opt->alloc : NULL;
+	unsigned char labels[256];
+	size_t label_count;
+
+#if DUMP_TIME
+	struct timeval tv_pre, tv_post;
+
+#define TIME(T) if (0 != gettimeofday(&T, NULL)) { assert(0); }
+#define DUMP_TIME_DELTA(NAME)				\
+	fprintf(stderr, "%-8s %.3f msec\n", NAME,	\
+	    1000.0 * (tv_post.tv_sec - tv_pre.tv_sec)	\
+	    + (tv_post.tv_usec - tv_pre.tv_usec)/1000.0);
+#else
+#define TIME(T)
+#define DUMP_TIME_DELTA(NAME)
+#endif
 
 	assert(fsm != NULL);
 
 	/* This should only be called with a DFA. */
 	assert(fsm_all(fsm, fsm_isdfa));
 
-	/*
-	 * Brzozowski's algorithm.
-	 */
+	if (!fsm_trim(fsm)) {
+		return 0;
+	}
 
-	r = fsm_reverse(fsm);
+	if (fsm->statecount == 0) {
+		return 1;	/* empty -- no-op */
+	}
+
+	mapping = f_malloc(alloc,
+	    fsm->statecount * sizeof(mapping[0]));
+	if (mapping == NULL) {
+		goto cleanup;
+	}
+
+	collect_labels(fsm, labels, &label_count);
+	if (label_count == 0) {
+		return 1;
+	}
+
+	states_before = fsm->statecount;
+
+	assert(fsm->statecount > 0);
+
+	TIME(tv_pre);
+	r = min_naive(fsm, labels, label_count, mapping, &states_naive);
+	TIME(tv_post);
+	DUMP_TIME_DELTA("naive");
+
+	if (!r) {
+		goto cleanup;
+	}
+
+	assert(fsm->statecount > 0);
+
+	TIME(tv_pre);
+	r = min_moore(fsm, labels, label_count, mapping, &states_moore);
+	TIME(tv_post);
+	DUMP_TIME_DELTA("moore");
+
+	if (!r) {
+		goto cleanup;
+	}
+
+	TIME(tv_pre);
+	r = min_exmoore(fsm, labels, label_count, mapping, &states_exmoore);
+	TIME(tv_post);
+	DUMP_TIME_DELTA("exmoore");
+
+	if (!r) {
+		goto cleanup;
+	}
+
+#if DO_HOPCROFT
+	TIME(tv_pre);
+	r = min_hopcroft(fsm, labels, label_count, mapping, &states_hopcroft);
+	TIME(tv_post);
+	DUMP_TIME_DELTA("hopcroft");
+#else
+	states_hopcroft = 0;
+#endif
+
+
+	if (!r) {
+		goto cleanup;
+	}
+
+
+	TIME(tv_pre);
+	r = min_brz(fsm, &states_brz);
+	TIME(tv_post);
+	DUMP_TIME_DELTA("brz");
+
+	fprintf(stdout, "# before: %lu, naive: %lu, moore: %lu, exmoore: %lu, hopcroft: %lu, brz: %lu\n",
+	    states_before, states_naive, states_moore, states_exmoore, states_hopcroft, states_brz);
+	fflush(stdout);
+
+	assert(states_naive <= states_brz);
+	assert(states_moore == states_naive);
+	assert(states_exmoore == states_moore);
+
+#if DO_HOPCROFT
+	assert(states_hopcroft == states_moore);
+#endif
+
+cleanup:
+	if (mapping != NULL) {
+		f_free(alloc, mapping);
+	}
+
+	return r;
+#else
+	assert(fsm != NULL);
+
+	/* This should only be called with a DFA. */
+	assert(fsm_all(fsm, fsm_isdfa));
+
+	return min_brz(fsm, NULL);
+#endif
+}
+
+/* Brzozowski's algorithm. Destructively modifies the input. */
+static int
+min_brz(struct fsm *fsm, size_t *minimized_state_count)
+{
+	int r = fsm_reverse(fsm);
 	if (!r) {
 		return 0;
 	}
@@ -48,8 +214,1995 @@ fsm_minimise(struct fsm *fsm)
 	r = fsm_determinise(fsm);
 	if (!r) {
 		return 0;
+	}
+
+	if (minimized_state_count != NULL) {
+		*minimized_state_count = fsm->statecount;
 	}
 
 	return 1;
 }
 
+
+#if MIN_ALT
+
+/* Build a bit set of labels used, then write the set
+ * into a sorted array. */
+static void
+collect_labels(const struct fsm *fsm,
+    unsigned char *labels, size_t *label_count)
+{
+	size_t count = 0;
+	uint64_t label_set[4] = { 0, 0, 0, 0 };
+	int i;
+
+	fsm_state_t id;
+	for (id = 0; id < fsm->statecount; id++) {
+		struct fsm_edge e;
+		struct edge_iter ei;
+		unsigned char label;
+		for (edge_set_reset(fsm->states[id].edges, &ei);
+		     edge_set_next(&ei, &e); ) {
+			if (e.state >= fsm->statecount) {
+				fprintf(stderr, "### ERROR: e.state %u >= fsm->statecount %lu\n",
+				    e.state, fsm->statecount);
+				continue;
+			}
+			assert(e.state < fsm->statecount);
+			label = e.symbol;
+
+			if (label_set[label/64] & (1UL << (label & 63))) {
+				/* already set, ignore */
+			} else {
+				label_set[label/64] |= (1UL << (label & 63));
+				count++;
+			}
+		}
+	}
+
+	*label_count = 0;
+	for (i = 0; i < 256; i++) {
+		if (label_set[i/64] & (1UL << (i & 63))) {
+			labels[*label_count] = i;
+			(*label_count)++;
+		}
+	}
+
+	assert(*label_count == count);
+}
+
+/* Naive O(N^2) minimization algorithm, as documented in ... */
+static int
+min_naive(const struct fsm *fsm,
+    const unsigned char *labels, size_t label_count,
+    fsm_state_t *mapping, size_t *minimized_state_count)
+{
+	int res = 0;
+	unsigned i, j, label_i;
+	int iter, changed;
+	fsm_state_t new_id;
+	const struct fsm_alloc *alloc = fsm->opt ? fsm->opt->alloc : NULL;
+	unsigned *table = NULL;
+	fsm_state_t *tmp_map = NULL;
+	const fsm_state_t dead_state = fsm->statecount;
+	const size_t table_states = (fsm->statecount + 1 /* dead state */);
+	const size_t row_words = table_states/(8*sizeof(unsigned))
+	    + 1 /* round up */;
+
+#define POS(X,Y) ((X*table_states) + Y)
+#define BITS (8*sizeof(unsigned))
+#define BIT_OP(X,Y,OP) (table[POS(X,Y)/BITS] OP (1UL << (POS(X,Y) & (BITS - 1))))
+#define MARK(X,Y) (BIT_OP(X, Y, |=))
+#define CLEAR(X,Y) (BIT_OP(X, Y, &=~))
+#define CHECK(X,Y) (BIT_OP(X, Y, &))
+
+	/* This implementation assumes that BITS is a power of 2,
+	 * to avoid the extra overhead from modulus. True when
+	 * sizeof(unsigned) is 4 or 8. */
+	assert((BITS & (BITS - 1)) == 0);
+
+	/* Allocate an NxN bit table, used to track which states have
+	 * not yet been proven indistinguishable.
+	 *
+	 * For two states A and B, only use the half of the table where
+	 * A <= B, to avoid redundantly comparing B with A. In other
+	 * words, only the bits below the diagonal are actually used.
+	 *
+	 * An extra state is added to internally represent a complete
+	 * graph -- for any state that does not have a particular label
+	 * used elsewhere, treat it as if it has that label leading to
+	 * an extra dead state. */
+	table = f_calloc(alloc,
+	    row_words * table_states, sizeof(table[0]));
+	if (table == NULL) { goto cleanup; }
+
+	tmp_map = f_malloc(alloc,
+	    fsm->statecount * sizeof(tmp_map[0]));
+	if (tmp_map == NULL) { goto cleanup; }
+
+	/* Mark all states as potentially indistinguishable from
+	 * themselves, as well as any pairs of states that are both
+	 * final or not final. */
+	for (i = 0; i < fsm->statecount; i++) {
+		MARK(i, i);
+		/* fprintf(stderr, "-- MARK %u, %u\n", i, i); */
+		for (j = 0; j < i; j++) {
+			if (fsm_isend(fsm, i) == fsm_isend(fsm, j)) {
+				/* fprintf(stderr, "-- MARK %u, %u: 1\n", i, j); */
+				MARK(i, j);
+			} else {
+				/* fprintf(stderr, "-- MARK %u, %u: 0\n", i, j); */
+			}
+		}
+	}
+	MARK(dead_state, dead_state);
+	/* fprintf(stderr, "-- MARK %u, %u\n", dead_state, dead_state); */
+
+	changed = 1;
+	iter = 0;
+	while (changed) {	/* run until reaching a fixpoint */
+		changed = 0;
+
+#if NAIVE_DUMP_TABLE
+		{
+			printf("==== iter %d\n", iter);
+			for (i = 0; i < table_states-1; i++) {
+				for (j = 0; j <= i; j++) {
+					printf("%s%d",
+					    j > 0 ? " " : "",
+					    CHECK(i, j) ? 1 : 0);
+				}
+				printf("\n");
+			}
+		}
+#endif
+
+		/* For every combination of states that are still
+		 * considered potentially indistinguishable, check
+		 * whether the current label leads both to a pair
+		 * of distinguishable states. If so, then they are
+		 * no longer distinguishable (transitively), so mark
+		 * them and set changed to note that another iteration
+		 * may be necessary. */
+		for (i = 0; i < table_states; i++) {
+			for (j = 0; j < i; j++) {
+				if (!CHECK(i, j)) { continue; }
+				for (label_i = 0; label_i < label_count; label_i++) {
+					const unsigned char label = labels[label_i];
+					const fsm_state_t to_i = naive_delta(fsm, i, label);
+					const fsm_state_t to_j = naive_delta(fsm, j, label);
+					int tbval;
+#if NAIVE_LOG_PARTITION
+					fprintf(stderr, "-- label '%c', %u -> %d, %u -> %d\n", label, i, to_i, j, to_j);
+#endif
+
+					if (to_i >= to_j) {
+						tbval = 0 != CHECK(to_i, to_j);
+					} else {
+						tbval = 0 != CHECK(to_j, to_i);
+					}
+					/* fprintf(stderr, "%d,%d -> %d ; %d -> %d\n",
+					 *     i, j, to_i, to_j, tbval); */
+					if (!tbval) {
+#if NAIVE_LOG_PARTITION
+						fprintf(stderr, "-- CLEAR: '%c', %u -> %d, %u -> %d\n", label, i, to_i, j, to_j);
+#endif
+						CLEAR(i, j);
+						changed = 1;
+						break;
+					}
+				}
+			}
+		}
+
+		iter++;
+	}
+
+	/* Initialize to (NO_ID) */
+	for (i = 0; i < fsm->statecount; i++) {
+		tmp_map[i] = NO_ID;
+	}
+
+	/* For any state that cannot be proven distinguishable from an
+	 * earlier state, map it back to the earlier one. */
+	for (i = 1; i < fsm->statecount; i++) {
+		for (j = 0; j < i; j++) {
+			if (CHECK(i, j)) {
+				tmp_map[i] = j;
+				/* fprintf(stderr, "# HIT %d,%d\n", i, j); */
+			}
+		}
+	}
+
+	/* Set IDs for the states, mapping some back to earlier states
+	 * (combining them). */
+	new_id = 0;
+	for (i = 0; i < fsm->statecount; i++) {
+		if (tmp_map[i] != (fsm_state_t)-1) {
+			mapping[i] = mapping[tmp_map[i]];
+		} else {
+			mapping[i] = new_id;
+			new_id++;
+		}
+	}
+
+	if (minimized_state_count != NULL) {
+		*minimized_state_count = new_id;
+#if DUMP_MAPPINGS
+		for (i = 0; i < *minimized_state_count; i++) {
+			fprintf(stderr, "# naive_mapping[%u]: %u\n",
+			    i, mapping[i]);
+		}
+#endif
+	}
+
+#if DUMP_STEPS
+	fprintf(stderr, "# done in %d step(s), %ld -> %d states\n",
+            iter, fsm->statecount, new_id);
+#endif
+
+	res = 1;
+#undef POS
+#undef BITS
+#undef MARK
+#undef CHECK
+#undef CLEAR
+#undef BIT_OP
+
+cleanup:
+	if (table != NULL) {
+		f_free(alloc, table);
+	}
+	if (tmp_map != NULL) {
+		f_free(alloc, tmp_map);
+	}
+	return res;
+}
+
+static fsm_state_t
+naive_delta(const struct fsm *fsm, fsm_state_t id, unsigned char label)
+{
+	struct fsm_edge e;
+	struct edge_iter ei;
+
+	assert(id < fsm->statecount);
+
+	for (edge_set_reset(fsm->states[id].edges, &ei);
+	     edge_set_next(&ei, &e); ) {
+		assert(e.state < fsm->statecount);
+		if (e.symbol == label) {
+			return e.state;
+		}
+		/* could skip rest if ordered */
+	}
+
+	return fsm->statecount;	/* dead end */
+}
+
+/* Implementation of Moore's DFA minimization algorithm,
+ * which is similar to Hopcroft's, but iterates to a fixpoint
+ * rather than using a queue to eliminate redundant work. */
+static int
+min_moore(const struct fsm *fsm,
+    const unsigned char *labels, size_t label_count,
+    fsm_state_t *mapping, size_t *minimized_state_count)
+{
+	struct moore_env env;
+	int changed, res = 0;
+	size_t i, iter = 0, steps = 0;
+	fsm_state_t ec_count, ec_offset;
+
+	/* Alloc for each state, plus the dead state. */
+	size_t alloc_size = (fsm->statecount + 1) * sizeof(env.state_ecs[0]);
+
+	/* Note that the ordering here is significant -- the
+	 * not-final EC may be skipped below. */
+	enum init_ec { INIT_EC_NOT_FINAL, INIT_EC_FINAL };
+
+	env.fsm = fsm;
+
+	/* This algorithm assumes the DFA is complete; if not,
+	 * then simulate a dead-end state internally and make
+	 * all other edges go to it. */
+	env.dead_state = fsm->statecount;
+
+	/* Data model: There are 1 or more equivalence classes
+	 * (hereafter, ECs) initially, which represent all the
+	 * end states and (if present) all the non-end states.
+	 * If there are no end states, the graph is already
+	 * empty, so this shouldn't run.
+	 *
+	 * The algorithm starts with all states divided into
+	 * these initial ECs, and as it detects different results
+	 * within an EC (i.e., for a given label, one state leads
+	 * to EC #2 but another state to EC #3) it partitions
+	 * them further, until it reaches a fixpoint.
+	 *
+	 * ECs[i] contains the state ID for the first state in
+	 * the linked list, then jump[id] contains the next
+	 * successive links, or NO_ID for the end of the list.
+	 * state_ecs[id] contains the current EC group.
+	 * In other words, state_ecs[ID] = EC, and ecs[EC] = X,
+	 * where X is either ID or jump[X], ... contains ID.
+	 * Ordering does not matter within the list. */
+	env.state_ecs = NULL;
+	env.jump = NULL;
+	env.ecs = NULL;
+	ec_count = 0;
+
+	assert(fsm->statecount != 0);
+	env.state_ecs = f_malloc(fsm->opt->alloc, alloc_size);
+	if (env.state_ecs == NULL) { goto cleanup; }
+
+	env.jump = f_malloc(fsm->opt->alloc, alloc_size);
+	if (env.jump == NULL) { goto cleanup; }
+
+	env.ecs = f_malloc(fsm->opt->alloc, alloc_size);
+	if (env.ecs == NULL) { goto cleanup; }
+
+	env.ecs[INIT_EC_NOT_FINAL] = NO_ID;
+	env.ecs[INIT_EC_FINAL] = NO_ID;
+	ec_count = 2;
+
+	/* build initial lists */
+	for (i = 0; i < fsm->statecount; i++) {
+		const fsm_state_t ec = fsm_isend(fsm, i)
+		    ? INIT_EC_FINAL : INIT_EC_NOT_FINAL;
+		env.state_ecs[i] = ec;
+		env.jump[i] = env.ecs[ec];
+		env.ecs[ec] = i;	/* may replace above */
+#if MOORE_DUMP_INIT
+		fprintf(stderr, "# --init[%lu]: ec %d, jump[]= %d\n", i, ec, env.jump[i]);
+#endif
+	}
+
+	env.state_ecs[env.dead_state] = NO_ID;
+
+#if MOORE_DUMP_INIT
+	for (i = 0; i < ec_count; i++) {
+		fprintf(stderr, "# --ec[%lu]: %d\n", i, env.ecs[i]);
+	}
+#endif
+
+	changed = 1;
+	while (changed) {	/* fixpoint */
+		size_t l_i, ec_i, cur_ec_count;
+		changed = 0;
+
+#if MOORE_DUMP_ECS
+		i = 0;
+		fprintf(stderr, "# iter %ld, steps %lu\n", iter, steps);
+		while (i < ec_count) {
+			fprintf(stderr, "M_EC[%lu]:", i);
+			moore_dump_ec(stderr, env.ecs[i], env.jump);
+			fprintf(stderr, "\n");
+			i++;
+		}
+#else
+		(void)moore_dump_ec;
+#endif
+
+		/* This loop can add new ECs, but they should not
+		 * be counted until the next pass. */
+		cur_ec_count = ec_count;
+
+		for (ec_i = 0; ec_i < cur_ec_count; ec_i++) {
+			for (l_i = 0; l_i < label_count; l_i++) {
+				steps++;
+				if (moore_try_partition(&env, labels[l_i],
+					ec_i, ec_count)) {
+					changed = 1;
+					ec_count++;
+				}
+			}
+		}
+		iter++;
+	}
+
+	/* When all of the original input states were final, then
+	 * the not-final EC will be empty. Skip it in the mapping,
+	 * otherwise an unnecessary state will be created for it. */
+	ec_offset = (env.ecs[INIT_EC_NOT_FINAL] == NO_ID) ? 1 : 0;
+
+	/* Build map condensing to unique states */
+	for (i = ec_offset; i < ec_count; i++) {
+		fsm_state_t cur = env.ecs[i];
+		while (cur != NO_ID) {
+			mapping[cur] = i - ec_offset;
+			cur = env.jump[cur];
+		}
+	}
+
+	if (minimized_state_count != NULL) {
+		*minimized_state_count = ec_count - ec_offset;
+#if DUMP_MAPPINGS
+		for (i = 0; i < *minimized_state_count; i++) {
+			fprintf(stderr, "# moore_mapping[%lu]: %u\n",
+			    i, mapping[i]);
+		}
+#endif
+	}
+
+#if DUMP_STEPS
+	fprintf(stderr, "# done in %lu iteration(s), %lu step(s), %ld -> %lu states, label_count %lu\n",
+            iter, steps, fsm->statecount, *minimized_state_count, label_count);
+#endif
+
+	res = 1;
+	/* fall through */
+cleanup:
+	f_free(fsm->opt->alloc, env.ecs);
+	f_free(fsm->opt->alloc, env.state_ecs);
+	f_free(fsm->opt->alloc, env.jump);
+	return res;
+}
+
+static void
+moore_dump_ec(FILE *f, fsm_state_t start, const fsm_state_t *jump)
+{
+	fsm_state_t cur = start;
+	while (cur != NO_ID) {
+		fprintf(f, " %u", cur);
+		cur = jump[cur];
+	}
+}
+
+static fsm_state_t
+moore_delta(const struct fsm *fsm, fsm_state_t id, unsigned char label)
+{
+	struct fsm_edge e;
+	struct edge_iter ei;
+
+	assert(id < fsm->statecount);
+
+	for (edge_set_reset(fsm->states[id].edges, &ei);
+	     edge_set_next(&ei, &e); ) {
+		assert(e.state < fsm->statecount);
+		if (e.symbol == label) {
+			return e.state;
+		}
+		/* could skip rest if ordered */
+	}
+
+	return fsm->statecount;	/* dead end */
+}
+
+static int
+moore_try_partition(struct moore_env *env, unsigned char label,
+    fsm_state_t ec_src, fsm_state_t ec_dst)
+{
+	size_t first_count, other_count = 0;
+	fsm_state_t cur = env->ecs[ec_src];
+	fsm_state_t to, to_ec, first_ec, prev;
+
+#if EXPENSIVE_INTEGRITY_CHECKS
+	size_t state_count = 0, psrc_count, pdst_count;
+	while (cur != NO_ID) {
+		cur = env->jump[cur];
+		state_count++;
+	}
+	cur = env->ecs[ec_src];
+#endif
+
+	/* Don't attempt to partition ECs with <2 states. */
+	if (cur == NO_ID || env->jump[cur] == NO_ID) { return 0; }
+
+#if MOORE_LOG_PARTITION
+	fprintf(stderr, "# --- mtp: checking '%c' for %u\n", label, ec_src);
+#endif
+
+	to = moore_delta(env->fsm, cur, label);
+	first_ec = env->state_ecs[to];
+
+#if MOORE_LOG_PARTITION
+	fprintf(stderr, "# --- mtp: first, %u, has to %d -> first_ec %d\n", cur, to, first_ec);
+#endif
+
+	first_count = 1;
+	prev = cur;
+	cur = env->jump[cur];
+
+	/* initialize the new EC -- empty */
+	env->ecs[ec_dst] = NO_ID;
+
+	while (cur != NO_ID) {
+		to = moore_delta(env->fsm, cur, label);
+		to_ec = env->state_ecs[to];
+#if MOORE_LOG_PARTITION
+		fprintf(stderr, "# --- mtp: next, cur %u, has to %d -> to_ec %d\n", cur, to, to_ec);
+#endif
+
+		if (to_ec == first_ec) { /* in same EC */
+			first_count++;
+			prev = cur;
+			cur = env->jump[cur];
+		} else {	/* unlink, split */
+			/* Unlink this state from the current EC,
+			 * instead put it as the start of a new one
+			 * at ecs[ec_dst]. */
+			fsm_state_t next = env->jump[cur];
+
+#if MOORE_LOG_PARTITION
+			fprintf(stderr, "# mtp: unlinking -- label '%c', src %u, dst %u, first_ec %d, cur %u -> to_ec %d\n", label, ec_src, ec_dst, first_ec, cur, to_ec);
+#endif
+
+			env->jump[prev] = next;
+			env->jump[cur] = env->ecs[ec_dst];
+			env->ecs[ec_dst] = cur;
+			cur = next;
+			other_count++;
+		}
+	}
+
+	/* If some were split off, update their state_ecs entries.
+	 * Wait to update until after they have all been compared,
+	 * otherwise the mix of updated and non-updated states can
+	 * lead to inconsistent results. */
+	if (other_count > 0) {
+		assert(env->ecs[ec_dst] != NO_ID);
+		cur = env->ecs[ec_dst];
+		while (cur != NO_ID) {
+			env->state_ecs[cur] = ec_dst;
+			cur = env->jump[cur];
+		}
+	}
+
+#if EXPENSIVE_INTEGRITY_CHECKS
+	psrc_count = 0;
+	cur = env->ecs[ec_src];
+	while (cur != NO_ID) {
+		cur = env->jump[cur];
+		psrc_count++;
+	}
+
+	pdst_count = 0;
+	cur = env->ecs[ec_dst];
+	while (cur != NO_ID) {
+		cur = env->jump[cur];
+		pdst_count++;
+	}
+
+	assert(state_count == psrc_count + pdst_count);
+#endif
+
+	return other_count > 0;
+}
+
+
+
+
+
+
+
+/* We only know the count for how many states are in an
+ * EC after an attempted partition. When the ECs have
+ * less than EXMOORE_EC_SMALL_THRESHOLD states, then
+ * set the upper bit to mark that it should get smarter
+ * handling -- instead of trying every label, look at what
+ * labels actually appear in the group, and then just try
+ * those, possibly guided by counts. */
+#define EXMOORE_EC_MSB (UINT_MAX ^ (UINT_MAX >> 1))
+#define EXMOORE_EC_SMALL_THRESHOLD 16
+#define EXMOORE_EC_LABELS_THRESHOLD 4
+#define EXMOORE_BOX_EC_HEAD(STATE_ID, IS_SMALL)	\
+	(STATE_ID | (IS_SMALL ? EXMOORE_EC_MSB : 0))
+#define EXMOORE_UNBOX_EC_HEAD(EC)		\
+	(EC &~ EXMOORE_EC_MSB)
+
+static void
+exmoore_update_ec(struct exmoore_env *env, fsm_state_t ec_dst)
+{
+	size_t count = 0;
+	fsm_state_t cur = env->ecs[ec_dst];
+
+	assert(cur != NO_ID);
+	while (cur != NO_ID) {
+		cur = EXMOORE_UNBOX_EC_HEAD(cur);
+		env->state_ecs[cur] = ec_dst;
+		cur = env->jump[cur];
+		count++;
+	}
+
+	/* Flag the EC for smarter label checking */
+	if (count <= EXMOORE_EC_SMALL_THRESHOLD
+		&& env->label_count >= EXMOORE_EC_LABELS_THRESHOLD) {
+		env->ecs[ec_dst] = EXMOORE_BOX_EC_HEAD(env->ecs[ec_dst], 1);
+	}
+}
+
+/* EXperimental, EXtended version of Moore's. */
+static int
+min_exmoore(const struct fsm *fsm,
+    const unsigned char *labels, size_t label_count,
+    fsm_state_t *mapping, size_t *minimized_state_count)
+{
+	struct exmoore_env env;
+	int changed, res = 0;
+	size_t i, iter = 0, steps = 0;
+
+	fsm_state_t ec_count, ec_offset;
+	fsm_state_t done_ec_offset;
+
+	/* Alloc for each state, plus the dead state. */
+	size_t alloc_size = (fsm->statecount + 1) * sizeof(env.state_ecs[0]);
+
+	/* Note that the ordering here is significant -- the
+	 * not-final EC may be skipped below. */
+	enum init_ec { INIT_EC_NOT_FINAL, INIT_EC_FINAL };
+
+	env.fsm = fsm;
+
+	/* This algorithm assumes the DFA is complete; if not,
+	 * then simulate a dead-end state internally and make
+	 * all other edges go to it. */
+	env.dead_state = fsm->statecount;
+
+	/* Data model: There are 1 or more equivalence classes
+	 * (hereafter, ECs) initially, which represent all the
+	 * end states and (if present) all the non-end states.
+	 * If there are no end states, the graph is already
+	 * empty, so this shouldn't run.
+	 *
+	 * The algorithm starts with all states divided into
+	 * these initial ECs, and as it detects different results
+	 * within an EC (i.e., for a given label, one state leads
+	 * to EC #2 but another state to EC #3) it partitions
+	 * them further, until it reaches a fixpoint.
+	 *
+	 * ECs[i] contains the state ID for the first state in
+	 * the linked list, then jump[id] contains the next
+	 * successive links, or NO_ID for the end of the list.
+	 * state_ecs[id] contains the current EC group.
+	 * In other words, state_ecs[ID] = EC, and ecs[EC] = X,
+	 * where X is either ID or jump[X], ... contains ID.
+	 * Ordering does not matter within the list. */
+	env.state_ecs = NULL;
+	env.jump = NULL;
+	env.ecs = NULL;
+	env.labels = labels;
+	env.label_count = label_count;
+	ec_count = 0;
+
+	assert(fsm->statecount != 0);
+	env.state_ecs = f_malloc(fsm->opt->alloc, alloc_size);
+	if (env.state_ecs == NULL) { goto cleanup; }
+
+	env.jump = f_malloc(fsm->opt->alloc, alloc_size);
+	if (env.jump == NULL) { goto cleanup; }
+
+	env.ecs = f_malloc(fsm->opt->alloc, alloc_size);
+	if (env.ecs == NULL) { goto cleanup; }
+
+	env.ecs[INIT_EC_NOT_FINAL] = NO_ID;
+	env.ecs[INIT_EC_FINAL] = NO_ID;
+	ec_count = 2;
+	done_ec_offset = ec_count;
+
+	/* build initial lists */
+	for (i = 0; i < fsm->statecount; i++) {
+		const fsm_state_t ec = fsm_isend(fsm, i)
+		    ? INIT_EC_FINAL : INIT_EC_NOT_FINAL;
+		env.state_ecs[i] = ec;
+		env.jump[i] = env.ecs[ec];
+		env.ecs[ec] = i;	/* may replace above */
+#if EXMOORE_DUMP_INIT
+		fprintf(stderr, "# --init[%lu]: ec %d, jump[]= %d\n", i, ec, env.jump[i]);
+#endif
+	}
+
+	env.state_ecs[env.dead_state] = NO_ID;
+
+#if EXMOORE_DUMP_INIT
+	for (i = 0; i < ec_count; i++) {
+		fprintf(stderr, "# --ec[%lu]: %d\n", i, env.ecs[i]);
+	}
+#endif
+
+	exmoore_heuristic_scan(stderr, &env, labels, label_count);
+
+	changed = 1;
+	while (changed) {	/* fixpoint */
+		size_t l_i, ec_i;
+		changed = 0;
+
+#if EXMOORE_DUMP_ECS
+		i = 0;
+		fprintf(stderr, "# iter %ld, steps %lu\n", iter, steps);
+		while (i < ec_count) {
+			fprintf(stderr, "M_EC[%lu]:", i);
+			exmoore_dump_ec(stderr,
+			    EXMOORE_UNBOX_EC_HEAD(env.ecs[i]),
+			    env.jump);
+			fprintf(stderr, "\n");
+			i++;
+		}
+#else
+		(void)exmoore_dump_ec;
+#endif
+
+		for (ec_i = 0; ec_i < done_ec_offset; ec_i++) {
+
+			/* Don't bother checking any ECs with less than two
+			 * states (they can't be split further), and note
+			 * if the flag was set for collecting the EC's edges. */
+			int special_handling;
+			struct exmoore_label_iterator li;
+	restart_EC:
+			{
+				fsm_state_t next = env.ecs[ec_i];
+				if (next == NO_ID) { continue; }
+				special_handling = next & EXMOORE_EC_MSB;
+				next = EXMOORE_UNBOX_EC_HEAD(next);
+
+				next = env.jump[next];
+				if (next == NO_ID) { continue; }
+			}
+
+			exmoore_init_label_iterator(&env, ec_i,
+			    special_handling, &li);
+
+			while (li.i < li.limit) {
+				size_t pcounts[2];
+				const fsm_state_t ec_src = ec_i;
+				const fsm_state_t ec_dst = ec_count;
+				unsigned char label;
+
+				l_i = li.i;
+				li.i++;
+
+				label = (li.use_special
+				    ? li.labels[l_i]
+				    : labels[l_i]);
+
+				steps++;
+				if (exmoore_try_partition(&env, label,
+					ec_src, ec_dst, pcounts)) {
+
+#if EXMOORE_LOG_PARTITION
+					fprintf(stderr, "# partition: ec_i %lu/%u/%u, l_i %lu/%u%s, pcounts [ %lu, %lu ]\n",
+					    ec_i, done_ec_offset, ec_count,
+					    l_i, li.limit, li.use_special ? "*" : "",
+					    pcounts[0], pcounts[1]);
+#endif
+
+					if (pcounts[1] == 1) {
+						assert(done_ec_offset > 0);
+						exmoore_update_ec(&env, ec_dst);
+					} else {
+						/* swap so that dst is before the done group */
+						const fsm_state_t ndst = done_ec_offset;
+						const fsm_state_t tmp = env.ecs[ec_dst];
+						env.ecs[ec_dst] = env.ecs[ndst];
+						env.ecs[ndst] = tmp;
+						exmoore_update_ec(&env, ec_dst);
+						exmoore_update_ec(&env, ndst);
+						done_ec_offset++;
+					}
+
+					/* if the src only has one, swap it into the done group */
+					if (pcounts[0] == 1 && done_ec_offset > 0) { /* swap */
+						fsm_state_t nsrc = done_ec_offset - 1;
+
+						/* swap ec[nsrc] and ec[ec_src] */
+						const fsm_state_t tmp = env.ecs[ec_src];
+						env.ecs[ec_src] = env.ecs[nsrc];
+						env.ecs[nsrc] = tmp;
+						exmoore_update_ec(&env, ec_src);
+						exmoore_update_ec(&env, nsrc);
+
+						done_ec_offset--;
+
+						/* The src EC just got swapped with another,
+						 * so start over at the beginning for the new EC. */
+						changed = 1;
+						ec_count++;
+						goto restart_EC;
+					}
+
+					changed = 1;
+					ec_count++;
+
+					assert(done_ec_offset >= 0);
+					assert(done_ec_offset <= ec_count);
+				}
+
+#if EXPENSIVE_INTEGRITY_CHECKS
+				for (i = 0; i < ec_count; i++) {
+					const fsm_state_t head = EXMOORE_UNBOX_EC_HEAD(env.ecs[i]);
+					if (i >= done_ec_offset) {
+						assert(head == NO_ID || env.jump[head] == NO_ID);
+					} else {
+						assert(env.jump[head] != NO_ID);
+					}
+				}
+#endif
+			}
+		}
+
+		iter++;
+	}
+
+	/* When all of the original input states were final, then
+	 * the not-final EC will be empty. Skip it in the mapping,
+	 * otherwise an unnecessary state will be created for it. */
+	ec_offset = (env.ecs[INIT_EC_NOT_FINAL] == NO_ID) ? 1 : 0;
+
+	/* Build map condensing to unique states */
+	for (i = ec_offset; i < ec_count; i++) {
+		fsm_state_t cur = EXMOORE_UNBOX_EC_HEAD(env.ecs[i]);
+		while (cur != NO_ID) {
+			mapping[cur] = i - ec_offset;
+			cur = env.jump[cur];
+		}
+	}
+
+	if (minimized_state_count != NULL) {
+		*minimized_state_count = ec_count - ec_offset;
+#if DUMP_MAPPINGS
+		for (i = 0; i < *minimized_state_count; i++) {
+			fprintf(stderr, "# exmoore_mapping[%lu]: %u\n",
+			    i, mapping[i]);
+		}
+#endif
+	}
+
+#if DUMP_STEPS
+	fprintf(stderr, "# done in %lu iteration(s), %lu step(s), %ld -> %lu states, label_count %lu\n",
+            iter, steps, fsm->statecount, *minimized_state_count, label_count);
+#endif
+
+	res = 1;
+	/* fall through */
+cleanup:
+	f_free(fsm->opt->alloc, env.ecs);
+	f_free(fsm->opt->alloc, env.state_ecs);
+	f_free(fsm->opt->alloc, env.jump);
+	return res;
+}
+
+static void
+exmoore_init_label_iterator(const struct exmoore_env *env,
+	fsm_state_t ec_i, int special_handling,
+	struct exmoore_label_iterator *li)
+{
+	/* If the MSB flag was set for the EC (indicating that it's fairly
+	 * small), then instead of trying every label, save time by only
+	 * checking the labels that are actually present. */
+	if (special_handling) {
+		fsm_state_t cur;
+		size_t i;
+		uint32_t label_set[8];
+		memset(label_set, 0x00, sizeof(label_set));
+
+		cur = env->ecs[ec_i];
+		assert(cur != NO_ID);
+		cur = EXMOORE_UNBOX_EC_HEAD(cur);
+
+		while (cur != NO_ID) {
+			struct fsm_edge e;
+			struct edge_iter ei;
+			for (edge_set_reset(env->fsm->states[cur].edges, &ei);
+			     edge_set_next(&ei, &e); ) {
+				const unsigned char label = e.symbol;
+				label_set[label/32] |= ((uint32_t)1 << (label & 31));
+			}
+			cur = env->jump[cur];
+		}
+
+		li->use_special = 1;
+		li->i = 0;
+		li->limit = 0;
+		i = 0;
+		while (i < 256) {
+			if ((i & 31) == 0 && label_set[i/32] == 0) {
+				i += 32;
+			} else {
+				if (label_set[i/32] & ((uint32_t)1 << (i & 31))) {
+					li->labels[li->limit] = i;
+					li->limit++;
+				}
+				i++;
+			}
+		}
+	} else {		/* all labels in sequence */
+		li->use_special = 0;
+		li->limit = env->label_count;
+		li->i = 0;
+	}
+}
+
+static void
+exmoore_dump_ec(FILE *f, fsm_state_t start, const fsm_state_t *jump)
+{
+	fsm_state_t cur = start;
+	while (cur != NO_ID) {
+		fprintf(f, " %u", cur);
+		cur = jump[cur];
+	}
+}
+
+static fsm_state_t
+exmoore_delta(const struct fsm *fsm, fsm_state_t id, unsigned char label)
+{
+	struct fsm_edge e;
+	struct edge_iter ei;
+
+	assert(id < fsm->statecount);
+
+	/* FIXME: use edge_set_find */
+	for (edge_set_reset(fsm->states[id].edges, &ei);
+	     edge_set_next(&ei, &e); ) {
+		assert(e.state < fsm->statecount);
+		if (e.symbol == label) {
+			return e.state;
+		}
+		/* could skip rest if ordered */
+	}
+
+	return fsm->statecount;	/* dead end */
+}
+
+/* unlike moore above:
+ * any split off get linked into EC_DST, but don't update the
+ * state_ec and other fields, because depending on how many are
+ * extracted, they may get swapped. */
+static int
+exmoore_try_partition(struct exmoore_env *env, unsigned char label,
+    fsm_state_t ec_src, fsm_state_t ec_dst,
+	size_t partition_counts[2])
+{
+	fsm_state_t cur = EXMOORE_UNBOX_EC_HEAD(env->ecs[ec_src]);
+	fsm_state_t to, to_ec, first_ec, prev;
+
+#if EXPENSIVE_INTEGRITY_CHECKS
+	size_t state_count = 0, psrc_count, pdst_count;
+	while (cur != NO_ID) {
+		cur = env->jump[cur];
+		state_count++;
+	}
+	cur = EXMOORE_UNBOX_EC_HEAD(env->ecs[ec_src]);
+#endif
+
+	memset(partition_counts, 0x00, 2*sizeof(partition_counts[0]));
+
+#if EXMOORE_LOG_PARTITION
+	fprintf(stderr, "# --- mtp: checking '%c' for %u\n", label, ec_src);
+#endif
+
+	to = exmoore_delta(env->fsm, cur, label);
+	first_ec = env->state_ecs[to];
+
+#if EXMOORE_LOG_PARTITION
+	fprintf(stderr, "# --- mtp: first, %u, has to %d -> first_ec %d\n", cur, to, first_ec);
+#endif
+
+	partition_counts[0] = 1;
+	prev = cur;
+	cur = env->jump[cur];
+
+	/* initialize the new EC -- empty */
+	env->ecs[ec_dst] = NO_ID;
+
+	while (cur != NO_ID) {
+		to = exmoore_delta(env->fsm, cur, label);
+		to_ec = env->state_ecs[to];
+#if EXMOORE_LOG_PARTITION
+		fprintf(stderr, "# --- mtp: next, cur %u, has to %d -> to_ec %d\n", cur, to, to_ec);
+#endif
+
+		if (to_ec == first_ec) { /* in same EC */
+			partition_counts[0]++;
+			prev = cur;
+			cur = env->jump[cur];
+		} else {	/* unlink, split */
+			/* Unlink this state from the current EC,
+			 * instead put it as the start of a new one
+			 * at ecs[ec_dst]. */
+			fsm_state_t next = env->jump[cur];
+
+#if EXMOORE_LOG_PARTITION
+			fprintf(stderr, "# mtp: unlinking -- label '%c', src %u, dst %u, first_ec %d, cur %u -> to_ec %d\n", label, ec_src, ec_dst, first_ec, cur, to_ec);
+#endif
+
+			env->jump[prev] = next;
+			env->jump[cur] = env->ecs[ec_dst];
+			env->ecs[ec_dst] = cur;
+			cur = next;
+			partition_counts[1]++;
+		}
+	}
+
+#if EXPENSIVE_INTEGRITY_CHECKS
+	psrc_count = 0;
+	cur = env->ecs[ec_src];
+	if (cur != NO_ID) {
+		cur = EXMOORE_UNBOX_EC_HEAD(cur);
+		while (cur != NO_ID) {
+			cur = env->jump[cur];
+			psrc_count++;
+		}
+	}
+
+	pdst_count = 0;
+	cur = env->ecs[ec_dst];
+	if (cur != NO_ID) {
+		cur = EXMOORE_UNBOX_EC_HEAD(cur);
+		while (cur != NO_ID) {
+			cur = env->jump[cur];
+			pdst_count++;
+		}
+	}
+
+	assert(state_count == psrc_count + pdst_count);
+#endif
+
+	return partition_counts[1] > 0;
+}
+
+static void
+exmoore_heuristic_scan(FILE *f, const struct exmoore_env *env,
+    const unsigned char *labels, size_t label_count)
+{
+#if 0
+	size_t i, s_i, e_i;
+	const struct fsm *fsm = env->fsm;
+	uint8_t label_map[256];
+	size_t *label_counts = calloc(label_count, sizeof(label_counts[0]));
+	assert(label_counts != NULL);
+
+	return;
+
+	for (i = 0; i < label_count; i++) {
+		label_map[labels[i]] = i;
+	}
+
+	for (s_i = 0; s_i < fsm->statecount; s_i++) {
+		struct fsm_edge e;
+		struct edge_iter ei;
+		const size_t edge_count = edge_set_count(fsm->states[s_i].edges);
+
+		e_i = 0;
+		for (edge_set_reset(fsm->states[s_i].edges, &ei);
+		     edge_set_next(&ei, &e); ) {
+			fprintf(f, "state %lu -- edge %lu/%lu -- '%c' -> %u\n",
+			    s_i, e_i, edge_count, e.symbol, e.state);
+			e_i++;
+			label_counts[label_map[e.symbol]]++;
+		}
+	}
+
+	for (i = 0; i < label_count; i++) {
+		fprintf(f, "label '%c': %lu\n", labels[i], label_counts[i]);
+	}
+
+	free(label_counts);
+#else
+	(void)f;
+	(void)env;
+	(void)labels;
+	(void)label_count;
+#endif
+}
+
+
+
+
+
+
+
+
+
+#if HOPCROFT_DUMP_INIT
+static void
+dump_edges(const struct fsm *fsm)
+{
+	struct fsm_edge e;
+	struct edge_iter ei;
+	fsm_state_t id;
+
+	for (id = 0; id < fsm->statecount; id++) {
+		for (edge_set_reset(fsm->states[id].edges, &ei);
+		     edge_set_next(&ei, &e); ) {
+			fprintf(stderr, "dump_edges: state[%d], edge <'%c' -> %u>\n",
+			    id, e.symbol, e.state);
+		}
+	}
+}
+#endif
+
+/* An fsm_state_id with the most significant bit set is
+ * an offset to the next cell on the freelist. The freelist
+ * is terminated with NO_ID, just like the EC lists. */
+#define FREELIST_MSB (UINT_MAX ^ (UINT_MAX >> 1))
+#define IS_FREELIST(ID) (ID & FREELIST_MSB)
+#define BOX_FREELIST(ID) (ID | FREELIST_MSB)
+#define UNBOX_FREELIST(ID) (ID &~ FREELIST_MSB)
+
+#if DO_HOPCROFT
+static int
+min_hopcroft(const struct fsm *fsm,
+    const unsigned char *labels, size_t label_count,
+    fsm_state_t *mapping, size_t *minimized_state_count)
+{
+	/* init splitter stack */
+	struct hopcroft_env env;
+	int res = 0;
+	size_t i, iter = 0, steps = 0;
+	fsm_state_t ec_count;
+
+	/* Alloc for each state, plus the dead state. */
+	size_t per_state_alloc_size = (fsm->statecount + 1)
+	    * sizeof(env.state_ecs[0]);
+
+	/* Note that the ordering here is significant -- the
+	 * not-final EC may be skipped below. */
+	enum init_ec { INIT_EC_NOT_FINAL, INIT_EC_FINAL };
+
+	memset(&env, 0x00, sizeof(env));
+
+	env.fsm = fsm;
+	env.labels = labels;
+	env.label_count = label_count;
+
+	/* This algorithm assumes the DFA is complete; if not,
+	 * then simulate a dead-end state internally and make
+	 * all other edges go to it. */
+	env.dead_state = fsm->statecount;
+
+	/* Data model: There are 1 or more equivalence classes
+	 * (hereafter, ECs) initially, which represent all the
+	 * end states and (if present) all the non-end states.
+	 * If there are no end states, the graph is already
+	 * empty, so this shouldn't run.
+	 *
+	 * The algorithm starts with all states divided into
+	 * these initial ECs, and as it detects different results
+	 * within an EC (i.e., for a given label, one state leads
+	 * to EC #2 but another state to EC #3) it partitions
+	 * them further, until it reaches a fixpoint.
+	 *
+	 * ECs[i] contains the state ID for the first state in
+	 * the linked list, then jump[id] contains the next
+	 * successive links, or NO_ID for the end of the list.
+	 * state_ecs[id] contains the current EC group.
+	 * In other words, state_ecs[ID] = EC, and ecs[EC] = X,
+	 * where X is either ID or jump[X], ... contains ID.
+	 * Ordering does not matter within the list. */
+
+	assert(fsm->statecount != 0);
+
+	if (!hopcroft_build_label_index(&env, labels, label_count)) {
+		goto cleanup;
+	}
+
+	env.stack.splitters = f_malloc(fsm->opt->alloc,
+	    DEF_SPLITTER_STACK_CEIL * sizeof(env.stack.splitters[0]));
+	if (env.stack.splitters == NULL) { goto cleanup; }
+	env.stack.ceil = DEF_SPLITTER_STACK_CEIL;
+	env.stack.count = 0;
+	for (i = 0; i < 256; i++) {
+		env.stack.index[i] = (size_t)-1;
+	}
+
+	env.ec_filter_bytes = (fsm->statecount/sizeof(uint64_t) + 1)
+	    * sizeof(uint64_t);
+	env.ec_filter = f_malloc(fsm->opt->alloc, env.ec_filter_bytes);
+	if (env.ec_filter == NULL) { goto cleanup; }
+
+	env.state_ecs = f_malloc(fsm->opt->alloc, per_state_alloc_size);
+	if (env.state_ecs == NULL) { goto cleanup; }
+
+	env.jump = f_malloc(fsm->opt->alloc, per_state_alloc_size);
+	if (env.jump == NULL) { goto cleanup; }
+
+	/* TODO: make this proportional to the state count */
+	env.ecs_ceil = 4;
+	env.ecs = f_malloc(fsm->opt->alloc, env.ecs_ceil * sizeof(env.ecs[0]));
+	if (env.ecs == NULL) { goto cleanup; }
+
+	env.updated_ecs_ceil = 4;
+	env.updated_ecs = f_malloc(fsm->opt->alloc,
+	    env.updated_ecs_ceil * sizeof(env.updated_ecs[0]));
+	if (env.updated_ecs == NULL) { goto cleanup; }
+
+	/* Build a freelist for available ECs */
+	for (i = 0; i < env.ecs_ceil; i++) {
+		env.ecs[i] = BOX_FREELIST(i + 1);
+	}
+	env.ecs[env.ecs_ceil - 1] = NO_ID;
+
+	env.ecs[INIT_EC_NOT_FINAL] = NO_ID;
+	env.ecs[INIT_EC_FINAL] = NO_ID;
+	env.max_ec_in_use = INIT_EC_FINAL;
+
+	env.ec_freelist = BOX_FREELIST(env.max_ec_in_use + 1);
+
+#if HOPCROFT_DUMP_INIT
+	for (i = 0; i < fsm->statecount; i++) {
+		fprintf(stderr, "freelist[%lu]: 0x%x\n", i, env.ecs[i]);
+	}
+#endif
+
+	{
+		size_t ecs_counts[2] = { 0, 0 };
+		size_t smaller_ec;
+
+		/* build initial lists */
+		for (i = 0; i < fsm->statecount; i++) {
+			const fsm_state_t ec = fsm_isend(fsm, i)
+			    ? INIT_EC_FINAL : INIT_EC_NOT_FINAL;
+			env.state_ecs[i] = ec;
+			env.jump[i] = env.ecs[ec];
+			env.ecs[ec] = i;	/* may replace above */
+#if HOPCROFT_DUMP_INIT
+			fprintf(stderr, "# --init[%lu]: ec %d, jump[]= %d\n", i, ec, env.jump[i]);
+#endif
+			ecs_counts[ec]++;
+
+		}
+
+		/* The dead state is an honorary member of the not-final EC.
+		 * Only add it if necessary. */
+		if (!fsm_all(fsm, fsm_iscomplete)) {
+			env.state_ecs[env.dead_state] = INIT_EC_NOT_FINAL;
+			env.jump[env.dead_state] = env.ecs[INIT_EC_NOT_FINAL];
+			env.ecs[INIT_EC_NOT_FINAL] = env.dead_state;
+			ecs_counts[INIT_EC_NOT_FINAL]++;
+		}
+
+		if (ecs_counts[INIT_EC_NOT_FINAL] == 0) {
+			env.ecs[INIT_EC_NOT_FINAL] = env.ec_freelist;
+			env.ec_freelist = BOX_FREELIST(INIT_EC_NOT_FINAL);
+		}
+
+		/* populate initial splitters */
+		smaller_ec = INIT_EC_FINAL;
+		if (ecs_counts[INIT_EC_NOT_FINAL] < ecs_counts[INIT_EC_FINAL]
+			&& ecs_counts[INIT_EC_NOT_FINAL] > 0) {
+			smaller_ec = INIT_EC_NOT_FINAL;
+		}
+
+		for (i = 0; i < label_count; i++) {
+			unsigned char label = labels[i];
+
+			if (!hopcroft_schedule_splitter(&env,
+				smaller_ec, label)) {
+				goto cleanup;
+			}
+		}
+	}
+
+#if HOPCROFT_DUMP_INIT
+	dump_edges(env.fsm);
+#endif
+
+	while (env.stack.count > 0) { /* until empty */
+		size_t l_i, ec_i;
+		struct splitter *splitter;
+		fsm_state_t splitter_ec;
+		unsigned char splitter_label;
+
+		/* FIXME: This should be dynamically allocated,
+		 * starting fairly small and growing on demand.
+		 * It's probably possible to determine the worst
+		 * case for this based on the number of input
+		 * states and preallocate it. */
+		size_t updated_ecs_i = 0;
+
+#if HOPCROFT_DUMP_INIT
+	for (i = 0; i < fsm->statecount; i++) {
+		fprintf(stderr, "freelist[%lu]: 0x%x\n", i, env.ecs[i]);
+	}
+#endif
+
+#if HOPCROFT_DUMP_ECS
+		i = 0;
+		fprintf(stderr, "# iter %ld, steps %lu\n", iter, steps);
+		while (i <= env.max_ec_in_use) {
+			if (IS_FREELIST(env.ecs[i])) {
+				i++;
+				continue;
+			}
+			fprintf(stderr, "H_EC[%lu]:", i);
+			hopcroft_dump_ec(stderr, env.ecs[i], env.jump);
+			fprintf(stderr, "\n");
+			i++;
+		}
+#else
+		(void)hopcroft_dump_ec;
+#endif
+
+#if HOPCROFT_LOG_STACK
+		fprintf(stderr, "# stack[%zu]: ", env.stack.count);
+		for (i = 0; i < env.stack.count; i++) {
+			fprintf(stderr, " <%d,'%c'>",
+			    env.stack.splitters[i].ec,
+			    env.stack.splitters[i].label);
+		}
+		fprintf(stderr, "\n");
+#endif
+
+		assert(env.stack.count > 0);
+		env.stack.count--;
+		splitter = &env.stack.splitters[env.stack.count];
+		splitter_ec = splitter->ec;
+		splitter_label = splitter->label;
+		env.stack.index[splitter_label] = splitter->prev;
+#if HOPCROFT_LOG_STACK
+		fprintf(stderr, "# popped splitter: <%d,'%c'>\n",
+		    splitter_ec, splitter_label);
+#endif
+
+		hopcroft_mark_ec_filter(&env, splitter_label);
+
+		/* This can add new ECs, but they should not be
+		 * considered active until after processing this
+		 * splitter. */
+		for (ec_i = 0; ec_i <= env.max_ec_in_use; ec_i++) {
+			const fsm_state_t ec_src = ec_i;
+			fsm_state_t ec_dst_a;
+			fsm_state_t ec_dst_b;
+			/* size_t l_i; */
+			size_t pcs[2]; /* partition counts */
+			enum hopcroft_try_partition_res pres;
+
+			if (!hopcroft_check_ec_filter(env.ec_filter, ec_i)) {
+				/* fprintf(stderr, "SKIP %u\n", ec_i); */
+				continue;
+			}
+
+#if !HOPCROFT_USE_LABEL_INDEX
+			if (IS_FREELIST(env.ecs[ec_i])) {
+				continue;
+			}
+#endif
+			steps++;
+
+			pres = hopcroft_try_partition(&env,
+			    splitter_ec, splitter_label,
+			    ec_src, &ec_dst_a, &ec_dst_b, pcs);
+
+			if (pres == HTP_ERROR_ALLOC) {
+				goto cleanup;
+			} else if (pres == HTP_PARTITIONED) {
+				struct updated_ecs *updated = &env.updated_ecs[updated_ecs_i];
+#if HOPCROFT_LOG_PARTITION
+				fprintf(stderr, "# partitioned EC %u into EC %u (w/ %lu) and EC %u (w/ %lu)\n",
+				    ec_src,
+				    ec_dst_a, pcs[0],
+				    ec_dst_b, pcs[1]);
+#endif
+
+				/* Note which ECs were updated, for
+				 * further bookkeeping after the
+				 * splitter pass completes. The dst EC
+				 * with fewer states always goes
+				 * first. */
+				updated->src = ec_src;
+				updated->dst[0] = pcs[0] < pcs[1] ? ec_dst_a : ec_dst_b;
+				updated->dst[1] = pcs[0] < pcs[1] ? ec_dst_b : ec_dst_a;
+
+				updated_ecs_i++;
+				if (updated_ecs_i == env.updated_ecs_ceil) {
+					if (!hopcroft_grow_updated_ecs(&env)) {
+						goto cleanup;
+					}
+				}
+
+				/* Box the newly created ECs so that they
+				 * will be ignored while doing the remainder
+				 * of the pass for this splitter. */
+				env.ecs[ec_dst_a] = BOX_FREELIST(env.ecs[ec_dst_a]);
+				env.ecs[ec_dst_b] = BOX_FREELIST(env.ecs[ec_dst_b]);
+			} else {
+				assert(pres == HTP_NO_CHANGE);
+			}
+		}
+
+		/* Now that the splitter pass is done, update ECs that
+		 * were processed by it -- the src EC gets put on the
+		 * freelist, the two dst ECs become active. */
+		for (ec_i = 0; ec_i < updated_ecs_i; ec_i++) {
+			struct updated_ecs *updated = &env.updated_ecs[ec_i];
+
+			/* put the partitioned EC back on the freelist */
+			assert(IS_FREELIST(env.ec_freelist));
+#if HOPCROFT_LOG_FREELIST
+			fprintf(stderr, "putting %u back on the freelist, pointing to 0x%x\n",
+			    updated->src, env.ec_freelist);
+#endif
+			env.ecs[updated->src] = env.ec_freelist;
+			env.ec_freelist = BOX_FREELIST(updated->src);
+
+			for (i = 0; i < 2; i++) {
+				fsm_state_t cur;
+				assert(IS_FREELIST(env.ecs[updated->dst[i]]));
+				env.ecs[updated->dst[i]] = UNBOX_FREELIST(env.ecs[updated->dst[i]]);
+				if (updated->dst[i] > env.max_ec_in_use) {
+					env.max_ec_in_use = updated->dst[i];
+				}
+
+				cur = env.ecs[updated->dst[i]];
+				while (cur != NO_ID) {
+					fsm_state_t next = env.jump[cur];
+					env.state_ecs[cur] = updated->dst[i];
+					assert(next != cur);
+					cur = next;
+				}
+			}
+
+			/* Schedule further splitters */
+			for (l_i = 0; l_i < label_count; l_i++) {
+				const unsigned char label = labels[l_i];
+				/* dst[0] always has <= states than dst[1], ordered above. */
+				fsm_state_t ec_min = updated->dst[0];
+				if (!hopcroft_update_splitter_stack(&env,
+					label, updated->src,
+					updated->dst[0], updated->dst[1], ec_min)) {
+					goto cleanup;
+				}
+			}
+		}
+
+		iter++;
+	}
+
+	/* Build map condensing to unique states */
+	ec_count = 0;
+	for (i = 0; i <= env.max_ec_in_use; i++) {
+		fsm_state_t cur;
+		size_t count = 0;
+
+		if (IS_FREELIST(env.ecs[i])) {
+			continue;
+		}
+
+		cur = env.ecs[i];
+		while (cur != NO_ID) {
+			/* Don't include the dead state in the result. */
+			if (cur == env.dead_state) {
+				cur = env.jump[cur];
+				if (cur == NO_ID) {
+					break;
+				}
+			}
+
+			count++;
+
+			mapping[cur] = ec_count;
+			cur = env.jump[cur];
+		}
+
+		if (count > 0) {
+			ec_count++;
+		}
+	}
+
+	if (minimized_state_count != NULL) {
+		*minimized_state_count = ec_count;
+
+#if DUMP_MAPPINGS
+		for (i = 0; i < *minimized_state_count; i++) {
+			fprintf(stderr, "# hopcroft_mapping[%lu]: %u\n",
+			    i, mapping[i]);
+		}
+#endif
+	}
+
+#if DUMP_STEPS
+	fprintf(stderr, "# done in %lu iteration(s), %lu step(s), %ld -> %lu states, label_count %lu\n",
+            iter, steps, fsm->statecount, *minimized_state_count, label_count);
+#endif
+
+	res = 1;
+	/* fall through */
+cleanup:
+	f_free(fsm->opt->alloc, env.ecs);
+	f_free(fsm->opt->alloc, env.updated_ecs);
+	f_free(fsm->opt->alloc, env.state_ecs);
+	f_free(fsm->opt->alloc, env.jump);
+	f_free(fsm->opt->alloc, env.stack.splitters);
+	f_free(fsm->opt->alloc, env.label_offsets);
+	f_free(fsm->opt->alloc, env.label_index);
+	f_free(fsm->opt->alloc, env.ec_filter);
+	return res;
+}
+
+static void
+hopcroft_dump_ec(FILE *f, fsm_state_t start, const fsm_state_t *jump)
+{
+	moore_dump_ec(f, start, jump);
+}
+
+static fsm_state_t
+hopcroft_delta(const struct fsm *fsm, fsm_state_t id, unsigned char label)
+{
+	struct fsm_edge e;
+	struct edge_iter ei;
+
+	if (id == fsm->statecount) {
+		return fsm->statecount;
+	}
+
+	assert(id < fsm->statecount);
+
+	for (edge_set_reset(fsm->states[id].edges, &ei);
+	     edge_set_next(&ei, &e); ) {
+		assert(e.state < fsm->statecount);
+		if (e.symbol == label) {
+			return e.state;
+		} else if (e.symbol > label) {
+			break;	/* ordered -- skip */
+		}
+	}
+
+	return fsm->statecount;	/* dead end */
+}
+
+static int
+hopcroft_freelist_pop(struct hopcroft_env *env,
+    fsm_state_t *id)
+{
+	assert(IS_FREELIST(env->ec_freelist));
+	if (env->ec_freelist == NO_ID) {
+		if (!hopcroft_grow_ecs_freelist(env)) {
+			return 0;
+		}
+	}
+
+	assert(env->ec_freelist != NO_ID);
+
+	*id = UNBOX_FREELIST(env->ec_freelist);
+	env->ec_freelist = env->ecs[*id];
+	return 1;
+}
+
+static void
+hopcroft_freelist_push(struct hopcroft_env *env,
+    fsm_state_t id)
+{
+	env->ecs[id] = env->ec_freelist;
+	env->ec_freelist = BOX_FREELIST(id);
+}
+
+static enum hopcroft_try_partition_res
+hopcroft_try_partition(struct hopcroft_env *env,
+    fsm_state_t ec_splitter, unsigned char label,
+    fsm_state_t ec_src,
+    fsm_state_t *ec_dst_a, fsm_state_t *ec_dst_b,
+    size_t partition_counts[2])
+{
+	enum hopcroft_try_partition_res res = HTP_NO_CHANGE;
+
+	/* Partition EC[ec_src] into the sets that have edges
+	 * with label that lead to EC_SPLITTER and those that
+	 * don't. */
+	fsm_state_t cur = env->ecs[ec_src];
+	fsm_state_t to, to_ec;
+
+	fsm_state_t dst_a, dst_b;
+
+	/* Don't attempt to partition ECs with <2 states. */
+	if (cur == NO_ID || env->jump[cur] == NO_ID) {
+		return HTP_NO_CHANGE;
+	}
+
+#if HOPCROFT_LOG_PARTITION
+	fprintf(stderr, "# --- htp: checking '%c' for %u\n", label, ec_src);
+#endif
+
+#if HOPCROFT_LOG_FREELIST
+	fprintf(stderr, "FL 0x%x\n", env->ec_freelist);
+#endif
+
+	if (!hopcroft_freelist_pop(env, &dst_a)) {
+		return HTP_ERROR_ALLOC;
+	}
+
+	if (!hopcroft_freelist_pop(env, &dst_b)) {
+		return HTP_ERROR_ALLOC;
+	}
+
+	/* initialize the new ECs -- empty */
+	env->ecs[dst_a] = NO_ID;
+	env->ecs[dst_b] = NO_ID;
+
+	partition_counts[0] = 0;
+	partition_counts[1] = 0;
+
+	while (cur != NO_ID) {
+		const fsm_state_t next = env->jump[cur];
+		to = hopcroft_delta(env->fsm, cur, label);
+		to_ec = env->state_ecs[to];
+
+#if HOPCROFT_LOG_PARTITION
+		fprintf(stderr, "# --- htp: cur %u, next %u, has to %d -> to_ec %d\n", cur, next, to, to_ec);
+#endif
+
+		if (to_ec == ec_splitter) { /* -> dst_a */
+#if HOPCROFT_LOG_PARTITION
+			fprintf(stderr, "#    ---> linked to EC %u (a), head was %u now %u\n",
+			    dst_a, env->ecs[dst_a], cur);
+#endif
+			env->jump[cur] = env->ecs[dst_a];
+			env->ecs[dst_a] = cur;
+			cur = next;
+			partition_counts[0]++;
+		} else {	/* -> dst_b */
+#if HOPCROFT_LOG_PARTITION
+			fprintf(stderr, "#    ---> linked to EC %u (b), head was %u now %u\n",
+			    dst_b, env->ecs[dst_b], cur);
+#endif
+			env->jump[cur] = env->ecs[dst_b];
+			env->ecs[dst_b] = cur;
+			cur = next;
+			partition_counts[1]++;
+		}
+	}
+
+#if HOPCROFT_LOG_PARTITION
+	fprintf(stderr, "# htp: partition counts: %lu, %lu\n",
+	    partition_counts[0], partition_counts[1]);
+#endif
+
+	/* If some were split off, update their state_ecs entries.
+	 * Wait to update until after they have all been compared,
+	 * otherwise the mix of updated and non-updated states can
+	 * lead to inconsistent results. */
+	if (partition_counts[0] > 0 && partition_counts[1] > 0) {
+		assert(env->ecs[dst_a] != NO_ID);
+		assert(env->ecs[dst_b] != NO_ID);
+
+		*ec_dst_a = dst_a;
+		*ec_dst_b = dst_b;
+		/* env->ec_freelist = freelist_head; */
+		res = HTP_PARTITIONED;
+	} else if (partition_counts[0] > 0) {
+		/* All were split off to ec_dst_a, but should be
+		 * restored to the original EC. */
+		assert(partition_counts[1] == 0);
+		env->ecs[ec_src] = env->ecs[dst_a];
+
+		hopcroft_freelist_push(env, dst_b);
+		hopcroft_freelist_push(env, dst_a);
+		/* env->ecs[dst_a] = BOX_FREELIST(dst_b); */
+		/* env->ecs[dst_b] = freelist_head; */
+		/* env->ec_freelist = BOX_FREELIST(dst_a); */
+	} else {
+		/* All were split off to ec_dst_b, but should be
+		 * restored to the original EC. */
+		assert(partition_counts[0] == 0);
+		assert(partition_counts[1] > 0);
+		env->ecs[ec_src] = env->ecs[dst_b];
+
+		/* env->ecs[dst_a] = BOX_FREELIST(dst_b); */
+		/* env->ecs[dst_b] = freelist_head; */
+		/* env->ec_freelist = BOX_FREELIST(dst_a); */
+		hopcroft_freelist_push(env, dst_b);
+		hopcroft_freelist_push(env, dst_a);
+	}
+
+	return res;
+}
+
+static int
+hopcroft_schedule_splitter(struct hopcroft_env *env,
+    fsm_state_t ec, unsigned char label)
+{
+	struct splitter *s;
+	if (env->stack.count == env->stack.ceil) {
+		size_t nceil = 2*env->stack.ceil;
+		struct splitter *nsplitters = f_realloc(env->fsm->opt->alloc,
+		    env->stack.splitters,
+		    nceil * sizeof(env->stack.splitters[0]));
+		if (nsplitters == NULL) { return 0; }
+		env->stack.ceil = nceil;
+		env->stack.splitters = nsplitters;
+	}
+
+#if HOPCROFT_LOG_STACK
+	fprintf(stderr, "# hopcroft_schedule_splitter: <%d,'%c'>\n",
+	    ec, label);
+#endif
+
+	s = &env->stack.splitters[env->stack.count];
+	s->ec = ec;
+	s->label = label;
+
+	/* Update index */
+	s->prev = env->stack.index[label];
+	env->stack.index[label] = env->stack.count;
+
+	env->stack.count++;
+	return 1;
+}
+
+static int
+hopcroft_update_splitter_stack(struct hopcroft_env *env,
+    unsigned char label, fsm_state_t ec_src,
+    fsm_state_t ec_dst_a, fsm_state_t ec_dst_b,
+    fsm_state_t ec_min)
+{
+	/* TODO this needs a search index */
+
+	/* If <ec_src, label> is already present then also add
+	 * <ec_dst, label> to the stack, otherwise add
+	 * <ec_min, label>, which represents whichever
+	 * of the new partition sets is smaller .*/
+	const size_t s_limit = env->stack.count;
+
+	size_t s_i;
+#if 0
+	for (s_i = 0; s_i < s_limit; s_i++) {
+		struct splitter *s = &env->stack.splitters[s_i];
+		if (s->ec == ec_src && s->label == label) {
+			/* fprintf(stderr, "XXX remap -> adding <%u,'%c'>\n", ec_dst, label); */
+			s->ec = ec_dst_a;
+			if (!hopcroft_schedule_splitter(env,
+				ec_dst_b, label)) {
+				return 0;
+			}
+			return 1;
+		}
+	}
+#else
+	s_i = env->stack.index[label];
+	while (s_i < s_limit) {
+		struct splitter *s = &env->stack.splitters[s_i];
+		assert(s->label == label);
+		if (s->label != label) { break; }
+		if (s->ec == ec_src) {
+			s->ec = ec_dst_a;
+			if (!hopcroft_schedule_splitter(env,
+				ec_dst_b, label)) {
+				return 0;
+			}
+			return 1;
+		}
+		s_i = s->prev;
+	}
+#endif
+
+	/* Not found, add smaller set. */
+	return hopcroft_schedule_splitter(env, ec_min, label);
+}
+
+static int
+hopcroft_grow_updated_ecs(struct hopcroft_env *env)
+{
+	const size_t nceil = 2*env->updated_ecs_ceil;
+	struct updated_ecs *nupdated_ecs = f_realloc(env->fsm->opt->alloc,
+	    env->updated_ecs, nceil * sizeof(env->updated_ecs[0]));
+	if (nupdated_ecs == NULL) {
+		return 0;
+	}
+
+	env->updated_ecs_ceil = nceil;
+	env->updated_ecs = nupdated_ecs;
+	return 1;
+}
+
+static int
+hopcroft_grow_ecs_freelist(struct hopcroft_env *env)
+{
+	/* todo: This could double in size up to a certain
+	 * point, then add a fixed number of states. */
+	const size_t nceil = 2*env->ecs_ceil;
+	size_t i;
+	fsm_state_t *necs = f_realloc(env->fsm->opt->alloc,
+	    env->ecs, nceil * sizeof(env->ecs[0]));
+#if HOPCROFT_LOG_FREELIST
+	fprintf(stderr, "# growing freelist %lu -> %lu\n", env->ecs_ceil, nceil);
+#endif
+
+	if (necs == NULL) {
+		return 0;
+	}
+
+	for (i = env->ecs_ceil; i < nceil; i++) {
+		necs[i] = BOX_FREELIST(i + 1);
+	}
+	necs[nceil - 1] = NO_ID;
+	env->ec_freelist = env->ecs_ceil;
+
+	env->ecs = necs;
+	env->ecs_ceil = nceil;
+	return 1;
+}
+
+/* Build two arrays:
+ * - label_index[]: series of states that have an edge with a label,
+ *       grouped by label.
+ * - label_offset[]: the offset into label_index where the states
+ *       who have a particular label start. This array only contains
+ *       the actual lables in labels[], which is assumed to be sorted.
+ *
+ * Note: This function can replace collect_labels above; in that case
+ * labels and label_count could be built during the first pass. */
+static int
+hopcroft_build_label_index(struct hopcroft_env *env,
+	const unsigned char *labels, size_t label_count)
+{
+#if !HOPCROFT_USE_LABEL_INDEX
+	(void)env;
+	(void)labels;
+	(void)label_count;
+	return 1;
+#else
+	const struct fsm *fsm = env->fsm;
+	size_t label_counts[256];
+
+	size_t i, edge_count = 0;
+	const size_t state_count = fsm->statecount;
+
+	memset(label_counts, 0x00, sizeof(label_counts));
+
+	/* Count the total number of edges, and how many
+	 * edges there are with each particular label. */
+	for (i = 0; i < state_count; i++) {
+		struct fsm_edge e;
+		struct edge_iter ei;
+		for (edge_set_reset(fsm->states[i].edges, &ei);
+		     edge_set_next(&ei, &e); ) {
+			edge_count++;
+			label_counts[e.symbol]++;
+		}
+	}
+
+	assert(edge_count > 0);
+
+	/* Histogram the label counts. */
+	for (i = 1; i < 256; i++) {
+		label_counts[i] += label_counts[i - 1];
+	}
+
+	env->label_index = f_malloc(fsm->opt->alloc,
+	    edge_count * sizeof(env->label_index[0]));
+	if (env->label_index == NULL) {
+		return 0;
+	}
+
+	env->label_offsets = f_malloc(fsm->opt->alloc,
+	    label_count * sizeof(env->label_offsets[0]));
+	if (env->label_offsets == NULL) {
+		f_free(fsm->opt->alloc, env->label_index);
+		return 0;
+	}
+
+	/* Save the offsets -- for labels[l_i], the states who have
+	 * edges with it will appear between label_offsets[l_i - 1]
+	 * and label_offsets[l_i], or 0 when l_i == 0. */
+	for (i = 0; i < label_count; i++) {
+		env->label_offsets[i] = label_counts[labels[i]];
+		if (i > 0) {	/* must be sorted */
+			assert(labels[i] > labels[i - 1]);
+		}
+	}
+
+	/* Use the histogram to group the state IDs by edge label.
+	 * label_counts[i] stores the offset where the next instance
+	 * of that label's index data should be stored. */
+	for (i = state_count; i > 0; i--) {
+		struct fsm_edge e;
+		struct edge_iter ei;
+		for (edge_set_reset(fsm->states[i - 1].edges, &ei);
+		     edge_set_next(&ei, &e); ) {
+			--label_counts[e.symbol];
+
+#if HOPCROFT_LOG_INDEX
+			fprintf(stderr, "label '%c', state[%ld]: count %u\n",
+			    e.symbol, i - 1,
+			    label_counts[e.symbol]);
+#endif
+			assert(label_counts[e.symbol] < edge_count);
+			env->label_index[label_counts[e.symbol]] = i - 1;
+		}
+	}
+
+#if HOPCROFT_LOG_INDEX
+	for (i = 0; i < label_count; i++) {
+		fprintf(stderr, "label_offsets[%lu]: %u\n",
+		    i, env->label_offsets[i]);
+	}
+
+	for (i = 0; i < edge_count; i++) {
+		fprintf(stderr, "label_index[%lu]: %u\n",
+		    i, env->label_index[i]);
+	}
+#endif
+
+#if EXPENSIVE_INTEGRITY_CHECKS
+	/* If a state is in the index for a label, it must have that
+	 * label, and there must not be any extras. */
+	{
+		size_t s_i, l_i;
+		for (s_i = 0; s_i < state_count; s_i++) {
+			struct fsm_edge e;
+			struct edge_iter ei;
+			unsigned char label;
+			size_t has_label_count = 0, found_label_count = 0;
+			uint64_t has_label[4] = { 0, 0, 0, 0 };
+			for (l_i = 0; l_i < label_count; l_i++) {
+				size_t i = (l_i == 0 ? 0 : env->label_offsets[l_i - 1]);
+				label = labels[l_i];
+				while (i < env->label_offsets[l_i]) {
+					if (env->label_index[i] == s_i) {
+						uint64_t bit;
+						bit = (uint64_t)1 << (label & 63);
+
+						if (!(has_label[label/64] & bit)) {
+							has_label[label/64] |= bit;
+							has_label_count++;
+						}
+					}
+					i++;
+				}
+			}
+
+			for (edge_set_reset(fsm->states[s_i].edges, &ei);
+			     edge_set_next(&ei, &e); ) {
+				label = e.symbol;
+				assert(has_label[label/64] & ((uint64_t)1 << (label&63)));
+				found_label_count++;
+			}
+
+			assert(has_label_count == found_label_count);
+		}
+	}
+#endif
+
+	return 1;
+#endif
+}
+
+static void
+hopcroft_mark_ec_filter(struct hopcroft_env *env,
+    unsigned char label)
+{
+#if HOPCROFT_USE_LABEL_INDEX
+	size_t l_i, i;		/* label_i */
+	uint64_t *filter = env->ec_filter;
+	if (filter == NULL) { return; }
+
+	memset(filter, 0x00, env->ec_filter_bytes);
+
+	for (l_i = 0; l_i < env->label_count; l_i++) {
+		size_t base, limit;
+		if (env->labels[l_i] != label) { continue; }
+		base = (l_i == 0
+		    ? 0
+		    : env->label_offsets[l_i - 1]);
+		limit = env->label_offsets[l_i];
+		for (i = base; i < limit; i++) {
+			const fsm_state_t s = env->label_index[i];
+			const fsm_state_t ec_id = env->state_ecs[s];
+
+			/* Don't mark single-entry ECs. */
+			if (env->ecs[ec_id] == s &&
+			    env->jump[s] == NO_ID) { continue; }
+
+			filter[ec_id/64] |= ((uint64_t)1 << (ec_id&63));
+		}
+		break;
+	}
+#else
+	(void)env;
+	(void)label;
+#endif
+}
+
+static int
+hopcroft_check_ec_filter(const uint64_t *filter,
+    fsm_state_t ec_id)
+{
+#if HOPCROFT_USE_LABEL_INDEX
+	return 0 != (filter[ec_id/64] & ((uint64_t)1 << (ec_id&63)));
+#else
+	(void)filter;
+	(void)ec_id;
+	return 1;
+#endif
+}
+#endif
+
+#endif /* MIN_ALT */

--- a/src/libfsm/minimise.c
+++ b/src/libfsm/minimise.c
@@ -18,106 +18,114 @@
 #include <fsm/alloc.h>
 
 #include <adt/edgeset.h>
-#include <adt/queue.h>
 #include <adt/set.h>
 
 #include "internal.h"
 
-#define MIN_REAL 1
-#define MIN_ALT 0
-#define DUMP_MAPPINGS 0
-#define DUMP_STEPS 0
-#define DUMP_TIME 0
+#define LOG_MAPPINGS 0
+#define LOG_STEPS 0
+#define LOG_TIME 0
+#define LOG_INIT 0
+#define LOG_ECS 0
+#define LOG_PARTITIONS 0
 
-#define NAIVE_DUMP_TABLE 0
-#define NAIVE_LOG_PARTITION 0
-
-#define MOORE_DUMP_INIT 0
-#define MOORE_DUMP_ECS 0
-#define MOORE_LOG_PARTITION 0
-
-#define EXMOORE_DUMP_INIT 1
-#define EXMOORE_DUMP_ECS 1
-#define EXMOORE_LOG_PARTITION 1
-
-#define DO_HOPCROFT 0
-#define HOPCROFT_DUMP_INIT 0
-#define HOPCROFT_DUMP_ECS 0
-#define HOPCROFT_LOG_STACK 0
-#define HOPCROFT_LOG_PARTITION 0
-#define HOPCROFT_LOG_FREELIST 0
-#define HOPCROFT_LOG_INDEX 0
-#define HOPCROFT_USE_LABEL_INDEX 0
-
-#define EXPENSIVE_INTEGRITY_CHECKS 0
-
-#if DUMP_TIME
+#if LOG_TIME
 #include <sys/time.h>
 #endif
 
-#if MIN_ALT
 #include "minimise_internal.h"
-#else
-static int
-min_brz(struct fsm *fsm, size_t *minimized_state_count);
-#endif
 
+int
+fsm_minimise(struct fsm *fsm)
+{
+	int r = 0;
+	struct fsm *dst = NULL;
 
-
-
-#if MIN_REAL
-#define NO_ID ((fsm_state_t)-1)
-
-struct exmoore_env {
-	const struct fsm *fsm;
-	fsm_state_t dead_state;
-	fsm_state_t *state_ecs;
-	fsm_state_t *jump;
-	fsm_state_t *ecs;
-	const unsigned char *labels;
-	size_t label_count;
-};
-
-struct exmoore_label_iterator {
-	unsigned i;
-	unsigned limit;
-	unsigned char use_special;
 	unsigned char labels[256];
-};
+	size_t label_count, orig_states, minimised_states;
+	fsm_state_t *mapping = NULL;
 
-static int
-min_exmoore(const struct fsm *fsm,
-    const unsigned char *labels, size_t label_count,
-    fsm_state_t *mapping, size_t *minimized_state_count);
+#if LOG_TIME
+	struct timeval tv_pre, tv_post;
 
-static void
-exmoore_dump_ec(FILE *f, fsm_state_t start, const fsm_state_t *jump);
-
-static int
-exmoore_try_partition(struct exmoore_env *env, unsigned char label,
-    fsm_state_t ec_src, fsm_state_t ec_dst,
-    size_t partition_counts[2]);
-
-static void
-exmoore_heuristic_scan(FILE *f, const struct exmoore_env *env,
-    const unsigned char *labels, size_t label_count);
-
-static void
-exmoore_init_label_iterator(const struct exmoore_env *env,
-	fsm_state_t ec_i, int special_handling,
-	struct exmoore_label_iterator *li);
+#define TIME(T) if (0 != gettimeofday(&T, NULL)) { assert(0); }
+#define LOG_TIME_DELTA(NAME)				\
+	fprintf(stderr, "%-8s %.3f msec\n", NAME,	\
+	    1000.0 * (tv_post.tv_sec - tv_pre.tv_sec)	\
+	    + (tv_post.tv_usec - tv_pre.tv_usec)/1000.0);
+#else
+#define TIME(T)
+#define LOG_TIME_DELTA(NAME)
 #endif
 
+	/* This should only be called with a DFA. */
+	assert(fsm != NULL);
+	assert(fsm_all(fsm, fsm_isdfa));
 
+	/* The algorithm used below won't remove states without a path
+	 * to an end state, because it cannot prove they're
+	 * unnecessary, so they must be trimmed away first. */
+	if (fsm_trim(fsm, FSM_TRIM_START_AND_END_REACHABLE) < 0) {
+		return 0;
+	}
 
+	if (fsm->statecount == 0) {
+		return 1;	/* empty -- no-op */
+	}
 
+	TIME(tv_pre);
+	collect_labels(fsm, labels, &label_count);
+	TIME(tv_post);
+	LOG_TIME_DELTA("collect_labels");
 
+	if (label_count == 0) {
+		return 1;	/* no edges -- no-op */
+	}
 
+	mapping = f_malloc(fsm->opt->alloc,
+	    fsm->statecount * sizeof(mapping[0]));
+	if (mapping == NULL) {
+		goto cleanup;
+	}
 
+	orig_states = fsm->statecount;
 
+	TIME(tv_pre);
+	r = build_minimised_mapping(fsm, labels, label_count,
+	    mapping, &minimised_states);
+	TIME(tv_post);
+	LOG_TIME_DELTA("minimise");
 
+	if (!r) {
+		goto cleanup;
+	}
 
-#if MIN_REAL || MIN_ALT
+	/* Minimisation should never add states. */
+	assert(minimised_states <= orig_states);
+
+	/* Use the mapping to consolidate the current states
+	 * into a new DFA, combining states that could not be
+	 * proven distinguishable. */
+	TIME(tv_pre);
+	dst = fsm_consolidate(fsm, mapping, fsm->statecount);
+	TIME(tv_post);
+	LOG_TIME_DELTA("consolidate");
+
+	if (dst == NULL) {
+		r = 0;
+		goto cleanup;
+	}
+
+	fsm_move(fsm, dst);
+
+cleanup:
+	if (mapping != NULL) {
+		f_free(fsm->opt->alloc, mapping);
+	}
+
+	return r;
+}
+
 /* Build a bit set of labels used, then write the set
  * into a sorted array. */
 static void
@@ -135,11 +143,6 @@ collect_labels(const struct fsm *fsm,
 		unsigned char label;
 		for (edge_set_reset(fsm->states[id].edges, &ei);
 		     edge_set_next(&ei, &e); ) {
-			if (e.state >= fsm->statecount) {
-				fprintf(stderr, "### ERROR: e.state %u >= fsm->statecount %lu\n",
-				    e.state, fsm->statecount);
-				continue;
-			}
 			assert(e.state < fsm->statecount);
 			label = e.symbol;
 
@@ -159,522 +162,56 @@ collect_labels(const struct fsm *fsm,
 			(*label_count)++;
 		}
 	}
-
 	assert(*label_count == count);
 }
-#endif
 
-int
-fsm_minimise(struct fsm *fsm)
-{
-#if MIN_REAL
-	/* build label mapping */
-	unsigned char labels[256];
-	size_t label_count, minimised_states;
-	struct fsm *dst = NULL;
-	fsm_state_t *mapping = NULL;
-	int r = 0;
-
-#if DUMP_TIME
-	struct timeval tv_pre, tv_post;
-
-#define TIME(T) if (0 != gettimeofday(&T, NULL)) { assert(0); }
-#define DUMP_TIME_DELTA(NAME)				\
-	fprintf(stderr, "%-8s %.3f msec\n", NAME,	\
-	    1000.0 * (tv_post.tv_sec - tv_pre.tv_sec)	\
-	    + (tv_post.tv_usec - tv_pre.tv_usec)/1000.0);
-#else
-#define TIME(T)
-#define DUMP_TIME_DELTA(NAME)
-#endif
-
-	assert(fsm != NULL);
-
-	/* This should only be called with a DFA. */
-	assert(fsm_all(fsm, fsm_isdfa));
-
-	if (fsm_trim(fsm, FSM_TRIM_START_AND_END_REACHABLE) < 0) {
-		return 0;
-	}
-
-	if (fsm->statecount == 0) {
-		return 1;	/* empty -- no-op */
-	}
-
-	TIME(tv_pre);
-	collect_labels(fsm, labels, &label_count);
-	TIME(tv_post);
-	DUMP_TIME_DELTA("collect_labels");
-
-	if (label_count == 0) {
-		return 1;	/* empty -- no-op */
-	}
-
-	mapping = f_malloc(fsm->opt->alloc,
-	    fsm->statecount * sizeof(mapping[0]));
-	if (mapping == NULL) {
-		goto cleanup;
-	}
-
-	/* exmoore */
-	TIME(tv_pre);
-	r = min_exmoore(fsm, labels, label_count, mapping, &minimised_states);
-	TIME(tv_post);
-	DUMP_TIME_DELTA("exmoore");
-
-	if (!r) {
-		goto cleanup;
-	}
-
-	/* consolidate */
-	TIME(tv_pre);
-	dst = fsm_consolidate(fsm, mapping, fsm->statecount);
-	TIME(tv_post);
-	DUMP_TIME_DELTA("consolidate");
-
-	(void)min_brz;
-
-	if (dst == NULL) {
-		r = 0;
-		goto cleanup;
-	}
-
-	(void)minimised_states;
-
-	fsm_move(fsm, dst);
-
-cleanup:
-	if (mapping != NULL) {
-		f_free(fsm->opt->alloc, mapping);
-	}
-
-	return r;
-
-
-#else
-#if MIN_ALT
-	int r = 0;
-	size_t states_before, states_naive,
-	    states_moore, states_exmoore,
-	    states_hopcroft, states_brz;
-	fsm_state_t *mapping = NULL;
-	const struct fsm_alloc *alloc = fsm->opt ? fsm->opt->alloc : NULL;
-	unsigned char labels[256];
-	size_t label_count;
-
-#if DUMP_TIME
-	struct timeval tv_pre, tv_post;
-
-#define TIME(T) if (0 != gettimeofday(&T, NULL)) { assert(0); }
-#define DUMP_TIME_DELTA(NAME)				\
-	fprintf(stderr, "%-8s %.3f msec\n", NAME,	\
-	    1000.0 * (tv_post.tv_sec - tv_pre.tv_sec)	\
-	    + (tv_post.tv_usec - tv_pre.tv_usec)/1000.0);
-#else
-#define TIME(T)
-#define DUMP_TIME_DELTA(NAME)
-#endif
-
-	assert(fsm != NULL);
-
-	/* This should only be called with a DFA. */
-	assert(fsm_all(fsm, fsm_isdfa));
-
-	if (fsm_trim(fsm, FSM_TRIM_START_AND_END_REACHABLE) < 0) {
-		return 0;
-	}
-
-	if (fsm->statecount == 0) {
-		return 1;	/* empty -- no-op */
-	}
-
-	mapping = f_malloc(alloc,
-	    fsm->statecount * sizeof(mapping[0]));
-	if (mapping == NULL) {
-		goto cleanup;
-	}
-
-	collect_labels(fsm, labels, &label_count);
-	if (label_count == 0) {
-		return 1;
-	}
-
-	states_before = fsm->statecount;
-
-	assert(fsm->statecount > 0);
-
-	TIME(tv_pre);
-	r = min_naive(fsm, labels, label_count, mapping, &states_naive);
-	TIME(tv_post);
-	DUMP_TIME_DELTA("naive");
-
-	if (!r) {
-		goto cleanup;
-	}
-
-	assert(fsm->statecount > 0);
-
-	TIME(tv_pre);
-	r = min_moore(fsm, labels, label_count, mapping, &states_moore);
-	TIME(tv_post);
-	DUMP_TIME_DELTA("moore");
-
-	if (!r) {
-		goto cleanup;
-	}
-
-	TIME(tv_pre);
-	r = min_exmoore(fsm, labels, label_count, mapping, &states_exmoore);
-	TIME(tv_post);
-	DUMP_TIME_DELTA("exmoore");
-
-	if (!r) {
-		goto cleanup;
-	}
-
-#if DO_HOPCROFT
-	TIME(tv_pre);
-	r = min_hopcroft(fsm, labels, label_count, mapping, &states_hopcroft);
-	TIME(tv_post);
-	DUMP_TIME_DELTA("hopcroft");
-#else
-	states_hopcroft = 0;
-#endif
-
-
-	if (!r) {
-		goto cleanup;
-	}
-
-
-	TIME(tv_pre);
-	r = min_brz(fsm, &states_brz);
-	TIME(tv_post);
-	DUMP_TIME_DELTA("brz");
-
-	fprintf(stdout, "# before: %lu, naive: %lu, moore: %lu, exmoore: %lu, hopcroft: %lu, brz: %lu\n",
-	    states_before, states_naive, states_moore, states_exmoore, states_hopcroft, states_brz);
-	fflush(stdout);
-
-	assert(states_naive <= states_brz);
-	assert(states_moore == states_naive);
-	assert(states_exmoore == states_moore);
-
-#if DO_HOPCROFT
-	assert(states_hopcroft == states_moore);
-#endif
-
-cleanup:
-	if (mapping != NULL) {
-		f_free(alloc, mapping);
-	}
-
-	return r;
-#else
-	assert(fsm != NULL);
-
-	/* This should only be called with a DFA. */
-	assert(fsm_all(fsm, fsm_isdfa));
-
-	return min_brz(fsm, NULL);
-#endif
-#endif
-}
-
-/* Brzozowski's algorithm. Destructively modifies the input. */
+/* Build a mapping for a minimised version of the DFA, using Moore's
+ * algorithm (with a couple performance improvements).
+ *
+ * For a good description of the algorithm (albeit one that incorrectly
+ * attributes it to Hopcroft) see pgs. 55-59 of Cooper & Torczon's
+ * _Engineering a Compiler_. For another, see pg. 13-20 of Erin van der
+ * Veen's thesis, _The Practical Performance of Automata Minimization
+ * Algorithms_.
+ *
+ * Intuitively, the algorithm starts by dividing all of the states into
+ * two sets, called Equivalence Classes (abbreviated EC below),
+ * containing all non-final and final states respectively. Then, for
+ * every EC, check whether any of its states' edges for the same label
+ * lead to states in distinct ECs (and therefore observably different
+ * results). If so, partition the EC into two ECs, containing the states
+ * with matching and non-matching destination ECs. (Which EC is chosen
+ * as matching doesn't affect correctness.) Repeat until no further
+ * progress can be made, meaning the algorithm cannot prove anything
+ * else is distinguishable via transitive final/non-final reachability.
+ * Each EC represents a state in the minimised DFA mapping, and multiple
+ * states in a single EC can be safely combined without affecting
+ * observable behavior. */
 static int
-min_brz(struct fsm *fsm, size_t *minimized_state_count)
-{
-	int r = fsm_reverse(fsm);
-	if (!r) {
-		return 0;
-	}
-
-	r = fsm_determinise(fsm);
-	if (!r) {
-		return 0;
-	}
-
-	r = fsm_reverse(fsm);
-	if (!r) {
-		return 0;
-	}
-
-	r = fsm_determinise(fsm);
-	if (!r) {
-		return 0;
-	}
-
-	if (minimized_state_count != NULL) {
-		*minimized_state_count = fsm->statecount;
-	}
-
-	return 1;
-}
-
-
-#if MIN_ALT
-
-/* Naive O(N^2) minimization algorithm, as documented in ... */
-static int
-min_naive(const struct fsm *fsm,
-    const unsigned char *labels, size_t label_count,
+build_minimised_mapping(const struct fsm *fsm,
+    const unsigned char *dfa_labels, size_t dfa_label_count,
     fsm_state_t *mapping, size_t *minimized_state_count)
 {
-	int res = 0;
-	unsigned i, j, label_i;
-	int iter, changed;
-	fsm_state_t new_id;
-	const struct fsm_alloc *alloc = fsm->opt ? fsm->opt->alloc : NULL;
-	unsigned *table = NULL;
-	fsm_state_t *tmp_map = NULL;
-	const fsm_state_t dead_state = fsm->statecount;
-	const size_t table_states = (fsm->statecount + 1 /* dead state */);
-	const size_t row_words = table_states/(8*sizeof(unsigned))
-	    + 1 /* round up */;
-
-#define POS(X,Y) ((X*table_states) + Y)
-#define BITS (8*sizeof(unsigned))
-#define BIT_OP(X,Y,OP) (table[POS(X,Y)/BITS] OP (1UL << (POS(X,Y) & (BITS - 1))))
-#define MARK(X,Y) (BIT_OP(X, Y, |=))
-#define CLEAR(X,Y) (BIT_OP(X, Y, &=~))
-#define CHECK(X,Y) (BIT_OP(X, Y, &))
-
-	/* This implementation assumes that BITS is a power of 2,
-	 * to avoid the extra overhead from modulus. True when
-	 * sizeof(unsigned) is 4 or 8. */
-	assert((BITS & (BITS - 1)) == 0);
-
-	/* Allocate an NxN bit table, used to track which states have
-	 * not yet been proven indistinguishable.
-	 *
-	 * For two states A and B, only use the half of the table where
-	 * A <= B, to avoid redundantly comparing B with A. In other
-	 * words, only the bits below the diagonal are actually used.
-	 *
-	 * An extra state is added to internally represent a complete
-	 * graph -- for any state that does not have a particular label
-	 * used elsewhere, treat it as if it has that label leading to
-	 * an extra dead state. */
-	table = f_calloc(alloc,
-	    row_words * table_states, sizeof(table[0]));
-	if (table == NULL) { goto cleanup; }
-
-	tmp_map = f_malloc(alloc,
-	    fsm->statecount * sizeof(tmp_map[0]));
-	if (tmp_map == NULL) { goto cleanup; }
-
-	/* Mark all states as potentially indistinguishable from
-	 * themselves, as well as any pairs of states that are both
-	 * final or not final. */
-	for (i = 0; i < fsm->statecount; i++) {
-		MARK(i, i);
-		/* fprintf(stderr, "-- MARK %u, %u\n", i, i); */
-		for (j = 0; j < i; j++) {
-			if (fsm_isend(fsm, i) == fsm_isend(fsm, j)) {
-				/* fprintf(stderr, "-- MARK %u, %u: 1\n", i, j); */
-				MARK(i, j);
-			} else {
-				/* fprintf(stderr, "-- MARK %u, %u: 0\n", i, j); */
-			}
-		}
-	}
-	MARK(dead_state, dead_state);
-	/* fprintf(stderr, "-- MARK %u, %u\n", dead_state, dead_state); */
-
-	changed = 1;
-	iter = 0;
-	while (changed) {	/* run until reaching a fixpoint */
-		changed = 0;
-
-#if NAIVE_DUMP_TABLE
-		{
-			printf("==== iter %d\n", iter);
-			for (i = 0; i < table_states-1; i++) {
-				for (j = 0; j <= i; j++) {
-					printf("%s%d",
-					    j > 0 ? " " : "",
-					    CHECK(i, j) ? 1 : 0);
-				}
-				printf("\n");
-			}
-		}
-#endif
-
-		/* For every combination of states that are still
-		 * considered potentially indistinguishable, check
-		 * whether the current label leads both to a pair
-		 * of distinguishable states. If so, then they are
-		 * no longer distinguishable (transitively), so mark
-		 * them and set changed to note that another iteration
-		 * may be necessary. */
-		for (i = 0; i < table_states; i++) {
-			for (j = 0; j < i; j++) {
-				if (!CHECK(i, j)) { continue; }
-				for (label_i = 0; label_i < label_count; label_i++) {
-					const unsigned char label = labels[label_i];
-					const fsm_state_t to_i = naive_delta(fsm, i, label);
-					const fsm_state_t to_j = naive_delta(fsm, j, label);
-					int tbval;
-#if NAIVE_LOG_PARTITION
-					fprintf(stderr, "-- label '%c', %u -> %d, %u -> %d\n", label, i, to_i, j, to_j);
-#endif
-
-					if (to_i >= to_j) {
-						tbval = 0 != CHECK(to_i, to_j);
-					} else {
-						tbval = 0 != CHECK(to_j, to_i);
-					}
-					/* fprintf(stderr, "%d,%d -> %d ; %d -> %d\n",
-					 *     i, j, to_i, to_j, tbval); */
-					if (!tbval) {
-#if NAIVE_LOG_PARTITION
-						fprintf(stderr, "-- CLEAR: '%c', %u -> %d, %u -> %d\n", label, i, to_i, j, to_j);
-#endif
-						CLEAR(i, j);
-						changed = 1;
-						break;
-					}
-				}
-			}
-		}
-
-		iter++;
-	}
-
-	/* Initialize to (NO_ID) */
-	for (i = 0; i < fsm->statecount; i++) {
-		tmp_map[i] = NO_ID;
-	}
-
-	/* For any state that cannot be proven distinguishable from an
-	 * earlier state, map it back to the earlier one. */
-	for (i = 1; i < fsm->statecount; i++) {
-		for (j = 0; j < i; j++) {
-			if (CHECK(i, j)) {
-				tmp_map[i] = j;
-				/* fprintf(stderr, "# HIT %d,%d\n", i, j); */
-			}
-		}
-	}
-
-	/* Set IDs for the states, mapping some back to earlier states
-	 * (combining them). */
-	new_id = 0;
-	for (i = 0; i < fsm->statecount; i++) {
-		if (tmp_map[i] != (fsm_state_t)-1) {
-			mapping[i] = mapping[tmp_map[i]];
-		} else {
-			mapping[i] = new_id;
-			new_id++;
-		}
-	}
-
-	if (minimized_state_count != NULL) {
-		*minimized_state_count = new_id;
-#if DUMP_MAPPINGS
-		for (i = 0; i < *minimized_state_count; i++) {
-			fprintf(stderr, "# naive_mapping[%u]: %u\n",
-			    i, mapping[i]);
-		}
-#endif
-	}
-
-#if DUMP_STEPS
-	fprintf(stderr, "# done in %d step(s), %ld -> %d states\n",
-            iter, fsm->statecount, new_id);
-#endif
-
-	res = 1;
-#undef POS
-#undef BITS
-#undef MARK
-#undef CHECK
-#undef CLEAR
-#undef BIT_OP
-
-cleanup:
-	if (table != NULL) {
-		f_free(alloc, table);
-	}
-	if (tmp_map != NULL) {
-		f_free(alloc, tmp_map);
-	}
-	return res;
-}
-
-static fsm_state_t
-naive_delta(const struct fsm *fsm, fsm_state_t id, unsigned char label)
-{
-	struct fsm_edge e;
-	struct edge_iter ei;
-
-	assert(id < fsm->statecount);
-
-	for (edge_set_reset(fsm->states[id].edges, &ei);
-	     edge_set_next(&ei, &e); ) {
-		assert(e.state < fsm->statecount);
-		if (e.symbol == label) {
-			return e.state;
-		}
-		/* could skip rest if ordered */
-	}
-
-	return fsm->statecount;	/* dead end */
-}
-
-/* Implementation of Moore's DFA minimization algorithm,
- * which is similar to Hopcroft's, but iterates to a fixpoint
- * rather than using a queue to eliminate redundant work. */
-static int
-min_moore(const struct fsm *fsm,
-    const unsigned char *labels, size_t label_count,
-    fsm_state_t *mapping, size_t *minimized_state_count)
-{
-	struct moore_env env;
+	struct min_env env;
 	int changed, res = 0;
-	size_t i, iter = 0, steps = 0;
-	fsm_state_t ec_count, ec_offset;
+	size_t i;
+	fsm_state_t ec_offset;
 
 	/* Alloc for each state, plus the dead state. */
 	size_t alloc_size = (fsm->statecount + 1) * sizeof(env.state_ecs[0]);
 
-	/* Note that the ordering here is significant -- the
-	 * not-final EC may be skipped below. */
-	enum init_ec { INIT_EC_NOT_FINAL, INIT_EC_FINAL };
-
 	env.fsm = fsm;
-
-	/* This algorithm assumes the DFA is complete; if not,
-	 * then simulate a dead-end state internally and make
-	 * all other edges go to it. */
 	env.dead_state = fsm->statecount;
+	env.iter = 0;
+	env.steps = 0;
 
-	/* Data model: There are 1 or more equivalence classes
-	 * (hereafter, ECs) initially, which represent all the
-	 * end states and (if present) all the non-end states.
-	 * If there are no end states, the graph is already
-	 * empty, so this shouldn't run.
-	 *
-	 * The algorithm starts with all states divided into
-	 * these initial ECs, and as it detects different results
-	 * within an EC (i.e., for a given label, one state leads
-	 * to EC #2 but another state to EC #3) it partitions
-	 * them further, until it reaches a fixpoint.
-	 *
-	 * ECs[i] contains the state ID for the first state in
-	 * the linked list, then jump[id] contains the next
-	 * successive links, or NO_ID for the end of the list.
-	 * state_ecs[id] contains the current EC group.
-	 * In other words, state_ecs[ID] = EC, and ecs[EC] = X,
-	 * where X is either ID or jump[X], ... contains ID.
-	 * Ordering does not matter within the list. */
+	assert(fsm->statecount > 0);
 	env.state_ecs = NULL;
 	env.jump = NULL;
 	env.ecs = NULL;
-	ec_count = 0;
+	env.dfa_labels = dfa_labels;
+	env.dfa_label_count = dfa_label_count;
 
-	assert(fsm->statecount != 0);
 	env.state_ecs = f_malloc(fsm->opt->alloc, alloc_size);
 	if (env.state_ecs == NULL) { goto cleanup; }
 
@@ -686,71 +223,96 @@ min_moore(const struct fsm *fsm,
 
 	env.ecs[INIT_EC_NOT_FINAL] = NO_ID;
 	env.ecs[INIT_EC_FINAL] = NO_ID;
-	ec_count = 2;
+	env.ec_count = 2;
+	env.done_ec_offset = env.ec_count;
 
-	/* build initial lists */
-	for (i = 0; i < fsm->statecount; i++) {
-		const fsm_state_t ec = fsm_isend(fsm, i)
-		    ? INIT_EC_FINAL : INIT_EC_NOT_FINAL;
-		env.state_ecs[i] = ec;
-		env.jump[i] = env.ecs[ec];
-		env.ecs[ec] = i;	/* may replace above */
-#if MOORE_DUMP_INIT
-		fprintf(stderr, "# --init[%lu]: ec %d, jump[]= %d\n", i, ec, env.jump[i]);
-#endif
-	}
+	populate_initial_ecs(&env, fsm);
 
-	env.state_ecs[env.dead_state] = NO_ID;
-
-#if MOORE_DUMP_INIT
-	for (i = 0; i < ec_count; i++) {
+#if LOG_INIT
+	for (i = 0; i < env.ec_count; i++) {
 		fprintf(stderr, "# --ec[%lu]: %d\n", i, env.ecs[i]);
 	}
 #endif
 
-	changed = 1;
-	while (changed) {	/* fixpoint */
-		size_t l_i, ec_i, cur_ec_count;
+	do {		/* repeat until no further progress can be made */
+		size_t l_i, ec_i;
 		changed = 0;
+		dump_ecs(stderr, &env);
 
-#if MOORE_DUMP_ECS
-		i = 0;
-		fprintf(stderr, "# iter %ld, steps %lu\n", iter, steps);
-		while (i < ec_count) {
-			fprintf(stderr, "M_EC[%lu]:", i);
-			moore_dump_ec(stderr, env.ecs[i], env.jump);
-			fprintf(stderr, "\n");
-			i++;
-		}
-#else
-		(void)moore_dump_ec;
-#endif
+		/* Check all active ECs for potential partitions. */
+		for (ec_i = 0; ec_i < env.done_ec_offset; ec_i++) {
+			int should_gather_EC_labels;
+			struct min_label_iterator li;
+	restart_EC:		/* ECs were swapped; restart the new EC here */
+			{
+				fsm_state_t next = env.ecs[ec_i];
+				if (next == NO_ID) {
+					continue;    /* 0 elements, skip */
+				}
+				should_gather_EC_labels = next & SMALL_EC_FLAG;
+				next = MASK_EC_HEAD(next);
 
-		/* This loop can add new ECs, but they should not
-		 * be counted until the next pass. */
-		cur_ec_count = ec_count;
-
-		for (ec_i = 0; ec_i < cur_ec_count; ec_i++) {
-			for (l_i = 0; l_i < label_count; l_i++) {
-				steps++;
-				if (moore_try_partition(&env, labels[l_i],
-					ec_i, ec_count)) {
-					changed = 1;
-					ec_count++;
+				if (env.jump[next] == NO_ID) {
+					continue;    /* only 1 element, skip */
 				}
 			}
-		}
-		iter++;
-	}
 
-	/* When all of the original input states were final, then
-	 * the not-final EC will be empty. Skip it in the mapping,
+			init_label_iterator(&env, ec_i,
+			    should_gather_EC_labels, &li);
+
+			while (li.i < li.limit) {
+				size_t pcounts[2];
+				const fsm_state_t ec_src = ec_i;
+				const fsm_state_t ec_dst = env.ec_count;
+				unsigned char label;
+
+				l_i = li.i;
+				li.i++;
+
+				label = (li.has_labels_for_EC
+				    ? li.labels[l_i]
+				    : env.dfa_labels[l_i]);
+
+				env.steps++;
+				if (try_partition(&env, label,
+					ec_src, ec_dst, pcounts)) {
+					int should_restart_EC;
+#if LOG_PARTITIONS > 0
+					fprintf(stderr, "# partition: ec_i %lu/%u/%u, l_i %lu/%u%s, pcounts [ %lu, %lu ]\n",
+					    ec_i, env.done_ec_offset, env.ec_count,
+					    l_i, li.limit, li.has_labels_for_EC ? "*" : "",
+					    pcounts[0], pcounts[1]);
+#endif
+
+					should_restart_EC =
+					    update_after_partition(&env,
+						pcounts, ec_src, ec_dst);
+
+					changed = 1;
+					env.ec_count++;
+					assert(env.done_ec_offset <= env.ec_count);
+					if (should_restart_EC) {
+						goto restart_EC;
+					}
+				}
+
+#if EXPENSIVE_INTEGRITY_CHECKS
+				check_done_ec_offset(&env);
+#endif
+			}
+		}
+
+		env.iter++;
+	} while (changed);
+
+	/* When all of the original input states are final, then the
+	 * initial not-final EC will be empty. Skip it in the mapping,
 	 * otherwise an unnecessary state will be created for it. */
 	ec_offset = (env.ecs[INIT_EC_NOT_FINAL] == NO_ID) ? 1 : 0;
 
 	/* Build map condensing to unique states */
-	for (i = ec_offset; i < ec_count; i++) {
-		fsm_state_t cur = env.ecs[i];
+	for (i = ec_offset; i < env.ec_count; i++) {
+		fsm_state_t cur = MASK_EC_HEAD(env.ecs[i]);
 		while (cur != NO_ID) {
 			mapping[cur] = i - ec_offset;
 			cur = env.jump[cur];
@@ -758,22 +320,25 @@ min_moore(const struct fsm *fsm,
 	}
 
 	if (minimized_state_count != NULL) {
-		*minimized_state_count = ec_count - ec_offset;
-#if DUMP_MAPPINGS
-		for (i = 0; i < *minimized_state_count; i++) {
-			fprintf(stderr, "# moore_mapping[%lu]: %u\n",
-			    i, mapping[i]);
-		}
-#endif
+		*minimized_state_count = env.ec_count - ec_offset;
 	}
 
-#if DUMP_STEPS
-	fprintf(stderr, "# done in %lu iteration(s), %lu step(s), %ld -> %lu states, label_count %lu\n",
-            iter, steps, fsm->statecount, *minimized_state_count, label_count);
+#if LOG_MAPPINGS
+	for (i = 0; i < fsm->statecount; i++) {
+		fprintf(stderr, "# minimised_mapping[%lu]: %u\n",
+		    i, mapping[i]);
+	}
+#endif
+
+#if LOG_STEPS
+	fprintf(stderr, "# done in %lu iteration(s), %lu step(s), %ld -> %ld states, label_count %lu\n",
+            env.iter, env.steps, fsm->statecount,
+	    (size_t)(env.ec_count - ec_offset), env.dfa_label_count);
 #endif
 
 	res = 1;
 	/* fall through */
+
 cleanup:
 	f_free(fsm->opt->alloc, env.ecs);
 	f_free(fsm->opt->alloc, env.state_ecs);
@@ -782,445 +347,169 @@ cleanup:
 }
 
 static void
-moore_dump_ec(FILE *f, fsm_state_t start, const fsm_state_t *jump)
+dump_ecs(FILE *f, const struct min_env *env)
 {
-	fsm_state_t cur = start;
-	while (cur != NO_ID) {
-		fprintf(f, " %u", cur);
-		cur = jump[cur];
-	}
-}
-
-static fsm_state_t
-moore_delta(const struct fsm *fsm, fsm_state_t id, unsigned char label)
-{
-	struct fsm_edge e;
-	struct edge_iter ei;
-
-	assert(id < fsm->statecount);
-
-	for (edge_set_reset(fsm->states[id].edges, &ei);
-	     edge_set_next(&ei, &e); ) {
-		assert(e.state < fsm->statecount);
-		if (e.symbol == label) {
-			return e.state;
-		}
-		/* could skip rest if ordered */
-	}
-
-	return fsm->statecount;	/* dead end */
-}
-
-static int
-moore_try_partition(struct moore_env *env, unsigned char label,
-    fsm_state_t ec_src, fsm_state_t ec_dst)
-{
-	size_t first_count, other_count = 0;
-	fsm_state_t cur = env->ecs[ec_src];
-	fsm_state_t to, to_ec, first_ec, prev;
-
-#if EXPENSIVE_INTEGRITY_CHECKS
-	size_t state_count = 0, psrc_count, pdst_count;
-	while (cur != NO_ID) {
-		cur = env->jump[cur];
-		state_count++;
-	}
-	cur = env->ecs[ec_src];
-#endif
-
-	/* Don't attempt to partition ECs with <2 states. */
-	if (cur == NO_ID || env->jump[cur] == NO_ID) { return 0; }
-
-#if MOORE_LOG_PARTITION
-	fprintf(stderr, "# --- mtp: checking '%c' for %u\n", label, ec_src);
-#endif
-
-	to = moore_delta(env->fsm, cur, label);
-	first_ec = env->state_ecs[to];
-
-#if MOORE_LOG_PARTITION
-	fprintf(stderr, "# --- mtp: first, %u, has to %d -> first_ec %d\n", cur, to, first_ec);
-#endif
-
-	first_count = 1;
-	prev = cur;
-	cur = env->jump[cur];
-
-	/* initialize the new EC -- empty */
-	env->ecs[ec_dst] = NO_ID;
-
-	while (cur != NO_ID) {
-		to = moore_delta(env->fsm, cur, label);
-		to_ec = env->state_ecs[to];
-#if MOORE_LOG_PARTITION
-		fprintf(stderr, "# --- mtp: next, cur %u, has to %d -> to_ec %d\n", cur, to, to_ec);
-#endif
-
-		if (to_ec == first_ec) { /* in same EC */
-			first_count++;
-			prev = cur;
-			cur = env->jump[cur];
-		} else {	/* unlink, split */
-			/* Unlink this state from the current EC,
-			 * instead put it as the start of a new one
-			 * at ecs[ec_dst]. */
-			fsm_state_t next = env->jump[cur];
-
-#if MOORE_LOG_PARTITION
-			fprintf(stderr, "# mtp: unlinking -- label '%c', src %u, dst %u, first_ec %d, cur %u -> to_ec %d\n", label, ec_src, ec_dst, first_ec, cur, to_ec);
-#endif
-
-			env->jump[prev] = next;
-			env->jump[cur] = env->ecs[ec_dst];
-			env->ecs[ec_dst] = cur;
-			cur = next;
-			other_count++;
-		}
-	}
-
-	/* If some were split off, update their state_ecs entries.
-	 * Wait to update until after they have all been compared,
-	 * otherwise the mix of updated and non-updated states can
-	 * lead to inconsistent results. */
-	if (other_count > 0) {
-		assert(env->ecs[ec_dst] != NO_ID);
-		cur = env->ecs[ec_dst];
+#if LOG_ECS
+	size_t i = 0;
+	fprintf(f, "# iter %ld, steps %lu\n", env->iter, env->steps);
+	while (i < env->ec_count) {
+		fsm_state_t cur = MASK_EC_HEAD(env->ecs[i]);
+		fprintf(f, "M_EC[%lu]:", i);
 		while (cur != NO_ID) {
-			env->state_ecs[cur] = ec_dst;
+			fprintf(f, " %u", cur);
 			cur = env->jump[cur];
 		}
+		fprintf(f, "\n");
+		i++;
 	}
-
-#if EXPENSIVE_INTEGRITY_CHECKS
-	psrc_count = 0;
-	cur = env->ecs[ec_src];
-	while (cur != NO_ID) {
-		cur = env->jump[cur];
-		psrc_count++;
-	}
-
-	pdst_count = 0;
-	cur = env->ecs[ec_dst];
-	while (cur != NO_ID) {
-		cur = env->jump[cur];
-		pdst_count++;
-	}
-
-	assert(state_count == psrc_count + pdst_count);
+#else
+	(void)f;
+	(void)env;
 #endif
-
-	return other_count > 0;
 }
-#endif
-
-
-
-
-
-#if MIN_ALT || MIN_REAL
-/* We only know the count for how many states are in an
- * EC after an attempted partition. When the ECs have
- * less than EXMOORE_EC_SMALL_THRESHOLD states, then
- * set the upper bit to mark that it should get smarter
- * handling -- instead of trying every label, look at what
- * labels actually appear in the group, and then just try
- * those, possibly guided by counts. */
-#define EXMOORE_EC_MSB (UINT_MAX ^ (UINT_MAX >> 1))
-#define EXMOORE_EC_SMALL_THRESHOLD 16
-#define EXMOORE_EC_LABELS_THRESHOLD 4
-#define EXMOORE_BOX_EC_HEAD(STATE_ID, IS_SMALL)	\
-	(STATE_ID | (IS_SMALL ? EXMOORE_EC_MSB : 0))
-#define EXMOORE_UNBOX_EC_HEAD(EC)		\
-	(EC &~ EXMOORE_EC_MSB)
 
 static void
-exmoore_update_ec(struct exmoore_env *env, fsm_state_t ec_dst)
+populate_initial_ecs(struct min_env *env, const struct fsm *fsm)
+{
+	size_t i;
+	for (i = 0; i < fsm->statecount; i++) {
+		const fsm_state_t ec = fsm_isend(fsm, i)
+		    ? INIT_EC_FINAL : INIT_EC_NOT_FINAL;
+		env->state_ecs[i] = ec;
+		/* link at head of the list */
+		env->jump[i] = env->ecs[ec];
+		env->ecs[ec] = i;
+#if LOG_INIT
+		fprintf(stderr, "# --init[%lu]: ec %d, jump[]= %d\n",
+		    i, ec, env->jump[i]);
+#endif
+	}
+
+	/* The dead state is not a member of any EC. */
+	env->state_ecs[env->dead_state] = NO_ID;
+}
+
+#if EXPENSIVE_INTEGRITY_CHECKS
+static void
+check_done_ec_offset(const struct min_env *env)
+{
+	size_t i;
+	/* All ECs after the done_ec_offset have less than two elements
+	 * (and cannot be partitioned further), all elements after the
+	 * first two but before the offset have two or more. The first
+	 * two are allowed to to have less, because for example the DFA
+	 * may start with only one end state. The done_ec_offset is used
+	 * to avoid redundantly scanning lots of small ECs that have
+	 * been split off from the initial sets, but it would not be
+	 * worth the added complexity to avoid checking ECs 0 and 1. */
+	for (i = 0; i < env->ec_count; i++) {
+		const fsm_state_t head = MASK_EC_HEAD(env->ecs[i]);
+		if (i >= done_ec_offset) {
+			assert(head == NO_ID || env->jump[head] == NO_ID);
+		} else if (i >= 2) {
+			assert(env->jump[head] != NO_ID);
+		}
+	}
+}
+#endif
+
+static int
+update_after_partition(struct min_env *env,
+    const size_t *partition_counts,
+    fsm_state_t ec_src, fsm_state_t ec_dst)
+{
+	int should_restart_EC = 0;
+	assert(partition_counts[0] > 0);
+	assert(partition_counts[1] > 0);
+
+	/* ec_dst is at the end, so ecs[ec_dst] is in the
+	 * done group by default. If there's only one,
+	 * leave it there. */
+	if (partition_counts[1] == 1) {
+		assert(env->done_ec_offset > 0);
+		update_ec_links(env, ec_dst);
+	} else {
+		/* Otherwise, swap and increment the offset so that dst
+		 * is moved immediately before the done group, but
+		 * outside of it. */
+		const fsm_state_t ndst = env->done_ec_offset;
+		const fsm_state_t tmp = env->ecs[ec_dst];
+		env->ecs[ec_dst] = env->ecs[ndst];
+		env->ecs[ndst] = tmp;
+
+		assert(partition_counts[1] > 1); /* not 0 */
+
+		update_ec_links(env, ec_dst);
+		update_ec_links(env, ndst);
+		env->done_ec_offset++;
+	}
+
+	/* If the src EC only has one, swap it immediately before
+	 * the done group and decrement the offset, expanding it
+	 * to include the src EC. */
+	if (partition_counts[0] == 1 && env->done_ec_offset > 0) {
+		fsm_state_t nsrc = env->done_ec_offset - 1;
+
+		/* swap ec[nsrc] and ec[ec_src] */
+		const fsm_state_t tmp = env->ecs[ec_src];
+		env->ecs[ec_src] = env->ecs[nsrc];
+		env->ecs[nsrc] = tmp;
+		update_ec_links(env, ec_src);
+		update_ec_links(env, nsrc);
+
+		assert(env->done_ec_offset > 0);
+		env->done_ec_offset--;
+
+		/* The src EC just got swapped with another,
+		 * so start over at the beginning of the labels
+		 * for the new EC. */
+		should_restart_EC = 1;
+	}
+
+	return should_restart_EC;
+}
+
+static void
+update_ec_links(struct min_env *env, fsm_state_t ec_dst)
 {
 	size_t count = 0;
 	fsm_state_t cur = env->ecs[ec_dst];
 
 	assert(cur != NO_ID);
 	while (cur != NO_ID) {
-		cur = EXMOORE_UNBOX_EC_HEAD(cur);
+		cur = MASK_EC_HEAD(cur);
 		env->state_ecs[cur] = ec_dst;
 		cur = env->jump[cur];
 		count++;
 	}
 
-	/* Flag the EC for smarter label checking */
-	if (count <= EXMOORE_EC_SMALL_THRESHOLD
-		&& env->label_count >= EXMOORE_EC_LABELS_THRESHOLD) {
-		env->ecs[ec_dst] = EXMOORE_BOX_EC_HEAD(env->ecs[ec_dst], 1);
+	/* If the EC count is smaller than the threshold (and it isn't a
+	 * DFA with a very small number of labels overall), then set the
+	 * flag indicating that it should get smarter label checking. */
+	if (count <= SMALL_EC_THRESHOLD
+		&& env->dfa_label_count >= DFA_LABELS_THRESHOLD) {
+		env->ecs[ec_dst] = SET_SMALL_EC_FLAG(env->ecs[ec_dst]);
 	}
-}
-
-/* EXperimental, EXtended version of Moore's. */
-static int
-min_exmoore(const struct fsm *fsm,
-    const unsigned char *labels, size_t label_count,
-    fsm_state_t *mapping, size_t *minimized_state_count)
-{
-	struct exmoore_env env;
-	int changed, res = 0;
-	size_t i, iter = 0, steps = 0;
-
-	fsm_state_t ec_count, ec_offset;
-	fsm_state_t done_ec_offset;
-
-	/* Alloc for each state, plus the dead state. */
-	size_t alloc_size = (fsm->statecount + 1) * sizeof(env.state_ecs[0]);
-
-	/* Note that the ordering here is significant -- the
-	 * not-final EC may be skipped below. */
-	enum init_ec { INIT_EC_NOT_FINAL, INIT_EC_FINAL };
-
-	env.fsm = fsm;
-
-	/* This algorithm assumes the DFA is complete; if not,
-	 * then simulate a dead-end state internally and make
-	 * all other edges go to it. */
-	env.dead_state = fsm->statecount;
-
-	/* Data model: There are 1 or more equivalence classes
-	 * (hereafter, ECs) initially, which represent all the
-	 * end states and (if present) all the non-end states.
-	 * If there are no end states, the graph is already
-	 * empty, so this shouldn't run.
-	 *
-	 * The algorithm starts with all states divided into
-	 * these initial ECs, and as it detects different results
-	 * within an EC (i.e., for a given label, one state leads
-	 * to EC #2 but another state to EC #3) it partitions
-	 * them further, until it reaches a fixpoint.
-	 *
-	 * ECs[i] contains the state ID for the first state in
-	 * the linked list, then jump[id] contains the next
-	 * successive links, or NO_ID for the end of the list.
-	 * state_ecs[id] contains the current EC group.
-	 * In other words, state_ecs[ID] = EC, and ecs[EC] = X,
-	 * where X is either ID or jump[X], ... contains ID.
-	 * Ordering does not matter within the list. */
-	env.state_ecs = NULL;
-	env.jump = NULL;
-	env.ecs = NULL;
-	env.labels = labels;
-	env.label_count = label_count;
-	ec_count = 0;
-
-	assert(fsm->statecount != 0);
-	env.state_ecs = f_malloc(fsm->opt->alloc, alloc_size);
-	if (env.state_ecs == NULL) { goto cleanup; }
-
-	env.jump = f_malloc(fsm->opt->alloc, alloc_size);
-	if (env.jump == NULL) { goto cleanup; }
-
-	env.ecs = f_malloc(fsm->opt->alloc, alloc_size);
-	if (env.ecs == NULL) { goto cleanup; }
-
-	env.ecs[INIT_EC_NOT_FINAL] = NO_ID;
-	env.ecs[INIT_EC_FINAL] = NO_ID;
-	ec_count = 2;
-	done_ec_offset = ec_count;
-
-	/* build initial lists */
-	for (i = 0; i < fsm->statecount; i++) {
-		const fsm_state_t ec = fsm_isend(fsm, i)
-		    ? INIT_EC_FINAL : INIT_EC_NOT_FINAL;
-		env.state_ecs[i] = ec;
-		env.jump[i] = env.ecs[ec];
-		env.ecs[ec] = i;	/* may replace above */
-#if EXMOORE_DUMP_INIT
-		fprintf(stderr, "# --init[%lu]: ec %d, jump[]= %d\n", i, ec, env.jump[i]);
-#endif
-	}
-
-	env.state_ecs[env.dead_state] = NO_ID;
-
-#if EXMOORE_DUMP_INIT
-	for (i = 0; i < ec_count; i++) {
-		fprintf(stderr, "# --ec[%lu]: %d\n", i, env.ecs[i]);
-	}
-#endif
-
-	exmoore_heuristic_scan(stderr, &env, labels, label_count);
-
-	changed = 1;
-	while (changed) {	/* fixpoint */
-		size_t l_i, ec_i;
-		changed = 0;
-
-#if EXMOORE_DUMP_ECS
-		i = 0;
-		fprintf(stderr, "# iter %ld, steps %lu\n", iter, steps);
-		while (i < ec_count) {
-			fprintf(stderr, "M_EC[%lu]:", i);
-			exmoore_dump_ec(stderr,
-			    EXMOORE_UNBOX_EC_HEAD(env.ecs[i]),
-			    env.jump);
-			fprintf(stderr, "\n");
-			i++;
-		}
-#else
-		(void)exmoore_dump_ec;
-#endif
-
-		for (ec_i = 0; ec_i < done_ec_offset; ec_i++) {
-
-			/* Don't bother checking any ECs with less than two
-			 * states (they can't be split further), and note
-			 * if the flag was set for collecting the EC's edges. */
-			int special_handling;
-			struct exmoore_label_iterator li;
-	restart_EC:
-			{
-				fsm_state_t next = env.ecs[ec_i];
-				if (next == NO_ID) { continue; }
-				special_handling = next & EXMOORE_EC_MSB;
-				next = EXMOORE_UNBOX_EC_HEAD(next);
-
-				next = env.jump[next];
-				if (next == NO_ID) { continue; }
-			}
-
-			exmoore_init_label_iterator(&env, ec_i,
-			    special_handling, &li);
-
-			while (li.i < li.limit) {
-				size_t pcounts[2];
-				const fsm_state_t ec_src = ec_i;
-				const fsm_state_t ec_dst = ec_count;
-				unsigned char label;
-
-				l_i = li.i;
-				li.i++;
-
-				label = (li.use_special
-				    ? li.labels[l_i]
-				    : labels[l_i]);
-
-				steps++;
-				if (exmoore_try_partition(&env, label,
-					ec_src, ec_dst, pcounts)) {
-
-#if EXMOORE_LOG_PARTITION
-					fprintf(stderr, "# partition: ec_i %lu/%u/%u, l_i %lu/%u%s, pcounts [ %lu, %lu ]\n",
-					    ec_i, done_ec_offset, ec_count,
-					    l_i, li.limit, li.use_special ? "*" : "",
-					    pcounts[0], pcounts[1]);
-#endif
-
-					if (pcounts[1] == 1) {
-						assert(done_ec_offset > 0);
-						exmoore_update_ec(&env, ec_dst);
-					} else {
-						/* swap so that dst is before the done group */
-						const fsm_state_t ndst = done_ec_offset;
-						const fsm_state_t tmp = env.ecs[ec_dst];
-						env.ecs[ec_dst] = env.ecs[ndst];
-						env.ecs[ndst] = tmp;
-						exmoore_update_ec(&env, ec_dst);
-						exmoore_update_ec(&env, ndst);
-						done_ec_offset++;
-					}
-
-					/* if the src only has one, swap it into the done group */
-					if (pcounts[0] == 1 && done_ec_offset > 0) { /* swap */
-						fsm_state_t nsrc = done_ec_offset - 1;
-
-						/* swap ec[nsrc] and ec[ec_src] */
-						const fsm_state_t tmp = env.ecs[ec_src];
-						env.ecs[ec_src] = env.ecs[nsrc];
-						env.ecs[nsrc] = tmp;
-						exmoore_update_ec(&env, ec_src);
-						exmoore_update_ec(&env, nsrc);
-
-						assert(done_ec_offset > 0);
-						done_ec_offset--;
-
-						/* The src EC just got swapped with another,
-						 * so start over at the beginning for the new EC. */
-						changed = 1;
-						ec_count++;
-						goto restart_EC;
-					}
-
-					changed = 1;
-					ec_count++;
-
-					assert(done_ec_offset <= ec_count);
-				}
-
-#if EXPENSIVE_INTEGRITY_CHECKS
-				for (i = 0; i < ec_count; i++) {
-					const fsm_state_t head = EXMOORE_UNBOX_EC_HEAD(env.ecs[i]);
-					if (i >= done_ec_offset) {
-						assert(head == NO_ID || env.jump[head] == NO_ID);
-					} else {
-						assert(env.jump[head] != NO_ID);
-					}
-				}
-#endif
-			}
-		}
-
-		iter++;
-	}
-
-	/* When all of the original input states were final, then
-	 * the not-final EC will be empty. Skip it in the mapping,
-	 * otherwise an unnecessary state will be created for it. */
-	ec_offset = (env.ecs[INIT_EC_NOT_FINAL] == NO_ID) ? 1 : 0;
-
-	/* Build map condensing to unique states */
-	for (i = ec_offset; i < ec_count; i++) {
-		fsm_state_t cur = EXMOORE_UNBOX_EC_HEAD(env.ecs[i]);
-		while (cur != NO_ID) {
-			mapping[cur] = i - ec_offset;
-			cur = env.jump[cur];
-		}
-	}
-
-	if (minimized_state_count != NULL) {
-		*minimized_state_count = ec_count - ec_offset;
-#if DUMP_MAPPINGS
-		for (i = 0; i < fsm->statecount; i++) {
-			fprintf(stderr, "# exmoore_mapping[%lu]: %u\n",
-			    i, mapping[i]);
-		}
-#endif
-	}
-
-#if DUMP_STEPS
-	fprintf(stderr, "# done in %lu iteration(s), %lu step(s), %ld -> %lu states, label_count %lu\n",
-            iter, steps, fsm->statecount, *minimized_state_count, label_count);
-#endif
-
-	res = 1;
-	/* fall through */
-cleanup:
-	f_free(fsm->opt->alloc, env.ecs);
-	f_free(fsm->opt->alloc, env.state_ecs);
-	f_free(fsm->opt->alloc, env.jump);
-	return res;
 }
 
 static void
-exmoore_init_label_iterator(const struct exmoore_env *env,
-	fsm_state_t ec_i, int special_handling,
-	struct exmoore_label_iterator *li)
+init_label_iterator(const struct min_env *env,
+	fsm_state_t ec_i, int should_gather_EC_labels,
+	struct min_label_iterator *li)
 {
-	/* If the MSB flag was set for the EC (indicating that it's fairly
-	 * small), then instead of trying every label, save time by only
-	 * checking the labels that are actually present. */
-	if (special_handling) {
+	/* If the SMALL_EC flag was set for the EC (indicating that it has a
+	 * small number of states), then gather the labels actually used
+	 * by those states rather than checking all labels in the entire
+	 * DFA. */
+	if (should_gather_EC_labels) {
 		fsm_state_t cur;
 		size_t i;
-		uint32_t label_set[8];
+		uint32_t label_set[256/32];
 		memset(label_set, 0x00, sizeof(label_set));
 
 		cur = env->ecs[ec_i];
 		assert(cur != NO_ID);
-		cur = EXMOORE_UNBOX_EC_HEAD(cur);
+		cur = MASK_EC_HEAD(cur);
 
 		while (cur != NO_ID) {
 			struct fsm_edge e;
@@ -1228,12 +517,13 @@ exmoore_init_label_iterator(const struct exmoore_env *env,
 			for (edge_set_reset(env->fsm->states[cur].edges, &ei);
 			     edge_set_next(&ei, &e); ) {
 				const unsigned char label = e.symbol;
-				label_set[label/32] |= ((uint32_t)1 << (label & 31));
+				label_set[label/32] |=
+				    ((uint32_t)1 << (label & 31));
 			}
 			cur = env->jump[cur];
 		}
 
-		li->use_special = 1;
+		li->has_labels_for_EC = 1;
 		li->i = 0;
 		li->limit = 0;
 		i = 0;
@@ -1248,90 +538,80 @@ exmoore_init_label_iterator(const struct exmoore_env *env,
 				i++;
 			}
 		}
-	} else {		/* all labels in sequence */
-		li->use_special = 0;
-		li->limit = env->label_count;
+	} else {		/* check all labels in sequence */
+		li->has_labels_for_EC = 0;
+		li->limit = env->dfa_label_count;
 		li->i = 0;
 	}
 }
 
-static void
-exmoore_dump_ec(FILE *f, fsm_state_t start, const fsm_state_t *jump)
-{
-	fsm_state_t cur = start;
-	while (cur != NO_ID) {
-		fprintf(f, " %u", cur);
-		cur = jump[cur];
-	}
-}
-
 static fsm_state_t
-exmoore_delta(const struct fsm *fsm, fsm_state_t id, unsigned char label)
+find_edge_destination(const struct fsm *fsm,
+    fsm_state_t id, unsigned char label)
 {
 	struct fsm_edge e;
-	struct edge_iter ei;
 
 	assert(id < fsm->statecount);
-
-	/* FIXME: use edge_set_find */
-	for (edge_set_reset(fsm->states[id].edges, &ei);
-	     edge_set_next(&ei, &e); ) {
-		assert(e.state < fsm->statecount);
-		if (e.symbol == label) {
-			return e.state;
-		}
-		/* could skip rest if ordered */
+	if (edge_set_find(fsm->states[id].edges, label, &e)) {
+		return e.state;
 	}
 
-	return fsm->statecount;	/* dead end */
+	return fsm->statecount;	/* dead state */
 }
 
-/* unlike moore above:
- * any split off get linked into EC_DST, but don't update the
- * state_ec and other fields, because depending on how many are
- * extracted, they may get swapped. */
 static int
-exmoore_try_partition(struct exmoore_env *env, unsigned char label,
+try_partition(struct min_env *env, unsigned char label,
     fsm_state_t ec_src, fsm_state_t ec_dst,
 	size_t partition_counts[2])
 {
-	fsm_state_t cur = EXMOORE_UNBOX_EC_HEAD(env->ecs[ec_src]);
+	fsm_state_t cur = MASK_EC_HEAD(env->ecs[ec_src]);
 	fsm_state_t to, to_ec, first_ec, prev;
 
 #if EXPENSIVE_INTEGRITY_CHECKS
+	/* Count states here, to compare against the partitioned
+	 * EC' counts later. */
 	size_t state_count = 0, psrc_count, pdst_count;
 	while (cur != NO_ID) {
 		cur = env->jump[cur];
 		state_count++;
 	}
-	cur = EXMOORE_UNBOX_EC_HEAD(env->ecs[ec_src]);
+	cur = MASK_EC_HEAD(env->ecs[ec_src]);
 #endif
 
 	memset(partition_counts, 0x00, 2*sizeof(partition_counts[0]));
 
-#if EXMOORE_LOG_PARTITION
-	fprintf(stderr, "# --- mtp: checking '%c' for %u\n", label, ec_src);
+#if LOG_PARTITIONS > 1
+	fprintf(stderr, "# --- try_partition: checking '%c' for %u\n", label, ec_src);
 #endif
 
-	to = exmoore_delta(env->fsm, cur, label);
+	/* There must be at least two states in this EC.
+	 * See where the current label leads on the first state.
+	 * Any states which has an edge to a different EC for
+	 * that label will be split into a new EC.
+	 *
+	 * Note that the ec_src EC is updated in place -- because this
+	 * is successively trying different labels on the same EC, it
+	 * can often do several partitions and make more progress in a
+	 * single pass, avoiding most of the theoretical overhead of the
+	 * fixpoint approach. */
+	to = find_edge_destination(env->fsm, cur, label);
 	first_ec = env->state_ecs[to];
-
-#if EXMOORE_LOG_PARTITION
-	fprintf(stderr, "# --- mtp: first, %u, has to %d -> first_ec %d\n", cur, to, first_ec);
-#endif
-
 	partition_counts[0] = 1;
 	prev = cur;
 	cur = env->jump[cur];
+
+#if LOG_PARTITIONS > 1
+	fprintf(stderr, "# --- try_partition: first, %u, has to %d -> first_ec %d\n", cur, to, first_ec);
+#endif
 
 	/* initialize the new EC -- empty */
 	env->ecs[ec_dst] = NO_ID;
 
 	while (cur != NO_ID) {
-		to = exmoore_delta(env->fsm, cur, label);
+		to = find_edge_destination(env->fsm, cur, label);
 		to_ec = env->state_ecs[to];
-#if EXMOORE_LOG_PARTITION
-		fprintf(stderr, "# --- mtp: next, cur %u, has to %d -> to_ec %d\n", cur, to, to_ec);
+#if LOG_PARTITIONS > 1
+		fprintf(stderr, "# --- try_partition: next, cur %u, has to %d -> to_ec %d\n", cur, to, to_ec);
 #endif
 
 		if (to_ec == first_ec) { /* in same EC */
@@ -1339,15 +619,15 @@ exmoore_try_partition(struct exmoore_env *env, unsigned char label,
 			prev = cur;
 			cur = env->jump[cur];
 		} else {	/* unlink, split */
+			fsm_state_t next;
+#if LOG_PARTITIONS > 1
+			fprintf(stderr, "# try_partition: unlinking -- label '%c', src %u, dst %u, first_ec %d, cur %u -> to_ec %d\n", label, ec_src, ec_dst, first_ec, cur, to_ec);
+#endif
+
 			/* Unlink this state from the current EC,
 			 * instead put it as the start of a new one
 			 * at ecs[ec_dst]. */
-			fsm_state_t next = env->jump[cur];
-
-#if EXMOORE_LOG_PARTITION
-			fprintf(stderr, "# mtp: unlinking -- label '%c', src %u, dst %u, first_ec %d, cur %u -> to_ec %d\n", label, ec_src, ec_dst, first_ec, cur, to_ec);
-#endif
-
+			next = env->jump[cur];
 			env->jump[prev] = next;
 			env->jump[cur] = env->ecs[ec_dst];
 			env->ecs[ec_dst] = cur;
@@ -1357,10 +637,12 @@ exmoore_try_partition(struct exmoore_env *env, unsigned char label,
 	}
 
 #if EXPENSIVE_INTEGRITY_CHECKS
+	/* Count how many states were split into each EC
+	 * and check that the sum matches the original count. */
 	psrc_count = 0;
 	cur = env->ecs[ec_src];
 	if (cur != NO_ID) {
-		cur = EXMOORE_UNBOX_EC_HEAD(cur);
+		cur = MASK_EC_HEAD(cur);
 		while (cur != NO_ID) {
 			cur = env->jump[cur];
 			psrc_count++;
@@ -1370,7 +652,7 @@ exmoore_try_partition(struct exmoore_env *env, unsigned char label,
 	pdst_count = 0;
 	cur = env->ecs[ec_dst];
 	if (cur != NO_ID) {
-		cur = EXMOORE_UNBOX_EC_HEAD(cur);
+		cur = MASK_EC_HEAD(cur);
 		while (cur != NO_ID) {
 			cur = env->jump[cur];
 			pdst_count++;
@@ -1382,971 +664,3 @@ exmoore_try_partition(struct exmoore_env *env, unsigned char label,
 
 	return partition_counts[1] > 0;
 }
-
-static void
-exmoore_heuristic_scan(FILE *f, const struct exmoore_env *env,
-    const unsigned char *labels, size_t label_count)
-{
-#if 0
-	size_t i, s_i, e_i;
-	const struct fsm *fsm = env->fsm;
-	uint8_t label_map[256];
-	size_t *label_counts = calloc(label_count, sizeof(label_counts[0]));
-	assert(label_counts != NULL);
-
-	return;
-
-	for (i = 0; i < label_count; i++) {
-		label_map[labels[i]] = i;
-	}
-
-	for (s_i = 0; s_i < fsm->statecount; s_i++) {
-		struct fsm_edge e;
-		struct edge_iter ei;
-		const size_t edge_count = edge_set_count(fsm->states[s_i].edges);
-
-		e_i = 0;
-		for (edge_set_reset(fsm->states[s_i].edges, &ei);
-		     edge_set_next(&ei, &e); ) {
-			fprintf(f, "state %lu -- edge %lu/%lu -- '%c' -> %u\n",
-			    s_i, e_i, edge_count, e.symbol, e.state);
-			e_i++;
-			label_counts[label_map[e.symbol]]++;
-		}
-	}
-
-	for (i = 0; i < label_count; i++) {
-		fprintf(f, "label '%c': %lu\n", labels[i], label_counts[i]);
-	}
-
-	free(label_counts);
-#else
-	(void)f;
-	(void)env;
-	(void)labels;
-	(void)label_count;
-#endif
-}
-#endif
-
-
-
-
-
-
-
-#if MIN_ALT
-#if HOPCROFT_DUMP_INIT
-static void
-dump_edges(const struct fsm *fsm)
-{
-	struct fsm_edge e;
-	struct edge_iter ei;
-	fsm_state_t id;
-
-	for (id = 0; id < fsm->statecount; id++) {
-		for (edge_set_reset(fsm->states[id].edges, &ei);
-		     edge_set_next(&ei, &e); ) {
-			fprintf(stderr, "dump_edges: state[%d], edge <'%c' -> %u>\n",
-			    id, e.symbol, e.state);
-		}
-	}
-}
-#endif
-
-/* An fsm_state_id with the most significant bit set is
- * an offset to the next cell on the freelist. The freelist
- * is terminated with NO_ID, just like the EC lists. */
-#define FREELIST_MSB (UINT_MAX ^ (UINT_MAX >> 1))
-#define IS_FREELIST(ID) (ID & FREELIST_MSB)
-#define BOX_FREELIST(ID) (ID | FREELIST_MSB)
-#define UNBOX_FREELIST(ID) (ID &~ FREELIST_MSB)
-
-#if DO_HOPCROFT
-static int
-min_hopcroft(const struct fsm *fsm,
-    const unsigned char *labels, size_t label_count,
-    fsm_state_t *mapping, size_t *minimized_state_count)
-{
-	/* init splitter stack */
-	struct hopcroft_env env;
-	int res = 0;
-	size_t i, iter = 0, steps = 0;
-	fsm_state_t ec_count;
-
-	/* Alloc for each state, plus the dead state. */
-	size_t per_state_alloc_size = (fsm->statecount + 1)
-	    * sizeof(env.state_ecs[0]);
-
-	/* Note that the ordering here is significant -- the
-	 * not-final EC may be skipped below. */
-	enum init_ec { INIT_EC_NOT_FINAL, INIT_EC_FINAL };
-
-	memset(&env, 0x00, sizeof(env));
-
-	env.fsm = fsm;
-	env.labels = labels;
-	env.label_count = label_count;
-
-	/* This algorithm assumes the DFA is complete; if not,
-	 * then simulate a dead-end state internally and make
-	 * all other edges go to it. */
-	env.dead_state = fsm->statecount;
-
-	/* Data model: There are 1 or more equivalence classes
-	 * (hereafter, ECs) initially, which represent all the
-	 * end states and (if present) all the non-end states.
-	 * If there are no end states, the graph is already
-	 * empty, so this shouldn't run.
-	 *
-	 * The algorithm starts with all states divided into
-	 * these initial ECs, and as it detects different results
-	 * within an EC (i.e., for a given label, one state leads
-	 * to EC #2 but another state to EC #3) it partitions
-	 * them further, until it reaches a fixpoint.
-	 *
-	 * ECs[i] contains the state ID for the first state in
-	 * the linked list, then jump[id] contains the next
-	 * successive links, or NO_ID for the end of the list.
-	 * state_ecs[id] contains the current EC group.
-	 * In other words, state_ecs[ID] = EC, and ecs[EC] = X,
-	 * where X is either ID or jump[X], ... contains ID.
-	 * Ordering does not matter within the list. */
-
-	assert(fsm->statecount != 0);
-
-	if (!hopcroft_build_label_index(&env, labels, label_count)) {
-		goto cleanup;
-	}
-
-	env.stack.splitters = f_malloc(fsm->opt->alloc,
-	    DEF_SPLITTER_STACK_CEIL * sizeof(env.stack.splitters[0]));
-	if (env.stack.splitters == NULL) { goto cleanup; }
-	env.stack.ceil = DEF_SPLITTER_STACK_CEIL;
-	env.stack.count = 0;
-	for (i = 0; i < 256; i++) {
-		env.stack.index[i] = (size_t)-1;
-	}
-
-	env.ec_filter_bytes = (fsm->statecount/sizeof(uint64_t) + 1)
-	    * sizeof(uint64_t);
-	env.ec_filter = f_malloc(fsm->opt->alloc, env.ec_filter_bytes);
-	if (env.ec_filter == NULL) { goto cleanup; }
-
-	env.state_ecs = f_malloc(fsm->opt->alloc, per_state_alloc_size);
-	if (env.state_ecs == NULL) { goto cleanup; }
-
-	env.jump = f_malloc(fsm->opt->alloc, per_state_alloc_size);
-	if (env.jump == NULL) { goto cleanup; }
-
-	/* TODO: make this proportional to the state count */
-	env.ecs_ceil = 4;
-	env.ecs = f_malloc(fsm->opt->alloc, env.ecs_ceil * sizeof(env.ecs[0]));
-	if (env.ecs == NULL) { goto cleanup; }
-
-	env.updated_ecs_ceil = 4;
-	env.updated_ecs = f_malloc(fsm->opt->alloc,
-	    env.updated_ecs_ceil * sizeof(env.updated_ecs[0]));
-	if (env.updated_ecs == NULL) { goto cleanup; }
-
-	/* Build a freelist for available ECs */
-	for (i = 0; i < env.ecs_ceil; i++) {
-		env.ecs[i] = BOX_FREELIST(i + 1);
-	}
-	env.ecs[env.ecs_ceil - 1] = NO_ID;
-
-	env.ecs[INIT_EC_NOT_FINAL] = NO_ID;
-	env.ecs[INIT_EC_FINAL] = NO_ID;
-	env.max_ec_in_use = INIT_EC_FINAL;
-
-	env.ec_freelist = BOX_FREELIST(env.max_ec_in_use + 1);
-
-#if HOPCROFT_DUMP_INIT
-	for (i = 0; i < fsm->statecount; i++) {
-		fprintf(stderr, "freelist[%lu]: 0x%x\n", i, env.ecs[i]);
-	}
-#endif
-
-	{
-		size_t ecs_counts[2] = { 0, 0 };
-		size_t smaller_ec;
-
-		/* build initial lists */
-		for (i = 0; i < fsm->statecount; i++) {
-			const fsm_state_t ec = fsm_isend(fsm, i)
-			    ? INIT_EC_FINAL : INIT_EC_NOT_FINAL;
-			env.state_ecs[i] = ec;
-			env.jump[i] = env.ecs[ec];
-			env.ecs[ec] = i;	/* may replace above */
-#if HOPCROFT_DUMP_INIT
-			fprintf(stderr, "# --init[%lu]: ec %d, jump[]= %d\n", i, ec, env.jump[i]);
-#endif
-			ecs_counts[ec]++;
-
-		}
-
-		/* The dead state is an honorary member of the not-final EC.
-		 * Only add it if necessary. */
-		if (!fsm_all(fsm, fsm_iscomplete)) {
-			env.state_ecs[env.dead_state] = INIT_EC_NOT_FINAL;
-			env.jump[env.dead_state] = env.ecs[INIT_EC_NOT_FINAL];
-			env.ecs[INIT_EC_NOT_FINAL] = env.dead_state;
-			ecs_counts[INIT_EC_NOT_FINAL]++;
-		}
-
-		if (ecs_counts[INIT_EC_NOT_FINAL] == 0) {
-			env.ecs[INIT_EC_NOT_FINAL] = env.ec_freelist;
-			env.ec_freelist = BOX_FREELIST(INIT_EC_NOT_FINAL);
-		}
-
-		/* populate initial splitters */
-		smaller_ec = INIT_EC_FINAL;
-		if (ecs_counts[INIT_EC_NOT_FINAL] < ecs_counts[INIT_EC_FINAL]
-			&& ecs_counts[INIT_EC_NOT_FINAL] > 0) {
-			smaller_ec = INIT_EC_NOT_FINAL;
-		}
-
-		for (i = 0; i < label_count; i++) {
-			unsigned char label = labels[i];
-
-			if (!hopcroft_schedule_splitter(&env,
-				smaller_ec, label)) {
-				goto cleanup;
-			}
-		}
-	}
-
-#if HOPCROFT_DUMP_INIT
-	dump_edges(env.fsm);
-#endif
-
-	while (env.stack.count > 0) { /* until empty */
-		size_t l_i, ec_i;
-		struct splitter *splitter;
-		fsm_state_t splitter_ec;
-		unsigned char splitter_label;
-
-		/* FIXME: This should be dynamically allocated,
-		 * starting fairly small and growing on demand.
-		 * It's probably possible to determine the worst
-		 * case for this based on the number of input
-		 * states and preallocate it. */
-		size_t updated_ecs_i = 0;
-
-#if HOPCROFT_DUMP_INIT
-	for (i = 0; i < fsm->statecount; i++) {
-		fprintf(stderr, "freelist[%lu]: 0x%x\n", i, env.ecs[i]);
-	}
-#endif
-
-#if HOPCROFT_DUMP_ECS
-		i = 0;
-		fprintf(stderr, "# iter %ld, steps %lu\n", iter, steps);
-		while (i <= env.max_ec_in_use) {
-			if (IS_FREELIST(env.ecs[i])) {
-				i++;
-				continue;
-			}
-			fprintf(stderr, "H_EC[%lu]:", i);
-			hopcroft_dump_ec(stderr, env.ecs[i], env.jump);
-			fprintf(stderr, "\n");
-			i++;
-		}
-#else
-		(void)hopcroft_dump_ec;
-#endif
-
-#if HOPCROFT_LOG_STACK
-		fprintf(stderr, "# stack[%zu]: ", env.stack.count);
-		for (i = 0; i < env.stack.count; i++) {
-			fprintf(stderr, " <%d,'%c'>",
-			    env.stack.splitters[i].ec,
-			    env.stack.splitters[i].label);
-		}
-		fprintf(stderr, "\n");
-#endif
-
-		assert(env.stack.count > 0);
-		env.stack.count--;
-		splitter = &env.stack.splitters[env.stack.count];
-		splitter_ec = splitter->ec;
-		splitter_label = splitter->label;
-		env.stack.index[splitter_label] = splitter->prev;
-#if HOPCROFT_LOG_STACK
-		fprintf(stderr, "# popped splitter: <%d,'%c'>\n",
-		    splitter_ec, splitter_label);
-#endif
-
-		hopcroft_mark_ec_filter(&env, splitter_label);
-
-		/* This can add new ECs, but they should not be
-		 * considered active until after processing this
-		 * splitter. */
-		for (ec_i = 0; ec_i <= env.max_ec_in_use; ec_i++) {
-			const fsm_state_t ec_src = ec_i;
-			fsm_state_t ec_dst_a;
-			fsm_state_t ec_dst_b;
-			/* size_t l_i; */
-			size_t pcs[2]; /* partition counts */
-			enum hopcroft_try_partition_res pres;
-
-			if (!hopcroft_check_ec_filter(env.ec_filter, ec_i)) {
-				/* fprintf(stderr, "SKIP %u\n", ec_i); */
-				continue;
-			}
-
-#if !HOPCROFT_USE_LABEL_INDEX
-			if (IS_FREELIST(env.ecs[ec_i])) {
-				continue;
-			}
-#endif
-			steps++;
-
-			pres = hopcroft_try_partition(&env,
-			    splitter_ec, splitter_label,
-			    ec_src, &ec_dst_a, &ec_dst_b, pcs);
-
-			if (pres == HTP_ERROR_ALLOC) {
-				goto cleanup;
-			} else if (pres == HTP_PARTITIONED) {
-				struct updated_ecs *updated = &env.updated_ecs[updated_ecs_i];
-#if HOPCROFT_LOG_PARTITION
-				fprintf(stderr, "# partitioned EC %u into EC %u (w/ %lu) and EC %u (w/ %lu)\n",
-				    ec_src,
-				    ec_dst_a, pcs[0],
-				    ec_dst_b, pcs[1]);
-#endif
-
-				/* Note which ECs were updated, for
-				 * further bookkeeping after the
-				 * splitter pass completes. The dst EC
-				 * with fewer states always goes
-				 * first. */
-				updated->src = ec_src;
-				updated->dst[0] = pcs[0] < pcs[1] ? ec_dst_a : ec_dst_b;
-				updated->dst[1] = pcs[0] < pcs[1] ? ec_dst_b : ec_dst_a;
-
-				updated_ecs_i++;
-				if (updated_ecs_i == env.updated_ecs_ceil) {
-					if (!hopcroft_grow_updated_ecs(&env)) {
-						goto cleanup;
-					}
-				}
-
-				/* Box the newly created ECs so that they
-				 * will be ignored while doing the remainder
-				 * of the pass for this splitter. */
-				env.ecs[ec_dst_a] = BOX_FREELIST(env.ecs[ec_dst_a]);
-				env.ecs[ec_dst_b] = BOX_FREELIST(env.ecs[ec_dst_b]);
-			} else {
-				assert(pres == HTP_NO_CHANGE);
-			}
-		}
-
-		/* Now that the splitter pass is done, update ECs that
-		 * were processed by it -- the src EC gets put on the
-		 * freelist, the two dst ECs become active. */
-		for (ec_i = 0; ec_i < updated_ecs_i; ec_i++) {
-			struct updated_ecs *updated = &env.updated_ecs[ec_i];
-
-			/* put the partitioned EC back on the freelist */
-			assert(IS_FREELIST(env.ec_freelist));
-#if HOPCROFT_LOG_FREELIST
-			fprintf(stderr, "putting %u back on the freelist, pointing to 0x%x\n",
-			    updated->src, env.ec_freelist);
-#endif
-			env.ecs[updated->src] = env.ec_freelist;
-			env.ec_freelist = BOX_FREELIST(updated->src);
-
-			for (i = 0; i < 2; i++) {
-				fsm_state_t cur;
-				assert(IS_FREELIST(env.ecs[updated->dst[i]]));
-				env.ecs[updated->dst[i]] = UNBOX_FREELIST(env.ecs[updated->dst[i]]);
-				if (updated->dst[i] > env.max_ec_in_use) {
-					env.max_ec_in_use = updated->dst[i];
-				}
-
-				cur = env.ecs[updated->dst[i]];
-				while (cur != NO_ID) {
-					fsm_state_t next = env.jump[cur];
-					env.state_ecs[cur] = updated->dst[i];
-					assert(next != cur);
-					cur = next;
-				}
-			}
-
-			/* Schedule further splitters */
-			for (l_i = 0; l_i < label_count; l_i++) {
-				const unsigned char label = labels[l_i];
-				/* dst[0] always has <= states than dst[1], ordered above. */
-				fsm_state_t ec_min = updated->dst[0];
-				if (!hopcroft_update_splitter_stack(&env,
-					label, updated->src,
-					updated->dst[0], updated->dst[1], ec_min)) {
-					goto cleanup;
-				}
-			}
-		}
-
-		iter++;
-	}
-
-	/* Build map condensing to unique states */
-	ec_count = 0;
-	for (i = 0; i <= env.max_ec_in_use; i++) {
-		fsm_state_t cur;
-		size_t count = 0;
-
-		if (IS_FREELIST(env.ecs[i])) {
-			continue;
-		}
-
-		cur = env.ecs[i];
-		while (cur != NO_ID) {
-			/* Don't include the dead state in the result. */
-			if (cur == env.dead_state) {
-				cur = env.jump[cur];
-				if (cur == NO_ID) {
-					break;
-				}
-			}
-
-			count++;
-
-			mapping[cur] = ec_count;
-			cur = env.jump[cur];
-		}
-
-		if (count > 0) {
-			ec_count++;
-		}
-	}
-
-	if (minimized_state_count != NULL) {
-		*minimized_state_count = ec_count;
-
-#if DUMP_MAPPINGS
-		for (i = 0; i < *minimized_state_count; i++) {
-			fprintf(stderr, "# hopcroft_mapping[%lu]: %u\n",
-			    i, mapping[i]);
-		}
-#endif
-	}
-
-#if DUMP_STEPS
-	fprintf(stderr, "# done in %lu iteration(s), %lu step(s), %ld -> %lu states, label_count %lu\n",
-            iter, steps, fsm->statecount, *minimized_state_count, label_count);
-#endif
-
-	res = 1;
-	/* fall through */
-cleanup:
-	f_free(fsm->opt->alloc, env.ecs);
-	f_free(fsm->opt->alloc, env.updated_ecs);
-	f_free(fsm->opt->alloc, env.state_ecs);
-	f_free(fsm->opt->alloc, env.jump);
-	f_free(fsm->opt->alloc, env.stack.splitters);
-	f_free(fsm->opt->alloc, env.label_offsets);
-	f_free(fsm->opt->alloc, env.label_index);
-	f_free(fsm->opt->alloc, env.ec_filter);
-	return res;
-}
-
-static void
-hopcroft_dump_ec(FILE *f, fsm_state_t start, const fsm_state_t *jump)
-{
-	moore_dump_ec(f, start, jump);
-}
-
-static fsm_state_t
-hopcroft_delta(const struct fsm *fsm, fsm_state_t id, unsigned char label)
-{
-	struct fsm_edge e;
-	struct edge_iter ei;
-
-	if (id == fsm->statecount) {
-		return fsm->statecount;
-	}
-
-	assert(id < fsm->statecount);
-
-	for (edge_set_reset(fsm->states[id].edges, &ei);
-	     edge_set_next(&ei, &e); ) {
-		assert(e.state < fsm->statecount);
-		if (e.symbol == label) {
-			return e.state;
-		} else if (e.symbol > label) {
-			break;	/* ordered -- skip */
-		}
-	}
-
-	return fsm->statecount;	/* dead end */
-}
-
-static int
-hopcroft_freelist_pop(struct hopcroft_env *env,
-    fsm_state_t *id)
-{
-	assert(IS_FREELIST(env->ec_freelist));
-	if (env->ec_freelist == NO_ID) {
-		if (!hopcroft_grow_ecs_freelist(env)) {
-			return 0;
-		}
-	}
-
-	assert(env->ec_freelist != NO_ID);
-
-	*id = UNBOX_FREELIST(env->ec_freelist);
-	env->ec_freelist = env->ecs[*id];
-	return 1;
-}
-
-static void
-hopcroft_freelist_push(struct hopcroft_env *env,
-    fsm_state_t id)
-{
-	env->ecs[id] = env->ec_freelist;
-	env->ec_freelist = BOX_FREELIST(id);
-}
-
-static enum hopcroft_try_partition_res
-hopcroft_try_partition(struct hopcroft_env *env,
-    fsm_state_t ec_splitter, unsigned char label,
-    fsm_state_t ec_src,
-    fsm_state_t *ec_dst_a, fsm_state_t *ec_dst_b,
-    size_t partition_counts[2])
-{
-	enum hopcroft_try_partition_res res = HTP_NO_CHANGE;
-
-	/* Partition EC[ec_src] into the sets that have edges
-	 * with label that lead to EC_SPLITTER and those that
-	 * don't. */
-	fsm_state_t cur = env->ecs[ec_src];
-	fsm_state_t to, to_ec;
-
-	fsm_state_t dst_a, dst_b;
-
-	/* Don't attempt to partition ECs with <2 states. */
-	if (cur == NO_ID || env->jump[cur] == NO_ID) {
-		return HTP_NO_CHANGE;
-	}
-
-#if HOPCROFT_LOG_PARTITION
-	fprintf(stderr, "# --- htp: checking '%c' for %u\n", label, ec_src);
-#endif
-
-#if HOPCROFT_LOG_FREELIST
-	fprintf(stderr, "FL 0x%x\n", env->ec_freelist);
-#endif
-
-	if (!hopcroft_freelist_pop(env, &dst_a)) {
-		return HTP_ERROR_ALLOC;
-	}
-
-	if (!hopcroft_freelist_pop(env, &dst_b)) {
-		return HTP_ERROR_ALLOC;
-	}
-
-	/* initialize the new ECs -- empty */
-	env->ecs[dst_a] = NO_ID;
-	env->ecs[dst_b] = NO_ID;
-
-	partition_counts[0] = 0;
-	partition_counts[1] = 0;
-
-	while (cur != NO_ID) {
-		const fsm_state_t next = env->jump[cur];
-		to = hopcroft_delta(env->fsm, cur, label);
-		to_ec = env->state_ecs[to];
-
-#if HOPCROFT_LOG_PARTITION
-		fprintf(stderr, "# --- htp: cur %u, next %u, has to %d -> to_ec %d\n", cur, next, to, to_ec);
-#endif
-
-		if (to_ec == ec_splitter) { /* -> dst_a */
-#if HOPCROFT_LOG_PARTITION
-			fprintf(stderr, "#    ---> linked to EC %u (a), head was %u now %u\n",
-			    dst_a, env->ecs[dst_a], cur);
-#endif
-			env->jump[cur] = env->ecs[dst_a];
-			env->ecs[dst_a] = cur;
-			cur = next;
-			partition_counts[0]++;
-		} else {	/* -> dst_b */
-#if HOPCROFT_LOG_PARTITION
-			fprintf(stderr, "#    ---> linked to EC %u (b), head was %u now %u\n",
-			    dst_b, env->ecs[dst_b], cur);
-#endif
-			env->jump[cur] = env->ecs[dst_b];
-			env->ecs[dst_b] = cur;
-			cur = next;
-			partition_counts[1]++;
-		}
-	}
-
-#if HOPCROFT_LOG_PARTITION
-	fprintf(stderr, "# htp: partition counts: %lu, %lu\n",
-	    partition_counts[0], partition_counts[1]);
-#endif
-
-	/* If some were split off, update their state_ecs entries.
-	 * Wait to update until after they have all been compared,
-	 * otherwise the mix of updated and non-updated states can
-	 * lead to inconsistent results. */
-	if (partition_counts[0] > 0 && partition_counts[1] > 0) {
-		assert(env->ecs[dst_a] != NO_ID);
-		assert(env->ecs[dst_b] != NO_ID);
-
-		*ec_dst_a = dst_a;
-		*ec_dst_b = dst_b;
-		/* env->ec_freelist = freelist_head; */
-		res = HTP_PARTITIONED;
-	} else if (partition_counts[0] > 0) {
-		/* All were split off to ec_dst_a, but should be
-		 * restored to the original EC. */
-		assert(partition_counts[1] == 0);
-		env->ecs[ec_src] = env->ecs[dst_a];
-
-		hopcroft_freelist_push(env, dst_b);
-		hopcroft_freelist_push(env, dst_a);
-		/* env->ecs[dst_a] = BOX_FREELIST(dst_b); */
-		/* env->ecs[dst_b] = freelist_head; */
-		/* env->ec_freelist = BOX_FREELIST(dst_a); */
-	} else {
-		/* All were split off to ec_dst_b, but should be
-		 * restored to the original EC. */
-		assert(partition_counts[0] == 0);
-		assert(partition_counts[1] > 0);
-		env->ecs[ec_src] = env->ecs[dst_b];
-
-		/* env->ecs[dst_a] = BOX_FREELIST(dst_b); */
-		/* env->ecs[dst_b] = freelist_head; */
-		/* env->ec_freelist = BOX_FREELIST(dst_a); */
-		hopcroft_freelist_push(env, dst_b);
-		hopcroft_freelist_push(env, dst_a);
-	}
-
-	return res;
-}
-
-static int
-hopcroft_schedule_splitter(struct hopcroft_env *env,
-    fsm_state_t ec, unsigned char label)
-{
-	struct splitter *s;
-	if (env->stack.count == env->stack.ceil) {
-		size_t nceil = 2*env->stack.ceil;
-		struct splitter *nsplitters = f_realloc(env->fsm->opt->alloc,
-		    env->stack.splitters,
-		    nceil * sizeof(env->stack.splitters[0]));
-		if (nsplitters == NULL) { return 0; }
-		env->stack.ceil = nceil;
-		env->stack.splitters = nsplitters;
-	}
-
-#if HOPCROFT_LOG_STACK
-	fprintf(stderr, "# hopcroft_schedule_splitter: <%d,'%c'>\n",
-	    ec, label);
-#endif
-
-	s = &env->stack.splitters[env->stack.count];
-	s->ec = ec;
-	s->label = label;
-
-	/* Update index */
-	s->prev = env->stack.index[label];
-	env->stack.index[label] = env->stack.count;
-
-	env->stack.count++;
-	return 1;
-}
-
-static int
-hopcroft_update_splitter_stack(struct hopcroft_env *env,
-    unsigned char label, fsm_state_t ec_src,
-    fsm_state_t ec_dst_a, fsm_state_t ec_dst_b,
-    fsm_state_t ec_min)
-{
-	/* TODO this needs a search index */
-
-	/* If <ec_src, label> is already present then also add
-	 * <ec_dst, label> to the stack, otherwise add
-	 * <ec_min, label>, which represents whichever
-	 * of the new partition sets is smaller .*/
-	const size_t s_limit = env->stack.count;
-
-	size_t s_i;
-#if 0
-	for (s_i = 0; s_i < s_limit; s_i++) {
-		struct splitter *s = &env->stack.splitters[s_i];
-		if (s->ec == ec_src && s->label == label) {
-			/* fprintf(stderr, "XXX remap -> adding <%u,'%c'>\n", ec_dst, label); */
-			s->ec = ec_dst_a;
-			if (!hopcroft_schedule_splitter(env,
-				ec_dst_b, label)) {
-				return 0;
-			}
-			return 1;
-		}
-	}
-#else
-	s_i = env->stack.index[label];
-	while (s_i < s_limit) {
-		struct splitter *s = &env->stack.splitters[s_i];
-		assert(s->label == label);
-		if (s->label != label) { break; }
-		if (s->ec == ec_src) {
-			s->ec = ec_dst_a;
-			if (!hopcroft_schedule_splitter(env,
-				ec_dst_b, label)) {
-				return 0;
-			}
-			return 1;
-		}
-		s_i = s->prev;
-	}
-#endif
-
-	/* Not found, add smaller set. */
-	return hopcroft_schedule_splitter(env, ec_min, label);
-}
-
-static int
-hopcroft_grow_updated_ecs(struct hopcroft_env *env)
-{
-	const size_t nceil = 2*env->updated_ecs_ceil;
-	struct updated_ecs *nupdated_ecs = f_realloc(env->fsm->opt->alloc,
-	    env->updated_ecs, nceil * sizeof(env->updated_ecs[0]));
-	if (nupdated_ecs == NULL) {
-		return 0;
-	}
-
-	env->updated_ecs_ceil = nceil;
-	env->updated_ecs = nupdated_ecs;
-	return 1;
-}
-
-static int
-hopcroft_grow_ecs_freelist(struct hopcroft_env *env)
-{
-	/* todo: This could double in size up to a certain
-	 * point, then add a fixed number of states. */
-	const size_t nceil = 2*env->ecs_ceil;
-	size_t i;
-	fsm_state_t *necs = f_realloc(env->fsm->opt->alloc,
-	    env->ecs, nceil * sizeof(env->ecs[0]));
-#if HOPCROFT_LOG_FREELIST
-	fprintf(stderr, "# growing freelist %lu -> %lu\n", env->ecs_ceil, nceil);
-#endif
-
-	if (necs == NULL) {
-		return 0;
-	}
-
-	for (i = env->ecs_ceil; i < nceil; i++) {
-		necs[i] = BOX_FREELIST(i + 1);
-	}
-	necs[nceil - 1] = NO_ID;
-	env->ec_freelist = env->ecs_ceil;
-
-	env->ecs = necs;
-	env->ecs_ceil = nceil;
-	return 1;
-}
-
-/* Build two arrays:
- * - label_index[]: series of states that have an edge with a label,
- *       grouped by label.
- * - label_offset[]: the offset into label_index where the states
- *       who have a particular label start. This array only contains
- *       the actual lables in labels[], which is assumed to be sorted.
- *
- * Note: This function can replace collect_labels above; in that case
- * labels and label_count could be built during the first pass. */
-static int
-hopcroft_build_label_index(struct hopcroft_env *env,
-	const unsigned char *labels, size_t label_count)
-{
-#if !HOPCROFT_USE_LABEL_INDEX
-	(void)env;
-	(void)labels;
-	(void)label_count;
-	return 1;
-#else
-	const struct fsm *fsm = env->fsm;
-	size_t label_counts[256];
-
-	size_t i, edge_count = 0;
-	const size_t state_count = fsm->statecount;
-
-	memset(label_counts, 0x00, sizeof(label_counts));
-
-	/* Count the total number of edges, and how many
-	 * edges there are with each particular label. */
-	for (i = 0; i < state_count; i++) {
-		struct fsm_edge e;
-		struct edge_iter ei;
-		for (edge_set_reset(fsm->states[i].edges, &ei);
-		     edge_set_next(&ei, &e); ) {
-			edge_count++;
-			label_counts[e.symbol]++;
-		}
-	}
-
-	assert(edge_count > 0);
-
-	/* Histogram the label counts. */
-	for (i = 1; i < 256; i++) {
-		label_counts[i] += label_counts[i - 1];
-	}
-
-	env->label_index = f_malloc(fsm->opt->alloc,
-	    edge_count * sizeof(env->label_index[0]));
-	if (env->label_index == NULL) {
-		return 0;
-	}
-
-	env->label_offsets = f_malloc(fsm->opt->alloc,
-	    label_count * sizeof(env->label_offsets[0]));
-	if (env->label_offsets == NULL) {
-		f_free(fsm->opt->alloc, env->label_index);
-		return 0;
-	}
-
-	/* Save the offsets -- for labels[l_i], the states who have
-	 * edges with it will appear between label_offsets[l_i - 1]
-	 * and label_offsets[l_i], or 0 when l_i == 0. */
-	for (i = 0; i < label_count; i++) {
-		env->label_offsets[i] = label_counts[labels[i]];
-		if (i > 0) {	/* must be sorted */
-			assert(labels[i] > labels[i - 1]);
-		}
-	}
-
-	/* Use the histogram to group the state IDs by edge label.
-	 * label_counts[i] stores the offset where the next instance
-	 * of that label's index data should be stored. */
-	for (i = state_count; i > 0; i--) {
-		struct fsm_edge e;
-		struct edge_iter ei;
-		for (edge_set_reset(fsm->states[i - 1].edges, &ei);
-		     edge_set_next(&ei, &e); ) {
-			--label_counts[e.symbol];
-
-#if HOPCROFT_LOG_INDEX
-			fprintf(stderr, "label '%c', state[%ld]: count %u\n",
-			    e.symbol, i - 1,
-			    label_counts[e.symbol]);
-#endif
-			assert(label_counts[e.symbol] < edge_count);
-			env->label_index[label_counts[e.symbol]] = i - 1;
-		}
-	}
-
-#if HOPCROFT_LOG_INDEX
-	for (i = 0; i < label_count; i++) {
-		fprintf(stderr, "label_offsets[%lu]: %u\n",
-		    i, env->label_offsets[i]);
-	}
-
-	for (i = 0; i < edge_count; i++) {
-		fprintf(stderr, "label_index[%lu]: %u\n",
-		    i, env->label_index[i]);
-	}
-#endif
-
-#if EXPENSIVE_INTEGRITY_CHECKS
-	/* If a state is in the index for a label, it must have that
-	 * label, and there must not be any extras. */
-	{
-		size_t s_i, l_i;
-		for (s_i = 0; s_i < state_count; s_i++) {
-			struct fsm_edge e;
-			struct edge_iter ei;
-			unsigned char label;
-			size_t has_label_count = 0, found_label_count = 0;
-			uint64_t has_label[4] = { 0, 0, 0, 0 };
-			for (l_i = 0; l_i < label_count; l_i++) {
-				size_t i = (l_i == 0 ? 0 : env->label_offsets[l_i - 1]);
-				label = labels[l_i];
-				while (i < env->label_offsets[l_i]) {
-					if (env->label_index[i] == s_i) {
-						uint64_t bit;
-						bit = (uint64_t)1 << (label & 63);
-
-						if (!(has_label[label/64] & bit)) {
-							has_label[label/64] |= bit;
-							has_label_count++;
-						}
-					}
-					i++;
-				}
-			}
-
-			for (edge_set_reset(fsm->states[s_i].edges, &ei);
-			     edge_set_next(&ei, &e); ) {
-				label = e.symbol;
-				assert(has_label[label/64] & ((uint64_t)1 << (label&63)));
-				found_label_count++;
-			}
-
-			assert(has_label_count == found_label_count);
-		}
-	}
-#endif
-
-	return 1;
-#endif
-}
-
-static void
-hopcroft_mark_ec_filter(struct hopcroft_env *env,
-    unsigned char label)
-{
-#if HOPCROFT_USE_LABEL_INDEX
-	size_t l_i, i;		/* label_i */
-	uint64_t *filter = env->ec_filter;
-	if (filter == NULL) { return; }
-
-	memset(filter, 0x00, env->ec_filter_bytes);
-
-	for (l_i = 0; l_i < env->label_count; l_i++) {
-		size_t base, limit;
-		if (env->labels[l_i] != label) { continue; }
-		base = (l_i == 0
-		    ? 0
-		    : env->label_offsets[l_i - 1]);
-		limit = env->label_offsets[l_i];
-		for (i = base; i < limit; i++) {
-			const fsm_state_t s = env->label_index[i];
-			const fsm_state_t ec_id = env->state_ecs[s];
-
-			/* Don't mark single-entry ECs. */
-			if (env->ecs[ec_id] == s &&
-			    env->jump[s] == NO_ID) { continue; }
-
-			filter[ec_id/64] |= ((uint64_t)1 << (ec_id&63));
-		}
-		break;
-	}
-#else
-	(void)env;
-	(void)label;
-#endif
-}
-
-static int
-hopcroft_check_ec_filter(const uint64_t *filter,
-    fsm_state_t ec_id)
-{
-#if HOPCROFT_USE_LABEL_INDEX
-	return 0 != (filter[ec_id/64] & ((uint64_t)1 << (ec_id&63)));
-#else
-	(void)filter;
-	(void)ec_id;
-	return 1;
-#endif
-}
-#endif
-
-#endif /* MIN_ALT */

--- a/src/libfsm/minimise.c
+++ b/src/libfsm/minimise.c
@@ -133,7 +133,7 @@ collect_labels(const struct fsm *fsm,
     unsigned char *labels, size_t *label_count)
 {
 	size_t count = 0;
-	uint64_t label_set[4] = { 0, 0, 0, 0 };
+	uint64_t label_set[FSM_SIGMA_COUNT/64] = { 0, 0, 0, 0 };
 	int i;
 
 	fsm_state_t id;
@@ -504,7 +504,7 @@ init_label_iterator(const struct min_env *env,
 	if (should_gather_EC_labels) {
 		fsm_state_t cur;
 		size_t i;
-		uint32_t label_set[256/32];
+		uint32_t label_set[FSM_SIGMA_COUNT/32];
 		memset(label_set, 0x00, sizeof(label_set));
 
 		cur = env->ecs[ec_i];
@@ -528,6 +528,8 @@ init_label_iterator(const struct min_env *env,
 		li->limit = 0;
 		i = 0;
 		while (i < 256) {
+			/* Check the bitset, skip forward 32 entries at a time
+			 * if they're all zero. */
 			if ((i & 31) == 0 && label_set[i/32] == 0) {
 				i += 32;
 			} else {

--- a/src/libfsm/minimise_internal.h
+++ b/src/libfsm/minimise_internal.h
@@ -1,141 +1,146 @@
 #ifndef MINIMISE_INTERNAL_H
 #define MINIMISE_INTERNAL_H
 
-#define DEF_ENDS_CEIL 2
-#define DEF_STATE_INFO_FROM_CEIL 2
-
-#define DEF_SPLITTER_STACK_CEIL 1
-
-#define NO_DEPTH ((size_t)-1)
-#define NO_PARTITION ((fsm_state_t)-1)
 #define NO_ID ((fsm_state_t)-1)
 
-#define DUMP_BACKWARDS_DEPTH_INFO 1
-#define DUMP_COARSE_PARTITIONS 1
-#define DUMP_FINE_PARTITIONS 1
+/* If set to non-zero, do extra intensive
+ * integrity checks inside some inner loops. */
+#define EXPENSIVE_INTEGRITY_CHECKS 0
 
-static int
-min_brz(struct fsm *fsm, size_t *minimized_state_count);
+struct min_env {
+	const struct fsm *fsm;
+
+	/* Counters, for benchmarking. */
+	size_t iter;		/* passes through the main loop */
+	size_t steps;		/* partition attempts */
+
+	/* ID for a special dead state. Since the DFA may not be
+	 * complete (with all states containing edges for every label in
+	 * use), any labels not present lead to an internal dead state,
+	 * which is non-final and only has edges to itself. */
+	fsm_state_t dead_state;
+
+	/* There are one or more equivalence classes (hereafter, ECs)
+	 * initially, which represent all the end states and (if
+	 * present) all the non-end states. If there are no end states,
+	 * the graph is already empty, so this shouldn't run.
+	 *
+	 * ecs[N] contains the state ID for the first state in EC group
+	 * N's linked list, then jump[ID] contains the next ID within
+	 * that EC, or NO_ID for the end of the list. state_ecs[ID]
+	 * contains the state's current EC group number.
+	 *
+	 * In other words, state_ecs[ID] = EC, and env.ecs[EC] = X,
+	 * where either X is ID or following the linked list in
+	 * env.jump[X] eventually leads to ID. Ordering within the
+	 * list does not matter. */
+	fsm_state_t *state_ecs;
+	fsm_state_t *ecs;
+	fsm_state_t *jump;
+
+	/* How many ECs appear in ecs[]. This increases as more states
+	 * are partitioned into independent ECs, but can never be larger
+	 * than the number of states in the DFA input. */
+	fsm_state_t ec_count;
+
+	/* Any ECs from ecs[done_ec_offset] to the end are done -- they
+	 * have less than two elements and can't be partitioned further,
+	 * so it would only waste time to check them. If partitioning an
+	 * EC creates a new EC with less than two elements, the offset
+	 * is updated and/or the ECs are swapped so that the new EC is
+	 * linked after the done offset. The first two ECs can start
+	 * with less than two states (for example, if all states are
+	 * final), so the loop body still needs to check and skip ECs
+	 * with <2 states, but this will skip scanning the majority of
+	 * new ECs.
+	 *
+	 * Skipping the ECs after done_ec_offset improves performance
+	 * signifcantly, with far less complexity or overhead compared
+	 * to the splitter queue management in Hopcroft's algorithm
+	 * (which becomes more expensive as label_count increases). */
+	fsm_state_t done_ec_offset;
+
+	/* The set of labels that appear through the entire DFA. */
+	const unsigned char *dfa_labels;
+	size_t dfa_label_count;
+};
+
+/* An iterator, used to try partitioning on either:
+ * - every label appearing throughout the entire DFA.
+ * - every label appearing within a specific EC.
+ *
+ * While attempting to partition an EC, the states split into the new
+ * ECs are counted. If either EC has less than SMALL_EC_THRESHOLD
+ * states, a flag is set indicating that the iterator should collect the
+ * labels that actually appear in the EC and just check those. This
+ * significantly reduces the overhead of checking for possible
+ * partitions in a large DFA label set when the EC's states only have a
+ * small number of edges. */
+struct min_label_iterator {
+	unsigned i;
+	unsigned limit;
+	unsigned char has_labels_for_EC;
+	unsigned char labels[256];
+};
+
+/* Note that the ordering here is significant -- the
+ * not-final EC may be skipped, so INIT_EC_NOT_FINAL
+ * must be first. */
+enum init_ec { INIT_EC_NOT_FINAL, INIT_EC_FINAL };
+
+/* We only know the state count for an EC immediately after an
+ * attempted partition. When the ECs have less than SMALL_EC_THRESHOLD
+ * states, then set the most significant bit to mark that the EC is
+ * small. In that case, it's probably more efficient to do an extra
+ * pass and collect which labels are actually used, then just check
+ * for possible partitions on those, rather than trying every label
+ * used in the entire DFA. */
+#define SMALL_EC_FLAG (UINT_MAX ^ (UINT_MAX >> 1))
+#define SMALL_EC_THRESHOLD 16	/* a guess -- needs experimentation */
+#define DFA_LABELS_THRESHOLD 4
+#define SET_SMALL_EC_FLAG(STATE_ID) (STATE_ID | SMALL_EC_FLAG)
+#define MASK_EC_HEAD(EC) (EC &~ SMALL_EC_FLAG)
 
 static void
 collect_labels(const struct fsm *fsm,
     unsigned char *labels, size_t *label_count);
 
 static int
-min_naive(const struct fsm *fsm,
-    const unsigned char *labels, size_t label_count,
-    fsm_state_t *mapping, size_t *minimized_state_count);
-
-static fsm_state_t
-naive_delta(const struct fsm *fsm, fsm_state_t id, unsigned char label);
-
-
-struct moore_env {
-	const struct fsm *fsm;
-	fsm_state_t dead_state;
-	fsm_state_t *state_ecs;
-	fsm_state_t *jump;
-	fsm_state_t *ecs;
-};
-
-static int
-min_moore(const struct fsm *fsm,
-    const unsigned char *labels, size_t label_count,
+build_minimised_mapping(const struct fsm *fsm,
+    const unsigned char *dfa_labels, size_t dfa_label_count,
     fsm_state_t *mapping, size_t *minimized_state_count);
 
 static void
-moore_dump_ec(FILE *f, fsm_state_t start, const fsm_state_t *jump);
+dump_ecs(FILE *f, const struct min_env *env);
+
+static void
+populate_initial_ecs(struct min_env *env, const struct fsm *fsm);
+
+#if EXPENSIVE_INTEGRITY_CHECKS
+static void
+check_done_ec_offset(const struct min_env *env);
+#endif
 
 static int
-moore_try_partition(struct moore_env *env, unsigned char label,
+update_after_partition(struct min_env *env,
+    const size_t *partition_counts,
     fsm_state_t ec_src, fsm_state_t ec_dst);
 
-#if DO_HOPCROFT
-struct hopcroft_env {
-	const struct fsm *fsm;
-	fsm_state_t ec_freelist;
-	fsm_state_t max_ec_in_use;
-
-	fsm_state_t dead_state;
-	fsm_state_t *state_ecs;
-	fsm_state_t *jump;
-
-	const unsigned char *labels;
-	size_t label_count;
-
-	size_t ecs_ceil;
-	fsm_state_t *ecs;
-
-	size_t updated_ecs_ceil;
-	struct updated_ecs {
-		fsm_state_t src;
-		fsm_state_t dst[2];
-	} *updated_ecs;
-
-	fsm_state_t *label_offsets;
-	fsm_state_t *label_index;
-	uint64_t *ec_filter;
-	size_t ec_filter_bytes;
-
-	struct {
-		size_t index[256];	/* label -> top splitter on stack */
-		size_t count;
-		size_t ceil;
-		struct splitter {
-			fsm_state_t ec;
-			unsigned char label;
-			size_t prev;
-		} *splitters;
-	} stack;
-};
-
-static int
-min_hopcroft(const struct fsm *fsm,
-    const unsigned char *labels, size_t label_count,
-    fsm_state_t *mapping, size_t *minimized_state_count);
+static void
+update_ec_links(struct min_env *env, fsm_state_t ec_dst);
 
 static void
-hopcroft_dump_ec(FILE *f, fsm_state_t start, const fsm_state_t *jump);
+init_label_iterator(const struct min_env *env,
+	fsm_state_t ec_i, int special_handling,
+	struct min_label_iterator *li);
 
-enum hopcroft_try_partition_res {
-	HTP_NO_CHANGE,
-	HTP_PARTITIONED,
-	HTP_ERROR_ALLOC = -1
-};
-static enum hopcroft_try_partition_res
-hopcroft_try_partition(struct hopcroft_env *env,
-    fsm_state_t ec_splitter, unsigned char label,
-    fsm_state_t ec_src,
-    fsm_state_t *ec_dst_a, fsm_state_t *ec_dst_b,
+static fsm_state_t
+find_edge_destination(const struct fsm *fsm,
+    fsm_state_t id, unsigned char label);
+
+static int
+try_partition(struct min_env *env, unsigned char label,
+    fsm_state_t ec_src, fsm_state_t ec_dst,
     size_t partition_counts[2]);
-
-static int
-hopcroft_schedule_splitter(struct hopcroft_env *env,
-    fsm_state_t ec, unsigned char label);
-
-static int
-hopcroft_update_splitter_stack(struct hopcroft_env *env,
-    unsigned char label, fsm_state_t ec_src,
-    fsm_state_t ec_dst_a, fsm_state_t ec_dst_b,
-    fsm_state_t ec_min);
-
-static int
-hopcroft_grow_updated_ecs(struct hopcroft_env *env);
-
-static int
-hopcroft_grow_ecs_freelist(struct hopcroft_env *env);
-
-static int
-hopcroft_build_label_index(struct hopcroft_env *env,
-    const unsigned char *labels, size_t label_count);
-
-static void
-hopcroft_mark_ec_filter(struct hopcroft_env *env,
-    unsigned char label);
-
-static int
-hopcroft_check_ec_filter(const uint64_t *filter,
-    fsm_state_t ec_id);
-#endif
 
 #endif

--- a/src/libfsm/minimise_internal.h
+++ b/src/libfsm/minimise_internal.h
@@ -1,0 +1,181 @@
+#ifndef MINIMISE_INTERNAL_H
+#define MINIMISE_INTERNAL_H
+
+#define DEF_ENDS_CEIL 2
+#define DEF_STATE_INFO_FROM_CEIL 2
+
+#define DEF_SPLITTER_STACK_CEIL 1
+
+#define NO_DEPTH ((size_t)-1)
+#define NO_PARTITION ((fsm_state_t)-1)
+#define NO_ID ((fsm_state_t)-1)
+
+#define DUMP_BACKWARDS_DEPTH_INFO 1
+#define DUMP_COARSE_PARTITIONS 1
+#define DUMP_FINE_PARTITIONS 1
+
+static int
+min_brz(struct fsm *fsm, size_t *minimized_state_count);
+
+static void
+collect_labels(const struct fsm *fsm,
+    unsigned char *labels, size_t *label_count);
+
+static int
+min_naive(const struct fsm *fsm,
+    const unsigned char *labels, size_t label_count,
+    fsm_state_t *mapping, size_t *minimized_state_count);
+
+static fsm_state_t
+naive_delta(const struct fsm *fsm, fsm_state_t id, unsigned char label);
+
+
+struct moore_env {
+	const struct fsm *fsm;
+	fsm_state_t dead_state;
+	fsm_state_t *state_ecs;
+	fsm_state_t *jump;
+	fsm_state_t *ecs;
+};
+
+static int
+min_moore(const struct fsm *fsm,
+    const unsigned char *labels, size_t label_count,
+    fsm_state_t *mapping, size_t *minimized_state_count);
+
+static void
+moore_dump_ec(FILE *f, fsm_state_t start, const fsm_state_t *jump);
+
+static int
+moore_try_partition(struct moore_env *env, unsigned char label,
+    fsm_state_t ec_src, fsm_state_t ec_dst);
+
+
+struct exmoore_env {
+	const struct fsm *fsm;
+	fsm_state_t dead_state;
+	fsm_state_t *state_ecs;
+	fsm_state_t *jump;
+	fsm_state_t *ecs;
+	const unsigned char *labels;
+	size_t label_count;
+};
+
+struct exmoore_label_iterator {
+	unsigned i;
+	unsigned limit;
+	unsigned char use_special;
+	unsigned char labels[256];
+};
+
+static int
+min_exmoore(const struct fsm *fsm,
+    const unsigned char *labels, size_t label_count,
+    fsm_state_t *mapping, size_t *minimized_state_count);
+
+static void
+exmoore_dump_ec(FILE *f, fsm_state_t start, const fsm_state_t *jump);
+
+static int
+exmoore_try_partition(struct exmoore_env *env, unsigned char label,
+    fsm_state_t ec_src, fsm_state_t ec_dst,
+    size_t partition_counts[2]);
+
+static void
+exmoore_heuristic_scan(FILE *f, const struct exmoore_env *env,
+    const unsigned char *labels, size_t label_count);
+
+static void
+exmoore_init_label_iterator(const struct exmoore_env *env,
+	fsm_state_t ec_i, int special_handling,
+	struct exmoore_label_iterator *li);
+
+#if DO_HOPCROFT
+struct hopcroft_env {
+	const struct fsm *fsm;
+	fsm_state_t ec_freelist;
+	fsm_state_t max_ec_in_use;
+
+	fsm_state_t dead_state;
+	fsm_state_t *state_ecs;
+	fsm_state_t *jump;
+
+	const unsigned char *labels;
+	size_t label_count;
+
+	size_t ecs_ceil;
+	fsm_state_t *ecs;
+
+	size_t updated_ecs_ceil;
+	struct updated_ecs {
+		fsm_state_t src;
+		fsm_state_t dst[2];
+	} *updated_ecs;
+
+	fsm_state_t *label_offsets;
+	fsm_state_t *label_index;
+	uint64_t *ec_filter;
+	size_t ec_filter_bytes;
+
+	struct {
+		size_t index[256];	/* label -> top splitter on stack */
+		size_t count;
+		size_t ceil;
+		struct splitter {
+			fsm_state_t ec;
+			unsigned char label;
+			size_t prev;
+		} *splitters;
+	} stack;
+};
+
+static int
+min_hopcroft(const struct fsm *fsm,
+    const unsigned char *labels, size_t label_count,
+    fsm_state_t *mapping, size_t *minimized_state_count);
+
+static void
+hopcroft_dump_ec(FILE *f, fsm_state_t start, const fsm_state_t *jump);
+
+enum hopcroft_try_partition_res {
+	HTP_NO_CHANGE,
+	HTP_PARTITIONED,
+	HTP_ERROR_ALLOC = -1
+};
+static enum hopcroft_try_partition_res
+hopcroft_try_partition(struct hopcroft_env *env,
+    fsm_state_t ec_splitter, unsigned char label,
+    fsm_state_t ec_src,
+    fsm_state_t *ec_dst_a, fsm_state_t *ec_dst_b,
+    size_t partition_counts[2]);
+
+static int
+hopcroft_schedule_splitter(struct hopcroft_env *env,
+    fsm_state_t ec, unsigned char label);
+
+static int
+hopcroft_update_splitter_stack(struct hopcroft_env *env,
+    unsigned char label, fsm_state_t ec_src,
+    fsm_state_t ec_dst_a, fsm_state_t ec_dst_b,
+    fsm_state_t ec_min);
+
+static int
+hopcroft_grow_updated_ecs(struct hopcroft_env *env);
+
+static int
+hopcroft_grow_ecs_freelist(struct hopcroft_env *env);
+
+static int
+hopcroft_build_label_index(struct hopcroft_env *env,
+    const unsigned char *labels, size_t label_count);
+
+static void
+hopcroft_mark_ec_filter(struct hopcroft_env *env,
+    unsigned char label);
+
+static int
+hopcroft_check_ec_filter(const uint64_t *filter,
+    fsm_state_t ec_id);
+#endif
+
+#endif

--- a/src/libfsm/minimise_internal.h
+++ b/src/libfsm/minimise_internal.h
@@ -50,46 +50,6 @@ static int
 moore_try_partition(struct moore_env *env, unsigned char label,
     fsm_state_t ec_src, fsm_state_t ec_dst);
 
-
-struct exmoore_env {
-	const struct fsm *fsm;
-	fsm_state_t dead_state;
-	fsm_state_t *state_ecs;
-	fsm_state_t *jump;
-	fsm_state_t *ecs;
-	const unsigned char *labels;
-	size_t label_count;
-};
-
-struct exmoore_label_iterator {
-	unsigned i;
-	unsigned limit;
-	unsigned char use_special;
-	unsigned char labels[256];
-};
-
-static int
-min_exmoore(const struct fsm *fsm,
-    const unsigned char *labels, size_t label_count,
-    fsm_state_t *mapping, size_t *minimized_state_count);
-
-static void
-exmoore_dump_ec(FILE *f, fsm_state_t start, const fsm_state_t *jump);
-
-static int
-exmoore_try_partition(struct exmoore_env *env, unsigned char label,
-    fsm_state_t ec_src, fsm_state_t ec_dst,
-    size_t partition_counts[2]);
-
-static void
-exmoore_heuristic_scan(FILE *f, const struct exmoore_env *env,
-    const unsigned char *labels, size_t label_count);
-
-static void
-exmoore_init_label_iterator(const struct exmoore_env *env,
-	fsm_state_t ec_i, int special_handling,
-	struct exmoore_label_iterator *li);
-
 #if DO_HOPCROFT
 struct hopcroft_env {
 	const struct fsm *fsm;

--- a/tests/ir/out5.json
+++ b/tests/ir/out5.json
@@ -4,10 +4,10 @@
 		{
 			"end": false,
 			"strategy": "dominant",
-			"mode": 1,
+			"mode": 2,
 			"groups": [
 				{
-					"to": 2,
+					"to": 1,
 					"ranges": [
 						{ "start": "x", "end": "x" }
 					]
@@ -16,21 +16,21 @@
 		},
 		{
 			"end": true,
-			"strategy": "none",
-			"example": "a"
-		},
-		{
-			"end": true,
 			"strategy": "partial",
 			"example": "x",
 			"groups": [
 				{
-					"to": 1,
+					"to": 2,
 					"ranges": [
 						{ "start": "y", "end": "y" }
 					]
 				}
 			]
+		},
+		{
+			"end": true,
+			"strategy": "none",
+			"example": "a"
 		}
 	]
 }

--- a/tests/ir/out7.json
+++ b/tests/ir/out7.json
@@ -1,29 +1,6 @@
 {
-	"start": 0,
+	"start": 1,
 	"states": [
-		{
-			"end": false,
-			"strategy": "same",
-			"to": 1
-		},
-		{
-			"end": false,
-			"strategy": "error",
-			"example": "a",
-			"mode": 2,
-			"error": [
-						{ "start": "a", "end": "l" },
-						{ "start": "n", "end": "y" }
-			],
-			"groups": [
-				{
-					"to": 3,
-					"ranges": [
-						{ "start": "z", "end": "z" }
-					]
-				}
-			]
-		},
 		{
 			"end": true,
 			"strategy": "none",
@@ -31,29 +8,52 @@
 		},
 		{
 			"end": false,
-			"strategy": "partial",
-			"example": "az",
+			"strategy": "same",
+			"to": 3
+		},
+		{
+			"end": false,
+			"strategy": "same",
+			"example": "aza",
+			"to": 0
+		},
+		{
+			"end": false,
+			"strategy": "error",
+			"example": "a",
+			"mode": 0,
+			"error": [
+						{ "start": "a", "end": "l" },
+						{ "start": "n", "end": "y" }
+			],
 			"groups": [
-				{
-					"to": 3,
-					"ranges": [
-						{ "start": "z", "end": "z" }
-					]
-				},
 				{
 					"to": 4,
 					"ranges": [
-						{ "start": "0", "end": "9" },
-						{ "start": "a", "end": "f" }
+						{ "start": "z", "end": "z" }
 					]
 				}
 			]
 		},
 		{
 			"end": false,
-			"strategy": "same",
-			"example": "aza",
-			"to": 2
+			"strategy": "partial",
+			"example": "az",
+			"groups": [
+				{
+					"to": 2,
+					"ranges": [
+						{ "start": "0", "end": "9" },
+						{ "start": "a", "end": "f" }
+					]
+				},
+				{
+					"to": 4,
+					"ranges": [
+						{ "start": "z", "end": "z" }
+					]
+				}
+			]
 		}
 	]
 }

--- a/theft/Makefile
+++ b/theft/Makefile
@@ -9,6 +9,7 @@ SRC += theft/fuzz_adt_edge_set.c
 SRC += theft/fuzz_adt_priq.c
 SRC += theft/fuzz_adt_set.c
 SRC += theft/fuzz_literals.c
+SRC += theft/fuzz_minimise.c
 SRC += theft/fuzz_nfa.c
 SRC += theft/fuzz_re_parser.c
 SRC += theft/fuzz_re_parser_literal.c

--- a/theft/fuzz_minimise.c
+++ b/theft/fuzz_minimise.c
@@ -12,8 +12,8 @@ check_minimise_matches_naive_fixpoint_algorithm(const struct dfa_spec *spec);
 static enum theft_trial_res
 prop_minimise_matches_naive_fixpoint_algorithm(struct theft *t, void *arg1);
 
-static size_t
-naive_minimised_count(const struct dfa_spec *spec);
+static bool
+naive_minimised_count(const struct dfa_spec *spec, size_t *count);
 
 static bool
 test_dfa_minimise(theft_seed seed,

--- a/theft/fuzz_minimise.c
+++ b/theft/fuzz_minimise.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2020 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include "type_info_dfa.h"
+
+static enum theft_trial_res
+check_minimise_matches_naive_fixpoint_algorithm(const struct dfa_spec *spec);
+
+static enum theft_trial_res
+prop_minimise_matches_naive_fixpoint_algorithm(struct theft *t, void *arg1);
+
+static size_t
+naive_minimised_count(const struct dfa_spec *spec);
+
+static bool
+test_dfa_minimise(theft_seed seed,
+    uintptr_t state_ceil_bits,
+    uintptr_t symbol_ceil_bits,
+    uintptr_t end_bits)
+{
+	enum theft_run_res res;
+
+	struct dfa_spec_env env = {
+		.tag = 'D',
+		.state_ceil_bits = state_ceil_bits,
+		.symbol_ceil_bits = symbol_ceil_bits,
+		.end_bits = end_bits,
+	};
+
+	const char *gen_seed = getenv("GEN_SEED");
+
+	if (gen_seed != NULL) {
+		seed = strtoul(gen_seed, NULL, 0);
+		theft_generate(stderr, seed,
+		    &type_info_dfa, (void *)&env);
+		return true;
+	}
+
+	struct theft_run_config config = {
+		.name = __func__,
+		.prop1 = prop_minimise_matches_naive_fixpoint_algorithm,
+		.type_info = { &type_info_dfa, },
+		.hooks = {
+			.trial_pre = theft_hook_first_fail_halt,
+			.env = (void *)&env,
+		},
+		.seed = seed,
+		.trials = 10000,
+		.fork = {
+			.enable = true,
+			.timeout = 1000,
+		},
+	};
+
+	res = theft_run(&config);
+	printf("%s: %s\n", __func__, theft_run_res_str(res));
+	return res == THEFT_RUN_PASS;
+}
+
+static enum theft_trial_res
+prop_minimise_matches_naive_fixpoint_algorithm(struct theft *t, void *arg1)
+{
+	(void)t;
+	const struct dfa_spec *spec = arg1;
+	return check_minimise_matches_naive_fixpoint_algorithm(spec);
+}
+
+static enum theft_trial_res
+check_minimise_matches_naive_fixpoint_algorithm(const struct dfa_spec *spec)
+{
+	enum theft_trial_res res = THEFT_TRIAL_FAIL;
+	(void)spec;
+
+	/* For an arbitrary DFA, the number of states remaining after
+	 * minimisation matches the number of unique states necessary
+	 * according to a naive fixpoint-based minimisation algorithm. */
+
+	if (spec->state_count == 0) {
+		return THEFT_TRIAL_SKIP;
+	}
+
+	struct fsm *fsm = dfa_spec_build_fsm(spec);
+	if (fsm == NULL) {
+		return THEFT_TRIAL_ERROR;
+	}
+
+	const size_t states_needed_naive = naive_minimised_count(spec);
+
+	if (!fsm_minimise(fsm)) {
+		fprintf(stderr, "-- fail: fsm_minimise\n");
+		goto cleanup;
+	}
+
+	const size_t states_post_minimise = fsm_countstates(fsm);
+	if (states_post_minimise != states_needed_naive) {
+		fprintf(stderr, "-- fail: state count after fsm_minimise: exp %zu, got %zu\n",
+		    states_needed_naive, states_post_minimise);
+		goto cleanup;
+	}
+
+	res = THEFT_TRIAL_PASS;
+
+cleanup:
+	if (fsm != NULL) { fsm_free(fsm); }
+	return res;
+}
+
+static size_t
+naive_minimised_count(const struct dfa_spec *spec)
+{
+	return spec->state_count; /* lies! */
+}
+
+void
+register_test_minimise(void)
+{
+	reg_test3("dfa_minimise", test_dfa_minimise,
+	    0, 0, 0);
+}

--- a/theft/fuzz_minimise.c
+++ b/theft/fuzz_minimise.c
@@ -6,6 +6,8 @@
 
 #include "type_info_dfa.h"
 
+#define LOG_NAIVE_MIN 0
+
 static enum theft_trial_res
 check_minimise_matches_naive_fixpoint_algorithm(const struct dfa_spec *spec);
 
@@ -14,6 +16,9 @@ prop_minimise_matches_naive_fixpoint_algorithm(struct theft *t, void *arg1);
 
 static bool
 naive_minimised_count(const struct dfa_spec *spec, size_t *count);
+
+static bool
+naive_minimised_count_inner(const struct dfa_spec *spec, size_t *count);
 
 static bool
 test_dfa_minimise(theft_seed seed,
@@ -44,13 +49,13 @@ test_dfa_minimise(theft_seed seed,
 		.prop1 = prop_minimise_matches_naive_fixpoint_algorithm,
 		.type_info = { &type_info_dfa, },
 		.hooks = {
-			.trial_pre = theft_hook_first_fail_halt,
+			/* .trial_pre = theft_hook_first_fail_halt, */
 			.env = (void *)&env,
 		},
 		.seed = seed,
 		.trials = 10000,
 		.fork = {
-			.enable = true,
+			/* .enable = true, */
 			.timeout = 1000,
 		},
 	};
@@ -79,15 +84,27 @@ check_minimise_matches_naive_fixpoint_algorithm(const struct dfa_spec *spec)
 	 * according to a naive fixpoint-based minimisation algorithm. */
 
 	if (spec->state_count == 0) {
+		fprintf(stderr, "-- skip, empty\n");
 		return THEFT_TRIAL_SKIP;
 	}
 
 	struct fsm *fsm = dfa_spec_build_fsm(spec);
 	if (fsm == NULL) {
+		fprintf(stderr, "-- ERROR: dfa_spec_build_fsm\n");
 		return THEFT_TRIAL_ERROR;
 	}
 
-	const size_t states_needed_naive = naive_minimised_count(spec);
+	size_t states_needed_naive;
+	if (!naive_minimised_count(spec, &states_needed_naive)) {
+		fprintf(stderr, "-- ERROR: naive_minimised_count\n");
+		res = THEFT_TRIAL_ERROR;
+		goto cleanup;
+	}
+
+	if (fsm_trim(fsm, FSM_TRIM_START_AND_END_REACHABLE) < 0) {
+		fprintf(stderr, "-- fail: fsm_trim\n");
+		goto cleanup;
+	}
 
 	if (!fsm_minimise(fsm)) {
 		fprintf(stderr, "-- fail: fsm_minimise\n");
@@ -95,6 +112,13 @@ check_minimise_matches_naive_fixpoint_algorithm(const struct dfa_spec *spec)
 	}
 
 	const size_t states_post_minimise = fsm_countstates(fsm);
+
+	if (states_post_minimise == 0) {
+		fprintf(stderr, "-- skip, empty (after trim)\n");
+		res = THEFT_TRIAL_SKIP;
+		goto cleanup;
+	}
+
 	if (states_post_minimise != states_needed_naive) {
 		fprintf(stderr, "-- fail: state count after fsm_minimise: exp %zu, got %zu\n",
 		    states_needed_naive, states_post_minimise);
@@ -108,15 +132,584 @@ cleanup:
 	return res;
 }
 
-static size_t
-naive_minimised_count(const struct dfa_spec *spec)
+static bool
+collect_labels(const struct dfa_spec *spec,
+    unsigned char **labels, size_t *label_count)
 {
-	return spec->state_count; /* lies! */
+	uint64_t used[4] = { 0 };
+	size_t count = 0;
+	for (size_t s_i = 0; s_i < spec->state_count; s_i++) {
+		const struct dfa_spec_state *s = &spec->states[s_i];
+		if (!s->used) { continue; }
+		for (size_t e_i = 0; e_i < s->edge_count; e_i++) {
+			const unsigned char symbol = s->edges[e_i].symbol;
+			if (!BITSET_CHECK(used, symbol)) {
+				BITSET_SET(used, symbol);
+				count++;
+			}
+		}
+	}
+
+	unsigned char *res = malloc(count * sizeof(res[0]));
+	if (res == NULL) {
+		return false;
+	}
+
+	size_t written = 0;
+	for (size_t i = 0; i < 256; i++) {
+		if (BITSET_CHECK(used, i)) {
+			res[written] = (unsigned char)i;
+			written++;
+		}
+	}
+	assert(written == count);
+
+	*labels = res;
+	*label_count = count;
+	return true;
 }
+
+static fsm_state_t
+naive_delta(const struct dfa_spec *spec,
+    fsm_state_t from, unsigned char label)
+{
+	assert(from < spec->state_count);
+
+	const struct dfa_spec_state *s = &spec->states[from];
+	assert(s->used);
+	for (size_t e_i = 0; e_i < s->edge_count; e_i++) {
+		const unsigned char symbol = s->edges[e_i].symbol;
+		if (symbol == label) {
+			return s->edges[e_i].state;
+		}
+	}
+
+	return spec->state_count;	/* dead state */
+}
+
+static struct dfa_spec *
+alloc_trimmed_spec(const struct dfa_spec *spec)
+{
+	struct dfa_spec *res = NULL;
+	uint64_t *live = NULL;
+	struct dfa_spec_state *nstates = NULL;
+	fsm_state_t *mapping = NULL;
+
+	const size_t live_words = spec->state_count/64 + 1;
+	live = calloc(live_words, sizeof(live[0]));
+	if (live == NULL) { goto cleanup; }
+
+	res = malloc(sizeof(*res));
+	if (res == NULL) { goto cleanup; }
+
+	size_t live_count;
+	if (!dfa_spec_check_liveness(spec, live, &live_count)) {
+		goto cleanup;
+	}
+#define NO_STATE ((fsm_state_t)-1)
+
+	nstates = calloc(live_count,
+	    sizeof(nstates[0]));
+	if (nstates == NULL) { goto cleanup; }
+
+	mapping = calloc(spec->state_count, sizeof(mapping[0]));
+	if (mapping == NULL) { goto cleanup; }
+
+	/* FIXME: how should this handle a dead start? */
+	assert(mapping[spec->start] != NO_STATE);
+
+	/* First pass: assign new IDs */
+	size_t dst = 0;
+	for (size_t s_i = 0; s_i < spec->state_count; s_i++) {
+		if (BITSET_CHECK(live, s_i)) {
+			mapping[s_i] = dst;
+			dst++;
+		} else {
+			mapping[s_i] = NO_STATE;
+		}
+	}
+	assert(dst == live_count);
+
+	/* Second pass: rewrite and compact states */
+	dst = 0;
+	for (size_t s_i = 0; s_i < spec->state_count; s_i++) {
+		if (mapping[s_i] == NO_STATE) { continue; }
+		const struct dfa_spec_state *os = &spec->states[s_i];
+		struct dfa_spec_state *ns = &nstates[dst];
+		ns->used = true;
+		ns->end = os->end;
+		for (size_t e_i = 0; e_i < os->edge_count; e_i++) {
+			const struct dfa_spec_edge *oe = &os->edges[e_i];
+			/* discard edges to trimmed states */
+			if (mapping[oe->state] == NO_STATE) { continue; }
+			ns->edges[ns->edge_count].symbol = oe->symbol;
+			ns->edges[ns->edge_count].state = mapping[oe->state];
+			ns->edge_count++;
+		}
+		dst++;
+	}
+	assert(dst == live_count);
+
+	res->state_count = live_count;
+	res->states = nstates;
+	res->start = mapping[spec->start];
+	free(live);
+	free(mapping);
+	return res;
+
+#undef NO_STATE
+cleanup:
+	if (res != NULL) { free(res); }
+	if (live != NULL) { free(live); }
+	if (nstates != NULL) { free(nstates); }
+	if (mapping != NULL) { free(mapping); }
+	return NULL;
+}
+
+static bool
+naive_minimised_count(const struct dfa_spec *spec, size_t *count)
+{
+	bool res = true;
+
+	struct dfa_spec *nspec = alloc_trimmed_spec(spec);
+	if (nspec == NULL) {
+		return false;
+	}
+
+	if (!naive_minimised_count_inner(nspec, count)) {
+		res = false;
+	}
+
+	free(nspec->states);
+	free(nspec);
+	return res;
+}
+
+static bool
+naive_minimised_count_inner(const struct dfa_spec *spec, size_t *count)
+{
+	bool res = false;
+
+	/* Naive, fixpoint-based algorithm for calculating equivalent
+	 * states from pages 68-69 ("A minimization algorithm") of
+	 * _Introduction to Automata Theory, Languages, and Computation_
+	 * by Hopcroft & Ullman. */
+
+	/* Allocate an NxN bit table, used to track which states have
+	 * not yet been proven indistinguishable.
+	 *
+	 * For two states A and B, only use the half of the table where
+	 * A <= B, to avoid redundantly comparing B with A. In other
+	 * words, only the bits below the diagonal are actually used.
+	 *
+	 * An extra state is added to internally represent a complete
+	 * graph -- for any state that does not have a particular label
+	 * used elsewhere, treat it as if it has that label leading to
+	 * an extra dead state. */
+	uint64_t *table = NULL;
+	const fsm_state_t dead_state = spec->state_count;
+	const size_t table_states = (spec->state_count + 1 /* dead state */);
+	const size_t row_words = table_states/64 + 1 /* round up */;
+	fsm_state_t *tmp_map = NULL;
+	size_t label_count;
+	unsigned char *labels = NULL;
+	fsm_state_t *mapping = NULL;
+
+	table = calloc(row_words * table_states, sizeof(table[0]));
+	if (table == NULL) { goto cleanup; }
+
+	tmp_map = malloc(spec->state_count * sizeof(tmp_map[0]));
+	if (tmp_map == NULL) { goto cleanup; }
+
+	mapping = malloc(spec->state_count * sizeof(mapping[0]));
+	if (mapping == NULL) { goto cleanup; }
+
+	if (!collect_labels(spec, &labels, &label_count)) {
+		goto cleanup;
+	}
+
+	/* macros for NxN bit table */
+#define POS(X,Y) ((X*table_states) + Y)
+#define BITS 64
+#define BIT_OP(X,Y,OP) (table[POS(X,Y)/BITS] OP (1ULL << (POS(X,Y) & (BITS - 1))))
+#define MARK(X,Y)  (BIT_OP(X, Y, |=))
+#define CLEAR(X,Y) (BIT_OP(X, Y, &=~))
+#define CHECK(X,Y) (BIT_OP(X, Y, &))
+	/* This implementation assumes that BITS is a power of 2,
+	 * to avoid the extra overhead from modulus. True when
+	 * sizeof(unsigned) is 4 or 8. */
+	assert((BITS & (BITS - 1)) == 0);
+
+	/* Mark all pairs of states where one is final and one is not.
+	 * This includes the dead state. */
+	for (size_t i = 0; i < table_states; i++) {
+		for (size_t j = 0; j < i; j++) {
+			const bool end_i = i == dead_state
+			    ? false : spec->states[i].end;
+			const bool end_j = j == dead_state
+			    ? false : spec->states[j].end;
+			if (end_i != end_j) {
+				if (LOG_NAIVE_MIN > 0) {
+					fprintf(stderr,
+					    "naive: setup mark %ld,%ld\n",
+					    i, j);
+				}
+				MARK(i, j);
+			}
+		}
+	}
+
+	bool changed;
+	do {			/* run until fixpoint */
+		changed = false;
+		/* For every combination of states that are still
+		 * considered potentially indistinguishable, check
+		 * whether the current label leads both to a pair of
+		 * distinguishable states. If so, then they are no
+		 * longer distinguishable (transitively), so mark them
+		 * and set changed to note that another iteration may be
+		 * necessary. */
+		if (LOG_NAIVE_MIN > 1) {
+			fprintf(stderr, "==== table\n");
+			for (size_t i = 0; i < table_states; i++) {
+				fprintf(stderr, "%-6zu%s ", i, "|");
+				for (size_t j = 0; j < i; j++) {
+					fprintf(stderr, "%-8d",
+					    CHECK(i, j) != 0);
+				}
+				fprintf(stderr, "\n");
+			}
+
+			fprintf(stderr, "%6s", " ");
+			for (size_t i = 0; i < table_states; i++) {
+				fprintf(stderr, "--------");
+			}
+			fprintf(stderr, "\n%8s", " ");
+			for (size_t i = 0; i < table_states; i++) {
+				fprintf(stderr, "%-8zu", i);
+			}
+			fprintf(stderr, "\n");
+
+			fprintf(stderr, "====\n");
+		}
+
+		for (size_t i = 0; i < spec->state_count; i++) {
+			for (size_t j = 0; j < i; j++) {
+				if (LOG_NAIVE_MIN > 0) {
+					fprintf(stderr, "naive: fix [%ld,%ld]: %d\n",
+					    i, j, 0 != CHECK(i,j));
+				}
+
+				if (CHECK(i, j)) { continue; }
+				for (size_t label_i = 0; label_i < label_count; label_i++) {
+					const unsigned char label = labels[label_i];
+					const fsm_state_t to_i = naive_delta(spec, i, label);
+					const fsm_state_t to_j = naive_delta(spec, j, label);
+					bool tbval;
+					if (to_i >= to_j) {
+						tbval = 0 != CHECK(to_i, to_j);
+					} else {
+						tbval = 0 != CHECK(to_j, to_i);
+					}
+
+					if (LOG_NAIVE_MIN > 0) {
+						fprintf(stderr,
+						    "naive: label 0x%x, i %ld -> %d, j %ld -> %d => tbs %d\n",
+						    label, i, to_i, j, to_j, tbval);
+					}
+
+					if (tbval) {
+						if (LOG_NAIVE_MIN > 0) {
+							fprintf(stderr,
+							    "naive: MARKING %ld,%ld\n",
+							    i, j);
+						}
+
+						MARK(i, j);
+						changed = true;
+						break;
+					}
+				}
+			}
+		}
+	} while (changed);
+
+#define NO_ID (fsm_state_t)-1
+
+	/* Initialize to (NO_ID) */
+	for (size_t i = 0; i < spec->state_count; i++) {
+		tmp_map[i] = NO_ID;
+	}
+
+	/* For any state that cannot be proven distinguishable from an
+	 * earlier state, map it back to the earlier one. */
+	for (size_t i = 1; i < spec->state_count; i++) {
+		for (size_t j = 0; j < i; j++) {
+			if (!CHECK(i, j)) {
+				tmp_map[i] = j;
+				if (LOG_NAIVE_MIN > 0) {
+					fprintf(stderr, "naive: merging %ld with %ld\n",
+					    i, j);
+				}
+			}
+		}
+	}
+
+	/* Set IDs for the states, mapping some back to earlier states
+	 * (combining them).
+	 *
+	 * Note: this does not count the dead state. */
+	fsm_state_t new_id = 0;
+	for (size_t i = 0; i < spec->state_count; i++) {
+		if (tmp_map[i] != NO_ID) {
+			fsm_state_t prev = mapping[tmp_map[i]];
+
+			mapping[i] = prev;
+		} else {
+			mapping[i] = new_id;
+			new_id++;
+		}
+	}
+
+	if (LOG_NAIVE_MIN > 1) {
+		for (size_t i = 0; i < spec->state_count; i++) {
+			fprintf(stderr, "mapping[%zu]: %d\n", i, mapping[i]);
+		}
+	}
+
+	*count = new_id;
+	res = true;
+
+#undef POS
+#undef BITS
+#undef MARK
+#undef CHECK
+#undef CLEAR
+#undef BIT_OP
+#undef NO_ID
+
+cleanup:
+	if (labels != NULL) { free(labels); }
+	if (table != NULL) { free(table); }
+	if (tmp_map != NULL) { free(tmp_map); }
+	if (mapping != NULL) { free(mapping); }
+	return res;
+}
+
+#define RUN_SPEC(STATES, START)					 \
+	{							 \
+		struct dfa_spec spec = {			 \
+			.state_count = sizeof(STATES)/sizeof(STATES[0]), \
+			.start = START,					\
+			.states = STATES,				\
+		};							\
+		const enum theft_trial_res tres =			\
+		    check_minimise_matches_naive_fixpoint_algorithm(&spec); \
+		if (tres == THEFT_TRIAL_ERROR) {			\
+			fprintf(stderr, "(ERROR)\n");			\
+			return false;					\
+		} else if (tres == THEFT_TRIAL_SKIP) {			\
+			fprintf(stderr, "(SKIP)\n");			\
+			return true;					\
+		} else {						\
+			return tres == THEFT_TRIAL_PASS;		\
+		}							\
+	}
+
+static bool
+dfa_min_ex(theft_seed seed)
+{
+	(void)seed;
+	/* example from Hopcroft & Ullman */
+	struct dfa_spec_state states[] = {
+		[0] = { .used = true,
+			.edge_count = 2, .edges = {
+				{ .symbol = 0, .state = 1, },
+				{ .symbol = 1, .state = 5, },
+			},
+		},
+		[1] = { .used = true,
+			.edge_count = 2, .edges = {
+				{ .symbol = 0, .state = 6, },
+				{ .symbol = 1, .state = 2, },
+			},
+		},
+		[2] = { .used = true, .end = true,
+			.edge_count = 2, .edges = {
+				{ .symbol = 0, .state = 0, },
+				{ .symbol = 1, .state = 2, },
+			},
+		},
+		[3] = { .used = true,
+			.edge_count = 2, .edges = {
+				{ .symbol = 0, .state = 2, },
+				{ .symbol = 1, .state = 6, },
+			},
+		},
+		[4] = { .used = true,
+			.edge_count = 2, .edges = {
+				{ .symbol = 0, .state = 7, },
+				{ .symbol = 1, .state = 5, },
+			},
+		},
+		[5] = { .used = true,
+			.edge_count = 2, .edges = {
+				{ .symbol = 0, .state = 2, },
+				{ .symbol = 1, .state = 6, },
+			},
+		},
+		[6] = { .used = true,
+			.edge_count = 2, .edges = {
+				{ .symbol = 0, .state = 6, },
+				{ .symbol = 1, .state = 4, },
+			},
+		},
+		[7] = { .used = true,
+			.edge_count = 2, .edges = {
+				{ .symbol = 0, .state = 6, },
+				{ .symbol = 1, .state = 2, },
+			},
+		},
+	};
+	RUN_SPEC(states, 0);
+}
+
+static bool
+dfa_min_reg0(theft_seed seed)
+{
+	(void)seed;
+	struct dfa_spec_state states[] = {
+		[0] = { .used = true,
+			.edge_count = 0,
+		},
+		[1] = { .used = true, .end = true,
+			.edge_count = 0,
+		},
+	};
+	RUN_SPEC(states, 0);
+}
+
+static bool
+dfa_min_reg1(theft_seed seed)
+{
+	(void)seed;
+	struct dfa_spec_state states[] = {
+		[0] = { .used = true, .end = true,
+			.edge_count = 0,
+		},
+		[1] = { .used = true,
+			.edge_count = 0,
+		},
+	};
+	RUN_SPEC(states, 0);
+}
+
+static bool
+dfa_min_reg2(theft_seed seed)
+{
+	(void)seed;
+	struct dfa_spec_state states[] = {
+		[0] = { .used = true,
+			.edge_count = 1, .edges = {
+				{ .symbol = 0x0, .state = 2 },
+			},
+		},
+		[1] = { .used = true,
+			.edge_count = 1, .edges = {
+				{ .symbol = 0x0, .state = 0 },
+			},
+		},
+		[2] = { .used = true, .end = true,
+			.edge_count = 1, .edges = {
+				{ .symbol = 0x0, .state = 1 },
+			},
+		},
+	};
+	RUN_SPEC(states, 0);
+}
+
+static bool
+dfa_min_reg3(theft_seed seed)
+{
+	(void)seed;
+	struct dfa_spec_state states[] = {
+		[0] = { .used = true, .end = true,
+			.edge_count = 0,
+		},
+		[1] = { .used = true,
+			.edge_count = 1, .edges = {
+				{ .symbol = 0x0, .state = 0 },
+			},
+		},
+	};
+	RUN_SPEC(states, 0);
+}
+
+static bool
+dfa_min_reg4(theft_seed seed)
+{
+	(void)seed;
+	struct dfa_spec_state states[] = {
+		[0] = { .used = true, .end = true,
+			.edge_count = 1, .edges = {
+				{ .symbol = 0x0, .state = 0 },
+			},
+		},
+		[1] = { .used = true,
+			.edge_count = 1, .edges = {
+				{ .symbol = 0x0, .state = 0 },
+			},
+		},
+	};
+	RUN_SPEC(states, 0);
+}
+
+static bool
+dfa_min_reg5(theft_seed seed)
+{
+	(void)seed;
+	struct dfa_spec_state states[] = {
+		[0] = { .used = true,
+			.edge_count = 1, .edges = {
+				{ .symbol = 0x0, .state = 1 },
+			},
+		},
+		[1] = { .used = true,
+			.edge_count = 1, .edges = {
+				{ .symbol = 0x1, .state = 2 },
+			},
+		},
+		[2] = { .used = true, .end = true,
+			.edge_count = 0,
+		},
+	};
+	RUN_SPEC(states, 0);
+}
+
+/* -- fail: state count after fsm_minimise: exp 2, got 3
+ *
+ *  -- Counter-Example: test_dfa_minimise
+ *     Trial 7, Seed 0x6bcf5d9a4f4c19f8
+ *     Argument 0:
+ * === DFA#0x5594531d45a0:
+ *  -- state[0], 2 edges, start:
+ *     -- 0: 0x1 -> 1
+ *     -- 1: 0x0 -> 0
+ *  -- state[1], 1 edge, end:
+ *     -- 0: 0x0 -> 0 */
+
 
 void
 register_test_minimise(void)
 {
+	reg_test("dfa_minimise_example", dfa_min_ex);
+	reg_test("dfa_minimise_regression0", dfa_min_reg0);
+	reg_test("dfa_minimise_regression1", dfa_min_reg1);
+	reg_test("dfa_minimise_regression2", dfa_min_reg2);
+	reg_test("dfa_minimise_regression3", dfa_min_reg3);
+	reg_test("dfa_minimise_regression4", dfa_min_reg4);
+	reg_test("dfa_minimise_regression5", dfa_min_reg5);
+
 	reg_test3("dfa_minimise", test_dfa_minimise,
 	    0, 0, 0);
 }

--- a/theft/fuzz_minimise.c
+++ b/theft/fuzz_minimise.c
@@ -730,6 +730,28 @@ dfa_min_reg5(theft_seed seed)
 	RUN_SPEC(states, 0);
 }
 
+/* The minimal example of a DFA where our implementation of Brzozowski's
+ * minimisation _added_ states. Found by the property tests. */
+static bool
+dfa_min_reg_brz(theft_seed seed)
+{
+	(void)seed;
+	struct dfa_spec_state states[] = {
+		[0] = { .used = true,
+			.edge_count = 2, .edges = {
+				{ .symbol = 0x0, .state = 0 },
+				{ .symbol = 0x1, .state = 1 },
+			},
+		},
+		[1] = { .used = true, .end = true,
+			.edge_count = 1, .edges = {
+				{ .symbol = 0x0, .state = 0 },
+			},
+		},
+	};
+	RUN_SPEC(states, 0);
+}
+
 static bool
 dfa_min_reg_m0(theft_seed seed)
 {
@@ -769,6 +791,8 @@ register_test_minimise(void)
 	reg_test("dfa_minimise_regression3", dfa_min_reg3);
 	reg_test("dfa_minimise_regression4", dfa_min_reg4);
 	reg_test("dfa_minimise_regression5", dfa_min_reg5);
+
+	reg_test("dfa_minimise_regression_brz", dfa_min_reg_brz);
 
 	reg_test("dfa_minimise_regression_m0", dfa_min_reg_m0);
 

--- a/theft/fuzz_trim.c
+++ b/theft/fuzz_trim.c
@@ -6,17 +6,11 @@
 
 #include "type_info_dfa.h"
 
-#include <adt/queue.h>
-
 static enum theft_trial_res
 check_trimming_matches_reachability(const struct dfa_spec *spec);
 
 static enum theft_trial_res
 prop_trimming_matches_reachability(struct theft *t, void *arg1);
-
-static bool
-count_expected_live(const struct dfa_spec *spec,
-    fsm_state_t start_state, size_t *exp);
 
 static bool
 test_dfa_trimming(theft_seed seed,
@@ -99,8 +93,8 @@ check_trimming_matches_reachability(const struct dfa_spec *spec)
 	}
 
 	size_t expected_post_states;
-	if (!count_expected_live(spec, spec->start, &expected_post_states)) {
-		fprintf(stderr, "-- ERROR: count_expected_live alloc\n");
+	if (!dfa_spec_check_liveness(spec, NULL, &expected_post_states)) {
+		fprintf(stderr, "-- ERROR: dfa_spec_check_liveness\n");
 		return THEFT_TRIAL_ERROR;
 	}
 
@@ -119,118 +113,6 @@ check_trimming_matches_reachability(const struct dfa_spec *spec)
 
 	fsm_free(fsm);
 	return THEFT_TRIAL_PASS;
-}
-
-static bool
-enqueue_reachable(const struct dfa_spec *spec, struct queue *q,
-    uint64_t *seen, fsm_state_t state)
-{
-	if (BITSET_CHECK(seen, state)) { return true; }
-	if (!queue_push(q, state)) { return false; }
-	BITSET_SET(seen, state);
-
-	const struct dfa_spec_state *s = &spec->states[state];
-	assert(s->used);
-
-	for (size_t i = 0; i < s->edge_count; i++) {
-		const fsm_state_t to = s->edges[i].state;
-		if (BITSET_CHECK(seen, to)) { continue; }
-		if (!enqueue_reachable(spec, q, seen, to)) {
-			return false;
-		}
-	}
-
-	return true;
-}
-
-static bool
-calc_reaches_end_by_fixpoint(const struct dfa_spec *spec,
-    uint64_t *reaches_end)
-{
-	/* A state reaches an end if it's an end, or one of its
-	 * edges transitively reaches an end. */
-	bool changed;
-	do {
-		changed = false;
-		for (size_t s_i = 0; s_i < spec->state_count; s_i++) {
-			const struct dfa_spec_state *s = &spec->states[s_i];
-			if (!s->used) { continue; }
-
-			if (s->end) {
-				if (!BITSET_CHECK(reaches_end, s_i)) {
-					changed = true;
-					BITSET_SET(reaches_end, s_i);
-				}
-				continue;
-			}
-
-			for (size_t i = 0; i < s->edge_count; i++) {
-				const fsm_state_t to = s->edges[i].state;
-				if (BITSET_CHECK(reaches_end, to)) {
-					if (!BITSET_CHECK(reaches_end, s_i)) {
-						changed = true;
-						BITSET_SET(reaches_end, s_i);
-					}
-				}
-			}
-		}
-	} while (changed);
-	return true;
-}
-
-static bool
-count_expected_live(const struct dfa_spec *spec, fsm_state_t start_state,
-	size_t *exp)
-{
-	bool res = false;
-	uint64_t *seen = NULL;
-	uint64_t *reaches_end = NULL;
-	size_t exp_count = 0;
-	struct queue *q = NULL;
-
-	if (spec->state_count == 0) {
-		*exp = 0;
-		return true;
-	}
-
-	q = queue_new(NULL, spec->state_count);
-	if (q == NULL) {
-		fprintf(stderr, "cleanup %d\n", __LINE__);
-		goto cleanup;
-	}
-
-	seen = calloc(spec->state_count/64 + 1, sizeof(seen[0]));
-	if (seen == NULL) { goto cleanup; }
-
-	reaches_end = calloc(spec->state_count/64 + 1, sizeof(reaches_end[0]));
-	if (reaches_end == NULL) { goto cleanup; }
-
-	if (!enqueue_reachable(spec, q, seen, start_state)) {
-		fprintf(stderr, "-- ERROR: enqueue_reachable\n");
-		goto cleanup;
-	}
-
-	if (!calc_reaches_end_by_fixpoint(spec, reaches_end)) {
-		fprintf(stderr, "-- ERROR: calc_reaches_end_by_fixpoint\n");
-		goto cleanup;
-	}
-
-	fsm_state_t s;
-	while (queue_pop(q, &s)) {
-		if (BITSET_CHECK(reaches_end, s)) {
-			exp_count++;
-		}
-	}
-
-	res = true;
-	*exp = exp_count;
-
-cleanup:
-	if (seen != NULL) { free(seen); }
-	if (reaches_end != NULL) { free(reaches_end); }
-	if (q != NULL) { queue_free(q); }
-
-	return res;
 }
 
 #define RUN_SPEC(STATES, START)					 \

--- a/theft/fuzz_trim.c
+++ b/theft/fuzz_trim.c
@@ -78,47 +78,17 @@ check_trimming_matches_reachability(const struct dfa_spec *spec)
 	 * trimming should match the expected count given what
 	 * states are on a path between the start state and
 	 * any end state -- no more, no less. */
-	struct fsm *fsm = fsm_new(NULL);
-	if (fsm == NULL) {
-		fprintf(stderr, "-- ERROR: fsm_new\n");
-		return THEFT_TRIAL_ERROR;
-	}
 
-	if (!fsm_addstate_bulk(fsm, spec->state_count)) {
-		fprintf(stderr, "-- ERROR: fsm_addstate_bulk\n");
+	struct fsm *fsm = dfa_spec_build_fsm(spec);
+	if (fsm == NULL) {
 		return THEFT_TRIAL_ERROR;
 	}
 
 	size_t expected_pre_states = 0;
-
-	if (spec->start < spec->state_count) {
-		fsm_setstart(fsm, spec->start);
-	}
-
 	for (size_t s_i = 0; s_i < spec->state_count; s_i++) {
-		const fsm_state_t state_id = (fsm_state_t)s_i;
 		const struct dfa_spec_state *s = &spec->states[s_i];
 		if (!s->used) { continue; }
 		expected_pre_states++;
-
-		if (s->end) {
-			fsm_setend(fsm, state_id, 1);
-		}
-
-		for (size_t e_i = 0; e_i < s->edge_count; e_i++) {
-			const fsm_state_t to = s->edges[e_i].state;
-			const unsigned char symbol = s->edges[e_i].symbol;
-			if (!fsm_addedge_literal(fsm,
-				state_id, to, symbol)) {
-				fprintf(stderr, "-- ERROR: fsm_addedge_literal\n");
-				return THEFT_TRIAL_ERROR;
-			}
-		}
-	}
-
-	if (!fsm_all(fsm, fsm_isdfa)) {
-		fprintf(stderr, "-- FAIL: all is_dfa\n");
-		return THEFT_TRIAL_FAIL;
 	}
 
 	const size_t pre_states = fsm_countstates(fsm);

--- a/theft/main.c
+++ b/theft/main.c
@@ -242,6 +242,7 @@ main(int argc, char **argv)
 	register_test_adt_set();
 	register_test_nfa();
 	register_test_trim();
+	register_test_minimise();
 
 	for (link = state.tests; link; link = link->next) {
 		bool hit, pass;

--- a/theft/theft_libfsm.h
+++ b/theft/theft_libfsm.h
@@ -73,6 +73,7 @@ void register_test_adt_set(void);
 void register_test_nfa(void);
 void register_test_adt_edge_set(void);
 void register_test_trim(void);
+void register_test_minimise(void);
 
 int test_get_verbosity(void);
 

--- a/theft/type_info_dfa.c
+++ b/theft/type_info_dfa.c
@@ -17,6 +17,10 @@ dfa_alloc(struct theft *t, void *unused_env, void **output)
 	const uint8_t end_bits = (env->end_bits
 	    ? env->end_bits : DEF_END_BITS);
 
+	assert(state_ceil_bits > 0);
+	assert(symbol_ceil_bits <= 8);
+	assert(end_bits > 0);
+
 	if (end_bits >= 64) {
 		return THEFT_ALLOC_ERROR;
 	}

--- a/theft/type_info_dfa.h
+++ b/theft/type_info_dfa.h
@@ -41,4 +41,19 @@ extern const struct theft_type_info type_info_dfa;
 struct fsm *
 dfa_spec_build_fsm(const struct dfa_spec *spec);
 
+/* Check which states are live, i.e., reachable from
+ * the start state and have a path to at least one end
+ * state. This corresponds to trimming -- fsm_trim
+ * removes states that are not live.
+ *
+ * This uses a simple approach and is intended for
+ * testing, rather than performance.
+ *
+ * Returns true on success, or false on alloc failure.
+ * If live is non-NULL, set bit flags for reachable states.
+ * If live_count is non-NULL, write into it. */
+bool
+dfa_spec_check_liveness(const struct dfa_spec *spec,
+    uint64_t *live, size_t *live_count);
+
 #endif

--- a/theft/type_info_dfa.h
+++ b/theft/type_info_dfa.h
@@ -38,4 +38,7 @@ struct dfa_spec {
 
 extern const struct theft_type_info type_info_dfa;
 
+struct fsm *
+dfa_spec_build_fsm(const struct dfa_spec *spec);
+
 #endif


### PR DESCRIPTION
The history for this is somewhat gnarly, there was some rebasing onto main to incorporate other changes (edge_set hash tables, other property tests) and there have been some false starts and intermediate commits squashed out.

- Add a property test for `fsm_minimise`: for any generated DFA specification, the number of states in the DFA produced by `fsm_minimise` should agree with the result from a simpler-but-inefficient algorithm, here used as a test oracle. This found inputs where the Brzozowski-based `fsm_minimise` actually added states -- see `dfa_minimise_regression_brz`.

- The liveness check previously used by the `fsm_trim` property test has been extracted so the `fsm_minimise` property test can use it for trimming the test data.

- Add `fsm_consolidate`, which takes a `struct fsm *` and a new state mapping, then produces a new `struct fsm *` with states renumbered and/or combined according to the mapping.

- Switch the `fsm_minimise` implementation from Brzozowski's algorithm to Moore's. This is substantially faster in typical cases, and the worst case (a single very deeply nested path to an end state) can be easily detected ahead of time.

- Add a couple small algorithmic improvements (summarized in `minimise_internal.h`: see `done_ec_offset` and `SMALL_EC_THRESHOLD`) that serve roughly the same purpose as the splitter queue management in Hopcroft's algorithm, but don't become significantly more expensive as k (the alphabet size) increases the way Hopcroft's will.

This is a draft, because:
- I'm not sure that `fsm_consolidate` is using `fsm_carryopaque_array` correctly, and I'm not sure how to set up a good standalone test for it.
- Many of the tests are currently failing, because the semantics around start states in empty DFAs have changed slightly -- `tests/native/in24.re` is representative. Still figuring this out.