### PR TITLE
minimisation: Group initial EC partitions by shortest end distance

### DIFF
--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -256,6 +256,15 @@ fsm_mergestates(struct fsm *fsm, fsm_state_t a, fsm_state_t b,
  * the state state's connected component), and optionally non-end
  * states that do not have a path to an end state.
  *
+ * If mode == FSM_TRIM_START_AND_END_REACHABLE and shortest_end_depth is
+ * non-NULL, then allocate and write an array with the length of the
+ * shortest distance to an end state for each state (post-trim) into
+ * *shortest_end_distance. Since checking for paths to an end state
+ * already does most of the work, this can be calculated at the same
+ * time with little overhead, and some operations (such as minimising)
+ * can make use of that information. On error, this array will
+ * automatically be freed.
+ *
  * Returns how many states were removed, or -1 on error.
  */
 enum fsm_trim_mode {
@@ -265,7 +274,8 @@ enum fsm_trim_mode {
 	FSM_TRIM_START_AND_END_REACHABLE
 };
 long
-fsm_trim(struct fsm *fsm, enum fsm_trim_mode mode);
+fsm_trim(struct fsm *fsm, enum fsm_trim_mode mode,
+	unsigned **shortest_end_distance);
 
 /*
  * Produce a short legible string that matches up to a goal state.

--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -492,7 +492,7 @@ main(int argc, char *argv[])
 		case OP_DETERMINISE: r = fsm_determinise(q);  break;
 		case OP_GLUSHKOVISE: r = fsm_glushkovise(q);  break;
 		case OP_TRIM:        r = fsm_trim(q,
-			FSM_TRIM_START_AND_END_REACHABLE);
+		    FSM_TRIM_START_AND_END_REACHABLE, NULL);
 			break;
 
 		case OP_CONCAT:      q = fsm_concat(a, b);    break;

--- a/src/libfsm/complement.c
+++ b/src/libfsm/complement.c
@@ -39,7 +39,7 @@ fsm_complement(struct fsm *fsm)
 		fsm_setend(fsm, i, !fsm_isend(fsm, i));
 	}
 
-	if (fsm_trim(fsm, FSM_TRIM_START_REACHABLE) < 0) {
+	if (fsm_trim(fsm, FSM_TRIM_START_REACHABLE, NULL) < 0) {
 		return 0;
 	}
 

--- a/src/libfsm/minimise.c
+++ b/src/libfsm/minimise.c
@@ -192,7 +192,12 @@ collect_labels(const struct fsm *fsm,
  * else is distinguishable via transitive final/non-final reachability.
  * Each EC represents a state in the minimised DFA mapping, and multiple
  * states in a single EC can be safely combined without affecting
- * observable behavior. */
+ * observable behavior.
+ *
+ * When PARTITION_BY_END_STATE_DISTANCE is non-zero, instead of
+ * starting with two ECs, do a pass grouping the states into ECs
+ * according to their distance to the closest end state. See the
+ * comments around it for further details. */
 static int
 build_minimised_mapping(const struct fsm *fsm,
     const unsigned char *dfa_labels, size_t dfa_label_count,
@@ -377,12 +382,254 @@ dump_ecs(FILE *f, const struct min_env *env)
 #endif
 }
 
+#define PARTITION_BY_END_STATE_DISTANCE 1
+#if PARTITION_BY_END_STATE_DISTANCE
+/* Use counting sort to construct a permutation vector -- this is an
+ * array of offsets into in[N] such that in[pv[0..N]] would give the
+ * values of in[] in ascending order (but don't actually rearrange in,
+ * just get the offsets). This is O(n). */
+static unsigned *
+build_permutation_vector(const struct fsm_alloc *alloc,
+    size_t length, size_t max_value, unsigned *in)
+{
+	unsigned *out = NULL;
+	unsigned *counts = NULL;
+	size_t i;
+
+	out = f_malloc(alloc, length * sizeof(*out));
+	if (out == NULL) {
+		goto cleanup;
+	}
+	counts = f_calloc(alloc, max_value + 1, sizeof(*out));
+	if (counts == NULL) {
+		goto cleanup;
+	}
+
+	/* Count each distinct value */
+	for (i = 0; i < length; i++) {
+		counts[in[i]]++;
+	}
+
+	/* Convert to cumulative counts, so counts[v] stores the upper
+	 * bound for where sorting would place each distinct value. */
+	for (i = 1; i <= max_value; i++) {
+		counts[i] += counts[i - 1];
+	}
+
+	/* Sweep backwards through the input array, placing each value
+	 * according to the cumulative count. Decrement the count so
+	 * progressively earlier instances of the same value will
+	 * receive earlier offsets in out[]. */
+	for (i = 0; i < length; i++) {
+	        const unsigned pos = length - i - 1;
+		const unsigned value = in[pos];
+		const unsigned count = --counts[value];
+		out[count] = pos;
+	}
+
+	f_free(alloc, counts);
+	return out;
+
+cleanup:
+	if (out != NULL) {
+		f_free(alloc, out);
+	}
+	if (counts != NULL) {
+		f_free(alloc, counts);
+	}
+	return NULL;
+}
+#endif
+
 static int
 populate_initial_ecs(struct min_env *env, const struct fsm *fsm,
 	const unsigned *shortest_end_distance)
 {
 	int res = 0;
 	size_t i;
+
+#if PARTITION_BY_END_STATE_DISTANCE
+	/* Populate the initial ECs, partitioned by their shortest
+	 * distance to an end state. Where Moore or Hopcroft's algorithm
+	 * would typically start with two ECs, one for final states and
+	 * one for non-final states, these states can be further
+	 * partitioned into groups with equal shortest distances to an
+	 * end state (0 for the end states themselves). This eliminates
+	 * the worst case in `build_minimised_mapping`, where a very
+	 * deeply nested path to an end state requires several passes:
+	 * for example, an EC with 1000 states where only the last
+	 * reaches the end state and is distinguishable, then 999, then
+	 * 998, ... Using an initial partitioning based on the
+	 * shortest_end_distance puts the states with each distance into
+	 * their own ECs, replacing quadratic repetition. This initial
+	 * pass can be done in linear time.
+	 *
+	 * This end-distance-based partitioning is described in
+	 * _Efficient Deterministic Finite Automata Minimization Based
+	 * on Backward Depth Information_ by Desheng Liu et. al. While
+	 * I'm not convinced their approach works as presented -- and
+	 * the pseudocode, diagrams, and test data tables in the paper
+	 * contain numerous errors -- their proposition that any two
+	 * states with different backwards depths to accept states must
+	 * be distinguishable appears to be valid. We use this
+	 * partitioning as a first pass, and then Moore's algorithm does
+	 * the rest. */
+
+	size_t count_ceil;
+	unsigned *counts = NULL;
+	unsigned *pv = NULL, *ranking = NULL;
+	unsigned count_max = 0, sed_max = 0, sed_limit;
+
+	assert(fsm != NULL);
+	assert(shortest_end_distance != NULL);
+
+	counts = f_calloc(fsm->opt->alloc,
+	    DEF_INITIAL_COUNT_CEIL, sizeof(counts[0]));
+	if (counts == NULL) {
+		goto cleanup;
+	}
+	count_ceil = DEF_INITIAL_COUNT_CEIL;
+
+	/* Count unique shortest_end_distances, growing the
+	 * counts array as necessary, and track the max SED
+	 * present. */
+	for (i = 0; i < fsm->statecount; i++) {
+		unsigned sed = shortest_end_distance[i];
+
+#if LOG_INIT
+		fprintf(stderr, "initial_ecs: %lu/%lu: sed %u\n",
+		    i, fsm->statecount, sed);
+#endif
+
+		assert(sed != (unsigned)-1);
+		if (sed >= count_ceil) {
+			size_t ni;
+			size_t nceil = 2 * count_ceil;
+			unsigned *ncounts;
+			while (sed >= nceil) {
+				nceil *= 2;
+			}
+			ncounts = f_realloc(fsm->opt->alloc,
+			    counts, nceil * sizeof(counts[0]));
+			if (ncounts == NULL) {
+				goto cleanup;
+			}
+
+			/* zero the newly allocated region */
+			for (ni = count_ceil; ni < nceil; ni++) {
+				ncounts[ni] = 0;
+			}
+			counts = ncounts;
+			count_ceil = nceil;
+		}
+
+		counts[sed]++;
+		if (sed > sed_max) {
+			sed_max = sed;
+		}
+		if (counts[sed] > count_max) {
+			count_max = counts[sed];
+		}
+	}
+
+	/* The upper limit includes the max value. */
+	sed_limit = sed_max + 1;
+
+	/* Build a permutation vector of the counts, such
+	 * that counts[pv[i..N]] would return the values
+	 * in counts[] in ascending order. */
+	pv = build_permutation_vector(fsm->opt->alloc,
+	    sed_limit, count_max, counts);
+	if (pv == NULL) {
+		goto cleanup;
+	}
+
+	/* Build a permutation vector of the permutation vector,
+	 * converting it into the rankings for counts[]. This is an
+	 * old APL idiom[1], composing the grade-up operator (which
+	 * builds an ascending permutation vector) with itself.
+	 *
+	 * Using k syntax & ngn's k [2] :
+	 *
+	 *   d:10?4		  / bind d to: draw 10 values 0 <= x < 4
+	 *   d			  / print d's contents
+	 * 3 3 0 1 3 1 1 3 2 2
+	 *   <d			  / build permutation vector of d
+	 * 2 3 5 6 8 9 0 1 4 7
+	 *   d[<d]		  / d sliced by pv of d -> sorted d
+	 * 0 1 1 1 2 2 3 3 3 3
+	 *   d			  / print d's contents, again
+	 * 3 3 0 1 3 1 1 3 2 2
+	 *   <<d		  / pv of (pv of d): ranking vector of d
+	 * 6 7 0 1 8 2 3 9 4 5
+	 *			  / see how (0) -> 0, (1 2 3) -> 1,
+	 *			  / (4 5) -> 2, (6 7 8 9) -> 3?
+	 *   9-<<d		  / subtract from the length to count
+	 * 3 2 9 8 1 7 6 0 5 4	  / from the end, for descending ranks.
+	 *			  / now (0 1 2 3) -> 3, (4 5) -> 2, ...
+	 *   dr:{(-1+#x)-<<x}	  / bind function: descending rank
+	 *   dr d		  / put it all together
+	 * 3 2 9 8 1 7 6 0 5 4
+	 *			  / one more example, to show the pattern
+	 *   d:5 5 5 2 2 2 2 1 1 1
+	 *   dr d
+	 * 2 1 0 6 5 4 3 9 8 7	  / (2 1 0) -> 5, (6 5 4 3) -> 2, (9 8 7) -> 1
+	 *
+	 * [1]: http://www.sudleyplace.com/APL/Anatomy%20of%20An%20Idiom.pdf
+	 * [2]: https://bitbucket.org/ngn/k/src
+	 */
+	ranking = build_permutation_vector(fsm->opt->alloc,
+	    sed_limit, sed_limit, pv);
+	if (ranking == NULL) {
+		goto cleanup;
+	}
+
+	/* Reverse the ranking offsets -- count from the end, rather
+	 * than the start, so ECs with higher counts appear first. */
+	for (i = 0; i < sed_limit; i++) {
+		ranking[i] = sed_max - ranking[i];
+		env->ecs[i] = NO_ID;
+	}
+
+	/* Assign the states to the ECs, ordered by descending ranking.
+	 * We want the largest ECs first, as they will need the most
+	 * processing. All ECs with less than 2 states are already done,
+	 * so they should be together at the end. */
+	for (i = 0; i < fsm->statecount; i++) {
+		const unsigned sed = shortest_end_distance[i];
+		fsm_state_t ec;
+		assert(sed < sed_limit);
+
+		/* assign EC and link state at head of list */
+		ec = ranking[sed];
+		env->state_ecs[i] = ec;
+		env->jump[i] = env->ecs[ec];
+		env->ecs[ec] = i;
+	}
+
+	/* Set done_ec_offset to the first EC with <2 states, if any. */
+	env->ec_count = sed_limit;
+	env->done_ec_offset = env->ec_count;
+	for (i = 0; i < sed_limit; i++) {
+		const unsigned count = counts[shortest_end_distance[env->ecs[i]]];
+		if (count < 2) {
+			env->done_ec_offset = i;
+			break;
+		}
+	}
+
+	/* The dead state is not a member of any EC. */
+	env->state_ecs[env->dead_state] = NO_ID;
+	res = 1;
+
+cleanup:
+	f_free(fsm->opt->alloc, counts);
+	f_free(fsm->opt->alloc, pv);
+	f_free(fsm->opt->alloc, ranking);
+	return res;
+
+#else
+	(void)shortest_end_distance;
 
 	for (i = 0; i < fsm->statecount; i++) {
 		const fsm_state_t ec = fsm_isend(fsm, i)
@@ -401,6 +648,7 @@ populate_initial_ecs(struct min_env *env, const struct fsm *fsm,
 	env->state_ecs[env->dead_state] = NO_ID;
 	res = 1;
 	return res;
+#endif
 }
 
 #if EXPENSIVE_INTEGRITY_CHECKS

--- a/src/libfsm/minimise_internal.h
+++ b/src/libfsm/minimise_internal.h
@@ -7,6 +7,8 @@
  * integrity checks inside some inner loops. */
 #define EXPENSIVE_INTEGRITY_CHECKS 0
 
+#define DEF_INITIAL_COUNT_CEIL 8
+
 struct min_env {
 	const struct fsm *fsm;
 

--- a/src/libfsm/minimise_internal.h
+++ b/src/libfsm/minimise_internal.h
@@ -108,13 +108,15 @@ collect_labels(const struct fsm *fsm,
 static int
 build_minimised_mapping(const struct fsm *fsm,
     const unsigned char *dfa_labels, size_t dfa_label_count,
+    const unsigned *shortest_end_distance,
     fsm_state_t *mapping, size_t *minimized_state_count);
 
 static void
 dump_ecs(FILE *f, const struct min_env *env);
 
-static void
-populate_initial_ecs(struct min_env *env, const struct fsm *fsm);
+static int
+populate_initial_ecs(struct min_env *env, const struct fsm *fsm,
+	const unsigned *shortest_end_distance);
 
 #if EXPENSIVE_INTEGRITY_CHECKS
 static void

--- a/tests/ir/out5.json
+++ b/tests/ir/out5.json
@@ -1,19 +1,6 @@
 {
-	"start": 0,
+	"start": 1,
 	"states": [
-		{
-			"end": false,
-			"strategy": "dominant",
-			"mode": 2,
-			"groups": [
-				{
-					"to": 1,
-					"ranges": [
-						{ "start": "x", "end": "x" }
-					]
-				}
-			]
-		},
 		{
 			"end": true,
 			"strategy": "partial",
@@ -23,6 +10,19 @@
 					"to": 2,
 					"ranges": [
 						{ "start": "y", "end": "y" }
+					]
+				}
+			]
+		},
+		{
+			"end": false,
+			"strategy": "dominant",
+			"mode": 2,
+			"groups": [
+				{
+					"to": 0,
+					"ranges": [
+						{ "start": "x", "end": "x" }
 					]
 				}
 			]

--- a/tests/ir/out7.json
+++ b/tests/ir/out7.json
@@ -1,6 +1,32 @@
 {
-	"start": 1,
+	"start": 3,
 	"states": [
+		{
+			"end": false,
+			"strategy": "same",
+			"example": "aza",
+			"to": 2
+		},
+		{
+			"end": false,
+			"strategy": "partial",
+			"example": "az",
+			"groups": [
+				{
+					"to": 0,
+					"ranges": [
+						{ "start": "0", "end": "9" },
+						{ "start": "a", "end": "f" }
+					]
+				},
+				{
+					"to": 1,
+					"ranges": [
+						{ "start": "z", "end": "z" }
+					]
+				}
+			]
+		},
 		{
 			"end": true,
 			"strategy": "none",
@@ -9,46 +35,20 @@
 		{
 			"end": false,
 			"strategy": "same",
-			"to": 3
-		},
-		{
-			"end": false,
-			"strategy": "same",
-			"example": "aza",
-			"to": 0
+			"to": 4
 		},
 		{
 			"end": false,
 			"strategy": "error",
 			"example": "a",
-			"mode": 0,
+			"mode": 2,
 			"error": [
 						{ "start": "a", "end": "l" },
 						{ "start": "n", "end": "y" }
 			],
 			"groups": [
 				{
-					"to": 4,
-					"ranges": [
-						{ "start": "z", "end": "z" }
-					]
-				}
-			]
-		},
-		{
-			"end": false,
-			"strategy": "partial",
-			"example": "az",
-			"groups": [
-				{
-					"to": 2,
-					"ranges": [
-						{ "start": "0", "end": "9" },
-						{ "start": "a", "end": "f" }
-					]
-				},
-				{
-					"to": 4,
+					"to": 1,
 					"ranges": [
 						{ "start": "z", "end": "z" }
 					]

--- a/theft/fuzz_minimise.c
+++ b/theft/fuzz_minimise.c
@@ -101,11 +101,6 @@ check_minimise_matches_naive_fixpoint_algorithm(const struct dfa_spec *spec)
 		goto cleanup;
 	}
 
-	if (fsm_trim(fsm, FSM_TRIM_START_AND_END_REACHABLE) < 0) {
-		fprintf(stderr, "-- fail: fsm_trim\n");
-		goto cleanup;
-	}
-
 	if (!fsm_minimise(fsm)) {
 		fprintf(stderr, "-- fail: fsm_minimise\n");
 		goto cleanup;

--- a/theft/fuzz_minimise.c
+++ b/theft/fuzz_minimise.c
@@ -56,8 +56,8 @@ test_dfa_minimise(theft_seed seed,
 		.seed = seed,
 		.trials = 10000,
 		.fork = {
-			/* .enable = true, */
-			.timeout = 1000,
+			.enable = true,
+			.timeout = 10000,
 		},
 	};
 
@@ -776,6 +776,97 @@ dfa_min_reg_m0(theft_seed seed)
 	RUN_SPEC(states, 0);
 }
 
+static bool
+dfa_min_reg_end_distance_compaction(theft_seed seed)
+{
+	(void)seed;
+	struct dfa_spec_state states[] = {
+		[0] = { .used = true,
+			.edge_count = 2, .edges = {
+				{ .symbol = 0x0, .state = 1 },
+				{ .symbol = 0x1, .state = 2 },
+			},
+		},
+		[1] = { .used = true, .edge_count = 0, },
+		[2] = { .used = true, .end = true,
+			.edge_count = 2, .edges = {
+				{ .symbol = 0x0, .state = 3 },
+				{ .symbol = 0x1, .state = 4 },
+			},
+		},
+		[3] = { .used = true, .edge_count = 0, },
+		[4] = { .used = true,
+			.edge_count = 1, .edges = {
+				{ .symbol = 0x0, .state = 5 },
+			},
+		},
+		[5] = { .used = true,
+			.edge_count = 1, .edges = {
+				{ .symbol = 0x0, .state = 2 },
+			},
+		},
+	};
+	RUN_SPEC(states, 0);
+}
+
+static bool
+dfa_min_reg_realloc_counts(theft_seed seed)
+{
+	(void)seed;
+	struct dfa_spec_state states[] = {
+		[0] = { .used = true,
+			.edge_count = 2, .edges = {
+				{ .symbol = 0x0, .state = 4 },
+				{ .symbol = 0x1, .state = 1 },
+			},
+		},
+		[1] = { .used = true,
+			.edge_count = 1, .edges = {
+				{ .symbol = 0x0, .state = 0 },
+			},
+		},
+		[2] = { .used = true, },
+		[3] = { .used = true, },
+		[4] = { .used = true,
+			.edge_count = 1, .edges = {
+				{ .symbol = 0x0, .state = 7 },
+			},
+		},
+		[5] = { .used = true, },
+		[6] = { .used = true, },
+		[7] = { .used = true, .end = true, },
+	};
+	RUN_SPEC(states, 0);
+}
+
+static bool
+dfa_min_ring(theft_seed seed)
+{
+#define LIMIT 2000
+	static struct dfa_spec_state ring_states[LIMIT];
+	size_t i;
+	(void)seed;
+	for (i = 0; i < LIMIT; i++) {
+		struct dfa_spec_state *s = &ring_states[i];
+		s->used = 1;
+		s->edge_count = 1;
+		s->edges[0].symbol = 0x0;
+		s->edges[0].state = i + 1;
+	}
+
+	/* wrap around to start */
+	ring_states[LIMIT - 1].edges[0].state = 0;
+
+	/* last state is edge state */
+	ring_states[LIMIT - 1].end = 1;
+
+	/* so is halfway */
+	ring_states[LIMIT/2 - 1].end = 1;
+
+	RUN_SPEC(ring_states, 0);
+#undef LIMIT
+}
+
 void
 register_test_minimise(void)
 {
@@ -790,6 +881,13 @@ register_test_minimise(void)
 	reg_test("dfa_minimise_regression_brz", dfa_min_reg_brz);
 
 	reg_test("dfa_minimise_regression_m0", dfa_min_reg_m0);
+	reg_test("dfa_minimise_regression_end_distance_compaction",
+	    dfa_min_reg_end_distance_compaction);
+	reg_test("dfa_minimise_regression_realloc_counts",
+	    dfa_min_reg_realloc_counts);
+
+	reg_test("dfa_minimise_ring", dfa_min_ring);
+
 
 	/* state, symbol, end */
 	reg_test3("dfa_minimise_0_0_0", test_dfa_minimise,

--- a/theft/fuzz_nfa.c
+++ b/theft/fuzz_nfa.c
@@ -250,7 +250,7 @@ apply_ops(struct test_env *env, struct nfa_spec *nfa_spec,
 			break;
 
 		case NFA_OP_TRIM:
-			if (!fsm_trim(nfa, FSM_TRIM_START_AND_END_REACHABLE)) {
+			if (!fsm_trim(nfa, FSM_TRIM_START_AND_END_REACHABLE, NULL)) {
 				if (verbosity > 0) {
 					fprintf(stdout, "FAIL: trim\n");
 				}
@@ -259,7 +259,7 @@ apply_ops(struct test_env *env, struct nfa_spec *nfa_spec,
 			break;
 
 		case NFA_OP_DOUBLE_REVERSE:
-			if (!fsm_trim(nfa, FSM_TRIM_START_AND_END_REACHABLE)) {
+			if (!fsm_trim(nfa, FSM_TRIM_START_AND_END_REACHABLE, NULL)) {
 				if (verbosity > 0) {
 					fprintf(stdout, "FAIL: first reverse's trim\n");
 				}
@@ -273,7 +273,7 @@ apply_ops(struct test_env *env, struct nfa_spec *nfa_spec,
 			}
 			PRINT_FSM("REVERSE");
 
-			if (!fsm_trim(nfa, FSM_TRIM_START_AND_END_REACHABLE)) {
+			if (!fsm_trim(nfa, FSM_TRIM_START_AND_END_REACHABLE, NULL)) {
 				if (verbosity > 0) {
 					fprintf(stdout, "FAIL: second reverse's trim\n");
 				}

--- a/theft/fuzz_trim.c
+++ b/theft/fuzz_trim.c
@@ -98,7 +98,7 @@ check_trimming_matches_reachability(const struct dfa_spec *spec)
 		return THEFT_TRIAL_ERROR;
 	}
 
-	long trim_res = fsm_trim(fsm, FSM_TRIM_START_AND_END_REACHABLE);
+	long trim_res = fsm_trim(fsm, FSM_TRIM_START_AND_END_REACHABLE, NULL);
 	if (trim_res < 0) {
 		fprintf(stderr, "-- FAIL: trim_res %ld\n", trim_res);
 		return THEFT_TRIAL_FAIL;


### PR DESCRIPTION
This adds a different version of `populate_initial_ecs` (enabled by `#define`ing `PARTITION_BY_END_STATE_DISTANCE` to `1`) which groups states with distinct end distances into their own ECs, rather than starting with two for final and non-final states. While this does not seem to have much impact on performance in typical cases (it may make `fsm_minimise` slightly slower), it completely eliminates the worst-case quadratic behavior in Moore's DFA minimization, which is when a large set of states with only a single deeply nested end state is partitioned, and info about the connection to the end state can only propagate one state further each pass. Now each state progressively further from the end state will be placed in a distinct EC to start.

The new implementation depends on an interface change in `fsm_trim` -- since it's already doing most of the necessary work while checking whether states have a path to any end states, add an argument to optionally track the shortest distance to an end state. Then, use this information in `populate_initial_ecs` to group states by shortest end distances, sorted by largest to smallest groups. Then, find the first EC with less than 2 states (if any); any ECs after that point are already done with processing. Hand the rest off to our variant of Moore's for the remaining processing.

Also, add an example of the previous worst case (`dfa_minimise_ring`) to `fuzz_minimise.c`'s regression tests, a ring of N states with one end state, with N set to 2000. This test still takes a while to run, because it's comparing the result against the Myhill-Nerode theorem-based minimisation test oracle (which is easy to verify but scales poorly), but the production implementation of minimisation should be a tiny portion of the runtime: on my laptop, `fsm_minimise` with `PARTITION_BY_END_STATE_DISTANCE` off takes about 34 msec, with it on the time drops to 0.15 msec.