### PR TITLE
ast.h: Add `extern` for `ast_expr_tombstone`.

### DIFF
--- a/src/libre/ast.h
+++ b/src/libre/ast.h
@@ -183,7 +183,7 @@ struct ast {
 	struct ast_expr *expr;
 };
 
-struct ast_expr *ast_expr_tombstone;
+extern struct ast_expr *ast_expr_tombstone;
 
 struct ast *
 ast_new(void);


### PR DESCRIPTION
This was missing the `extern` declaration, so multiple compilation units including `libre/ast.h` by way of `src/libre/parser.act` were
defining the symbol.

Reported in #115 (tangential to the main issue).