### PR TITLE
Code generation to Rust

### DIFF
--- a/include/fsm/print.h
+++ b/include/fsm/print.h
@@ -24,6 +24,7 @@ struct fsm;
  *  fsm_print_json   - JavaScript Object Notation
  *  fsm_print_vmc    - ISO C90 code, VM style
  *  fsm_print_vmdot  - Graphviz Dot format, showing VM opcodes
+ *  fsm_print_rust   - Rust code
  *  fsm_print_sh     - Shell script (bash dialect)
  *  fsm_print_go     - Go code
  *
@@ -50,6 +51,7 @@ fsm_print fsm_print_vmasm_amd64_nasm; /* output amd64 assembler in NASM format *
 fsm_print fsm_print_vmasm_amd64_go;   /* output amd64 assembler in Go format */
 fsm_print fsm_print_sh;
 fsm_print fsm_print_go;
+fsm_print fsm_print_rust;
 
 #endif
 

--- a/include/print/esc.h
+++ b/include/print/esc.h
@@ -19,9 +19,14 @@ escputc dot_escputc_html_record;
 escputc fsm_escputc;
 escputc json_escputc;
 escputc pcre_escputc;
+escputc rust_escputc_char;
+escputc rust_escputc_str;
 
 void
 c_escputcharlit(FILE *f, const struct fsm_options *opt, char c);
+
+void
+rust_escputcharlit(FILE *f, const struct fsm_options *opt, char c);
 
 int
 escputs(FILE *f, const struct fsm_options *opt, escputc *escputc,

--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -163,6 +163,7 @@ print_name(const char *name)
 		{ "json",  fsm_print_json  },
 		{ "vmc",   fsm_print_vmc   },
 		{ "vmdot", fsm_print_vmdot },
+		{ "rust",  fsm_print_rust  },
 		{ "sh",    fsm_print_sh    },
 		{ "go",    fsm_print_go    },
 

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -40,6 +40,7 @@ fsm_print_vmasm
 fsm_print_vmasm_amd64_att
 fsm_print_vmasm_amd64_nasm
 fsm_print_vmasm_amd64_go
+fsm_print_rust
 fsm_print_sh
 fsm_print_go
 

--- a/src/libfsm/print/Makefile
+++ b/src/libfsm/print/Makefile
@@ -8,13 +8,14 @@ SRC += src/libfsm/print/ir.c
 SRC += src/libfsm/print/irdot.c
 SRC += src/libfsm/print/irjson.c
 SRC += src/libfsm/print/json.c
+SRC += src/libfsm/print/rust.c
 SRC += src/libfsm/print/sh.c
 SRC += src/libfsm/print/go.c
 SRC += src/libfsm/print/vmc.c
 SRC += src/libfsm/print/vmdot.c
 SRC += src/libfsm/print/vmasm.c
 
-.for src in ${SRC:Msrc/libfsm/print/vmc.c} ${SRC:Msrc/libfsm/print/sh.c} ${SRC:Msrc/libfsm/print/go.c} ${SRC:Msrc/libfsm/print/vmasm.c} ${SRC:Msrc/libfsm/print/vmdot.c}
+.for src in ${SRC:Msrc/libfsm/print/vmc.c} ${SRC:Msrc/libfsm/print/rust.c} ${SRC:Msrc/libfsm/print/sh.c} ${SRC:Msrc/libfsm/print/go.c} ${SRC:Msrc/libfsm/print/vmasm.c} ${SRC:Msrc/libfsm/print/vmdot.c}
 CFLAGS.${src} += -std=c99 # XXX: for ir.h
 DFLAGS.${src} += -std=c99 # XXX: for ir.h
 .endfor

--- a/src/libfsm/print/rust.c
+++ b/src/libfsm/print/rust.c
@@ -1,0 +1,389 @@
+/*
+ * Copyright 2008-2020 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdint.h>
+#include <errno.h>
+#include <stdio.h>
+
+#include <print/esc.h>
+
+#include <adt/set.h>
+
+#include <fsm/fsm.h>
+#include <fsm/pred.h>
+#include <fsm/walk.h>
+#include <fsm/print.h>
+#include <fsm/options.h>
+#include <fsm/vm.h>
+
+#include "libfsm/internal.h"
+
+#include "libfsm/vm/vm.h"
+
+#include "ir.h"
+
+#define START UINT32_MAX
+
+static int
+leaf(FILE *f, const void *state_opaque, const void *leaf_opaque)
+{
+	assert(f != NULL);
+	assert(leaf_opaque == NULL);
+
+	(void) state_opaque;
+	(void) leaf_opaque;
+
+	/* XXX: this should be FSM_UNKNOWN or something non-EOF,
+	 * maybe user defined */
+	fprintf(f, "return TOK_UNKNOWN;");
+
+	return 0;
+}
+
+static const char *
+cmp_operator(int cmp)
+{
+	switch (cmp) {
+	case VM_CMP_LT: return "<";
+	case VM_CMP_LE: return "<=";
+	case VM_CMP_EQ: return "==";
+	case VM_CMP_GE: return ">=";
+	case VM_CMP_GT: return ">";
+	case VM_CMP_NE: return "!=";
+
+	case VM_CMP_ALWAYS:
+	default:
+		assert("unreached");
+		return NULL;
+	}
+}
+
+static void
+print_label(FILE *f, const struct dfavm_op_ir *op)
+{
+	if (op->index == START) {
+		fprintf(f, "Ls");
+	} else {
+		fprintf(f, "L%lu", (unsigned long) op->index);
+	}
+}
+
+static void
+print_cond(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt)
+{
+	if (op->cmp == VM_CMP_ALWAYS) {
+		return;
+	}
+
+	fprintf(f, "if c %s ", cmp_operator(op->cmp));
+	rust_escputcharlit(f, opt, op->cmp_arg);
+	fprintf(f, " ");
+}
+
+static void
+print_end(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt,
+	enum dfavm_op_end end_bits, const struct ir *ir)
+{
+	if (end_bits == VM_END_FAIL) {
+		fprintf(f, "return None");
+		return;
+	}
+
+	if (opt->endleaf != NULL) {
+		opt->endleaf(f, op->ir_state->opaque, opt->endleaf_opaque);
+	} else {
+		fprintf(f, "return Some(%lu)", (unsigned long) (op->ir_state - ir->states));
+	}
+}
+
+static void
+print_jump(FILE *f, const struct dfavm_op_ir *op)
+{
+	fprintf(f, "state = ");
+	print_label(f, op);
+	fprintf(f, "; continue;");
+}
+
+static void
+print_branch(FILE *f, const struct dfavm_op_ir *op)
+{
+	print_jump(f, op->u.br.dest_arg);
+}
+
+static void
+print_fetch(FILE *f, const struct fsm_options *opt)
+{
+	assert(opt->io == FSM_IO_STR);
+
+	fprintf(f, "bytes.next()");
+}
+
+/* TODO: eventually to be non-static */
+static int
+fsm_print_rustfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
+	const char *cp,
+	int (*leaf)(FILE *, const void *state_opaque, const void *leaf_opaque),
+	const void *leaf_opaque)
+{
+	static const struct dfavm_assembler_ir zero;
+	struct dfavm_assembler_ir a;
+	struct dfavm_op_ir *op;
+	bool fallthrough;
+
+	static const struct fsm_vm_compile_opts vm_opts = { FSM_VM_COMPILE_DEFAULT_FLAGS, FSM_VM_COMPILE_VM_V1, NULL };
+
+	assert(f != NULL);
+	assert(ir != NULL);
+	assert(opt != NULL);
+	assert(cp != NULL);
+
+	a = zero;
+
+	/* TODO: we don't currently have .opaque information attached to struct dfavm_op_ir.
+	 * We'll need that in order to be able to use the leaf callback here. */
+	(void) leaf;
+	(void) leaf_opaque;
+
+	/* TODO: we'll need to heed cp for e.g. lx's codegen */
+	(void) cp;
+
+	if (!dfavm_compile_ir(&a, ir, vm_opts)) {
+		return -1;
+	}
+
+	/*
+	 * We only output labels for ops which are branched to. This gives
+	 * gaps in the sequence for ops which don't need a label.
+	 * So here we renumber just the ones we use.
+	 */
+	{
+		uint32_t l;
+
+		l = START;
+
+		for (op = a.linked; op != NULL; op = op->next) {
+			if (op == a.linked || op->num_incoming > 0) {
+				op->index = l++;
+			}
+		}
+	}
+
+	fprintf(f, "    pub enum StateMachine {\n       ");
+	for (op = a.linked; op != NULL; op = op->next) {
+		if (op == a.linked || op->num_incoming > 0) {
+			fprintf(f, " ");
+			print_label(f, op);
+			fprintf(f, ",");
+		}
+	}
+	fprintf(f, "\n");
+	fprintf(f, "    }\n");
+	fprintf(f, "\n");
+
+	fprintf(f, "    let mut state = StateMachine::Ls;\n");
+	fprintf(f, "\n");
+
+	fprintf(f, "    loop {\n");
+	fprintf(f, "        match state {\n");
+
+	fallthrough = true;
+
+	for (op = a.linked; op != NULL; op = op->next) {
+		if (op == a.linked || op->num_incoming > 0) {
+			if (op != a.linked) {
+				if (fallthrough) {
+					fprintf(f, "                ");
+					print_jump(f, op);
+					fprintf(f, "\n");
+				}
+				fprintf(f, "            }\n");
+				fprintf(f, "\n");
+			}
+
+			fprintf(f, "            ");
+			print_label(f, op);
+			fprintf(f, " => {");
+
+			if (op->ir_state->example != NULL) {
+				/* C's escaping seems to be a subset of rust's, and these are
+				 * for comments anyway. So I'm borrowing this for C here */
+				fprintf(f, " // e.g. \"");
+				escputs(f, opt, c_escputc_str, op->ir_state->example);
+				fprintf(f, "\"");
+			}
+
+			fprintf(f, "\n");
+		}
+
+		fallthrough = true;
+
+		fprintf(f, "                ");
+
+		switch (op->instr) {
+		case VM_OP_STOP:
+			print_cond(f, op, opt);
+			if (op->cmp != VM_CMP_ALWAYS) {
+				fprintf(f, "{ ");
+			}
+			print_end(f, op, opt, op->u.stop.end_bits, ir);
+			fprintf(f, ";");
+			if (op->cmp != VM_CMP_ALWAYS) {
+				fprintf(f, " }");
+			}
+
+			if (op->cmp == VM_CMP_ALWAYS) {
+				/* the code for fallthrough would be unreachable */
+				fallthrough = false;
+			}
+			break;
+
+		case VM_OP_FETCH: {
+			const char *c;
+
+			/*
+			 * If the following instruction is an unconditional return,
+			 * we won't be using this value.
+			 */
+			if (op->next != NULL && op->next->instr == VM_OP_STOP && op->next->cmp == VM_CMP_ALWAYS) {
+				c =  "_c";
+			} else {
+				c = "c";
+			}
+
+			fprintf(f, "let %s = match ", c);
+			print_fetch(f, opt);
+			fprintf(f, " {\n");
+
+			fprintf(f, "                    ");
+			fprintf(f, "None => ");
+			print_end(f, op, opt, op->u.fetch.end_bits, ir);
+			fprintf(f, ",\n");
+			fprintf(f, "                    ");
+
+			fprintf(f, "Some(%s) => %s", c, c);
+			fprintf(f, ",\n");
+			fprintf(f, "                ");
+			fprintf(f, "};");
+
+			break;
+		}
+
+		case VM_OP_BRANCH:
+			print_cond(f, op, opt);
+			if (op->cmp != VM_CMP_ALWAYS) {
+				fprintf(f, "{ ");
+			}
+			print_branch(f, op);
+			if (op->cmp != VM_CMP_ALWAYS) {
+				fprintf(f, " }");
+			}
+
+			if (op->cmp == VM_CMP_ALWAYS) {
+				/* the code for fallthrough would be unreachable */
+				fallthrough = false;
+			}
+			break;
+
+		default:
+			assert(!"unreached");
+			break;
+		}
+
+		fprintf(f, "\n");
+	}
+
+	fprintf(f, "            }\n");
+	fprintf(f, "        }\n");
+	fprintf(f, "    }\n");
+
+	dfavm_opasm_finalize_op(&a);
+
+	return 0;
+}
+
+void
+fsm_print_rust_complete(FILE *f, const struct ir *ir,
+	const struct fsm_options *opt, const char *prefix, const char *cp)
+{
+	assert(f != NULL);
+	assert(ir != NULL);
+	assert(opt != NULL);
+
+	if (opt->fragment) {
+		fsm_print_rustfrag(f, ir, opt, cp,
+			opt->leaf != NULL ? opt->leaf : leaf, opt->leaf_opaque);
+		return;
+	}
+
+	fprintf(f, "\n");
+
+	fprintf(f, "pub fn\n%smain", prefix);
+
+	switch (opt->io) {
+	case FSM_IO_GETC:
+		fprintf(stderr, "unsupported IO API\n");
+		break;
+
+	case FSM_IO_STR:
+		fprintf(f, "(input: &str) -> Option<usize> {\n");
+		fprintf(f, "    use StateMachine::*;\n");
+		fprintf(f, "    let mut bytes = input.bytes();\n");
+		fprintf(f, "\n");
+		break;
+
+	case FSM_IO_PAIR:
+		fprintf(stderr, "unsupported IO API\n");
+		break;
+	}
+
+	fsm_print_rustfrag(f, ir, opt, cp,
+		opt->leaf != NULL ? opt->leaf : leaf, opt->leaf_opaque);
+
+	fprintf(f, "}\n");
+	fprintf(f, "\n");
+
+}
+
+void
+fsm_print_rust(FILE *f, const struct fsm *fsm)
+{
+	struct ir *ir;
+	const char *prefix;
+	const char *cp;
+
+	assert(f != NULL);
+	assert(fsm != NULL);
+	assert(fsm->opt != NULL);
+
+	ir = make_ir(fsm);
+	if (ir == NULL) {
+		return;
+	}
+
+	if (fsm->opt->prefix != NULL) {
+		prefix = fsm->opt->prefix;
+	} else {
+		prefix = "fsm_";
+	}
+
+	if (fsm->opt->cp != NULL) {
+		cp = fsm->opt->cp;
+	} else {
+		switch (fsm->opt->io) {
+		case FSM_IO_GETC: cp = "c"; break; /* XXX */
+		case FSM_IO_STR:  cp = "c"; break;
+		case FSM_IO_PAIR: cp = "c"; break; /* XXX */
+		}
+	}
+
+	fsm_print_rust_complete(f, ir, fsm->opt, prefix, cp);
+
+	free_ir(fsm, ir);
+}
+

--- a/src/libfsm/print/rust.c
+++ b/src/libfsm/print/rust.c
@@ -186,7 +186,7 @@ fsm_print_rustfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 	fprintf(f, "    }\n");
 	fprintf(f, "\n");
 
-	fprintf(f, "    let mut l = Label::Ls;\n");
+	fprintf(f, "    let mut l = Ls;\n");
 	fprintf(f, "\n");
 
 	fprintf(f, "    loop {\n");

--- a/src/libfsm/print/rust.c
+++ b/src/libfsm/print/rust.c
@@ -105,7 +105,7 @@ print_end(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt,
 static void
 print_jump(FILE *f, const struct dfavm_op_ir *op)
 {
-	fprintf(f, "state = ");
+	fprintf(f, "l = ");
 	print_label(f, op);
 	fprintf(f, "; continue;");
 }
@@ -174,7 +174,7 @@ fsm_print_rustfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 		}
 	}
 
-	fprintf(f, "    pub enum StateMachine {\n       ");
+	fprintf(f, "    pub enum Label {\n       ");
 	for (op = a.linked; op != NULL; op = op->next) {
 		if (op == a.linked || op->num_incoming > 0) {
 			fprintf(f, " ");
@@ -186,11 +186,11 @@ fsm_print_rustfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 	fprintf(f, "    }\n");
 	fprintf(f, "\n");
 
-	fprintf(f, "    let mut state = StateMachine::Ls;\n");
+	fprintf(f, "    let mut l = Label::Ls;\n");
 	fprintf(f, "\n");
 
 	fprintf(f, "    loop {\n");
-	fprintf(f, "        match state {\n");
+	fprintf(f, "        match l {\n");
 
 	fallthrough = true;
 
@@ -332,7 +332,7 @@ fsm_print_rust_complete(FILE *f, const struct ir *ir,
 
 	case FSM_IO_STR:
 		fprintf(f, "(input: &str) -> Option<usize> {\n");
-		fprintf(f, "    use StateMachine::*;\n");
+		fprintf(f, "    use Label::*;\n");
 		fprintf(f, "    let mut bytes = input.bytes();\n");
 		fprintf(f, "\n");
 		break;

--- a/src/libfsm/print/rust.c
+++ b/src/libfsm/print/rust.c
@@ -323,7 +323,7 @@ fsm_print_rust_complete(FILE *f, const struct ir *ir,
 
 	fprintf(f, "\n");
 
-	fprintf(f, "pub fn\n%smain", prefix);
+	fprintf(f, "pub fn %smain", prefix);
 
 	switch (opt->io) {
 	case FSM_IO_GETC:

--- a/src/libfsm/print/rust.c
+++ b/src/libfsm/print/rust.c
@@ -256,20 +256,27 @@ fsm_print_rustfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 				c = "c";
 			}
 
-			fprintf(f, "let %s = match ", c);
-			print_fetch(f, opt);
-			fprintf(f, " {\n");
+			/* a more compact form, as an aesthetic optimisation */
+			if (op->u.fetch.end_bits == VM_END_FAIL) {
+				fprintf(f, "let %s = ", c);
+				print_fetch(f, opt);
+				fprintf(f, "?;");
+			} else {
+				fprintf(f, "let %s = match ", c);
+				print_fetch(f, opt);
+				fprintf(f, " {\n");
 
-			fprintf(f, "                    ");
-			fprintf(f, "None => ");
-			print_end(f, op, opt, op->u.fetch.end_bits, ir);
-			fprintf(f, ",\n");
-			fprintf(f, "                    ");
+				fprintf(f, "                    ");
+				fprintf(f, "None => ");
+				print_end(f, op, opt, op->u.fetch.end_bits, ir);
+				fprintf(f, ",\n");
+				fprintf(f, "                    ");
 
-			fprintf(f, "Some(%s) => %s", c, c);
-			fprintf(f, ",\n");
-			fprintf(f, "                ");
-			fprintf(f, "};");
+				fprintf(f, "Some(%s) => %s", c, c);
+				fprintf(f, ",\n");
+				fprintf(f, "                ");
+				fprintf(f, "};");
+			}
 
 			break;
 		}

--- a/src/libfsm/print/vmasm.c
+++ b/src/libfsm/print/vmasm.c
@@ -60,6 +60,13 @@ print_asm_amd64(FILE *f, const char *funcname, const struct ir *ir, const struct
 	const struct dfavm_op_ir *op;
 
 	char *comment;
+	const char *prefix;
+
+#if defined(__MACH__)
+	prefix = "_";
+#else
+	prefix = "";
+#endif
 
 	assert(f != NULL);
 	assert(funcname != NULL);
@@ -86,15 +93,15 @@ print_asm_amd64(FILE *f, const char *funcname, const struct ir *ir, const struct
 	/* print preamble */
 	switch (dialect) {
 	case AMD64_ATT:
-		fprintf(f, ".globl _%s\n", funcname);
+		fprintf(f, ".globl %s%s\n", prefix, funcname);
 		fprintf(f, ".text\n");
-		fprintf(f, "_%s:\n", funcname);
+		fprintf(f, "%s%s:\n", prefix, funcname);
 		break;
 
 	case AMD64_NASM:
 		fprintf(f, "section .text\n");
-		fprintf(f, "global _%s\n", funcname);
-		fprintf(f, "_%s:\n", funcname);
+		fprintf(f, "global %s%s\n", prefix, funcname);
+		fprintf(f, "%s%s:\n", prefix, funcname);
 		break;
 
 	case AMD64_GO:

--- a/src/print/Makefile
+++ b/src/print/Makefile
@@ -6,8 +6,10 @@ SRC += src/print/abnf.c
 SRC += src/print/fsm.c
 SRC += src/print/json.c
 SRC += src/print/pcre.c
-SRC += src/print/puts.c
+SRC += src/print/rust.c
 SRC += src/print/tok.c
+
+SRC += src/print/puts.c
 
 .for src in ${SRC:Msrc/print/*.c}
 CFLAGS.${src} += -I src # XXX: for internal.h

--- a/src/print/rust.c
+++ b/src/print/rust.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2008-2017 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <ctype.h>
+#include <assert.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <fsm/fsm.h>
+#include <fsm/options.h>
+
+#include <print/esc.h>
+
+int
+rust_escputc_char(FILE *f, const struct fsm_options *opt, char c)
+{
+	assert(f != NULL);
+	assert(opt != NULL);
+
+	if (opt->always_hex) {
+		return fprintf(f, "\\x%02x", (unsigned char) c);
+	}
+
+	switch (c) {
+	case '\\': return fputs("\\\\", f);
+	case '\'': return fputs("\\\'", f);
+
+	case '\a': return fputs("\\a", f);
+	case '\b': return fputs("\\b", f);
+	case '\f': return fputs("\\f", f);
+	case '\n': return fputs("\\n", f);
+	case '\r': return fputs("\\r", f);
+	case '\t': return fputs("\\t", f);
+	case '\v': return fputs("\\v", f);
+
+	default:
+		break;
+	}
+
+	if (!isprint((unsigned char) c)) {
+		return fprintf(f, "\\x%02x", (unsigned char) c);
+	}
+
+	return fprintf(f, "%c", c);
+}
+
+void
+rust_escputcharlit(FILE *f, const struct fsm_options *opt, char c)
+{
+	assert(f != NULL);
+	assert(opt != NULL);
+
+	if (opt->always_hex || (unsigned char) c > SCHAR_MAX) {
+		fprintf(f, "0x%02x", (unsigned char) c);
+		return;
+	}
+
+	fprintf(f, "b'");
+	rust_escputc_char(f, opt, c);
+	fprintf(f, "'");
+}
+

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -113,6 +113,7 @@ print_name(const char *name,
 		{ "json",   fsm_print_json,   NULL },
 		{ "vmc",    fsm_print_vmc,    NULL },
 		{ "vmdot",  fsm_print_vmdot,  NULL },
+		{ "rust",   fsm_print_rust,   NULL },
 		{ "sh",     fsm_print_sh,     NULL },
 		{ "go",     fsm_print_go,     NULL },
 

--- a/src/retest/reperf.c
+++ b/src/retest/reperf.c
@@ -479,7 +479,6 @@ parse_perf_case(FILE *f, enum implementation impl, enum halt halt, int quiet, in
 			if (tsv) {
 				perf_case_report_tsv(&c, halt, err, quiet, &t);
 			} else {
-printf("halt=%d\n", halt);
 				perf_case_report_txt(&c, halt, err, quiet, &t);
 				perf_case_report_error(err);
 			}
@@ -947,8 +946,6 @@ usage(void)
 	fprintf(stderr, "\n");
 	fprintf(stderr, "        -H <halt>\n");
 	fprintf(stderr, "             halt after compile, glushkovise, determinise, minimise or execute\n");
-	fprintf(stderr, "                 0 = disable optimizations\n");
-	fprintf(stderr, "                 1 = basic optimizations\n");
 
 	fprintf(stderr, "\n");
 	fprintf(stderr, "        -O <olevel>\n");

--- a/src/retest/reperf.c
+++ b/src/retest/reperf.c
@@ -969,6 +969,7 @@ usage(void)
 	fprintf(stderr, "                 asm       generate assembly and assemble\n");
 	fprintf(stderr, "                 c         compile as per fsm_print_c()\n");
 	fprintf(stderr, "                 vmc       compile as per fsm_print_vmc()\n");
+	fprintf(stderr, "                 rust      compile as per fsm_print_rust()\n");
 
 	fprintf(stderr, "\n");
 	fprintf(stderr, "        -x <encoding>\n");
@@ -1025,6 +1026,8 @@ main(int argc, char *argv[])
 	 * The IO API would depend on c->mt == MATCH_STRING ? FSM_IO_PAIR : FSM_IO_GETC;
 	 * except we read in the entire file below anyway, so we just
 	 * use FSM_IO_PAIR for both. The type of fsm_main depends on the IO API.
+	 *
+	 * The IO API also affects the trampoline code for FFI.
 	 */
 	opt.io = FSM_IO_PAIR;
 
@@ -1060,6 +1063,8 @@ main(int argc, char *argv[])
 					impl = IMPL_INTERPRET;
 				} else if (strcmp(optarg, "c") == 0) {
 					impl = IMPL_C;
+				} else if (strcmp(optarg, "rust") == 0) {
+					impl = IMPL_RUST;
 				} else if (strcmp(optarg, "asm") == 0) {
 					impl = IMPL_VMASM;
 				} else if (strcmp(optarg, "vmc") == 0) {

--- a/src/retest/reperf.c
+++ b/src/retest/reperf.c
@@ -602,15 +602,17 @@ perf_case_run(struct perf_case *c, enum halt halt,
 
 		struct re_err comp_err;
 		enum re_flags flags;
-		const char *re;
 
 		comp_err = err_zero;
 		flags = 0;
-		re = c->regexp.data;
 
 		xclock_gettime(&c0);
 
 		for (iter=0; iter < c->count; iter++) {
+			const char *re;
+
+			re = c->regexp.data;
+
 			fsm = re_comp(c->dialect, fsm_sgetc, &re, &opt, flags, &comp_err);
 			if (fsm == NULL) {
 				return ERROR_PARSING_REGEXP;

--- a/src/retest/runner.c
+++ b/src/retest/runner.c
@@ -20,23 +20,23 @@ runner_init_compiled(struct fsm *fsm, struct fsm_runner *r, enum implementation 
 {
 	static fsm_print *asm_print = fsm_print_vmasm_amd64_att;
 
-	char tmp_c[]  = "/tmp/fsmcompile_c-XXXXXX";
-	char tmp_o[]  = "/tmp/fsmcompile_o-XXXXXX";
-	char tmp_so[] = "/tmp/fsmcompile_so-XXXXXX";
+	char tmp_src[] = "/tmp/fsmcompile_src-XXXXXX";
+	char tmp_o[]   = "/tmp/fsmcompile_o-XXXXXX";
+	char tmp_so[]  = "/tmp/fsmcompile_so-XXXXXX";
 
-	char cmd[sizeof tmp_c + sizeof tmp_o + sizeof tmp_so + 256];
+	char cmd[sizeof tmp_src + sizeof tmp_o + sizeof tmp_so + 256];
 	const char *cc, *cflags, *as, *asflags;
-	int fd_c, fd_so, fd_o;
+	int fd_src, fd_so, fd_o;
 	FILE *f = NULL;
 	void *h = NULL;
 
-	fd_c  = mkstemp(tmp_c);
-	fd_so = mkstemp(tmp_so);
-	fd_o  = -1;
+	fd_src = mkstemp(tmp_src);
+	fd_so  = mkstemp(tmp_so);
+	fd_o   = -1;
 
-	f = fdopen(fd_c, "w");
+	f = fdopen(fd_src, "w");
 	if (f == NULL) {
-		perror(tmp_c);
+		perror(tmp_src);
 		return ERROR_FILE_IO;
 	}
 
@@ -51,7 +51,7 @@ runner_init_compiled(struct fsm *fsm, struct fsm_runner *r, enum implementation 
 	}
 
 	if (EOF == fflush(f)) {
-		perror(tmp_c);
+		perror(tmp_src);
 		return ERROR_FILE_IO;
 	}
 
@@ -63,7 +63,7 @@ runner_init_compiled(struct fsm *fsm, struct fsm_runner *r, enum implementation 
 	case IMPL_VMC:
 		(void) snprintf(cmd, sizeof cmd, "%s %s -xc -shared -fPIC %s -o %s",
 				cc ? cc : "gcc", cflags ? cflags : "-std=c89 -pedantic -Wall -O3",
-				tmp_c, tmp_so);
+				tmp_src, tmp_so);
 
 		if (0 != system(cmd)) {
 			perror(cmd);
@@ -79,7 +79,7 @@ runner_init_compiled(struct fsm *fsm, struct fsm_runner *r, enum implementation 
 		fd_o = mkstemp(tmp_o);
 
 		(void) snprintf(cmd, sizeof cmd, "%s %s -o %s %s",
-				as ? as : "as", asflags ? asflags : "", tmp_o, tmp_c);
+				as ? as : "as", asflags ? asflags : "", tmp_o, tmp_src);
 
 		if (0 != system(cmd)) {
 			perror(cmd);
@@ -103,12 +103,12 @@ runner_init_compiled(struct fsm *fsm, struct fsm_runner *r, enum implementation 
 	}
 
 	if (EOF == fclose(f)) {
-		perror(tmp_c);
+		perror(tmp_src);
 		return ERROR_FILE_IO;
 	}
 
-	if (-1 == unlinkat(-1, tmp_c, 0)) {
-		perror(tmp_c);
+	if (-1 == unlinkat(-1, tmp_src, 0)) {
+		perror(tmp_src);
 		return ERROR_FILE_IO;
 	}
 

--- a/src/retest/runner.h
+++ b/src/retest/runner.h
@@ -25,6 +25,7 @@ enum error_type {
 
 enum implementation {
 	IMPL_C,
+	IMPL_RUST,
 	IMPL_VMC,
 	IMPL_VMASM,
 	IMPL_INTERPRET
@@ -38,6 +39,12 @@ struct fsm_runner {
 			void *h;
 			int (*func)(const char *, const char *);
 		} impl_c;
+
+		struct {
+			/* pub extern "C" fn f(ptr: *const c_uchar, len: usize) -> usize */
+			void *h;
+			size_t (*func)(const unsigned char *, size_t);
+		} impl_rust;
 
 		struct {
 			void *h;


### PR DESCRIPTION
This is a first attempt at translating the DFA VM opcodes to Rust.

Taking the same example rendered to Graphviz from #217, the numberings for labels should match:
```rust
; ./build/bin/re -bpl rust '(.ab?c)+es$|[0-9]f*'

pub fn fsm_main(mut bytes: impl Iterator<Item = u8>) -> Option<usize> {
    use Label::*;
    pub enum Label {
        Ls, L0, L1, L2, L3, L4, L5,
    }

    let mut l = Ls;

    loop {
        match l {
            Ls => {
                let c = bytes.next()?;
                if c <= b'/' { l = L0; continue; }
                if c <= b'9' { l = L3; continue; }
                l = L0; continue;
            }

            L0 => { // e.g. "a"
                let c = bytes.next()?;
                if c != b'a' { return None; }
                l = L1; continue;
            }

            L1 => { // e.g. "aa"
                let c = bytes.next()?;
                if c == b'b' { l = L5; continue; }
                if c != b'c' { return None; }
                l = L2; continue;
            }

            L2 => { // e.g. "aac"
                let c = bytes.next()?;
                if c != b'e' { l = L0; continue; }
                let c = bytes.next()?;
                if c == b'a' { l = L1; continue; }
                if c != b's' { return None; }
                let _c = match bytes.next() {
                    None => return Some(8),
                    Some(_c) => _c,
                };
                return None;
            }

            L3 => { // e.g. "0"
                let c = match bytes.next() {
                    None => return Some(2),
                    Some(c) => c,
                };
                if c == b'a' { l = L1; continue; }
                if c != b'f' { return None; }
                l = L4; continue;
            }

            L4 => { // e.g. "0f"
                let c = match bytes.next() {
                    None => return Some(4),
                    Some(c) => c,
                };
                if c != b'f' { return None; }
                l = L4; continue;
            }

            L5 => { // e.g. "aab"
                let c = bytes.next()?;
                if c != b'c' { return None; }
                l = L2; continue;
            }
        }
    }
}
```

and `FSM_IO_PAIR` and `FSM_IO_STR` look like this:
```rust
pub fn fsm_main(input: &[u8]) -> Option<usize> {
pub fn fsm_main(input: &str) -> Option<usize> {
```

With much help from Jane Lusby, thank you!