### PR TITLE
parser.act: Use a hash table for token interning in the parser.

### DIFF
--- a/src/fsm/parser.act
+++ b/src/fsm/parser.act
@@ -44,21 +44,30 @@
 	typedef char *      string;
 	typedef fsm_state_t state;
 
+	struct act_statelist {
+		char *id;
+		fsm_state_t state;
+		struct act_statelist *next;
+	};
+
+	/* hash table with chaining */
+	#define DEF_BUCKETS 64	    /* must be a power of 2 */
+	#define MAX_CHAIN_LENGTH 16 /* grow hash table if longer than this */
+	struct act_stateset {
+		size_t longest_chain_length;
+		size_t bucket_count;
+		struct act_statelist **buckets;
+	};
+
 	struct act_state {
 		int lex_tok;
 		int lex_tok_save;
-		struct act_statelist *sl;
+		struct act_stateset states;
 	};
 
 	struct lex_state {
 		struct lx lx;
 		struct lx_dynbuf buf;
-	};
-
-	struct act_statelist {
-		char *id;
-		fsm_state_t state;
-		struct act_statelist *next;
 	};
 
 	#define CURRENT_TERMINAL (act_state->lex_tok)
@@ -88,6 +97,54 @@
 	{
 		err(lex_state, "Syntax error: expected %s", token);
 		exit(EXIT_FAILURE);
+	}
+
+	/* FNV1a 32-bit hash function, in the public domain. For details,
+	 * see: http://www.isthe.com/chongo/tech/comp/fnv/index.html . */
+	#define FNV1a_32_OFFSET_BASIS 	2166136261UL
+	#define FNV1a_32_PRIME		16777619UL
+
+	static unsigned
+	hash_of_id(const char *id)
+	{
+		unsigned h = FNV1a_32_OFFSET_BASIS;
+		while (*id) {
+			h ^= *id;
+			h *= FNV1a_32_PRIME;
+			id++;
+		}
+		return h;
+	}
+
+	static void
+	grow_state_hash_table(struct act_stateset *htab)
+	{
+		const size_t ncount = 2 * htab->bucket_count;
+		struct act_statelist **nbuckets = xcalloc(ncount, sizeof(*nbuckets));
+		size_t max_chain_length = 0;
+		size_t old_i;
+		unsigned mask = ncount - 1;
+
+		for (old_i = 0; old_i < htab->bucket_count; old_i++) {
+			struct act_statelist *p, *next;
+			size_t chain_length = 0;
+			for (p = htab->buckets[old_i]; p != NULL; p = next) {
+				const unsigned hash = hash_of_id(p->id);
+				next = p->next;
+				p->next = nbuckets[hash & mask];
+				nbuckets[hash & mask] = p;
+				chain_length++;
+			}
+
+			if (chain_length > max_chain_length) {
+				max_chain_length = chain_length;
+			}
+		}
+
+		free(htab->buckets);
+		htab->buckets = nbuckets;
+		htab->bucket_count = ncount;
+		htab->longest_chain_length = max_chain_length;
 	}
 
 @}, @{
@@ -194,16 +251,31 @@
 
 	<add-state>: (n :string) -> (s :state) = @{
 		struct act_statelist *p;
+		const unsigned hash = hash_of_id(@n);
+		const unsigned mask = act_state->states.bucket_count - 1;
+		size_t chain_length = 0;
+		unsigned bucket_id = hash & mask;
 
 		assert(@n != NULL);
 
-		for (p = act_state->sl; p != NULL; p = p->next) {
+		if (act_state->states.longest_chain_length > MAX_CHAIN_LENGTH) {
+			grow_state_hash_table(&act_state->states);
+			bucket_id = hash & (act_state->states.bucket_count - 1);
+		}
+
+		for (p = act_state->states.buckets[bucket_id]; p != NULL; p = p->next) {
 			assert(p->id != NULL);
+
+			chain_length++;
 
 			if (0 == strcmp(p->id, @n)) {
 				@s = p->state;
 				break;
 			}
+		}
+
+		if (chain_length > act_state->states.longest_chain_length) {
+			act_state->states.longest_chain_length = chain_length;
 		}
 
 		if (p == NULL) {
@@ -228,8 +300,8 @@
 
 			new->state = @s;
 
-			new->next = act_state->sl;
-			act_state->sl = new;
+			new->next = act_state->states.buckets[bucket_id];
+			act_state->states.buckets[bucket_id] = new;
 		}
 	@};
 
@@ -248,14 +320,15 @@
 	<free-statelist> = @{
 		struct act_statelist *p;
 		struct act_statelist *next;
+		unsigned b_i;	/* bucket */
 
-		for (p = act_state->sl; p != NULL; p = next) {
-			next = p->next;
-
-			assert(p->id != NULL);
-
-			free(p->id);
-			free(p);
+		for (b_i = 0; b_i < act_state->states.bucket_count; b_i++) {
+			for (p = act_state->states.buckets[b_i]; p != NULL; p = next) {
+				next = p->next;
+				assert(p->id != NULL);
+				free(p->id);
+				free(p);
+			}
 		}
 	@};
 
@@ -336,7 +409,10 @@
 		lx->clear      = lx_dynclear;
 		lx->free       = lx_dynfree;
 
-		act_state_s.sl = NULL;
+		act_state_s.states.buckets = xcalloc(DEF_BUCKETS, sizeof(act_state_s.states.buckets));
+		assert(act_state_s.states.buckets != NULL);
+		act_state_s.states.bucket_count = DEF_BUCKETS;
+		act_state_s.states.longest_chain_length = 0;
 
 		/* This is a workaround for ADVANCE_LEXER assuming a pointer */
 		act_state = &act_state_s;

--- a/src/fsm/parser.c
+++ b/src/fsm/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 93 "src/fsm/parser.act"
+#line 26 "src/fsm/parser.act"
 
 
 	#include <assert.h>
@@ -31,21 +31,30 @@
 	typedef char *      string;
 	typedef fsm_state_t state;
 
+	struct act_statelist {
+		char *id;
+		fsm_state_t state;
+		struct act_statelist *next;
+	};
+
+	/* hash table with chaining */
+	#define DEF_BUCKETS 64	    /* must be a power of 2 */
+	#define MAX_CHAIN_LENGTH 16 /* grow hash table if longer than this */
+	struct act_stateset {
+		size_t longest_chain_length;
+		size_t bucket_count;
+		struct act_statelist **buckets;
+	};
+
 	struct act_state {
 		int lex_tok;
 		int lex_tok_save;
-		struct act_statelist *sl;
+		struct act_stateset states;
 	};
 
 	struct lex_state {
 		struct lx lx;
 		struct lx_dynbuf buf;
-	};
-
-	struct act_statelist {
-		char *id;
-		fsm_state_t state;
-		struct act_statelist *next;
 	};
 
 	#define CURRENT_TERMINAL (act_state->lex_tok)
@@ -77,7 +86,55 @@
 		exit(EXIT_FAILURE);
 	}
 
-#line 81 "src/fsm/parser.c"
+	/* FNV1a 32-bit hash function, in the public domain. For details,
+	 * see: http://www.isthe.com/chongo/tech/comp/fnv/index.html . */
+	#define FNV1a_32_OFFSET_BASIS 	2166136261UL
+	#define FNV1a_32_PRIME		16777619UL
+
+	static unsigned
+	hash_of_id(const char *id)
+	{
+		unsigned h = FNV1a_32_OFFSET_BASIS;
+		while (*id) {
+			h ^= *id;
+			h *= FNV1a_32_PRIME;
+			id++;
+		}
+		return h;
+	}
+
+	static void
+	grow_state_hash_table(struct act_stateset *htab)
+	{
+		const size_t ncount = 2 * htab->bucket_count;
+		struct act_statelist **nbuckets = xcalloc(ncount, sizeof(*nbuckets));
+		size_t max_chain_length = 0;
+		size_t old_i;
+		unsigned mask = ncount - 1;
+
+		for (old_i = 0; old_i < htab->bucket_count; old_i++) {
+			struct act_statelist *p, *next;
+			size_t chain_length = 0;
+			for (p = htab->buckets[old_i]; p != NULL; p = next) {
+				const unsigned hash = hash_of_id(p->id);
+				next = p->next;
+				p->next = nbuckets[hash & mask];
+				nbuckets[hash & mask] = p;
+				chain_length++;
+			}
+
+			if (chain_length > max_chain_length) {
+				max_chain_length = chain_length;
+			}
+		}
+
+		free(htab->buckets);
+		htab->buckets = nbuckets;
+		htab->bucket_count = ncount;
+		htab->longest_chain_length = max_chain_length;
+	}
+
+#line 138 "src/fsm/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -117,14 +174,14 @@ p_label(fsm fsm, lex_state lex_state, act_state act_state, char *ZOc)
 				{
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
-#line 182 "src/fsm/parser.act"
+#line 235 "src/fsm/parser.act"
 
 		assert(lex_state->buf.a[0] != '\0');
 		assert(lex_state->buf.a[1] == '\0');
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 128 "src/fsm/parser.c"
+#line 185 "src/fsm/parser.c"
 					}
 					/* END OF EXTRACT: CHAR */
 					ADVANCE_LEXER;
@@ -134,7 +191,7 @@ p_label(fsm fsm, lex_state lex_state, act_state act_state, char *ZOc)
 				{
 					/* BEGINNING OF EXTRACT: ESC */
 					{
-#line 110 "src/fsm/parser.act"
+#line 163 "src/fsm/parser.act"
 
 		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
 		assert(2 == strlen(lex_state->buf.a));
@@ -152,7 +209,7 @@ p_label(fsm fsm, lex_state lex_state, act_state act_state, char *ZOc)
 		default:              break;
 		}
 	
-#line 156 "src/fsm/parser.c"
+#line 213 "src/fsm/parser.c"
 					}
 					/* END OF EXTRACT: ESC */
 					ADVANCE_LEXER;
@@ -162,7 +219,7 @@ p_label(fsm fsm, lex_state lex_state, act_state act_state, char *ZOc)
 				{
 					/* BEGINNING OF EXTRACT: HEX */
 					{
-#line 175 "src/fsm/parser.act"
+#line 208 "src/fsm/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -189,7 +246,7 @@ p_label(fsm fsm, lex_state lex_state, act_state act_state, char *ZOc)
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 193 "src/fsm/parser.c"
+#line 250 "src/fsm/parser.c"
 					}
 					/* END OF EXTRACT: HEX */
 					ADVANCE_LEXER;
@@ -199,7 +256,7 @@ p_label(fsm fsm, lex_state lex_state, act_state act_state, char *ZOc)
 				{
 					/* BEGINNING OF EXTRACT: OCT */
 					{
-#line 148 "src/fsm/parser.act"
+#line 181 "src/fsm/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -226,7 +283,7 @@ p_label(fsm fsm, lex_state lex_state, act_state act_state, char *ZOc)
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 230 "src/fsm/parser.c"
+#line 287 "src/fsm/parser.c"
 					}
 					/* END OF EXTRACT: OCT */
 					ADVANCE_LEXER;
@@ -272,7 +329,7 @@ ZL2_items:;
 							case (TOK_IDENT):
 								/* BEGINNING OF EXTRACT: IDENT */
 								{
-#line 186 "src/fsm/parser.act"
+#line 242 "src/fsm/parser.act"
 
 		ZIa = xstrdup(lex_state->buf.a);
 		if (ZIa == NULL) {
@@ -280,7 +337,7 @@ ZL2_items:;
 			exit(EXIT_FAILURE);
 		}
 	
-#line 284 "src/fsm/parser.c"
+#line 341 "src/fsm/parser.c"
 								}
 								/* END OF EXTRACT: IDENT */
 								break;
@@ -303,7 +360,7 @@ ZL2_items:;
 			goto ZL2_items;
 			/* END OF INLINE: items */
 		}
-		/*UNREACHED*/
+		/* UNREACHED */
 	case (ERROR_TERMINAL):
 		return;
 	default:
@@ -340,11 +397,11 @@ p_xstart(fsm fsm, lex_state lex_state, act_state act_state)
 				{
 					/* BEGINNING OF ACTION: err-expected-start */
 					{
-#line 298 "src/fsm/parser.act"
+#line 369 "src/fsm/parser.act"
 
 		err_expected(lex_state, "'start:'");
 	
-#line 348 "src/fsm/parser.c"
+#line 405 "src/fsm/parser.c"
 					}
 					/* END OF ACTION: err-expected-start */
 				}
@@ -358,7 +415,7 @@ p_xstart(fsm fsm, lex_state lex_state, act_state act_state)
 					case (TOK_IDENT):
 						/* BEGINNING OF EXTRACT: IDENT */
 						{
-#line 186 "src/fsm/parser.act"
+#line 242 "src/fsm/parser.act"
 
 		ZIn = xstrdup(lex_state->buf.a);
 		if (ZIn == NULL) {
@@ -366,7 +423,7 @@ p_xstart(fsm fsm, lex_state lex_state, act_state act_state)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 370 "src/fsm/parser.c"
+#line 427 "src/fsm/parser.c"
 						}
 						/* END OF EXTRACT: IDENT */
 						break;
@@ -384,19 +441,34 @@ p_xstart(fsm fsm, lex_state lex_state, act_state act_state)
 			}
 			/* BEGINNING OF ACTION: add-state */
 			{
-#line 198 "src/fsm/parser.act"
+#line 252 "src/fsm/parser.act"
 
 		struct act_statelist *p;
+		const unsigned hash = hash_of_id((ZIn));
+		const unsigned mask = act_state->states.bucket_count - 1;
+		size_t chain_length = 0;
+		unsigned bucket_id = hash & mask;
 
 		assert((ZIn) != NULL);
 
-		for (p = act_state->sl; p != NULL; p = p->next) {
+		if (act_state->states.longest_chain_length > MAX_CHAIN_LENGTH) {
+			grow_state_hash_table(&act_state->states);
+			bucket_id = hash & (act_state->states.bucket_count - 1);
+		}
+
+		for (p = act_state->states.buckets[bucket_id]; p != NULL; p = p->next) {
 			assert(p->id != NULL);
+
+			chain_length++;
 
 			if (0 == strcmp(p->id, (ZIn))) {
 				(ZIs) = p->state;
 				break;
 			}
+		}
+
+		if (chain_length > act_state->states.longest_chain_length) {
+			act_state->states.longest_chain_length = chain_length;
 		}
 
 		if (p == NULL) {
@@ -421,29 +493,29 @@ p_xstart(fsm fsm, lex_state lex_state, act_state act_state)
 
 			new->state = (ZIs);
 
-			new->next = act_state->sl;
-			act_state->sl = new;
+			new->next = act_state->states.buckets[bucket_id];
+			act_state->states.buckets[bucket_id] = new;
 		}
 	
-#line 429 "src/fsm/parser.c"
+#line 501 "src/fsm/parser.c"
 			}
 			/* END OF ACTION: add-state */
 			/* BEGINNING OF ACTION: mark-start */
 			{
-#line 237 "src/fsm/parser.act"
+#line 308 "src/fsm/parser.act"
 
 		fsm_setstart(fsm, (ZIs));
 	
-#line 438 "src/fsm/parser.c"
+#line 510 "src/fsm/parser.c"
 			}
 			/* END OF ACTION: mark-start */
 			/* BEGINNING OF ACTION: free */
 			{
-#line 245 "src/fsm/parser.act"
+#line 316 "src/fsm/parser.act"
 
 		free((ZIn));
 	
-#line 447 "src/fsm/parser.c"
+#line 519 "src/fsm/parser.c"
 			}
 			/* END OF ACTION: free */
 		}
@@ -481,11 +553,11 @@ p_xend(fsm fsm, lex_state lex_state, act_state act_state)
 				{
 					/* BEGINNING OF ACTION: err-expected-end */
 					{
-#line 302 "src/fsm/parser.act"
+#line 373 "src/fsm/parser.act"
 
 		err_expected(lex_state, "'end:'");
 	
-#line 489 "src/fsm/parser.c"
+#line 561 "src/fsm/parser.c"
 					}
 					/* END OF ACTION: err-expected-end */
 				}
@@ -531,11 +603,11 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-sep */
 		{
-#line 286 "src/fsm/parser.act"
+#line 357 "src/fsm/parser.act"
 
 		err_expected(lex_state, "';'");
 	
-#line 539 "src/fsm/parser.c"
+#line 611 "src/fsm/parser.c"
 		}
 		/* END OF ACTION: err-expected-sep */
 	}
@@ -559,7 +631,7 @@ p_63(fsm fsm, lex_state lex_state, act_state act_state, string *ZIa)
 					case (TOK_IDENT):
 						/* BEGINNING OF EXTRACT: IDENT */
 						{
-#line 186 "src/fsm/parser.act"
+#line 242 "src/fsm/parser.act"
 
 		ZIb = xstrdup(lex_state->buf.a);
 		if (ZIb == NULL) {
@@ -567,7 +639,7 @@ p_63(fsm fsm, lex_state lex_state, act_state act_state, string *ZIa)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 571 "src/fsm/parser.c"
+#line 643 "src/fsm/parser.c"
 						}
 						/* END OF EXTRACT: IDENT */
 						break;
@@ -580,19 +652,34 @@ p_63(fsm fsm, lex_state lex_state, act_state act_state, string *ZIa)
 			/* END OF INLINE: id */
 			/* BEGINNING OF ACTION: add-state */
 			{
-#line 198 "src/fsm/parser.act"
+#line 252 "src/fsm/parser.act"
 
 		struct act_statelist *p;
+		const unsigned hash = hash_of_id((*ZIa));
+		const unsigned mask = act_state->states.bucket_count - 1;
+		size_t chain_length = 0;
+		unsigned bucket_id = hash & mask;
 
 		assert((*ZIa) != NULL);
 
-		for (p = act_state->sl; p != NULL; p = p->next) {
+		if (act_state->states.longest_chain_length > MAX_CHAIN_LENGTH) {
+			grow_state_hash_table(&act_state->states);
+			bucket_id = hash & (act_state->states.bucket_count - 1);
+		}
+
+		for (p = act_state->states.buckets[bucket_id]; p != NULL; p = p->next) {
 			assert(p->id != NULL);
+
+			chain_length++;
 
 			if (0 == strcmp(p->id, (*ZIa))) {
 				(ZIx) = p->state;
 				break;
 			}
+		}
+
+		if (chain_length > act_state->states.longest_chain_length) {
+			act_state->states.longest_chain_length = chain_length;
 		}
 
 		if (p == NULL) {
@@ -617,28 +704,43 @@ p_63(fsm fsm, lex_state lex_state, act_state act_state, string *ZIa)
 
 			new->state = (ZIx);
 
-			new->next = act_state->sl;
-			act_state->sl = new;
+			new->next = act_state->states.buckets[bucket_id];
+			act_state->states.buckets[bucket_id] = new;
 		}
 	
-#line 625 "src/fsm/parser.c"
+#line 712 "src/fsm/parser.c"
 			}
 			/* END OF ACTION: add-state */
 			/* BEGINNING OF ACTION: add-state */
 			{
-#line 198 "src/fsm/parser.act"
+#line 252 "src/fsm/parser.act"
 
 		struct act_statelist *p;
+		const unsigned hash = hash_of_id((ZIb));
+		const unsigned mask = act_state->states.bucket_count - 1;
+		size_t chain_length = 0;
+		unsigned bucket_id = hash & mask;
 
 		assert((ZIb) != NULL);
 
-		for (p = act_state->sl; p != NULL; p = p->next) {
+		if (act_state->states.longest_chain_length > MAX_CHAIN_LENGTH) {
+			grow_state_hash_table(&act_state->states);
+			bucket_id = hash & (act_state->states.bucket_count - 1);
+		}
+
+		for (p = act_state->states.buckets[bucket_id]; p != NULL; p = p->next) {
 			assert(p->id != NULL);
+
+			chain_length++;
 
 			if (0 == strcmp(p->id, (ZIb))) {
 				(ZIy) = p->state;
 				break;
 			}
+		}
+
+		if (chain_length > act_state->states.longest_chain_length) {
+			act_state->states.longest_chain_length = chain_length;
 		}
 
 		if (p == NULL) {
@@ -663,29 +765,29 @@ p_63(fsm fsm, lex_state lex_state, act_state act_state, string *ZIa)
 
 			new->state = (ZIy);
 
-			new->next = act_state->sl;
-			act_state->sl = new;
+			new->next = act_state->states.buckets[bucket_id];
+			act_state->states.buckets[bucket_id] = new;
 		}
 	
-#line 671 "src/fsm/parser.c"
+#line 773 "src/fsm/parser.c"
 			}
 			/* END OF ACTION: add-state */
 			/* BEGINNING OF ACTION: free */
 			{
-#line 245 "src/fsm/parser.act"
+#line 316 "src/fsm/parser.act"
 
 		free((*ZIa));
 	
-#line 680 "src/fsm/parser.c"
+#line 782 "src/fsm/parser.c"
 			}
 			/* END OF ACTION: free */
 			/* BEGINNING OF ACTION: free */
 			{
-#line 245 "src/fsm/parser.act"
+#line 316 "src/fsm/parser.act"
 
 		free((ZIb));
 	
-#line 689 "src/fsm/parser.c"
+#line 791 "src/fsm/parser.c"
 			}
 			/* END OF ACTION: free */
 			/* BEGINNING OF INLINE: 42 */
@@ -696,14 +798,14 @@ p_63(fsm fsm, lex_state lex_state, act_state act_state, string *ZIa)
 						ADVANCE_LEXER;
 						/* BEGINNING OF ACTION: add-edge-any */
 						{
-#line 270 "src/fsm/parser.act"
+#line 342 "src/fsm/parser.act"
 
 		if (!fsm_addedge_any(fsm, (ZIx), (ZIy))) {
 			perror("fsm_addedge_any");
 			exit(EXIT_FAILURE);
 		}
 	
-#line 707 "src/fsm/parser.c"
+#line 809 "src/fsm/parser.c"
 						}
 						/* END OF ACTION: add-edge-any */
 					}
@@ -719,14 +821,14 @@ p_63(fsm fsm, lex_state lex_state, act_state act_state, string *ZIa)
 						}
 						/* BEGINNING OF ACTION: add-edge-literal */
 						{
-#line 263 "src/fsm/parser.act"
+#line 335 "src/fsm/parser.act"
 
 		if (!fsm_addedge_literal(fsm, (ZIx), (ZIy), (ZIc))) {
 			perror("fsm_addedge_literal");
 			exit(EXIT_FAILURE);
 		}
 	
-#line 730 "src/fsm/parser.c"
+#line 832 "src/fsm/parser.c"
 						}
 						/* END OF ACTION: add-edge-literal */
 					}
@@ -735,14 +837,14 @@ p_63(fsm fsm, lex_state lex_state, act_state act_state, string *ZIa)
 					{
 						/* BEGINNING OF ACTION: add-edge-epsilon */
 						{
-#line 277 "src/fsm/parser.act"
+#line 349 "src/fsm/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (ZIy))) {
 			perror("fsm_addedge_epsilon");
 			exit(EXIT_FAILURE);
 		}
 	
-#line 746 "src/fsm/parser.c"
+#line 848 "src/fsm/parser.c"
 						}
 						/* END OF ACTION: add-edge-epsilon */
 					}
@@ -753,11 +855,11 @@ p_63(fsm fsm, lex_state lex_state, act_state act_state, string *ZIa)
 				{
 					/* BEGINNING OF ACTION: err-expected-trans */
 					{
-#line 290 "src/fsm/parser.act"
+#line 361 "src/fsm/parser.act"
 
 		err_expected(lex_state, "transition");
 	
-#line 761 "src/fsm/parser.c"
+#line 863 "src/fsm/parser.c"
 					}
 					/* END OF ACTION: err-expected-trans */
 				}
@@ -777,19 +879,34 @@ p_63(fsm fsm, lex_state lex_state, act_state act_state, string *ZIa)
 
 			/* BEGINNING OF ACTION: add-state */
 			{
-#line 198 "src/fsm/parser.act"
+#line 252 "src/fsm/parser.act"
 
 		struct act_statelist *p;
+		const unsigned hash = hash_of_id((*ZIa));
+		const unsigned mask = act_state->states.bucket_count - 1;
+		size_t chain_length = 0;
+		unsigned bucket_id = hash & mask;
 
 		assert((*ZIa) != NULL);
 
-		for (p = act_state->sl; p != NULL; p = p->next) {
+		if (act_state->states.longest_chain_length > MAX_CHAIN_LENGTH) {
+			grow_state_hash_table(&act_state->states);
+			bucket_id = hash & (act_state->states.bucket_count - 1);
+		}
+
+		for (p = act_state->states.buckets[bucket_id]; p != NULL; p = p->next) {
 			assert(p->id != NULL);
+
+			chain_length++;
 
 			if (0 == strcmp(p->id, (*ZIa))) {
 				(ZI45) = p->state;
 				break;
 			}
+		}
+
+		if (chain_length > act_state->states.longest_chain_length) {
+			act_state->states.longest_chain_length = chain_length;
 		}
 
 		if (p == NULL) {
@@ -814,20 +931,20 @@ p_63(fsm fsm, lex_state lex_state, act_state act_state, string *ZIa)
 
 			new->state = (ZI45);
 
-			new->next = act_state->sl;
-			act_state->sl = new;
+			new->next = act_state->states.buckets[bucket_id];
+			act_state->states.buckets[bucket_id] = new;
 		}
 	
-#line 822 "src/fsm/parser.c"
+#line 939 "src/fsm/parser.c"
 			}
 			/* END OF ACTION: add-state */
 			/* BEGINNING OF ACTION: free */
 			{
-#line 245 "src/fsm/parser.act"
+#line 316 "src/fsm/parser.act"
 
 		free((*ZIa));
 	
-#line 831 "src/fsm/parser.c"
+#line 948 "src/fsm/parser.c"
 			}
 			/* END OF ACTION: free */
 			p_61 (fsm, lex_state, act_state);
@@ -870,21 +987,22 @@ p_fsm(fsm fsm, lex_state lex_state, act_state act_state)
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: free-statelist */
 		{
-#line 260 "src/fsm/parser.act"
+#line 320 "src/fsm/parser.act"
 
 		struct act_statelist *p;
 		struct act_statelist *next;
+		unsigned b_i;	/* bucket */
 
-		for (p = act_state->sl; p != NULL; p = next) {
-			next = p->next;
-
-			assert(p->id != NULL);
-
-			free(p->id);
-			free(p);
+		for (b_i = 0; b_i < act_state->states.bucket_count; b_i++) {
+			for (p = act_state->states.buckets[b_i]; p != NULL; p = next) {
+				next = p->next;
+				assert(p->id != NULL);
+				free(p->id);
+				free(p);
+			}
 		}
 	
-#line 888 "src/fsm/parser.c"
+#line 1006 "src/fsm/parser.c"
 		}
 		/* END OF ACTION: free-statelist */
 	}
@@ -893,12 +1011,12 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-syntax */
 		{
-#line 307 "src/fsm/parser.act"
+#line 377 "src/fsm/parser.act"
 
 		err(lex_state, "Syntax error");
 		exit(EXIT_FAILURE);
 	
-#line 902 "src/fsm/parser.c"
+#line 1020 "src/fsm/parser.c"
 		}
 		/* END OF ACTION: err-syntax */
 	}
@@ -934,11 +1052,11 @@ ZL2_xend_C_Cend_Hids:;
 						{
 							/* BEGINNING OF ACTION: err-expected-comma */
 							{
-#line 294 "src/fsm/parser.act"
+#line 365 "src/fsm/parser.act"
 
 		err_expected(lex_state, "','");
 	
-#line 942 "src/fsm/parser.c"
+#line 1060 "src/fsm/parser.c"
 							}
 							/* END OF ACTION: err-expected-comma */
 						}
@@ -949,7 +1067,7 @@ ZL2_xend_C_Cend_Hids:;
 					goto ZL2_xend_C_Cend_Hids;
 					/* END OF INLINE: xend::end-ids */
 				}
-				/*UNREACHED*/
+				/* UNREACHED */
 			case (ERROR_TERMINAL):
 				RESTORE_LEXER;
 				goto ZL1;
@@ -982,7 +1100,7 @@ p_xend_C_Cend_Hid(fsm fsm, lex_state lex_state, act_state act_state)
 				case (TOK_IDENT):
 					/* BEGINNING OF EXTRACT: IDENT */
 					{
-#line 186 "src/fsm/parser.act"
+#line 242 "src/fsm/parser.act"
 
 		ZIn = xstrdup(lex_state->buf.a);
 		if (ZIn == NULL) {
@@ -990,7 +1108,7 @@ p_xend_C_Cend_Hid(fsm fsm, lex_state lex_state, act_state act_state)
 			exit(EXIT_FAILURE);
 		}
 	
-#line 994 "src/fsm/parser.c"
+#line 1112 "src/fsm/parser.c"
 					}
 					/* END OF EXTRACT: IDENT */
 					break;
@@ -1003,19 +1121,34 @@ p_xend_C_Cend_Hid(fsm fsm, lex_state lex_state, act_state act_state)
 		/* END OF INLINE: id */
 		/* BEGINNING OF ACTION: add-state */
 		{
-#line 198 "src/fsm/parser.act"
+#line 252 "src/fsm/parser.act"
 
 		struct act_statelist *p;
+		const unsigned hash = hash_of_id((ZIn));
+		const unsigned mask = act_state->states.bucket_count - 1;
+		size_t chain_length = 0;
+		unsigned bucket_id = hash & mask;
 
 		assert((ZIn) != NULL);
 
-		for (p = act_state->sl; p != NULL; p = p->next) {
+		if (act_state->states.longest_chain_length > MAX_CHAIN_LENGTH) {
+			grow_state_hash_table(&act_state->states);
+			bucket_id = hash & (act_state->states.bucket_count - 1);
+		}
+
+		for (p = act_state->states.buckets[bucket_id]; p != NULL; p = p->next) {
 			assert(p->id != NULL);
+
+			chain_length++;
 
 			if (0 == strcmp(p->id, (ZIn))) {
 				(ZIs) = p->state;
 				break;
 			}
+		}
+
+		if (chain_length > act_state->states.longest_chain_length) {
+			act_state->states.longest_chain_length = chain_length;
 		}
 
 		if (p == NULL) {
@@ -1040,29 +1173,29 @@ p_xend_C_Cend_Hid(fsm fsm, lex_state lex_state, act_state act_state)
 
 			new->state = (ZIs);
 
-			new->next = act_state->sl;
-			act_state->sl = new;
+			new->next = act_state->states.buckets[bucket_id];
+			act_state->states.buckets[bucket_id] = new;
 		}
 	
-#line 1048 "src/fsm/parser.c"
+#line 1181 "src/fsm/parser.c"
 		}
 		/* END OF ACTION: add-state */
 		/* BEGINNING OF ACTION: mark-end */
 		{
-#line 241 "src/fsm/parser.act"
+#line 312 "src/fsm/parser.act"
 
 		fsm_setend(fsm, (ZIs), 1);
 	
-#line 1057 "src/fsm/parser.c"
+#line 1190 "src/fsm/parser.c"
 		}
 		/* END OF ACTION: mark-end */
 		/* BEGINNING OF ACTION: free */
 		{
-#line 245 "src/fsm/parser.act"
+#line 316 "src/fsm/parser.act"
 
 		free((ZIn));
 	
-#line 1066 "src/fsm/parser.c"
+#line 1199 "src/fsm/parser.c"
 		}
 		/* END OF ACTION: free */
 	}
@@ -1074,7 +1207,7 @@ ZL1:;
 
 /* BEGINNING OF TRAILER */
 
-#line 359 "src/fsm/parser.act"
+#line 382 "src/fsm/parser.act"
 
 
 	struct fsm *fsm_parse(FILE *f, const struct fsm_options *opt) {
@@ -1105,7 +1238,10 @@ ZL1:;
 		lx->clear      = lx_dynclear;
 		lx->free       = lx_dynfree;
 
-		act_state_s.sl = NULL;
+		act_state_s.states.buckets = xcalloc(DEF_BUCKETS, sizeof(act_state_s.states.buckets));
+		assert(act_state_s.states.buckets != NULL);
+		act_state_s.states.bucket_count = DEF_BUCKETS;
+		act_state_s.states.longest_chain_length = 0;
 
 		/* This is a workaround for ADVANCE_LEXER assuming a pointer */
 		act_state = &act_state_s;
@@ -1125,6 +1261,6 @@ ZL1:;
 		return new;
 	}
 
-#line 1129 "src/fsm/parser.c"
+#line 1265 "src/fsm/parser.c"
 
 /* END OF FILE */

--- a/src/fsm/parser.h
+++ b/src/fsm/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 102 "src/fsm/parser.act"
+#line 150 "src/fsm/parser.act"
 
 
 	typedef struct lex_state * lex_state;
@@ -26,7 +26,7 @@
 extern void p_fsm(fsm, lex_state, act_state);
 /* BEGINNING OF TRAILER */
 
-#line 360 "src/fsm/parser.act"
+#line 435 "src/fsm/parser.act"
 
 #line 32 "src/fsm/parser.h"
 


### PR DESCRIPTION
The parser's token interning dominates everything else when profiling
large test data sets, because previously it was walking an entire linked
list of tokens to find matches, which is quadratic on input size.

Switch to an add-only hash table with separate chaining for the tokens,
and grow whenever any of the chains are longer than MAX_CHAIN_LENGTH.

This uses FNV-1a for hashing, which is in the public domain.

I will update the generated parser code in a separate commit.