### PR TITLE
Do not assume long has 64 bits.

### DIFF
--- a/src/adt/hashset.c
+++ b/src/adt/hashset.c
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <string.h>
 #include <stdio.h>
+#include <stdint.h>
 
 #include <adt/alloc.h>
 
@@ -24,7 +25,7 @@ static const unsigned char hashk[] = {
 unsigned long
 hashrec(const void *p, size_t n)
 {
-	unsigned long h = 0;
+	uint64_t h = 0;
 
 	siphash(p, n, hashk, (void *) &h, sizeof h);
 

--- a/src/libfsm/Makefile
+++ b/src/libfsm/Makefile
@@ -41,7 +41,7 @@ SRC += src/libfsm/intersect.c
 SRC += src/libfsm/subtract.c
 SRC += src/libfsm/walk2.c
 
-.for src in ${SRC:Msrc/libfsm/closure.c} ${SRC:Msrc/libfsm/vm.c}
+.for src in ${SRC:Msrc/libfsm/closure.c} ${SRC:Msrc/libfsm/minimise.c} ${SRC:Msrc/libfsm/vm.c}
 CFLAGS.${src} += -std=c99
 DFLAGS.${src} += -std=c99
 .endfor

--- a/src/libfsm/minimise.c
+++ b/src/libfsm/minimise.c
@@ -152,10 +152,10 @@ collect_labels(const struct fsm *fsm,
 			assert(e.state < fsm->statecount);
 			label = e.symbol;
 
-			if (label_set[label/64] & (1UL << (label & 63))) {
+			if (label_set[label/64] & (UINT64_C(1) << (label & 63))) {
 				/* already set, ignore */
 			} else {
-				label_set[label/64] |= (1UL << (label & 63));
+				label_set[label/64] |= (UINT64_C(1) << (label & 63));
 				count++;
 			}
 		}
@@ -163,7 +163,7 @@ collect_labels(const struct fsm *fsm,
 
 	*label_count = 0;
 	for (i = 0; i < 256; i++) {
-		if (label_set[i/64] & (1UL << (i & 63))) {
+		if (label_set[i/64] & (UINT64_C(1) << (i & 63))) {
 			labels[*label_count] = i;
 			(*label_count)++;
 		}


### PR DESCRIPTION
In hashset.c, siphash is called with a size of sizeof(unsigned long),
but siphash asserts that the size is either 8 or 16. Change h's type to
uint64_t instead. On platforms where long does not have 64 bits, this
will implicitly truncate the result in the return statement, which is
fine.

In minimise.c, use UINT64_C(1) instead of 1UL when a 64-bit constant is
needed.

This allows libfsm to work on 32 bit platforms.