### PR TITLE
Fix a memory leak when freeing AST_EXPR_ALT nodes

### DIFF
--- a/src/libre/ast.c
+++ b/src/libre/ast.c
@@ -110,6 +110,8 @@ ast_expr_free(struct ast_expr *n)
 		for (i = 0; i < n->u.alt.count; i++) {
 			ast_expr_free(n->u.alt.n[i]);
 		}
+
+		free(n->u.alt.n);
 		break;
 	}
 


### PR DESCRIPTION
Like AST_EXPR_CONCAT nodes, AST_EXPR_ALT nodes consist of two blocks of memory: the node itself, and the array of children. Free both of them.