### PR TITLE
determinise: If there's no start state, just leave it empty.

### DIFF
--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -201,9 +201,8 @@ fsm_determinise(struct fsm *nfa)
 		 */
 
 		if (!fsm_getstart(nfa, &start)) {
-			errno = EINVAL;
-			/* TODO: free mappings */
-			return 0;
+			mapping_hashset_free(mappings);
+			return 1;
 		}
 
 		set = NULL;


### PR DESCRIPTION
Cherry-picked from #233, since it's tangential to that PR and easier to merge first.