### PR TITLE
Fix printing of ASTs as PCRE.

### DIFF
--- a/src/print/pcre.c
+++ b/src/print/pcre.c
@@ -38,6 +38,8 @@ pcre_escputc(FILE *f, const struct fsm_options *opt, char c)
 	case '*': return fputs("\\*", f);
 	case '?': return fputs("\\?", f);
 	case '.': return fputs("\\.", f);
+	case '{': return fputs("\\{", f);
+	case '}': return fputs("\\}", f);
 
 	case '\f': return fputs("\\f", f);
 	case '\n': return fputs("\\n", f);


### PR DESCRIPTION
This fixes three aspects of PCRE printing:
- Not escaping two characters that do require it: { and }
- Not handling certain node types: (?:ab)* would crash
- Not taking precedence into account: a(?:b|c) would be printed as ab|c

The first of these is trivial, the second and third are related and a
bit more involved. It would have been easy to fix the crash by
supporting all node types in atomic(), and to handle precendence by
always emitting (?:...) where possibly required, but to avoid cluttering
the output this commit takes care to only use (?:...) grouping where
required, by ordering the node types according to PCRE precedence.