### PR TITLE
Changes AST parsing to use a "pooled" allocator

### DIFF
--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -349,6 +349,15 @@ gen_words(FILE *f, const struct fsm *fsm)
 }
 #endif /* 0 */
 
+static struct fsm *fsm_to_cleanup = NULL;
+
+static void
+do_fsm_cleanup(void)
+{
+	if (fsm_to_cleanup != NULL) {
+		fsm_free(fsm_to_cleanup);
+	}
+}
 
 int
 main(int argc, char *argv[])
@@ -364,6 +373,8 @@ main(int argc, char *argv[])
 	int (*query)(const struct fsm *, fsm_state_t);
 	int (*walk )(const struct fsm *,
 		 int (*)(const struct fsm *, fsm_state_t));
+
+	atexit(do_fsm_cleanup);
 
 	opt.comments = 1;
 	opt.io       = FSM_IO_GETC;
@@ -523,6 +534,8 @@ main(int argc, char *argv[])
 			q = NULL;
 		}
 
+		fsm_to_cleanup = q;
+
 		if (-1 == clock_gettime(CLOCK_MONOTONIC, &post)) {
 			perror("clock_gettime");
 			exit(EXIT_FAILURE);
@@ -645,6 +658,7 @@ main(int argc, char *argv[])
 	}
 
 	fsm_free(fsm);
+	fsm_to_cleanup = NULL;
 
 	return r;
 }

--- a/src/libfsm/closure.c
+++ b/src/libfsm/closure.c
@@ -258,5 +258,7 @@ closure_free(struct state_set **closures, size_t n)
 	for (s = 0; s < n; s++) {
 		state_set_free(closures[s]);
 	}
+
+	free(closures);
 }
 

--- a/src/libfsm/closure.c
+++ b/src/libfsm/closure.c
@@ -116,6 +116,8 @@ start:
 		fsm->states[p].visited = 0;
 	}
 
+	queue_free(q);
+
 	return 1;
 
 error:

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -356,11 +356,14 @@ fsm_determinise(struct fsm *nfa)
 		}
 	}
 
+	mapping_hashset_free(mappings);
+
 	return 1;
 
 error:
 
 	/* TODO: free stuff */
+	mapping_hashset_free(mappings);
 
 	return 0;
 }

--- a/src/libfsm/glushkovise.c
+++ b/src/libfsm/glushkovise.c
@@ -111,6 +111,7 @@ fsm_glushkovise(struct fsm *nfa)
 error:
 
 	/* TODO: free stuff */
+	closure_free(eclosures, nfa->statecount);
 
 	return 0;
 }

--- a/src/libfsm/minimise.c
+++ b/src/libfsm/minimise.c
@@ -72,7 +72,8 @@ fsm_minimise(struct fsm *fsm)
 	}
 
 	if (fsm->statecount == 0) {
-		return 1;	/* empty -- no-op */
+		r = 1;
+		goto cleanup;
 	}
 
 	TIME(tv_pre);
@@ -81,7 +82,8 @@ fsm_minimise(struct fsm *fsm)
 	LOG_TIME_DELTA("collect_labels");
 
 	if (label_count == 0) {
-		return 1;	/* no edges -- no-op */
+		r = 1;
+		goto cleanup;
 	}
 
 	mapping = f_malloc(fsm->opt->alloc,

--- a/src/libfsm/parser.act
+++ b/src/libfsm/parser.act
@@ -427,6 +427,7 @@
 		ADVANCE_LEXER; /* XXX: what if the first token is unrecognised? */
 		p_fsm(new, lex_state, act_state);
 
+		free(act_state_s.states.buckets);
 		lx->free(lx->buf_opaque);
 
 		return new;

--- a/src/libfsm/parser.c
+++ b/src/libfsm/parser.c
@@ -1256,11 +1256,12 @@ ZL1:;
 		ADVANCE_LEXER; /* XXX: what if the first token is unrecognised? */
 		p_fsm(new, lex_state, act_state);
 
+		free(act_state_s.states.buckets);
 		lx->free(lx->buf_opaque);
 
 		return new;
 	}
 
-#line 1265 "src/libfsm/parser.c"
+#line 1266 "src/libfsm/parser.c"
 
 /* END OF FILE */

--- a/src/libfsm/parser.h
+++ b/src/libfsm/parser.h
@@ -26,7 +26,7 @@
 extern void p_fsm(fsm, lex_state, act_state);
 /* BEGINNING OF TRAILER */
 
-#line 435 "src/libfsm/parser.act"
+#line 436 "src/libfsm/parser.act"
 
 #line 32 "src/libfsm/parser.h"
 

--- a/src/libfsm/state.c
+++ b/src/libfsm/state.c
@@ -211,6 +211,9 @@ fsm_compact_states(struct fsm *fsm,
 	for (i = 0, dst = 0, removed_count = 0; i < orig_statecount; i++) {
 		assert(dst <= i);
 		if (mapping[i] == FSM_STATE_REMAP_NO_STATE) { /* dead */
+			state_set_free(fsm->states[i].epsilons);
+			edge_set_free(fsm->opt->alloc, fsm->states[i].edges);
+
 			fsm->statecount--;
 			removed_count++;
 		} else {				      /* keep */

--- a/src/libfsm/union.c
+++ b/src/libfsm/union.c
@@ -32,8 +32,8 @@ fsm_union(struct fsm *a, struct fsm *b)
 		return NULL;
 	}
 
-	if (a->statecount == 0) { return b; }
-	if (b->statecount == 0) { return a; }
+	if (a->statecount == 0) { fsm_free(a); return b; }
+	if (b->statecount == 0) { fsm_free(b); return a; }
 
 	if (!fsm_getstart(a, &sa) || !fsm_getstart(b, &sb)) {
 		errno = EINVAL;

--- a/src/libre/ast.c
+++ b/src/libre/ast.c
@@ -24,10 +24,52 @@
 static struct ast_expr the_tombstone;
 struct ast_expr *ast_expr_tombstone = &the_tombstone;
 
+/* FIXME: this isn't safe for multiple threads! */
+static struct ast_expr_pool *global_pool = NULL;
+
+struct ast_expr *
+ast_expr_pool_new(struct ast_expr_pool **poolp) 
+{
+	struct ast_expr_pool *p;
+
+	assert(poolp != NULL);
+
+	p = *poolp;
+	if (p == NULL || p->count >= AST_EXPR_POOL_SIZE) {
+		p = calloc(1, sizeof *p);
+		if (p == NULL) {
+			return NULL;
+		}
+
+		p->next = *poolp;
+		*poolp = p;
+	}
+
+	assert(p != NULL && p->count < AST_EXPR_POOL_SIZE);
+
+	return &p->pool[p->count++];
+}
+
+struct ast_expr *
+ast_expr_new(void)
+{
+	return ast_expr_pool_new(&global_pool);
+}
+
+struct ast_expr_pool *
+ast_expr_pool_save(void)
+{
+	struct ast_expr_pool *p = global_pool;
+	global_pool = NULL;
+	return p;
+}
+
 struct ast *
 ast_new(void)
 {
 	struct ast *res;
+
+	assert(global_pool == NULL);
 
 	res = calloc(1, sizeof *res);
 	if (res == NULL) {
@@ -41,9 +83,30 @@ ast_new(void)
 }
 
 void
+ast_pool_free(struct ast_expr_pool *pool)
+{
+	struct ast_expr_pool *curr;
+	for (curr=pool; curr != NULL; curr=curr->next) {
+		unsigned i;
+
+		for (i=0; i < curr->count; i++) {
+			ast_expr_free(&curr->pool[i]);
+		}
+	}
+
+	while (pool != NULL) {
+		curr = pool;
+		pool = pool->next;
+
+		free(curr);
+	}
+}
+
+void
 ast_free(struct ast *ast)
 {
 	ast_expr_free(ast->expr);
+	ast_pool_free(ast->pool);
 	free(ast);
 }
 
@@ -75,6 +138,8 @@ ast_make_count(unsigned min, const struct ast_pos *start,
 void
 ast_expr_free(struct ast_expr *n)
 {
+	static const struct ast_expr zero;
+
 	if (n == NULL) {
 		return;
 	}
@@ -131,7 +196,7 @@ ast_expr_free(struct ast_expr *n)
 		assert(!"unreached");
 	}
 
-	free(n);
+	*n = zero;
 }
 
 int
@@ -469,7 +534,7 @@ ast_make_expr_empty(enum re_flags re_flags)
 {
 	struct ast_expr *res;
 
-	res = calloc(1, sizeof *res);
+	res = ast_expr_new();
 	if (res == NULL) {
 		return NULL;
 	}
@@ -485,7 +550,7 @@ ast_make_expr_concat(enum re_flags re_flags)
 {
 	struct ast_expr *res;
 
-	res = calloc(1, sizeof *res);
+	res = ast_expr_new();
 	if (res == NULL) {
 		return NULL;
 	}
@@ -497,7 +562,6 @@ ast_make_expr_concat(enum re_flags re_flags)
 
 	res->u.concat.n = malloc(res->u.concat.alloc * sizeof *res->u.concat.n);
 	if (res->u.concat.n == NULL) {
-		free(res);
 		return NULL;
 	}
 
@@ -533,7 +597,7 @@ ast_make_expr_alt(enum re_flags re_flags)
 {
 	struct ast_expr *res;
 
-	res = calloc(1, sizeof *res);
+	res = ast_expr_new();
 	if (res == NULL) {
 		return NULL;
 	}
@@ -545,7 +609,6 @@ ast_make_expr_alt(enum re_flags re_flags)
 
 	res->u.alt.n = malloc(res->u.alt.alloc * sizeof *res->u.alt.n);
 	if (res->u.alt.n == NULL) {
-		free(res);
 		return NULL;
 	}
 
@@ -581,7 +644,7 @@ ast_make_expr_literal(enum re_flags re_flags, char c)
 {
 	struct ast_expr *res;
 
-	res = calloc(1, sizeof *res);
+	res = ast_expr_new();
 	if (res == NULL) {
 		return NULL;
 	}
@@ -598,7 +661,7 @@ ast_make_expr_codepoint(enum re_flags re_flags, uint32_t u)
 {
 	struct ast_expr *res;
 
-	res = calloc(1, sizeof *res);
+	res = ast_expr_new();
 	if (res == NULL) {
 		return NULL;
 	}
@@ -622,7 +685,7 @@ ast_make_expr_repeat(enum re_flags re_flags, struct ast_expr *e, struct ast_coun
 		return NULL;
 	}
 
-	res = calloc(1, sizeof *res);
+	res = ast_expr_new();
 	if (res == NULL) {
 		return NULL;
 	}
@@ -641,7 +704,7 @@ ast_make_expr_group(enum re_flags re_flags, struct ast_expr *e)
 {
 	struct ast_expr *res;
 
-	res = calloc(1, sizeof *res);
+	res = ast_expr_new();
 	if (res == NULL) {
 		return NULL;
 	}
@@ -659,7 +722,7 @@ ast_make_expr_anchor(enum re_flags re_flags, enum ast_anchor_type type)
 {
 	struct ast_expr *res;
 
-	res = calloc(1, sizeof *res);
+	res = ast_expr_new();
 	if (res == NULL) {
 		return NULL;
 	}
@@ -676,7 +739,7 @@ ast_make_expr_subtract(enum re_flags re_flags, struct ast_expr *a, struct ast_ex
 {
 	struct ast_expr *res;
 
-	res = calloc(1, sizeof *res);
+	res = ast_expr_new();
 	if (res == NULL) {
 		return NULL;
 	}
@@ -696,7 +759,7 @@ ast_make_expr_range(enum re_flags re_flags,
 {
 	struct ast_expr *res;
 
-	res = calloc(1, sizeof *res);
+	res = ast_expr_new();
 	if (res == NULL) {
 		return NULL;
 	}
@@ -722,7 +785,7 @@ ast_make_expr_named(enum re_flags re_flags, const struct class *class)
 
 	assert(class != NULL);
 
-	res = calloc(1, sizeof *res);
+	res = ast_expr_new();
 	if (res == NULL) {
 		return NULL;
 	}
@@ -734,7 +797,6 @@ ast_make_expr_named(enum re_flags re_flags, const struct class *class)
 
 	res->u.alt.n = malloc(res->u.alt.alloc * sizeof *res->u.alt.n);
 	if (res->u.alt.n == NULL) {
-		free(res);
 		return NULL;
 	}
 

--- a/src/libre/ast.h
+++ b/src/libre/ast.h
@@ -221,7 +221,7 @@ void
 ast_expr_free(struct ast_expr *n);
 
 int
-ast_expr_clone(struct ast_expr **n);
+ast_expr_clone(struct ast_expr_pool **poolp, struct ast_expr **n);
 
 int
 ast_expr_cmp(const struct ast_expr *a, const struct ast_expr *b);

--- a/src/libre/ast.h
+++ b/src/libre/ast.h
@@ -174,7 +174,30 @@ struct ast_expr {
 	} u;
 };
 
+enum { AST_EXPR_POOL_SIZE = 64 };
+
+struct ast_expr_pool {
+	struct ast_expr_pool *next;
+	unsigned count;
+	struct ast_expr pool[AST_EXPR_POOL_SIZE];
+};
+
+struct ast_expr *
+ast_expr_pool_new(struct ast_expr_pool **poolp);
+
+void
+ast_pool_free(struct ast_expr_pool *pool);
+
+/* Returns current global expression pool, setting
+ * global to NULL.
+ *
+ * This is a hack.
+ */
+struct ast_expr_pool *
+ast_expr_pool_save(void);
+
 struct ast {
+	struct ast_expr_pool *pool;
 	struct ast_expr *expr;
 };
 

--- a/src/libre/ast.h
+++ b/src/libre/ast.h
@@ -177,9 +177,18 @@ struct ast_expr {
 enum { AST_EXPR_POOL_SIZE = 64 };
 
 struct ast_expr_pool {
+	struct {
+		struct ast_expr expr;
+
+#if defined(ASAN)
+		struct {
+			void *ptr[8]; /* force 8-byte alignment on amd64 */
+		} redzone;
+#endif
+	} pool[AST_EXPR_POOL_SIZE];
+
 	struct ast_expr_pool *next;
 	unsigned count;
-	struct ast_expr pool[AST_EXPR_POOL_SIZE];
 };
 
 struct ast_expr *

--- a/src/libre/ast.h
+++ b/src/libre/ast.h
@@ -233,45 +233,45 @@ int
 ast_contains_expr(const struct ast_expr *node, struct ast_expr * const *a, size_t n);
 
 struct ast_expr *
-ast_make_expr_empty(enum re_flags re_flags);
+ast_make_expr_empty(struct ast_expr_pool **poolp, enum re_flags re_flags);
 
 struct ast_expr *
-ast_make_expr_concat(enum re_flags re_flags);
+ast_make_expr_concat(struct ast_expr_pool **poolp, enum re_flags re_flags);
 
 struct ast_expr *
-ast_make_expr_alt(enum re_flags re_flags);
+ast_make_expr_alt(struct ast_expr_pool **poolp, enum re_flags re_flags);
 
 int
 ast_add_expr_alt(struct ast_expr *alt, struct ast_expr *node);
 
 struct ast_expr *
-ast_make_expr_literal(enum re_flags re_flags, char c);
+ast_make_expr_literal(struct ast_expr_pool **poolp, enum re_flags re_flags, char c);
 
 struct ast_expr *
-ast_make_expr_codepoint(enum re_flags re_flags, uint32_t u);
+ast_make_expr_codepoint(struct ast_expr_pool **poolp, enum re_flags re_flags, uint32_t u);
 
 struct ast_expr *
-ast_make_expr_repeat(enum re_flags re_flags, struct ast_expr *e, struct ast_count count);
+ast_make_expr_repeat(struct ast_expr_pool **poolp, enum re_flags re_flags, struct ast_expr *e, struct ast_count count);
 
 struct ast_expr *
-ast_make_expr_group(enum re_flags re_flags, struct ast_expr *e);
+ast_make_expr_group(struct ast_expr_pool **poolp, enum re_flags re_flags, struct ast_expr *e);
 
 struct ast_expr *
-ast_make_expr_anchor(enum re_flags re_flags, enum ast_anchor_type type);
+ast_make_expr_anchor(struct ast_expr_pool **poolp, enum re_flags re_flags, enum ast_anchor_type type);
 
 struct ast_expr *
-ast_make_expr_subtract(enum re_flags re_flags, struct ast_expr *a, struct ast_expr *b);
+ast_make_expr_subtract(struct ast_expr_pool **poolp, enum re_flags re_flags, struct ast_expr *a, struct ast_expr *b);
 
 int
 ast_add_expr_concat(struct ast_expr *cat, struct ast_expr *node);
 
 struct ast_expr *
-ast_make_expr_range(enum re_flags re_flags,
+ast_make_expr_range(struct ast_expr_pool **poolp, enum re_flags re_flags,
 	const struct ast_endpoint *from, struct ast_pos start,
 	const struct ast_endpoint *to, struct ast_pos end);
 
 struct ast_expr *
-ast_make_expr_named(enum re_flags re_flags, const struct class *class);
+ast_make_expr_named(struct ast_expr_pool **poolp, enum re_flags re_flags, const struct class *class);
 
 /* XXX: exposed for sake of re(1) printing an ast;
  * it's not part of the <re/re.h> API proper */

--- a/src/libre/ast_new_from_fsm.c
+++ b/src/libre/ast_new_from_fsm.c
@@ -306,7 +306,7 @@ remove_state(struct ast_expr_pool **poolp, struct rese *state)
 			}
 
 			tmp = p->expr;
-			if (!ast_expr_clone(&tmp)) {
+			if (!ast_expr_clone(poolp, &tmp)) {
 				ast_expr_free(cat);
 				return 0;
 			}
@@ -320,7 +320,7 @@ remove_state(struct ast_expr_pool **poolp, struct rese *state)
 			if (state->expr) {
 				struct ast_expr *rep;
 				tmp = state->expr;
-				if (!ast_expr_clone(&tmp)) {
+				if (!ast_expr_clone(poolp, &tmp)) {
 					ast_expr_free(cat);
 					return 0;
 				}
@@ -339,7 +339,7 @@ remove_state(struct ast_expr_pool **poolp, struct rese *state)
 			}
 
 			tmp = s->expr;
-			if (!ast_expr_clone(&tmp)) {
+			if (!ast_expr_clone(poolp, &tmp)) {
 				ast_expr_free(cat);
 				return 0;
 			}

--- a/src/libre/ast_new_from_fsm.c
+++ b/src/libre/ast_new_from_fsm.c
@@ -190,7 +190,7 @@ build_edge_literal(const struct fsm *fsm, fsm_state_t from, fsm_state_t to, char
 		return 0;
 
 	if (!build_edge_expr(fsm, from, to, expr, udata)) {
-		/* ast_expr_free(expr); */
+		ast_expr_free(expr);
 		return 0;
 	}
 
@@ -213,7 +213,7 @@ build_edge_epsilon(const struct fsm *fsm, fsm_state_t from, fsm_state_t to, void
 		return 0;
 
 	if (!build_edge_expr(fsm, from, to, expr, udata)) {
-		/* ast_expr_free(expr); */
+		ast_expr_free(expr);
 		return 0;
 	}
 

--- a/src/libre/ast_new_from_fsm.c
+++ b/src/libre/ast_new_from_fsm.c
@@ -13,8 +13,13 @@
 #include "ast.h"
 #include "ast_analysis.h"
 
+struct restates_opaque {
+	struct ast_expr_pool **poolp;
+	struct rese *states;
+};
+
 static int
-change_to_alt(struct ast_expr **n)
+change_to_alt(struct ast_expr_pool **poolp, struct ast_expr **n)
 {
 	struct ast_expr *alt;
 
@@ -24,7 +29,7 @@ change_to_alt(struct ast_expr **n)
 	if ((*n)->type == AST_EXPR_ALT)
 		return 1;
 
-	alt = ast_make_expr_alt(0);
+	alt = ast_make_expr_alt(poolp, 0);
 	if (!alt)
 		return 0;
 
@@ -141,15 +146,15 @@ build_reedge(struct rese *from, struct rese *to)
 }
 
 static int
-build_edge_expr(const struct fsm *fsm, fsm_state_t from, fsm_state_t to, struct ast_expr *expr, void *opaque)
+build_edge_expr(const struct fsm *fsm, fsm_state_t from, fsm_state_t to, struct ast_expr *expr, struct restates_opaque *udata)
 {
 	struct rese *restates, *reedge;
 
 	assert(fsm);
 	assert(expr);
-	assert(opaque);
+	assert(udata != NULL);
 
-	restates = opaque;
+	restates = udata->states;
 
 	reedge = build_reedge(&restates[from], &restates[to]);
 	if (!reedge)
@@ -160,7 +165,7 @@ build_edge_expr(const struct fsm *fsm, fsm_state_t from, fsm_state_t to, struct 
 		return 1;
 	}
 
-	if (!change_to_alt(&reedge->expr))
+	if (!change_to_alt(udata->poolp, &reedge->expr))
 		return 0;
 
 	if (!ast_add_expr_alt(reedge->expr, expr))
@@ -173,16 +178,19 @@ static int
 build_edge_literal(const struct fsm *fsm, fsm_state_t from, fsm_state_t to, char c, void *opaque)
 {
 	struct ast_expr *expr;
+	struct restates_opaque *udata;
 
 	assert(fsm);
 	assert(opaque);
 
-	expr = ast_make_expr_literal(0, c);
+	udata = opaque;
+
+	expr = ast_make_expr_literal(udata->poolp, 0, c);
 	if (!expr)
 		return 0;
 
-	if (!build_edge_expr(fsm, from, to, expr, opaque)) {
-		ast_expr_free(expr);
+	if (!build_edge_expr(fsm, from, to, expr, udata)) {
+		/* ast_expr_free(expr); */
 		return 0;
 	}
 
@@ -193,16 +201,19 @@ static int
 build_edge_epsilon(const struct fsm *fsm, fsm_state_t from, fsm_state_t to, void *opaque)
 {
 	struct ast_expr *expr;
+	struct restates_opaque *udata;
 
 	assert(fsm);
 	assert(opaque);
 
-	expr = ast_make_expr_empty(0);
+	udata = opaque;
+
+	expr = ast_make_expr_empty(udata->poolp, 0);
 	if (!expr)
 		return 0;
 
-	if (!build_edge_expr(fsm, from, to, expr, opaque)) {
-		ast_expr_free(expr);
+	if (!build_edge_expr(fsm, from, to, expr, udata)) {
+		/* ast_expr_free(expr); */
 		return 0;
 	}
 
@@ -251,7 +262,7 @@ free_restates(struct rese *states, unsigned int numstates)
 }
 
 static int
-remove_state(struct rese *state)
+remove_state(struct ast_expr_pool **poolp, struct rese *state)
 {
 	struct rese *p /*pred*/, *ps /*predsucc*/, *s /*succ*/;
 
@@ -289,7 +300,7 @@ remove_state(struct rese *state)
 			assert(p->expr);
 			assert(s->expr);
 
-			cat = ast_make_expr_concat(0);
+			cat = ast_make_expr_concat(poolp, 0);
 			if (!cat) {
 				return 0;
 			}
@@ -313,7 +324,7 @@ remove_state(struct rese *state)
 					ast_expr_free(cat);
 					return 0;
 				}
-				rep = ast_make_expr_repeat(0, tmp,
+				rep = ast_make_expr_repeat(poolp, 0, tmp,
 					ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL));
 				if (!rep) {
 					ast_expr_free(tmp);
@@ -341,7 +352,7 @@ remove_state(struct rese *state)
 			if (!e->expr) {
 				e->expr = cat;
 			} else {
-				if (!change_to_alt(&e->expr)) {
+				if (!change_to_alt(poolp, &e->expr)) {
 					ast_expr_free(cat);
 					return 0;
 				}
@@ -359,7 +370,7 @@ remove_state(struct rese *state)
 }
 
 static struct ast_expr *
-ast_expr_new_from_fsm(const struct fsm *fsm)
+ast_expr_new_from_fsm(struct ast_expr_pool **poolp, const struct fsm *fsm)
 {
 	struct ast_expr *expr;
 
@@ -367,6 +378,7 @@ ast_expr_new_from_fsm(const struct fsm *fsm)
 	fsm_state_t start;
 	struct rese *restates;
 	struct rese *restart, *reend;
+	struct restates_opaque opaque;
 
 	unsigned int i;
 
@@ -384,11 +396,14 @@ ast_expr_new_from_fsm(const struct fsm *fsm)
 	if (!restates)
 		return NULL;
 
+	opaque.states = restates;
+	opaque.poolp = poolp;
+
 	restart = &restates[start];
 	reend = &restates[numstates];
 
 	/* Copy FSM edges as RE edges */
-	if (!fsm_walk_edges(fsm, restates, build_edge_literal, build_edge_epsilon)) {
+	if (!fsm_walk_edges(fsm, &opaque, build_edge_literal, build_edge_epsilon)) {
 		free_restates(restates, numstates + 1);
 		return NULL;
 	}
@@ -410,7 +425,7 @@ ast_expr_new_from_fsm(const struct fsm *fsm)
 		if (i == start)
 			continue;
 
-		if (!remove_state(&restates[i])) {
+		if (!remove_state(poolp, &restates[i])) {
 			free_restates(restates, numstates + 1);
 			return NULL;
 		}
@@ -431,14 +446,14 @@ ast_expr_new_from_fsm(const struct fsm *fsm)
 	if (restart->expr) {
 		struct ast_expr *cat, *rep;
 
-		cat = ast_make_expr_concat(0);
+		cat = ast_make_expr_concat(poolp, 0);
 		if (!cat) {
 			free_restates(restates, numstates + 1);
 			return NULL;
 		}
 
 		rep = ast_make_expr_repeat(
-			0, restart->expr, ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL));
+			poolp, 0, restart->expr, ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL));
 		if (!rep) {
 			ast_expr_free(cat);
 			free_restates(restates, numstates + 1);
@@ -474,10 +489,11 @@ ast_new_from_fsm(const struct fsm *fsm)
 {
 	struct ast *ast;
 	struct ast_expr *expr;
+	struct ast_expr_pool *pool = NULL;
 
 	assert(fsm);
 
-	expr = ast_expr_new_from_fsm(fsm);
+	expr = ast_expr_new_from_fsm(&pool, fsm);
 	if (!expr)
 		return NULL;
 
@@ -488,6 +504,7 @@ ast_new_from_fsm(const struct fsm *fsm)
 	}
 
 	ast->expr = expr;
+	ast->pool = pool;
 
 	if (!ast_rewrite(ast, 0)) {
 		ast_free(ast);

--- a/src/libre/ast_new_from_fsm.c
+++ b/src/libre/ast_new_from_fsm.c
@@ -414,7 +414,7 @@ ast_expr_new_from_fsm(struct ast_expr_pool **poolp, const struct fsm *fsm)
 		if (!fsm_isend(fsm, i))
 			continue;
 
-		if (!build_edge_epsilon(fsm, i, numstates, restates)) {
+		if (!build_edge_epsilon(fsm, i, numstates, &opaque)) {
 			free_restates(restates, numstates + 1);
 			return NULL;
 		}

--- a/src/libre/ast_rewrite.c
+++ b/src/libre/ast_rewrite.c
@@ -228,6 +228,12 @@ empty:
 
 tombstone:
 
+	for (i = 0; i < n->u.concat.count; i++) {
+		ast_expr_free(n->u.concat.n[i]);
+	}
+
+	free(n->u.concat.n);
+
 	n->type = AST_EXPR_TOMBSTONE;
 
 	return 1;

--- a/src/libre/ast_rewrite.c
+++ b/src/libre/ast_rewrite.c
@@ -117,6 +117,7 @@ compile_subexpr(struct ast_expr *e, enum re_flags flags)
 static int
 rewrite_concat(struct ast_expr *n, enum re_flags flags)
 {
+	static const struct ast_expr zero;
 	size_t i;
 
 	assert(n != NULL);
@@ -209,10 +210,11 @@ rewrite_concat(struct ast_expr *n, enum re_flags flags)
 	}
 
 	if (n->u.concat.count == 1) {
-		void *p = n->u.concat.n, *q = n->u.concat.n[0];
-		*n = *n->u.concat.n[0];
+		void *p = n->u.concat.n;
+		struct ast_expr *q = n->u.concat.n[0];
+		*n = *q;
+		*q = zero;
 		free(p);
-		free(q);
 		return 1;
 	}
 
@@ -234,6 +236,7 @@ tombstone:
 static int
 rewrite_alt(struct ast_expr *n, enum re_flags flags)
 {
+	static const struct ast_expr zero;
 	size_t i;
 
 	assert(n != NULL);
@@ -310,10 +313,11 @@ rewrite_alt(struct ast_expr *n, enum re_flags flags)
 	}
 
 	if (n->u.alt.count == 1) {
-		void *p = n->u.alt.n, *q = n->u.alt.n[0];
-		*n = *n->u.alt.n[0];
+		void *p = n->u.alt.n;
+		struct ast_expr *q = n->u.alt.n[0];
+		*n = *q;
+		*q = zero;
 		free(p);
-		free(q);
 		return 1;
 	}
 

--- a/src/libre/dialect/comp.h
+++ b/src/libre/dialect/comp.h
@@ -16,6 +16,7 @@
 typedef struct ast *
 re_dialect_parse_fun(re_getchar_fun *getchar, void *opaque,
 	const struct fsm_options *opt,
+	struct ast_expr_pool **poolp,
 	enum re_flags flags, int overlap,
 	struct re_err *err);
 

--- a/src/libre/dialect/glob/parser.c
+++ b/src/libre/dialect/glob/parser.c
@@ -92,6 +92,8 @@
 	typedef struct ast_endpoint t_endpoint;
 
 	struct act_state {
+		struct ast_expr_pool **poolp;
+
 		enum LX_TOKEN lex_tok;
 		enum LX_TOKEN lex_tok_save;
 		int overlap; /* permit overlap in groups */
@@ -204,7 +206,7 @@
 		return s;
 	}
 
-#line 208 "src/libre/dialect/glob/parser.c"
+#line 210 "src/libre/dialect/glob/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -239,13 +241,13 @@ ZL2_list_Hof_Hatoms:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 825 "src/libre/parser.act"
+#line 827 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
 		}
 	
-#line 249 "src/libre/dialect/glob/parser.c"
+#line 251 "src/libre/dialect/glob/parser.c"
 		}
 		/* END OF ACTION: ast-add-concat */
 		/* BEGINNING OF INLINE: 100 */
@@ -283,24 +285,24 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: class-any */
 			{
-#line 567 "src/libre/parser.act"
+#line 569 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
 		(ZIa) = &class_any;
 	
-#line 292 "src/libre/dialect/glob/parser.c"
+#line 294 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 818 "src/libre/parser.act"
+#line 820 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_named(*flags, (ZIa));
+		(ZIe) = ast_make_expr_named(act_state->poolp, *flags, (ZIa));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 304 "src/libre/dialect/glob/parser.c"
+#line 306 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 		}
@@ -313,7 +315,7 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
-#line 405 "src/libre/parser.act"
+#line 407 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -323,20 +325,20 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 327 "src/libre/dialect/glob/parser.c"
+#line 329 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 677 "src/libre/parser.act"
+#line 679 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_literal(*flags, (ZIc));
+		(ZIe) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 340 "src/libre/dialect/glob/parser.c"
+#line 342 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -350,52 +352,52 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: class-any */
 			{
-#line 567 "src/libre/parser.act"
+#line 569 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
 		(ZIa) = &class_any;
 	
-#line 359 "src/libre/dialect/glob/parser.c"
+#line 361 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 818 "src/libre/parser.act"
+#line 820 "src/libre/parser.act"
 
-		(ZIg) = ast_make_expr_named(*flags, (ZIa));
+		(ZIg) = ast_make_expr_named(act_state->poolp, *flags, (ZIa));
 		if ((ZIg) == NULL) {
 			goto ZL1;
 		}
 	
-#line 371 "src/libre/dialect/glob/parser.c"
+#line 373 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 			/* BEGINNING OF ACTION: count-zero-or-more */
 			{
-#line 589 "src/libre/parser.act"
+#line 591 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 380 "src/libre/dialect/glob/parser.c"
+#line 382 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 			/* BEGINNING OF ACTION: ast-make-piece */
 			{
-#line 688 "src/libre/parser.act"
+#line 690 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
-			(ZIe) = ast_make_expr_empty(*flags);
+			(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
 		} else if ((ZIc).min == 1 && (ZIc).max == 1) {
 			(ZIe) = (ZIg);
 		} else {
-			(ZIe) = ast_make_expr_repeat(*flags, (ZIg), (ZIc));
+			(ZIe) = ast_make_expr_repeat(act_state->poolp, *flags, (ZIg), (ZIc));
 		}
 		if ((ZIe) == NULL) {
 			err->e = RE_EXEOF;
 			goto ZL1;
 		}
 	
-#line 399 "src/libre/dialect/glob/parser.c"
+#line 401 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: ast-make-piece */
 		}
@@ -410,26 +412,26 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-atom */
 		{
-#line 474 "src/libre/parser.act"
+#line 476 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXATOM;
 		}
 		goto ZL2;
 	
-#line 421 "src/libre/dialect/glob/parser.c"
+#line 423 "src/libre/dialect/glob/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 656 "src/libre/parser.act"
+#line 658 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_empty(*flags);
+		(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZIe) == NULL) {
 			goto ZL2;
 		}
 	
-#line 433 "src/libre/dialect/glob/parser.c"
+#line 435 "src/libre/dialect/glob/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -457,14 +459,14 @@ p_re__glob(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 				{
 					/* BEGINNING OF ACTION: ast-make-concat */
 					{
-#line 663 "src/libre/parser.act"
+#line 665 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_concat(*flags);
+		(ZInode) = ast_make_expr_concat(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 468 "src/libre/dialect/glob/parser.c"
+#line 470 "src/libre/dialect/glob/parser.c"
 					}
 					/* END OF ACTION: ast-make-concat */
 					p_list_Hof_Hatoms (flags, lex_state, act_state, err, ZInode);
@@ -478,14 +480,14 @@ p_re__glob(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 				{
 					/* BEGINNING OF ACTION: ast-make-empty */
 					{
-#line 656 "src/libre/parser.act"
+#line 658 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_empty(*flags);
+		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 489 "src/libre/dialect/glob/parser.c"
+#line 491 "src/libre/dialect/glob/parser.c"
 					}
 					/* END OF ACTION: ast-make-empty */
 				}
@@ -509,14 +511,14 @@ p_re__glob(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 523 "src/libre/parser.act"
+#line 525 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
 		}
 		goto ZL1;
 	
-#line 520 "src/libre/dialect/glob/parser.c"
+#line 522 "src/libre/dialect/glob/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
@@ -534,7 +536,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 837 "src/libre/parser.act"
+#line 839 "src/libre/parser.act"
 
 
 	static int
@@ -555,6 +557,7 @@ ZL0:;
 	struct ast *
 	DIALECT_PARSE(re_getchar_fun *f, void *opaque,
 		const struct fsm_options *opt,
+		struct ast_expr_pool **poolp,
 		enum re_flags flags, int overlap,
 		struct re_err *err)
 	{
@@ -603,6 +606,7 @@ ZL0:;
 		act_state = &act_state_s;
 
 		act_state->overlap = overlap;
+		act_state->poolp   = poolp;
 
 		err->e = RE_ESUCCESS;
 
@@ -674,6 +678,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 678 "src/libre/dialect/glob/parser.c"
+#line 682 "src/libre/dialect/glob/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/glob/parser.h
+++ b/src/libre/dialect/glob/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 216 "src/libre/parser.act"
+#line 218 "src/libre/parser.act"
 
 
 	#include <re/re.h>
@@ -28,7 +28,7 @@
 extern void p_re__glob(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 976 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/glob/parser.h"

--- a/src/libre/dialect/like/parser.c
+++ b/src/libre/dialect/like/parser.c
@@ -92,6 +92,8 @@
 	typedef struct ast_endpoint t_endpoint;
 
 	struct act_state {
+		struct ast_expr_pool **poolp;
+
 		enum LX_TOKEN lex_tok;
 		enum LX_TOKEN lex_tok_save;
 		int overlap; /* permit overlap in groups */
@@ -204,7 +206,7 @@
 		return s;
 	}
 
-#line 208 "src/libre/dialect/like/parser.c"
+#line 210 "src/libre/dialect/like/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -239,13 +241,13 @@ ZL2_list_Hof_Hatoms:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 825 "src/libre/parser.act"
+#line 827 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
 		}
 	
-#line 249 "src/libre/dialect/like/parser.c"
+#line 251 "src/libre/dialect/like/parser.c"
 		}
 		/* END OF ACTION: ast-add-concat */
 		/* BEGINNING OF INLINE: 100 */
@@ -283,24 +285,24 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: class-any */
 			{
-#line 567 "src/libre/parser.act"
+#line 569 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
 		(ZIa) = &class_any;
 	
-#line 292 "src/libre/dialect/like/parser.c"
+#line 294 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 818 "src/libre/parser.act"
+#line 820 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_named(*flags, (ZIa));
+		(ZIe) = ast_make_expr_named(act_state->poolp, *flags, (ZIa));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 304 "src/libre/dialect/like/parser.c"
+#line 306 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 		}
@@ -313,7 +315,7 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
-#line 405 "src/libre/parser.act"
+#line 407 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -323,20 +325,20 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 327 "src/libre/dialect/like/parser.c"
+#line 329 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 677 "src/libre/parser.act"
+#line 679 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_literal(*flags, (ZIc));
+		(ZIe) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 340 "src/libre/dialect/like/parser.c"
+#line 342 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -350,52 +352,52 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: class-any */
 			{
-#line 567 "src/libre/parser.act"
+#line 569 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
 		(ZIa) = &class_any;
 	
-#line 359 "src/libre/dialect/like/parser.c"
+#line 361 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 818 "src/libre/parser.act"
+#line 820 "src/libre/parser.act"
 
-		(ZIg) = ast_make_expr_named(*flags, (ZIa));
+		(ZIg) = ast_make_expr_named(act_state->poolp, *flags, (ZIa));
 		if ((ZIg) == NULL) {
 			goto ZL1;
 		}
 	
-#line 371 "src/libre/dialect/like/parser.c"
+#line 373 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 			/* BEGINNING OF ACTION: count-zero-or-more */
 			{
-#line 589 "src/libre/parser.act"
+#line 591 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 380 "src/libre/dialect/like/parser.c"
+#line 382 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 			/* BEGINNING OF ACTION: ast-make-piece */
 			{
-#line 688 "src/libre/parser.act"
+#line 690 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
-			(ZIe) = ast_make_expr_empty(*flags);
+			(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
 		} else if ((ZIc).min == 1 && (ZIc).max == 1) {
 			(ZIe) = (ZIg);
 		} else {
-			(ZIe) = ast_make_expr_repeat(*flags, (ZIg), (ZIc));
+			(ZIe) = ast_make_expr_repeat(act_state->poolp, *flags, (ZIg), (ZIc));
 		}
 		if ((ZIe) == NULL) {
 			err->e = RE_EXEOF;
 			goto ZL1;
 		}
 	
-#line 399 "src/libre/dialect/like/parser.c"
+#line 401 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: ast-make-piece */
 		}
@@ -410,26 +412,26 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-atom */
 		{
-#line 474 "src/libre/parser.act"
+#line 476 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXATOM;
 		}
 		goto ZL2;
 	
-#line 421 "src/libre/dialect/like/parser.c"
+#line 423 "src/libre/dialect/like/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 656 "src/libre/parser.act"
+#line 658 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_empty(*flags);
+		(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZIe) == NULL) {
 			goto ZL2;
 		}
 	
-#line 433 "src/libre/dialect/like/parser.c"
+#line 435 "src/libre/dialect/like/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -457,14 +459,14 @@ p_re__like(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 				{
 					/* BEGINNING OF ACTION: ast-make-concat */
 					{
-#line 663 "src/libre/parser.act"
+#line 665 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_concat(*flags);
+		(ZInode) = ast_make_expr_concat(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 468 "src/libre/dialect/like/parser.c"
+#line 470 "src/libre/dialect/like/parser.c"
 					}
 					/* END OF ACTION: ast-make-concat */
 					p_list_Hof_Hatoms (flags, lex_state, act_state, err, ZInode);
@@ -478,14 +480,14 @@ p_re__like(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 				{
 					/* BEGINNING OF ACTION: ast-make-empty */
 					{
-#line 656 "src/libre/parser.act"
+#line 658 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_empty(*flags);
+		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 489 "src/libre/dialect/like/parser.c"
+#line 491 "src/libre/dialect/like/parser.c"
 					}
 					/* END OF ACTION: ast-make-empty */
 				}
@@ -509,14 +511,14 @@ p_re__like(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 523 "src/libre/parser.act"
+#line 525 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
 		}
 		goto ZL1;
 	
-#line 520 "src/libre/dialect/like/parser.c"
+#line 522 "src/libre/dialect/like/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
@@ -534,7 +536,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 837 "src/libre/parser.act"
+#line 839 "src/libre/parser.act"
 
 
 	static int
@@ -555,6 +557,7 @@ ZL0:;
 	struct ast *
 	DIALECT_PARSE(re_getchar_fun *f, void *opaque,
 		const struct fsm_options *opt,
+		struct ast_expr_pool **poolp,
 		enum re_flags flags, int overlap,
 		struct re_err *err)
 	{
@@ -603,6 +606,7 @@ ZL0:;
 		act_state = &act_state_s;
 
 		act_state->overlap = overlap;
+		act_state->poolp   = poolp;
 
 		err->e = RE_ESUCCESS;
 
@@ -674,6 +678,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 678 "src/libre/dialect/like/parser.c"
+#line 682 "src/libre/dialect/like/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/like/parser.h
+++ b/src/libre/dialect/like/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 216 "src/libre/parser.act"
+#line 218 "src/libre/parser.act"
 
 
 	#include <re/re.h>
@@ -28,7 +28,7 @@
 extern void p_re__like(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 976 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/like/parser.h"

--- a/src/libre/dialect/literal/parser.c
+++ b/src/libre/dialect/literal/parser.c
@@ -92,6 +92,8 @@
 	typedef struct ast_endpoint t_endpoint;
 
 	struct act_state {
+		struct ast_expr_pool **poolp;
+
 		enum LX_TOKEN lex_tok;
 		enum LX_TOKEN lex_tok_save;
 		int overlap; /* permit overlap in groups */
@@ -204,7 +206,7 @@
 		return s;
 	}
 
-#line 208 "src/libre/dialect/literal/parser.c"
+#line 210 "src/libre/dialect/literal/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -239,13 +241,13 @@ ZL2_list_Hof_Hatoms:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 825 "src/libre/parser.act"
+#line 827 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
 		}
 	
-#line 249 "src/libre/dialect/literal/parser.c"
+#line 251 "src/libre/dialect/literal/parser.c"
 		}
 		/* END OF ACTION: ast-add-concat */
 		/* BEGINNING OF INLINE: 99 */
@@ -286,14 +288,14 @@ p_re__literal(flags flags, lex_state lex_state, act_state act_state, err err, t_
 				{
 					/* BEGINNING OF ACTION: ast-make-concat */
 					{
-#line 663 "src/libre/parser.act"
+#line 665 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_concat(*flags);
+		(ZInode) = ast_make_expr_concat(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 297 "src/libre/dialect/literal/parser.c"
+#line 299 "src/libre/dialect/literal/parser.c"
 					}
 					/* END OF ACTION: ast-make-concat */
 					p_list_Hof_Hatoms (flags, lex_state, act_state, err, ZInode);
@@ -307,14 +309,14 @@ p_re__literal(flags flags, lex_state lex_state, act_state act_state, err err, t_
 				{
 					/* BEGINNING OF ACTION: ast-make-empty */
 					{
-#line 656 "src/libre/parser.act"
+#line 658 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_empty(*flags);
+		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 318 "src/libre/dialect/literal/parser.c"
+#line 320 "src/libre/dialect/literal/parser.c"
 					}
 					/* END OF ACTION: ast-make-empty */
 				}
@@ -338,14 +340,14 @@ p_re__literal(flags flags, lex_state lex_state, act_state act_state, err err, t_
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 523 "src/libre/parser.act"
+#line 525 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
 		}
 		goto ZL1;
 	
-#line 349 "src/libre/dialect/literal/parser.c"
+#line 351 "src/libre/dialect/literal/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
@@ -378,7 +380,7 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 		case (TOK_CHAR):
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
-#line 405 "src/libre/parser.act"
+#line 407 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -388,7 +390,7 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 392 "src/libre/dialect/literal/parser.c"
+#line 394 "src/libre/dialect/literal/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			break;
@@ -398,14 +400,14 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-make-literal */
 		{
-#line 677 "src/libre/parser.act"
+#line 679 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_literal(*flags, (ZIc));
+		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 409 "src/libre/dialect/literal/parser.c"
+#line 411 "src/libre/dialect/literal/parser.c"
 		}
 		/* END OF ACTION: ast-make-literal */
 	}
@@ -414,26 +416,26 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-atom */
 		{
-#line 474 "src/libre/parser.act"
+#line 476 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXATOM;
 		}
 		goto ZL2;
 	
-#line 425 "src/libre/dialect/literal/parser.c"
+#line 427 "src/libre/dialect/literal/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 656 "src/libre/parser.act"
+#line 658 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_empty(*flags);
+		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL2;
 		}
 	
-#line 437 "src/libre/dialect/literal/parser.c"
+#line 439 "src/libre/dialect/literal/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -447,7 +449,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 837 "src/libre/parser.act"
+#line 839 "src/libre/parser.act"
 
 
 	static int
@@ -468,6 +470,7 @@ ZL0:;
 	struct ast *
 	DIALECT_PARSE(re_getchar_fun *f, void *opaque,
 		const struct fsm_options *opt,
+		struct ast_expr_pool **poolp,
 		enum re_flags flags, int overlap,
 		struct re_err *err)
 	{
@@ -516,6 +519,7 @@ ZL0:;
 		act_state = &act_state_s;
 
 		act_state->overlap = overlap;
+		act_state->poolp   = poolp;
 
 		err->e = RE_ESUCCESS;
 
@@ -587,6 +591,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 591 "src/libre/dialect/literal/parser.c"
+#line 595 "src/libre/dialect/literal/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/literal/parser.h
+++ b/src/libre/dialect/literal/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 216 "src/libre/parser.act"
+#line 218 "src/libre/parser.act"
 
 
 	#include <re/re.h>
@@ -28,7 +28,7 @@
 extern void p_re__literal(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 976 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/literal/parser.h"

--- a/src/libre/dialect/native/parser.c
+++ b/src/libre/dialect/native/parser.c
@@ -92,6 +92,8 @@
 	typedef struct ast_endpoint t_endpoint;
 
 	struct act_state {
+		struct ast_expr_pool **poolp;
+
 		enum LX_TOKEN lex_tok;
 		enum LX_TOKEN lex_tok_save;
 		int overlap; /* permit overlap in groups */
@@ -204,7 +206,7 @@
 		return s;
 	}
 
-#line 208 "src/libre/dialect/native/parser.c"
+#line 210 "src/libre/dialect/native/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -245,17 +247,17 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: INVERT */
 			{
-#line 231 "src/libre/parser.act"
+#line 233 "src/libre/parser.act"
 
 		ZI109 = '^';
 	
-#line 253 "src/libre/dialect/native/parser.c"
+#line 255 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: INVERT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-invert */
 			{
-#line 747 "src/libre/parser.act"
+#line 749 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -283,17 +285,17 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead(flags flags, lex_state lex_state, act_
 		 * a better idea.
 		 */
 
-		any = ast_make_expr_named(*flags, &class_any);
+		any = ast_make_expr_named(act_state->poolp, *flags, &class_any);
 		if (any == NULL) {
 			goto ZL1;
 		}
 
-		(*ZIclass) = ast_make_expr_subtract(*flags, any, (*ZIclass));
+		(*ZIclass) = ast_make_expr_subtract(act_state->poolp, *flags, any, (*ZIclass));
 		if ((*ZIclass) == NULL) {
 			goto ZL1;
 		}
 	
-#line 297 "src/libre/dialect/native/parser.c"
+#line 299 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-invert */
 		}
@@ -329,13 +331,13 @@ ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 				}
 				/* BEGINNING OF ACTION: ast-add-alt */
 				{
-#line 831 "src/libre/parser.act"
+#line 833 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIclass), (ZInode))) {
 			goto ZL4;
 		}
 	
-#line 339 "src/libre/dialect/native/parser.c"
+#line 341 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF ACTION: ast-add-alt */
 			}
@@ -344,14 +346,14 @@ ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 			{
 				/* BEGINNING OF ACTION: err-expected-term */
 				{
-#line 460 "src/libre/parser.act"
+#line 462 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXTERM;
 		}
 		goto ZL1;
 	
-#line 355 "src/libre/dialect/native/parser.c"
+#line 357 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF ACTION: err-expected-term */
 			}
@@ -398,13 +400,13 @@ ZL2_expr_C_Clist_Hof_Hpieces:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 825 "src/libre/parser.act"
+#line 827 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
 		}
 	
-#line 408 "src/libre/dialect/native/parser.c"
+#line 410 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-add-concat */
 		/* BEGINNING OF INLINE: 179 */
@@ -452,7 +454,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
-#line 405 "src/libre/parser.act"
+#line 407 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -462,7 +464,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 466 "src/libre/dialect/native/parser.c"
+#line 468 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: CHAR */
 					ADVANCE_LEXER;
@@ -475,7 +477,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 					/* BEGINNING OF EXTRACT: ESC */
 					{
-#line 277 "src/libre/parser.act"
+#line 279 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -496,7 +498,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		ZI96 = lex_state->lx.start;
 		ZI97   = lex_state->lx.end;
 	
-#line 500 "src/libre/dialect/native/parser.c"
+#line 502 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: ESC */
 					ADVANCE_LEXER;
@@ -509,7 +511,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 					/* BEGINNING OF EXTRACT: HEX */
 					{
-#line 365 "src/libre/parser.act"
+#line 367 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -549,7 +551,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 553 "src/libre/dialect/native/parser.c"
+#line 555 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: HEX */
 					ADVANCE_LEXER;
@@ -562,7 +564,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 					/* BEGINNING OF EXTRACT: OCT */
 					{
-#line 325 "src/libre/parser.act"
+#line 327 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -602,7 +604,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 606 "src/libre/dialect/native/parser.c"
+#line 608 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: OCT */
 					ADVANCE_LEXER;
@@ -615,14 +617,14 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		/* END OF INLINE: 94 */
 		/* BEGINNING OF ACTION: ast-make-literal */
 		{
-#line 677 "src/libre/parser.act"
+#line 679 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_literal(*flags, (ZIc));
+		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 626 "src/libre/dialect/native/parser.c"
+#line 628 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-make-literal */
 	}
@@ -648,7 +650,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
-#line 405 "src/libre/parser.act"
+#line 407 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -658,7 +660,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 		ZI212 = lex_state->buf.a[0];
 	
-#line 662 "src/libre/dialect/native/parser.c"
+#line 664 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
@@ -677,7 +679,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: ESC */
 			{
-#line 277 "src/libre/parser.act"
+#line 279 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -698,7 +700,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		ZI201 = lex_state->lx.start;
 		ZI202   = lex_state->lx.end;
 	
-#line 702 "src/libre/dialect/native/parser.c"
+#line 704 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: ESC */
 			ADVANCE_LEXER;
@@ -717,7 +719,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: HEX */
 			{
-#line 365 "src/libre/parser.act"
+#line 367 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -757,7 +759,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 		ZI208 = (char) (unsigned char) u;
 	
-#line 761 "src/libre/dialect/native/parser.c"
+#line 763 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: HEX */
 			ADVANCE_LEXER;
@@ -776,7 +778,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: OCT */
 			{
-#line 325 "src/libre/parser.act"
+#line 327 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -816,7 +818,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 		ZI204 = (char) (unsigned char) u;
 	
-#line 820 "src/libre/dialect/native/parser.c"
+#line 822 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: OCT */
 			ADVANCE_LEXER;
@@ -867,12 +869,12 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		case (TOK_OPENGROUP):
 			/* BEGINNING OF EXTRACT: OPENGROUP */
 			{
-#line 241 "src/libre/parser.act"
+#line 243 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
 		ZI155   = lex_state->lx.end;
 	
-#line 876 "src/libre/dialect/native/parser.c"
+#line 878 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: OPENGROUP */
 			break;
@@ -882,14 +884,14 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-make-alt */
 		{
-#line 670 "src/libre/parser.act"
+#line 672 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_alt(*flags);
+		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 893 "src/libre/dialect/native/parser.c"
+#line 895 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-make-alt */
 		ZItmp = ZInode;
@@ -909,13 +911,13 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 				case (TOK_CLOSEGROUP):
 					/* BEGINNING OF EXTRACT: CLOSEGROUP */
 					{
-#line 261 "src/libre/parser.act"
+#line 263 "src/libre/parser.act"
 
 		ZI159 = ']';
 		ZI160 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 919 "src/libre/dialect/native/parser.c"
+#line 921 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: CLOSEGROUP */
 					break;
@@ -925,12 +927,12 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 				ADVANCE_LEXER;
 				/* BEGINNING OF ACTION: mark-group */
 				{
-#line 537 "src/libre/parser.act"
+#line 539 "src/libre/parser.act"
 
 		mark(&act_state->groupstart, &(ZIstart));
 		mark(&act_state->groupend,   &(ZIend));
 	
-#line 934 "src/libre/dialect/native/parser.c"
+#line 936 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF ACTION: mark-group */
 			}
@@ -939,14 +941,14 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			{
 				/* BEGINNING OF ACTION: err-expected-closegroup */
 				{
-#line 495 "src/libre/parser.act"
+#line 497 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCLOSEGROUP;
 		}
 		goto ZL1;
 	
-#line 950 "src/libre/dialect/native/parser.c"
+#line 952 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF ACTION: err-expected-closegroup */
 				ZIend = ZIstart;
@@ -956,7 +958,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		/* END OF INLINE: 158 */
 		/* BEGINNING OF ACTION: mark-expr */
 		{
-#line 552 "src/libre/parser.act"
+#line 554 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -971,7 +973,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		(ZItmp)->u.class.end   = ast_end;
 */
 	
-#line 975 "src/libre/dialect/native/parser.c"
+#line 977 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: mark-expr */
 	}
@@ -1003,21 +1005,21 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 		}
 		/* BEGINNING OF ACTION: ast-make-piece */
 		{
-#line 688 "src/libre/parser.act"
+#line 690 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
-			(ZInode) = ast_make_expr_empty(*flags);
+			(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		} else if ((ZIc).min == 1 && (ZIc).max == 1) {
 			(ZInode) = (ZIe);
 		} else {
-			(ZInode) = ast_make_expr_repeat(*flags, (ZIe), (ZIc));
+			(ZInode) = ast_make_expr_repeat(act_state->poolp, *flags, (ZIe), (ZIc));
 		}
 		if ((ZInode) == NULL) {
 			err->e = RE_EXEOF;
 			goto ZL1;
 		}
 	
-#line 1021 "src/libre/dialect/native/parser.c"
+#line 1023 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-make-piece */
 	}
@@ -1041,14 +1043,14 @@ p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__ex
 		{
 			/* BEGINNING OF ACTION: ast-make-alt */
 			{
-#line 670 "src/libre/parser.act"
+#line 672 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_alt(*flags);
+		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1052 "src/libre/dialect/native/parser.c"
+#line 1054 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-alt */
 			p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, ZInode);
@@ -1062,14 +1064,14 @@ p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__ex
 		{
 			/* BEGINNING OF ACTION: ast-make-empty */
 			{
-#line 656 "src/libre/parser.act"
+#line 658 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_empty(*flags);
+		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1073 "src/libre/dialect/native/parser.c"
+#line 1075 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-empty */
 		}
@@ -1082,26 +1084,26 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-alts */
 		{
-#line 481 "src/libre/parser.act"
+#line 483 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXALTS;
 		}
 		goto ZL2;
 	
-#line 1093 "src/libre/dialect/native/parser.c"
+#line 1095 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 656 "src/libre/parser.act"
+#line 658 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_empty(*flags);
+		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL2;
 		}
 	
-#line 1105 "src/libre/dialect/native/parser.c"
+#line 1107 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -1149,14 +1151,14 @@ p_re__native(flags flags, lex_state lex_state, act_state act_state, err err, t_a
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 523 "src/libre/parser.act"
+#line 525 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
 		}
 		goto ZL1;
 	
-#line 1160 "src/libre/dialect/native/parser.c"
+#line 1162 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
@@ -1182,14 +1184,14 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		{
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 677 "src/libre/parser.act"
+#line 679 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_literal(*flags, (*ZI212));
+		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (*ZI212));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1193 "src/libre/dialect/native/parser.c"
+#line 1195 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -1203,12 +1205,12 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 625 "src/libre/parser.act"
+#line 627 "src/libre/parser.act"
 
 		(ZIa).type = AST_ENDPOINT_LITERAL;
 		(ZIa).u.literal.c = (*ZI212);
 	
-#line 1212 "src/libre/dialect/native/parser.c"
+#line 1214 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF INLINE: 131 */
@@ -1222,13 +1224,13 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 					case (TOK_RANGE):
 						/* BEGINNING OF EXTRACT: RANGE */
 						{
-#line 235 "src/libre/parser.act"
+#line 237 "src/libre/parser.act"
 
 		ZI132 = '-';
 		ZI133 = lex_state->lx.start;
 		ZI134   = lex_state->lx.end;
 	
-#line 1232 "src/libre/dialect/native/parser.c"
+#line 1234 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF EXTRACT: RANGE */
 						break;
@@ -1242,14 +1244,14 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 				{
 					/* BEGINNING OF ACTION: err-expected-range */
 					{
-#line 488 "src/libre/parser.act"
+#line 490 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXRANGE;
 		}
 		goto ZL1;
 	
-#line 1253 "src/libre/dialect/native/parser.c"
+#line 1255 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: err-expected-range */
 				}
@@ -1265,7 +1267,7 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 						/* BEGINNING OF EXTRACT: CHAR */
 						{
-#line 405 "src/libre/parser.act"
+#line 407 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -1275,7 +1277,7 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 		ZIcz = lex_state->buf.a[0];
 	
-#line 1279 "src/libre/dialect/native/parser.c"
+#line 1281 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF EXTRACT: CHAR */
 						ADVANCE_LEXER;
@@ -1287,7 +1289,7 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 						/* BEGINNING OF EXTRACT: ESC */
 						{
-#line 277 "src/libre/parser.act"
+#line 279 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -1308,7 +1310,7 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		ZI137 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1312 "src/libre/dialect/native/parser.c"
+#line 1314 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF EXTRACT: ESC */
 						ADVANCE_LEXER;
@@ -1320,7 +1322,7 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 						/* BEGINNING OF EXTRACT: HEX */
 						{
-#line 365 "src/libre/parser.act"
+#line 367 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -1360,7 +1362,7 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 		ZIcz = (char) (unsigned char) u;
 	
-#line 1364 "src/libre/dialect/native/parser.c"
+#line 1366 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF EXTRACT: HEX */
 						ADVANCE_LEXER;
@@ -1372,7 +1374,7 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 						/* BEGINNING OF EXTRACT: OCT */
 						{
-#line 325 "src/libre/parser.act"
+#line 327 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -1412,7 +1414,7 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 		ZIcz = (char) (unsigned char) u;
 	
-#line 1416 "src/libre/dialect/native/parser.c"
+#line 1418 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF EXTRACT: OCT */
 						ADVANCE_LEXER;
@@ -1424,13 +1426,13 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 						/* BEGINNING OF EXTRACT: RANGE */
 						{
-#line 235 "src/libre/parser.act"
+#line 237 "src/libre/parser.act"
 
 		ZIcz = '-';
 		ZI142 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1434 "src/libre/dialect/native/parser.c"
+#line 1436 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF EXTRACT: RANGE */
 						ADVANCE_LEXER;
@@ -1443,27 +1445,27 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			/* END OF INLINE: 135 */
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 625 "src/libre/parser.act"
+#line 627 "src/libre/parser.act"
 
 		(ZIz).type = AST_ENDPOINT_LITERAL;
 		(ZIz).u.literal.c = (ZIcz);
 	
-#line 1452 "src/libre/dialect/native/parser.c"
+#line 1454 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF ACTION: mark-range */
 			{
-#line 542 "src/libre/parser.act"
+#line 544 "src/libre/parser.act"
 
 		mark(&act_state->rangestart, &(*ZI213));
 		mark(&act_state->rangeend,   &(ZIend));
 	
-#line 1462 "src/libre/dialect/native/parser.c"
+#line 1464 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-range-distinct */
 			{
-#line 635 "src/libre/parser.act"
+#line 637 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -1480,12 +1482,12 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			goto ZL1;
 		}
 	
-#line 1484 "src/libre/dialect/native/parser.c"
+#line 1486 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-range-distinct */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 785 "src/libre/parser.act"
+#line 787 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -1513,12 +1515,12 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			goto ZL1;
 		}
 
-		(ZInode) = ast_make_expr_range(*flags, &(ZIa), ast_start, &(ZIz), ast_end);
+		(ZInode) = ast_make_expr_range(act_state->poolp, *flags, &(ZIa), ast_start, &(ZIz), ast_end);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1522 "src/libre/dialect/native/parser.c"
+#line 1524 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -1547,28 +1549,28 @@ p_218(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 
 			/* BEGINNING OF EXTRACT: CLOSECOUNT */
 			{
-#line 272 "src/libre/parser.act"
+#line 274 "src/libre/parser.act"
 
 		ZI172 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1556 "src/libre/dialect/native/parser.c"
+#line 1558 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: CLOSECOUNT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 547 "src/libre/parser.act"
+#line 549 "src/libre/parser.act"
 
 		mark(&act_state->countstart, &(*ZI216));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 1567 "src/libre/dialect/native/parser.c"
+#line 1569 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 605 "src/libre/parser.act"
+#line 607 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -1588,7 +1590,7 @@ p_218(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (*ZIm), &ast_end);
 	
-#line 1592 "src/libre/dialect/native/parser.c"
+#line 1594 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: count-range */
 		}
@@ -1604,7 +1606,7 @@ p_218(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			case (TOK_COUNT):
 				/* BEGINNING OF EXTRACT: COUNT */
 				{
-#line 415 "src/libre/parser.act"
+#line 417 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -1624,7 +1626,7 @@ p_218(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 
 		ZIn = (unsigned int) u;
 	
-#line 1628 "src/libre/dialect/native/parser.c"
+#line 1630 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -1636,12 +1638,12 @@ p_218(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			case (TOK_CLOSECOUNT):
 				/* BEGINNING OF EXTRACT: CLOSECOUNT */
 				{
-#line 272 "src/libre/parser.act"
+#line 274 "src/libre/parser.act"
 
 		ZI175 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1645 "src/libre/dialect/native/parser.c"
+#line 1647 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF EXTRACT: CLOSECOUNT */
 				break;
@@ -1651,17 +1653,17 @@ p_218(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 547 "src/libre/parser.act"
+#line 549 "src/libre/parser.act"
 
 		mark(&act_state->countstart, &(*ZI216));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 1660 "src/libre/dialect/native/parser.c"
+#line 1662 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 605 "src/libre/parser.act"
+#line 607 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -1681,7 +1683,7 @@ p_218(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (ZIn), &ast_end);
 	
-#line 1685 "src/libre/dialect/native/parser.c"
+#line 1687 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: count-range */
 		}
@@ -1716,13 +1718,13 @@ ZL2_expr_C_Clist_Hof_Halts:;
 		}
 		/* BEGINNING OF ACTION: ast-add-alt */
 		{
-#line 831 "src/libre/parser.act"
+#line 833 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIalts), (ZIa))) {
 			goto ZL1;
 		}
 	
-#line 1726 "src/libre/dialect/native/parser.c"
+#line 1728 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-add-alt */
 		/* BEGINNING OF INLINE: 185 */
@@ -1747,14 +1749,14 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-alts */
 		{
-#line 481 "src/libre/parser.act"
+#line 483 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXALTS;
 		}
 		goto ZL4;
 	
-#line 1758 "src/libre/dialect/native/parser.c"
+#line 1760 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
 	}
@@ -1779,12 +1781,12 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 			/* BEGINNING OF EXTRACT: OPENCOUNT */
 			{
-#line 267 "src/libre/parser.act"
+#line 269 "src/libre/parser.act"
 
 		ZI216 = lex_state->lx.start;
 		ZI217   = lex_state->lx.end;
 	
-#line 1788 "src/libre/dialect/native/parser.c"
+#line 1790 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: OPENCOUNT */
 			ADVANCE_LEXER;
@@ -1792,7 +1794,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			case (TOK_COUNT):
 				/* BEGINNING OF EXTRACT: COUNT */
 				{
-#line 415 "src/libre/parser.act"
+#line 417 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -1812,7 +1814,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		ZIm = (unsigned int) u;
 	
-#line 1816 "src/libre/dialect/native/parser.c"
+#line 1818 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -1832,11 +1834,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-zero-or-one */
 			{
-#line 597 "src/libre/parser.act"
+#line 599 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, 1, NULL);
 	
-#line 1840 "src/libre/dialect/native/parser.c"
+#line 1842 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-one */
 		}
@@ -1846,11 +1848,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-one-or-more */
 			{
-#line 593 "src/libre/parser.act"
+#line 595 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 1854 "src/libre/dialect/native/parser.c"
+#line 1856 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: count-one-or-more */
 		}
@@ -1860,11 +1862,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-zero-or-more */
 			{
-#line 589 "src/libre/parser.act"
+#line 591 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 1868 "src/libre/dialect/native/parser.c"
+#line 1870 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 		}
@@ -1873,11 +1875,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 		{
 			/* BEGINNING OF ACTION: count-one */
 			{
-#line 601 "src/libre/parser.act"
+#line 603 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 1881 "src/libre/dialect/native/parser.c"
+#line 1883 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: count-one */
 		}
@@ -1890,23 +1892,23 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-count */
 		{
-#line 467 "src/libre/parser.act"
+#line 469 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCOUNT;
 		}
 		goto ZL2;
 	
-#line 1901 "src/libre/dialect/native/parser.c"
+#line 1903 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: err-expected-count */
 		/* BEGINNING OF ACTION: count-one */
 		{
-#line 601 "src/libre/parser.act"
+#line 603 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 1910 "src/libre/dialect/native/parser.c"
+#line 1912 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: count-one */
 	}
@@ -1931,24 +1933,24 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: class-any */
 			{
-#line 567 "src/libre/parser.act"
+#line 569 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
 		(ZIa) = &class_any;
 	
-#line 1940 "src/libre/dialect/native/parser.c"
+#line 1942 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 818 "src/libre/parser.act"
+#line 820 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_named(*flags, (ZIa));
+		(ZIe) = ast_make_expr_named(act_state->poolp, *flags, (ZIa));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1952 "src/libre/dialect/native/parser.c"
+#line 1954 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 		}
@@ -1958,14 +1960,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-anchor-end */
 			{
-#line 733 "src/libre/parser.act"
+#line 735 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_anchor(*flags, AST_ANCHOR_END);
+		(ZIe) = ast_make_expr_anchor(act_state->poolp, *flags, AST_ANCHOR_END);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1969 "src/libre/dialect/native/parser.c"
+#line 1971 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-end */
 		}
@@ -1982,14 +1984,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			}
 			/* BEGINNING OF ACTION: ast-make-group */
 			{
-#line 702 "src/libre/parser.act"
+#line 704 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_group(*flags, (ZIg));
+		(ZIe) = ast_make_expr_group(act_state->poolp, *flags, (ZIg));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1993 "src/libre/dialect/native/parser.c"
+#line 1995 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-group */
 			switch (CURRENT_TERMINAL) {
@@ -2006,14 +2008,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-anchor-start */
 			{
-#line 726 "src/libre/parser.act"
+#line 728 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_anchor(*flags, AST_ANCHOR_START);
+		(ZIe) = ast_make_expr_anchor(act_state->poolp, *flags, AST_ANCHOR_START);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2017 "src/libre/dialect/native/parser.c"
+#line 2019 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-start */
 		}
@@ -2046,26 +2048,26 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-atom */
 		{
-#line 474 "src/libre/parser.act"
+#line 476 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXATOM;
 		}
 		goto ZL2;
 	
-#line 2057 "src/libre/dialect/native/parser.c"
+#line 2059 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 656 "src/libre/parser.act"
+#line 658 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_empty(*flags);
+		(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZIe) == NULL) {
 			goto ZL2;
 		}
 	
-#line 2069 "src/libre/dialect/native/parser.c"
+#line 2071 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -2094,7 +2096,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed(flags flags, lex_state lex_state, act
 		case (TOK_NAMED__CLASS):
 			/* BEGINNING OF EXTRACT: NAMED_CLASS */
 			{
-#line 435 "src/libre/parser.act"
+#line 437 "src/libre/parser.act"
 
 		ZIid = DIALECT_CLASS(lex_state->buf.a);
 		if (ZIid == NULL) {
@@ -2105,7 +2107,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed(flags flags, lex_state lex_state, act
 		ZI147 = lex_state->lx.start;
 		ZI148   = lex_state->lx.end;
 	
-#line 2109 "src/libre/dialect/native/parser.c"
+#line 2111 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			break;
@@ -2115,14 +2117,14 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed(flags flags, lex_state lex_state, act
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-make-named */
 		{
-#line 818 "src/libre/parser.act"
+#line 820 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_named(*flags, (ZIid));
+		(ZInode) = ast_make_expr_named(act_state->poolp, *flags, (ZIid));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2126 "src/libre/dialect/native/parser.c"
+#line 2128 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-make-named */
 	}
@@ -2145,14 +2147,14 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 	{
 		/* BEGINNING OF ACTION: ast-make-concat */
 		{
-#line 663 "src/libre/parser.act"
+#line 665 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_concat(*flags);
+		(ZInode) = ast_make_expr_concat(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2156 "src/libre/dialect/native/parser.c"
+#line 2158 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-make-concat */
 		p_expr_C_Clist_Hof_Hpieces (flags, lex_state, act_state, err, ZInode);
@@ -2171,7 +2173,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 837 "src/libre/parser.act"
+#line 839 "src/libre/parser.act"
 
 
 	static int
@@ -2192,6 +2194,7 @@ ZL0:;
 	struct ast *
 	DIALECT_PARSE(re_getchar_fun *f, void *opaque,
 		const struct fsm_options *opt,
+		struct ast_expr_pool **poolp,
 		enum re_flags flags, int overlap,
 		struct re_err *err)
 	{
@@ -2240,6 +2243,7 @@ ZL0:;
 		act_state = &act_state_s;
 
 		act_state->overlap = overlap;
+		act_state->poolp   = poolp;
 
 		err->e = RE_ESUCCESS;
 
@@ -2311,6 +2315,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 2315 "src/libre/dialect/native/parser.c"
+#line 2319 "src/libre/dialect/native/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/native/parser.h
+++ b/src/libre/dialect/native/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 216 "src/libre/parser.act"
+#line 218 "src/libre/parser.act"
 
 
 	#include <re/re.h>
@@ -28,7 +28,7 @@
 extern void p_re__native(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 976 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/native/parser.h"

--- a/src/libre/dialect/pcre/parser.c
+++ b/src/libre/dialect/pcre/parser.c
@@ -92,6 +92,8 @@
 	typedef struct ast_endpoint t_endpoint;
 
 	struct act_state {
+		struct ast_expr_pool **poolp;
+
 		enum LX_TOKEN lex_tok;
 		enum LX_TOKEN lex_tok_save;
 		int overlap; /* permit overlap in groups */
@@ -204,7 +206,7 @@
 		return s;
 	}
 
-#line 208 "src/libre/dialect/pcre/parser.c"
+#line 210 "src/libre/dialect/pcre/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -259,17 +261,17 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: INVERT */
 			{
-#line 231 "src/libre/parser.act"
+#line 233 "src/libre/parser.act"
 
 		ZI113 = '^';
 	
-#line 267 "src/libre/dialect/pcre/parser.c"
+#line 269 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: INVERT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-invert */
 			{
-#line 747 "src/libre/parser.act"
+#line 749 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -297,17 +299,17 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead(flags flags, lex_state lex_state, act_
 		 * a better idea.
 		 */
 
-		any = ast_make_expr_named(*flags, &class_any);
+		any = ast_make_expr_named(act_state->poolp, *flags, &class_any);
 		if (any == NULL) {
 			goto ZL1;
 		}
 
-		(*ZIclass) = ast_make_expr_subtract(*flags, any, (*ZIclass));
+		(*ZIclass) = ast_make_expr_subtract(act_state->poolp, *flags, any, (*ZIclass));
 		if ((*ZIclass) == NULL) {
 			goto ZL1;
 		}
 	
-#line 311 "src/libre/dialect/pcre/parser.c"
+#line 313 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-invert */
 		}
@@ -335,21 +337,21 @@ p_expr_C_Cflags_C_Cflag__set(flags flags, lex_state lex_state, act_state act_sta
 
 			/* BEGINNING OF EXTRACT: FLAG_INSENSITIVE */
 			{
-#line 446 "src/libre/parser.act"
+#line 448 "src/libre/parser.act"
 
 		ZIc = RE_ICASE;
 	
-#line 343 "src/libre/dialect/pcre/parser.c"
+#line 345 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: FLAG_INSENSITIVE */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: re-flag-union */
 			{
-#line 581 "src/libre/parser.act"
+#line 583 "src/libre/parser.act"
 
 		(ZIo) = (ZIi) | (ZIc);
 	
-#line 353 "src/libre/dialect/pcre/parser.c"
+#line 355 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: re-flag-union */
 		}
@@ -360,14 +362,14 @@ p_expr_C_Cflags_C_Cflag__set(flags flags, lex_state lex_state, act_state act_sta
 			ZIo = ZIi;
 			/* BEGINNING OF ACTION: err-unknown-flag */
 			{
-#line 509 "src/libre/parser.act"
+#line 511 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EFLAG;
 		}
 		goto ZL1;
 	
-#line 371 "src/libre/dialect/pcre/parser.c"
+#line 373 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: err-unknown-flag */
 		}
@@ -405,7 +407,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 				{
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
-#line 405 "src/libre/parser.act"
+#line 407 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -415,7 +417,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 419 "src/libre/dialect/pcre/parser.c"
+#line 421 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CHAR */
 					ADVANCE_LEXER;
@@ -425,7 +427,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 				{
 					/* BEGINNING OF EXTRACT: CONTROL */
 					{
-#line 309 "src/libre/parser.act"
+#line 311 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] == 'c');
@@ -441,20 +443,20 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 445 "src/libre/dialect/pcre/parser.c"
+#line 447 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CONTROL */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: err-unsupported */
 					{
-#line 530 "src/libre/parser.act"
+#line 532 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXUNSUPPORTD;
 		}
 		goto ZL1;
 	
-#line 458 "src/libre/dialect/pcre/parser.c"
+#line 460 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: err-unsupported */
 				}
@@ -463,7 +465,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 				{
 					/* BEGINNING OF EXTRACT: ESC */
 					{
-#line 277 "src/libre/parser.act"
+#line 279 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -484,7 +486,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 488 "src/libre/dialect/pcre/parser.c"
+#line 490 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: ESC */
 					ADVANCE_LEXER;
@@ -494,7 +496,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 				{
 					/* BEGINNING OF EXTRACT: HEX */
 					{
-#line 365 "src/libre/parser.act"
+#line 367 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -534,7 +536,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 538 "src/libre/dialect/pcre/parser.c"
+#line 540 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: HEX */
 					ADVANCE_LEXER;
@@ -544,7 +546,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 				{
 					/* BEGINNING OF EXTRACT: OCT */
 					{
-#line 325 "src/libre/parser.act"
+#line 327 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -584,7 +586,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 588 "src/libre/dialect/pcre/parser.c"
+#line 590 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OCT */
 					ADVANCE_LEXER;
@@ -597,12 +599,12 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 		/* END OF INLINE: 138 */
 		/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 		{
-#line 625 "src/libre/parser.act"
+#line 627 "src/libre/parser.act"
 
 		(ZIr).type = AST_ENDPOINT_LITERAL;
 		(ZIr).u.literal.c = (ZIc);
 	
-#line 606 "src/libre/dialect/pcre/parser.c"
+#line 608 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-range-endpoint-literal */
 	}
@@ -636,13 +638,13 @@ ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 				}
 				/* BEGINNING OF ACTION: ast-add-alt */
 				{
-#line 831 "src/libre/parser.act"
+#line 833 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIclass), (ZInode))) {
 			goto ZL4;
 		}
 	
-#line 646 "src/libre/dialect/pcre/parser.c"
+#line 648 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: ast-add-alt */
 			}
@@ -651,14 +653,14 @@ ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 			{
 				/* BEGINNING OF ACTION: err-expected-term */
 				{
-#line 460 "src/libre/parser.act"
+#line 462 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXTERM;
 		}
 		goto ZL1;
 	
-#line 662 "src/libre/dialect/pcre/parser.c"
+#line 664 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: err-expected-term */
 			}
@@ -687,14 +689,14 @@ p_271(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 		{
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 818 "src/libre/parser.act"
+#line 820 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_named(*flags, (*ZI268));
+		(ZInode) = ast_make_expr_named(act_state->poolp, *flags, (*ZI268));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 698 "src/libre/dialect/pcre/parser.c"
+#line 700 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 		}
@@ -707,12 +709,12 @@ p_271(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-class */
 			{
-#line 630 "src/libre/parser.act"
+#line 632 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_NAMED;
 		(ZIlower).u.named.class = (*ZI268);
 	
-#line 716 "src/libre/dialect/pcre/parser.c"
+#line 718 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-class */
 			p_151 (flags, lex_state, act_state, err);
@@ -723,17 +725,17 @@ p_271(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 			}
 			/* BEGINNING OF ACTION: mark-range */
 			{
-#line 542 "src/libre/parser.act"
+#line 544 "src/libre/parser.act"
 
 		mark(&act_state->rangestart, &(*ZI269));
 		mark(&act_state->rangeend,   &(ZIend));
 	
-#line 732 "src/libre/dialect/pcre/parser.c"
+#line 734 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 785 "src/libre/parser.act"
+#line 787 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -761,12 +763,12 @@ p_271(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 			goto ZL1;
 		}
 
-		(ZInode) = ast_make_expr_range(*flags, &(ZIlower), ast_start, &(ZIupper), ast_end);
+		(ZInode) = ast_make_expr_range(act_state->poolp, *flags, &(ZIlower), ast_start, &(ZIupper), ast_end);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 770 "src/libre/dialect/pcre/parser.c"
+#line 772 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -797,13 +799,13 @@ p_151(flags flags, lex_state lex_state, act_state act_state, err err)
 		case (TOK_RANGE):
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 235 "src/libre/parser.act"
+#line 237 "src/libre/parser.act"
 
 		ZI152 = '-';
 		ZI153 = lex_state->lx.start;
 		ZI154   = lex_state->lx.end;
 	
-#line 807 "src/libre/dialect/pcre/parser.c"
+#line 809 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			break;
@@ -817,14 +819,14 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-range */
 		{
-#line 488 "src/libre/parser.act"
+#line 490 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXRANGE;
 		}
 		goto ZL2;
 	
-#line 828 "src/libre/dialect/pcre/parser.c"
+#line 830 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-expected-range */
 	}
@@ -845,14 +847,14 @@ p_291(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		{
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 677 "src/libre/parser.act"
+#line 679 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_literal(*flags, (*ZI288));
+		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (*ZI288));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 856 "src/libre/dialect/pcre/parser.c"
+#line 858 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -865,12 +867,12 @@ p_291(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 625 "src/libre/parser.act"
+#line 627 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_LITERAL;
 		(ZIlower).u.literal.c = (*ZI288);
 	
-#line 874 "src/libre/dialect/pcre/parser.c"
+#line 876 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			p_151 (flags, lex_state, act_state, err);
@@ -881,17 +883,17 @@ p_291(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			}
 			/* BEGINNING OF ACTION: mark-range */
 			{
-#line 542 "src/libre/parser.act"
+#line 544 "src/libre/parser.act"
 
 		mark(&act_state->rangestart, &(*ZI289));
 		mark(&act_state->rangeend,   &(ZIend));
 	
-#line 890 "src/libre/dialect/pcre/parser.c"
+#line 892 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 785 "src/libre/parser.act"
+#line 787 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -919,12 +921,12 @@ p_291(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			goto ZL1;
 		}
 
-		(ZInode) = ast_make_expr_range(*flags, &(ZIlower), ast_start, &(ZIupper), ast_end);
+		(ZInode) = ast_make_expr_range(act_state->poolp, *flags, &(ZIlower), ast_start, &(ZIupper), ast_end);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 928 "src/libre/dialect/pcre/parser.c"
+#line 930 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -957,13 +959,13 @@ ZL2_expr_C_Clist_Hof_Hpieces:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 825 "src/libre/parser.act"
+#line 827 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
 		}
 	
-#line 967 "src/libre/dialect/pcre/parser.c"
+#line 969 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-add-concat */
 		/* BEGINNING OF INLINE: 249 */
@@ -1005,28 +1007,28 @@ p_294(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 
 			/* BEGINNING OF EXTRACT: CLOSECOUNT */
 			{
-#line 272 "src/libre/parser.act"
+#line 274 "src/libre/parser.act"
 
 		ZI236 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1014 "src/libre/dialect/pcre/parser.c"
+#line 1016 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: CLOSECOUNT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 547 "src/libre/parser.act"
+#line 549 "src/libre/parser.act"
 
 		mark(&act_state->countstart, &(*ZI292));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 1025 "src/libre/dialect/pcre/parser.c"
+#line 1027 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 605 "src/libre/parser.act"
+#line 607 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -1046,7 +1048,7 @@ p_294(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (*ZIm), &ast_end);
 	
-#line 1050 "src/libre/dialect/pcre/parser.c"
+#line 1052 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-range */
 		}
@@ -1088,37 +1090,37 @@ p_295(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 
 			/* BEGINNING OF EXTRACT: CLOSECOUNT */
 			{
-#line 272 "src/libre/parser.act"
+#line 274 "src/libre/parser.act"
 
 		ZI241 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1097 "src/libre/dialect/pcre/parser.c"
+#line 1099 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: CLOSECOUNT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 547 "src/libre/parser.act"
+#line 549 "src/libre/parser.act"
 
 		mark(&act_state->countstart, &(*ZI292));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 1108 "src/libre/dialect/pcre/parser.c"
+#line 1110 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-unbounded */
 			{
-#line 585 "src/libre/parser.act"
+#line 587 "src/libre/parser.act"
 
 		(ZIn) = AST_COUNT_UNBOUNDED;
 	
-#line 1117 "src/libre/dialect/pcre/parser.c"
+#line 1119 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-unbounded */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 605 "src/libre/parser.act"
+#line 607 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -1138,7 +1140,7 @@ p_295(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (ZIn), &ast_end);
 	
-#line 1142 "src/libre/dialect/pcre/parser.c"
+#line 1144 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-range */
 		}
@@ -1151,7 +1153,7 @@ p_295(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 
 			/* BEGINNING OF EXTRACT: COUNT */
 			{
-#line 415 "src/libre/parser.act"
+#line 417 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -1171,7 +1173,7 @@ p_295(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 
 		ZIn = (unsigned int) u;
 	
-#line 1175 "src/libre/dialect/pcre/parser.c"
+#line 1177 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: COUNT */
 			ADVANCE_LEXER;
@@ -1179,12 +1181,12 @@ p_295(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			case (TOK_CLOSECOUNT):
 				/* BEGINNING OF EXTRACT: CLOSECOUNT */
 				{
-#line 272 "src/libre/parser.act"
+#line 274 "src/libre/parser.act"
 
 		ZI239 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1188 "src/libre/dialect/pcre/parser.c"
+#line 1190 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF EXTRACT: CLOSECOUNT */
 				break;
@@ -1194,17 +1196,17 @@ p_295(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 547 "src/libre/parser.act"
+#line 549 "src/libre/parser.act"
 
 		mark(&act_state->countstart, &(*ZI292));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 1203 "src/libre/dialect/pcre/parser.c"
+#line 1205 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 605 "src/libre/parser.act"
+#line 607 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -1224,7 +1226,7 @@ p_295(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (ZIn), &ast_end);
 	
-#line 1228 "src/libre/dialect/pcre/parser.c"
+#line 1230 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-range */
 		}
@@ -1263,7 +1265,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
-#line 405 "src/libre/parser.act"
+#line 407 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -1273,7 +1275,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 1277 "src/libre/dialect/pcre/parser.c"
+#line 1279 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CHAR */
 					ADVANCE_LEXER;
@@ -1286,7 +1288,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 					/* BEGINNING OF EXTRACT: ESC */
 					{
-#line 277 "src/libre/parser.act"
+#line 279 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -1307,7 +1309,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		ZI98 = lex_state->lx.start;
 		ZI99   = lex_state->lx.end;
 	
-#line 1311 "src/libre/dialect/pcre/parser.c"
+#line 1313 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: ESC */
 					ADVANCE_LEXER;
@@ -1320,7 +1322,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 					/* BEGINNING OF EXTRACT: HEX */
 					{
-#line 365 "src/libre/parser.act"
+#line 367 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -1360,7 +1362,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 1364 "src/libre/dialect/pcre/parser.c"
+#line 1366 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: HEX */
 					ADVANCE_LEXER;
@@ -1373,7 +1375,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 					/* BEGINNING OF EXTRACT: NOESC */
 					{
-#line 298 "src/libre/parser.act"
+#line 300 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -1384,7 +1386,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		ZI100 = lex_state->lx.start;
 		ZI101   = lex_state->lx.end;
 	
-#line 1388 "src/libre/dialect/pcre/parser.c"
+#line 1390 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: NOESC */
 					ADVANCE_LEXER;
@@ -1397,7 +1399,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 					/* BEGINNING OF EXTRACT: OCT */
 					{
-#line 325 "src/libre/parser.act"
+#line 327 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -1437,7 +1439,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 1441 "src/libre/dialect/pcre/parser.c"
+#line 1443 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OCT */
 					ADVANCE_LEXER;
@@ -1450,14 +1452,14 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		/* END OF INLINE: 96 */
 		/* BEGINNING OF ACTION: ast-make-literal */
 		{
-#line 677 "src/libre/parser.act"
+#line 679 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_literal(*flags, (ZIc));
+		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1461 "src/libre/dialect/pcre/parser.c"
+#line 1463 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-literal */
 	}
@@ -1483,7 +1485,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
-#line 405 "src/libre/parser.act"
+#line 407 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -1493,7 +1495,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 		ZI284 = lex_state->buf.a[0];
 	
-#line 1497 "src/libre/dialect/pcre/parser.c"
+#line 1499 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
@@ -1512,7 +1514,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: CONTROL */
 			{
-#line 309 "src/libre/parser.act"
+#line 311 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] == 'c');
@@ -1528,20 +1530,20 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		ZI289 = lex_state->lx.start;
 		ZI290   = lex_state->lx.end;
 	
-#line 1532 "src/libre/dialect/pcre/parser.c"
+#line 1534 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: CONTROL */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: err-unsupported */
 			{
-#line 530 "src/libre/parser.act"
+#line 532 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXUNSUPPORTD;
 		}
 		goto ZL1;
 	
-#line 1545 "src/libre/dialect/pcre/parser.c"
+#line 1547 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: err-unsupported */
 			p_291 (flags, lex_state, act_state, err, &ZI288, &ZI289, &ZInode);
@@ -1559,7 +1561,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: ESC */
 			{
-#line 277 "src/libre/parser.act"
+#line 279 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -1580,7 +1582,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		ZI273 = lex_state->lx.start;
 		ZI274   = lex_state->lx.end;
 	
-#line 1584 "src/libre/dialect/pcre/parser.c"
+#line 1586 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: ESC */
 			ADVANCE_LEXER;
@@ -1599,7 +1601,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: HEX */
 			{
-#line 365 "src/libre/parser.act"
+#line 367 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -1639,7 +1641,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 		ZI280 = (char) (unsigned char) u;
 	
-#line 1643 "src/libre/dialect/pcre/parser.c"
+#line 1645 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: HEX */
 			ADVANCE_LEXER;
@@ -1658,7 +1660,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: NAMED_CLASS */
 			{
-#line 435 "src/libre/parser.act"
+#line 437 "src/libre/parser.act"
 
 		ZI268 = DIALECT_CLASS(lex_state->buf.a);
 		if (ZI268 == NULL) {
@@ -1669,7 +1671,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		ZI269 = lex_state->lx.start;
 		ZI270   = lex_state->lx.end;
 	
-#line 1673 "src/libre/dialect/pcre/parser.c"
+#line 1675 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			ADVANCE_LEXER;
@@ -1688,7 +1690,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: NOESC */
 			{
-#line 298 "src/libre/parser.act"
+#line 300 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -1699,20 +1701,20 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		ZI119 = lex_state->lx.start;
 		ZI120   = lex_state->lx.end;
 	
-#line 1703 "src/libre/dialect/pcre/parser.c"
+#line 1705 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: NOESC */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 677 "src/libre/parser.act"
+#line 679 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_literal(*flags, (ZIc));
+		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1716 "src/libre/dialect/pcre/parser.c"
+#line 1718 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -1725,7 +1727,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: OCT */
 			{
-#line 325 "src/libre/parser.act"
+#line 327 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -1765,7 +1767,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 		ZI276 = (char) (unsigned char) u;
 	
-#line 1769 "src/libre/dialect/pcre/parser.c"
+#line 1771 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: OCT */
 			ADVANCE_LEXER;
@@ -1806,7 +1808,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hclass(flags fl
 		case (TOK_NAMED__CLASS):
 			/* BEGINNING OF EXTRACT: NAMED_CLASS */
 			{
-#line 435 "src/libre/parser.act"
+#line 437 "src/libre/parser.act"
 
 		ZIid = DIALECT_CLASS(lex_state->buf.a);
 		if (ZIid == NULL) {
@@ -1817,7 +1819,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hclass(flags fl
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1821 "src/libre/dialect/pcre/parser.c"
+#line 1823 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			break;
@@ -1827,12 +1829,12 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hclass(flags fl
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-range-endpoint-class */
 		{
-#line 630 "src/libre/parser.act"
+#line 632 "src/libre/parser.act"
 
 		(ZIr).type = AST_ENDPOINT_NAMED;
 		(ZIr).u.named.class = (ZIid);
 	
-#line 1836 "src/libre/dialect/pcre/parser.c"
+#line 1838 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-range-endpoint-class */
 	}
@@ -1868,25 +1870,25 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 					/* BEGINNING OF EXTRACT: OPENGROUP */
 					{
-#line 241 "src/libre/parser.act"
+#line 243 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
 		ZI165   = lex_state->lx.end;
 	
-#line 1877 "src/libre/dialect/pcre/parser.c"
+#line 1879 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OPENGROUP */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-alt */
 					{
-#line 670 "src/libre/parser.act"
+#line 672 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_alt(*flags);
+		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1890 "src/libre/dialect/pcre/parser.c"
+#line 1892 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-alt */
 					ZItmp = ZInode;
@@ -1906,35 +1908,35 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 					/* BEGINNING OF EXTRACT: OPENGROUPCB */
 					{
-#line 251 "src/libre/parser.act"
+#line 253 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
 		ZI186   = lex_state->lx.end;
 	
-#line 1915 "src/libre/dialect/pcre/parser.c"
+#line 1917 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OPENGROUPCB */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-alt */
 					{
-#line 670 "src/libre/parser.act"
+#line 672 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_alt(*flags);
+		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1928 "src/libre/dialect/pcre/parser.c"
+#line 1930 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-alt */
 					ZItmp = ZInode;
 					/* BEGINNING OF ACTION: make-literal-cbrak */
 					{
-#line 684 "src/libre/parser.act"
+#line 686 "src/libre/parser.act"
 
 		(ZIcbrak) = ']';
 	
-#line 1938 "src/libre/dialect/pcre/parser.c"
+#line 1940 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: make-literal-cbrak */
 					p_196 (flags, lex_state, act_state, err, &ZIstart, &ZIcbrak, &ZInode1);
@@ -1944,13 +1946,13 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 					}
 					/* BEGINNING OF ACTION: ast-add-alt */
 					{
-#line 831 "src/libre/parser.act"
+#line 833 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZItmp), (ZInode1))) {
 			goto ZL1;
 		}
 	
-#line 1954 "src/libre/dialect/pcre/parser.c"
+#line 1956 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-add-alt */
 					p_200 (flags, lex_state, act_state, err, &ZItmp);
@@ -1966,31 +1968,31 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 					/* BEGINNING OF EXTRACT: OPENGROUPINV */
 					{
-#line 246 "src/libre/parser.act"
+#line 248 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
 		ZI177   = lex_state->lx.end;
 	
-#line 1975 "src/libre/dialect/pcre/parser.c"
+#line 1977 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OPENGROUPINV */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-alt */
 					{
-#line 670 "src/libre/parser.act"
+#line 672 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_alt(*flags);
+		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1988 "src/libre/dialect/pcre/parser.c"
+#line 1990 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-alt */
 					ZItmp = ZInode;
 					/* BEGINNING OF ACTION: ast-make-invert */
 					{
-#line 747 "src/libre/parser.act"
+#line 749 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -2018,17 +2020,17 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		 * a better idea.
 		 */
 
-		any = ast_make_expr_named(*flags, &class_any);
+		any = ast_make_expr_named(act_state->poolp, *flags, &class_any);
 		if (any == NULL) {
 			goto ZL1;
 		}
 
-		(ZInode) = ast_make_expr_subtract(*flags, any, (ZInode));
+		(ZInode) = ast_make_expr_subtract(act_state->poolp, *flags, any, (ZInode));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2032 "src/libre/dialect/pcre/parser.c"
+#line 2034 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-invert */
 					p_179 (flags, lex_state, act_state, err, &ZItmp);
@@ -2046,31 +2048,31 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 					/* BEGINNING OF EXTRACT: OPENGROUPINVCB */
 					{
-#line 256 "src/libre/parser.act"
+#line 258 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
 		ZI194   = lex_state->lx.end;
 	
-#line 2055 "src/libre/dialect/pcre/parser.c"
+#line 2057 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OPENGROUPINVCB */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-alt */
 					{
-#line 670 "src/libre/parser.act"
+#line 672 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_alt(*flags);
+		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2068 "src/libre/dialect/pcre/parser.c"
+#line 2070 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-alt */
 					ZItmp = ZInode;
 					/* BEGINNING OF ACTION: ast-make-invert */
 					{
-#line 747 "src/libre/parser.act"
+#line 749 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -2098,26 +2100,26 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		 * a better idea.
 		 */
 
-		any = ast_make_expr_named(*flags, &class_any);
+		any = ast_make_expr_named(act_state->poolp, *flags, &class_any);
 		if (any == NULL) {
 			goto ZL1;
 		}
 
-		(ZInode) = ast_make_expr_subtract(*flags, any, (ZInode));
+		(ZInode) = ast_make_expr_subtract(act_state->poolp, *flags, any, (ZInode));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2112 "src/libre/dialect/pcre/parser.c"
+#line 2114 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-invert */
 					/* BEGINNING OF ACTION: make-literal-cbrak */
 					{
-#line 684 "src/libre/parser.act"
+#line 686 "src/libre/parser.act"
 
 		(ZIcbrak) = ']';
 	
-#line 2121 "src/libre/dialect/pcre/parser.c"
+#line 2123 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: make-literal-cbrak */
 					p_196 (flags, lex_state, act_state, err, &ZIstart, &ZIcbrak, &ZInode1);
@@ -2127,13 +2129,13 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 					}
 					/* BEGINNING OF ACTION: ast-add-alt */
 					{
-#line 831 "src/libre/parser.act"
+#line 833 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZItmp), (ZInode1))) {
 			goto ZL1;
 		}
 	
-#line 2137 "src/libre/dialect/pcre/parser.c"
+#line 2139 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-add-alt */
 					p_200 (flags, lex_state, act_state, err, &ZItmp);
@@ -2158,13 +2160,13 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 				case (TOK_CLOSEGROUP):
 					/* BEGINNING OF EXTRACT: CLOSEGROUP */
 					{
-#line 261 "src/libre/parser.act"
+#line 263 "src/libre/parser.act"
 
 		ZI202 = ']';
 		ZI203 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 2168 "src/libre/dialect/pcre/parser.c"
+#line 2170 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CLOSEGROUP */
 					break;
@@ -2174,12 +2176,12 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 				ADVANCE_LEXER;
 				/* BEGINNING OF ACTION: mark-group */
 				{
-#line 537 "src/libre/parser.act"
+#line 539 "src/libre/parser.act"
 
 		mark(&act_state->groupstart, &(ZIstart));
 		mark(&act_state->groupend,   &(ZIend));
 	
-#line 2183 "src/libre/dialect/pcre/parser.c"
+#line 2185 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: mark-group */
 			}
@@ -2188,14 +2190,14 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			{
 				/* BEGINNING OF ACTION: err-expected-closegroup */
 				{
-#line 495 "src/libre/parser.act"
+#line 497 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCLOSEGROUP;
 		}
 		goto ZL1;
 	
-#line 2199 "src/libre/dialect/pcre/parser.c"
+#line 2201 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: err-expected-closegroup */
 				ZIend = ZIstart;
@@ -2205,7 +2207,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		/* END OF INLINE: 201 */
 		/* BEGINNING OF ACTION: mark-expr */
 		{
-#line 552 "src/libre/parser.act"
+#line 554 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -2220,7 +2222,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		(ZItmp)->u.class.end   = ast_end;
 */
 	
-#line 2224 "src/libre/dialect/pcre/parser.c"
+#line 2226 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: mark-expr */
 	}
@@ -2245,13 +2247,13 @@ p_179(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 235 "src/libre/parser.act"
+#line 237 "src/libre/parser.act"
 
 		ZIc = '-';
 		ZIrstart = lex_state->lx.start;
 		ZI180   = lex_state->lx.end;
 	
-#line 2255 "src/libre/dialect/pcre/parser.c"
+#line 2257 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
@@ -2262,14 +2264,14 @@ p_179(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 					{
 						/* BEGINNING OF ACTION: ast-make-literal */
 						{
-#line 677 "src/libre/parser.act"
+#line 679 "src/libre/parser.act"
 
-		(ZInode1) = ast_make_expr_literal(*flags, (ZIc));
+		(ZInode1) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZInode1) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2273 "src/libre/dialect/pcre/parser.c"
+#line 2275 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF ACTION: ast-make-literal */
 					}
@@ -2285,23 +2287,23 @@ p_179(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 
 						/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 						{
-#line 625 "src/libre/parser.act"
+#line 627 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_LITERAL;
 		(ZIlower).u.literal.c = (ZIc);
 	
-#line 2294 "src/libre/dialect/pcre/parser.c"
+#line 2296 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF ACTION: ast-range-endpoint-literal */
 						/* BEGINNING OF EXTRACT: RANGE */
 						{
-#line 235 "src/libre/parser.act"
+#line 237 "src/libre/parser.act"
 
 		ZI182 = '-';
 		ZI183 = lex_state->lx.start;
 		ZI184   = lex_state->lx.end;
 	
-#line 2305 "src/libre/dialect/pcre/parser.c"
+#line 2307 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF EXTRACT: RANGE */
 						ADVANCE_LEXER;
@@ -2312,7 +2314,7 @@ p_179(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 						}
 						/* BEGINNING OF ACTION: ast-make-range */
 						{
-#line 785 "src/libre/parser.act"
+#line 787 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -2340,12 +2342,12 @@ p_179(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			goto ZL1;
 		}
 
-		(ZInode1) = ast_make_expr_range(*flags, &(ZIlower), ast_start, &(ZIupper), ast_end);
+		(ZInode1) = ast_make_expr_range(act_state->poolp, *flags, &(ZIlower), ast_start, &(ZIupper), ast_end);
 		if ((ZInode1) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2349 "src/libre/dialect/pcre/parser.c"
+#line 2351 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF ACTION: ast-make-range */
 					}
@@ -2355,13 +2357,13 @@ p_179(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			/* END OF INLINE: 181 */
 			/* BEGINNING OF ACTION: ast-add-alt */
 			{
-#line 831 "src/libre/parser.act"
+#line 833 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((*ZItmp), (ZInode1))) {
 			goto ZL1;
 		}
 	
-#line 2365 "src/libre/dialect/pcre/parser.c"
+#line 2367 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 			p_200 (flags, lex_state, act_state, err, ZItmp);
@@ -2412,24 +2414,24 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_Hend(flags flags, lex_state lex_st
 
 					/* BEGINNING OF EXTRACT: RANGE */
 					{
-#line 235 "src/libre/parser.act"
+#line 237 "src/libre/parser.act"
 
 		ZIc = '-';
 		ZI146 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 2422 "src/libre/dialect/pcre/parser.c"
+#line 2424 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: RANGE */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 					{
-#line 625 "src/libre/parser.act"
+#line 627 "src/libre/parser.act"
 
 		(ZIr).type = AST_ENDPOINT_LITERAL;
 		(ZIr).u.literal.c = (ZIc);
 	
-#line 2433 "src/libre/dialect/pcre/parser.c"
+#line 2435 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-range-endpoint-literal */
 				}
@@ -2491,30 +2493,30 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 
 					/* BEGINNING OF ACTION: count-one */
 					{
-#line 601 "src/libre/parser.act"
+#line 603 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 2499 "src/libre/dialect/pcre/parser.c"
+#line 2501 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: count-one */
 					/* BEGINNING OF ACTION: ast-make-piece */
 					{
-#line 688 "src/libre/parser.act"
+#line 690 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
-			(ZInode) = ast_make_expr_empty(*flags);
+			(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		} else if ((ZIc).min == 1 && (ZIc).max == 1) {
 			(ZInode) = (ZIe);
 		} else {
-			(ZInode) = ast_make_expr_repeat(*flags, (ZIe), (ZIc));
+			(ZInode) = ast_make_expr_repeat(act_state->poolp, *flags, (ZIe), (ZIc));
 		}
 		if ((ZInode) == NULL) {
 			err->e = RE_EXEOF;
 			goto ZL1;
 		}
 	
-#line 2518 "src/libre/dialect/pcre/parser.c"
+#line 2520 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-piece */
 				}
@@ -2545,14 +2547,14 @@ p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__ex
 	{
 		/* BEGINNING OF ACTION: ast-make-alt */
 		{
-#line 670 "src/libre/parser.act"
+#line 672 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_alt(*flags);
+		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2556 "src/libre/dialect/pcre/parser.c"
+#line 2558 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-alt */
 		p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, ZInode);
@@ -2566,26 +2568,26 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-alts */
 		{
-#line 481 "src/libre/parser.act"
+#line 483 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXALTS;
 		}
 		goto ZL2;
 	
-#line 2577 "src/libre/dialect/pcre/parser.c"
+#line 2579 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 656 "src/libre/parser.act"
+#line 658 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_empty(*flags);
+		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL2;
 		}
 	
-#line 2589 "src/libre/dialect/pcre/parser.c"
+#line 2591 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -2607,14 +2609,14 @@ p_196(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 		{
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 677 "src/libre/parser.act"
+#line 679 "src/libre/parser.act"
 
-		(ZInode1) = ast_make_expr_literal(*flags, (*ZIcbrak));
+		(ZInode1) = ast_make_expr_literal(act_state->poolp, *flags, (*ZIcbrak));
 		if ((ZInode1) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2618 "src/libre/dialect/pcre/parser.c"
+#line 2620 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -2631,23 +2633,23 @@ p_196(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 625 "src/libre/parser.act"
+#line 627 "src/libre/parser.act"
 
 		(ZIr).type = AST_ENDPOINT_LITERAL;
 		(ZIr).u.literal.c = (*ZIcbrak);
 	
-#line 2640 "src/libre/dialect/pcre/parser.c"
+#line 2642 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 235 "src/libre/parser.act"
+#line 237 "src/libre/parser.act"
 
 		ZI197 = '-';
 		ZI198 = lex_state->lx.start;
 		ZI199   = lex_state->lx.end;
 	
-#line 2651 "src/libre/dialect/pcre/parser.c"
+#line 2653 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
@@ -2658,17 +2660,17 @@ p_196(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 			}
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 625 "src/libre/parser.act"
+#line 627 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_LITERAL;
 		(ZIlower).u.literal.c = (*ZIcbrak);
 	
-#line 2667 "src/libre/dialect/pcre/parser.c"
+#line 2669 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 785 "src/libre/parser.act"
+#line 787 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -2696,12 +2698,12 @@ p_196(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 			goto ZL1;
 		}
 
-		(ZInode1) = ast_make_expr_range(*flags, &(ZIlower), ast_start, &(ZIupper), ast_end);
+		(ZInode1) = ast_make_expr_range(act_state->poolp, *flags, &(ZIlower), ast_start, &(ZIupper), ast_end);
 		if ((ZInode1) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2705 "src/libre/dialect/pcre/parser.c"
+#line 2707 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -2740,20 +2742,20 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: re-flag-none */
 		{
-#line 577 "src/libre/parser.act"
+#line 579 "src/libre/parser.act"
 
 		(ZIempty__pos) = RE_FLAGS_NONE;
 	
-#line 2748 "src/libre/dialect/pcre/parser.c"
+#line 2750 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: re-flag-none */
 		/* BEGINNING OF ACTION: re-flag-none */
 		{
-#line 577 "src/libre/parser.act"
+#line 579 "src/libre/parser.act"
 
 		(ZIempty__neg) = RE_FLAGS_NONE;
 	
-#line 2757 "src/libre/dialect/pcre/parser.c"
+#line 2759 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: re-flag-none */
 		/* BEGINNING OF INLINE: 216 */
@@ -2809,7 +2811,7 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 				ADVANCE_LEXER;
 				/* BEGINNING OF ACTION: ast-mask-re-flags */
 				{
-#line 717 "src/libre/parser.act"
+#line 719 "src/libre/parser.act"
 
 		/*
 		 * Note: in cases like `(?i-i)`, the negative is
@@ -2818,7 +2820,7 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 		*flags |= (ZIpos);
 		*flags &= ~(ZIneg);
 	
-#line 2822 "src/libre/dialect/pcre/parser.c"
+#line 2824 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: ast-mask-re-flags */
 			}
@@ -2827,14 +2829,14 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 			{
 				/* BEGINNING OF ACTION: err-expected-closeflags */
 				{
-#line 516 "src/libre/parser.act"
+#line 518 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCLOSEFLAGS;
 		}
 		goto ZL1;
 	
-#line 2838 "src/libre/dialect/pcre/parser.c"
+#line 2840 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: err-expected-closeflags */
 			}
@@ -2843,14 +2845,14 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 		/* END OF INLINE: 221 */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 656 "src/libre/parser.act"
+#line 658 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_empty(*flags);
+		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2854 "src/libre/dialect/pcre/parser.c"
+#line 2856 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -2880,21 +2882,21 @@ p_expr_C_Cpiece_C_Clist_Hof_Hcounts(flags flags, lex_state lex_state, act_state 
 		}
 		/* BEGINNING OF ACTION: ast-make-piece */
 		{
-#line 688 "src/libre/parser.act"
+#line 690 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
-			(ZInode) = ast_make_expr_empty(*flags);
+			(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		} else if ((ZIc).min == 1 && (ZIc).max == 1) {
 			(ZInode) = (ZIe);
 		} else {
-			(ZInode) = ast_make_expr_repeat(*flags, (ZIe), (ZIc));
+			(ZInode) = ast_make_expr_repeat(act_state->poolp, *flags, (ZIe), (ZIc));
 		}
 		if ((ZInode) == NULL) {
 			err->e = RE_EXEOF;
 			goto ZL1;
 		}
 	
-#line 2898 "src/libre/dialect/pcre/parser.c"
+#line 2900 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-piece */
 		/* BEGINNING OF INLINE: 244 */
@@ -2946,13 +2948,13 @@ ZL2_200:;
 							}
 							/* BEGINNING OF ACTION: ast-add-alt */
 							{
-#line 831 "src/libre/parser.act"
+#line 833 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((*ZItmp), (ZInode))) {
 			goto ZL5;
 		}
 	
-#line 2956 "src/libre/dialect/pcre/parser.c"
+#line 2958 "src/libre/dialect/pcre/parser.c"
 							}
 							/* END OF ACTION: ast-add-alt */
 						}
@@ -2961,14 +2963,14 @@ ZL2_200:;
 						{
 							/* BEGINNING OF ACTION: err-expected-term */
 							{
-#line 460 "src/libre/parser.act"
+#line 462 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXTERM;
 		}
 		goto ZL1;
 	
-#line 2972 "src/libre/dialect/pcre/parser.c"
+#line 2974 "src/libre/dialect/pcre/parser.c"
 							}
 							/* END OF ACTION: err-expected-term */
 						}
@@ -3061,7 +3063,7 @@ p_class_Hnamed(flags flags, lex_state lex_state, act_state act_state, err err, t
 		case (TOK_NAMED__CLASS):
 			/* BEGINNING OF EXTRACT: NAMED_CLASS */
 			{
-#line 435 "src/libre/parser.act"
+#line 437 "src/libre/parser.act"
 
 		ZIid = DIALECT_CLASS(lex_state->buf.a);
 		if (ZIid == NULL) {
@@ -3072,7 +3074,7 @@ p_class_Hnamed(flags flags, lex_state lex_state, act_state act_state, err err, t
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 3076 "src/libre/dialect/pcre/parser.c"
+#line 3078 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			break;
@@ -3082,14 +3084,14 @@ p_class_Hnamed(flags flags, lex_state lex_state, act_state act_state, err err, t
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-make-named */
 		{
-#line 818 "src/libre/parser.act"
+#line 820 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_named(*flags, (ZIid));
+		(ZInode) = ast_make_expr_named(act_state->poolp, *flags, (ZIid));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3093 "src/libre/dialect/pcre/parser.c"
+#line 3095 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-named */
 	}
@@ -3120,13 +3122,13 @@ ZL2_expr_C_Clist_Hof_Halts:;
 		}
 		/* BEGINNING OF ACTION: ast-add-alt */
 		{
-#line 831 "src/libre/parser.act"
+#line 833 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIalts), (ZIa))) {
 			goto ZL1;
 		}
 	
-#line 3130 "src/libre/dialect/pcre/parser.c"
+#line 3132 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-add-alt */
 		/* BEGINNING OF INLINE: 255 */
@@ -3151,14 +3153,14 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-alts */
 		{
-#line 481 "src/libre/parser.act"
+#line 483 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXALTS;
 		}
 		goto ZL4;
 	
-#line 3162 "src/libre/dialect/pcre/parser.c"
+#line 3164 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
 	}
@@ -3183,12 +3185,12 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 			/* BEGINNING OF EXTRACT: OPENCOUNT */
 			{
-#line 267 "src/libre/parser.act"
+#line 269 "src/libre/parser.act"
 
 		ZI292 = lex_state->lx.start;
 		ZI293   = lex_state->lx.end;
 	
-#line 3192 "src/libre/dialect/pcre/parser.c"
+#line 3194 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: OPENCOUNT */
 			ADVANCE_LEXER;
@@ -3196,7 +3198,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			case (TOK_COUNT):
 				/* BEGINNING OF EXTRACT: COUNT */
 				{
-#line 415 "src/libre/parser.act"
+#line 417 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -3216,7 +3218,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		ZIm = (unsigned int) u;
 	
-#line 3220 "src/libre/dialect/pcre/parser.c"
+#line 3222 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -3236,11 +3238,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-zero-or-one */
 			{
-#line 597 "src/libre/parser.act"
+#line 599 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, 1, NULL);
 	
-#line 3244 "src/libre/dialect/pcre/parser.c"
+#line 3246 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-one */
 		}
@@ -3250,11 +3252,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-one-or-more */
 			{
-#line 593 "src/libre/parser.act"
+#line 595 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 3258 "src/libre/dialect/pcre/parser.c"
+#line 3260 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-one-or-more */
 		}
@@ -3264,11 +3266,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-zero-or-more */
 			{
-#line 589 "src/libre/parser.act"
+#line 591 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 3272 "src/libre/dialect/pcre/parser.c"
+#line 3274 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 		}
@@ -3283,23 +3285,23 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-count */
 		{
-#line 467 "src/libre/parser.act"
+#line 469 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCOUNT;
 		}
 		goto ZL2;
 	
-#line 3294 "src/libre/dialect/pcre/parser.c"
+#line 3296 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-expected-count */
 		/* BEGINNING OF ACTION: count-one */
 		{
-#line 601 "src/libre/parser.act"
+#line 603 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 3303 "src/libre/dialect/pcre/parser.c"
+#line 3305 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: count-one */
 	}
@@ -3347,14 +3349,14 @@ p_re__pcre(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 523 "src/libre/parser.act"
+#line 525 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
 		}
 		goto ZL1;
 	
-#line 3358 "src/libre/dialect/pcre/parser.c"
+#line 3360 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
@@ -3383,24 +3385,24 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: class-any */
 			{
-#line 567 "src/libre/parser.act"
+#line 569 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
 		(ZIa) = &class_any;
 	
-#line 3392 "src/libre/dialect/pcre/parser.c"
+#line 3394 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 818 "src/libre/parser.act"
+#line 820 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_named(*flags, (ZIa));
+		(ZIe) = ast_make_expr_named(act_state->poolp, *flags, (ZIa));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3404 "src/libre/dialect/pcre/parser.c"
+#line 3406 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 		}
@@ -3413,7 +3415,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 
 			/* BEGINNING OF EXTRACT: CONTROL */
 			{
-#line 309 "src/libre/parser.act"
+#line 311 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] == 'c');
@@ -3429,32 +3431,32 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 		ZI229 = lex_state->lx.start;
 		ZI230   = lex_state->lx.end;
 	
-#line 3433 "src/libre/dialect/pcre/parser.c"
+#line 3435 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: CONTROL */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: err-unsupported */
 			{
-#line 530 "src/libre/parser.act"
+#line 532 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXUNSUPPORTD;
 		}
 		goto ZL1;
 	
-#line 3446 "src/libre/dialect/pcre/parser.c"
+#line 3448 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: err-unsupported */
 			/* BEGINNING OF ACTION: ast-make-empty */
 			{
-#line 656 "src/libre/parser.act"
+#line 658 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_empty(*flags);
+		(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3458 "src/libre/dialect/pcre/parser.c"
+#line 3460 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-empty */
 		}
@@ -3464,14 +3466,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-anchor-end */
 			{
-#line 733 "src/libre/parser.act"
+#line 735 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_anchor(*flags, AST_ANCHOR_END);
+		(ZIe) = ast_make_expr_anchor(act_state->poolp, *flags, AST_ANCHOR_END);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3475 "src/libre/dialect/pcre/parser.c"
+#line 3477 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-end */
 		}
@@ -3484,11 +3486,11 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-get-re-flags */
 			{
-#line 709 "src/libre/parser.act"
+#line 711 "src/libre/parser.act"
 
 		(ZIflags) = *flags;
 	
-#line 3492 "src/libre/dialect/pcre/parser.c"
+#line 3494 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-get-re-flags */
 			p_expr (flags, lex_state, act_state, err, &ZIg);
@@ -3498,23 +3500,23 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			}
 			/* BEGINNING OF ACTION: ast-set-re-flags */
 			{
-#line 713 "src/libre/parser.act"
+#line 715 "src/libre/parser.act"
 
 		*flags = (ZIflags);
 	
-#line 3506 "src/libre/dialect/pcre/parser.c"
+#line 3508 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-set-re-flags */
 			/* BEGINNING OF ACTION: ast-make-group */
 			{
-#line 702 "src/libre/parser.act"
+#line 704 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_group(*flags, (ZIg));
+		(ZIe) = ast_make_expr_group(act_state->poolp, *flags, (ZIg));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3518 "src/libre/dialect/pcre/parser.c"
+#line 3520 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-group */
 			switch (CURRENT_TERMINAL) {
@@ -3533,11 +3535,11 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-get-re-flags */
 			{
-#line 709 "src/libre/parser.act"
+#line 711 "src/libre/parser.act"
 
 		(ZIflags) = *flags;
 	
-#line 3541 "src/libre/dialect/pcre/parser.c"
+#line 3543 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-get-re-flags */
 			p_expr (flags, lex_state, act_state, err, &ZIe);
@@ -3547,11 +3549,11 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			}
 			/* BEGINNING OF ACTION: ast-set-re-flags */
 			{
-#line 713 "src/libre/parser.act"
+#line 715 "src/libre/parser.act"
 
 		*flags = (ZIflags);
 	
-#line 3555 "src/libre/dialect/pcre/parser.c"
+#line 3557 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-set-re-flags */
 			switch (CURRENT_TERMINAL) {
@@ -3568,14 +3570,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-anchor-start */
 			{
-#line 726 "src/libre/parser.act"
+#line 728 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_anchor(*flags, AST_ANCHOR_START);
+		(ZIe) = ast_make_expr_anchor(act_state->poolp, *flags, AST_ANCHOR_START);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3579 "src/libre/dialect/pcre/parser.c"
+#line 3581 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-start */
 		}
@@ -3627,26 +3629,26 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-atom */
 		{
-#line 474 "src/libre/parser.act"
+#line 476 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXATOM;
 		}
 		goto ZL2;
 	
-#line 3638 "src/libre/dialect/pcre/parser.c"
+#line 3640 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 656 "src/libre/parser.act"
+#line 658 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_empty(*flags);
+		(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZIe) == NULL) {
 			goto ZL2;
 		}
 	
-#line 3650 "src/libre/dialect/pcre/parser.c"
+#line 3652 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -3672,14 +3674,14 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 		{
 			/* BEGINNING OF ACTION: ast-make-concat */
 			{
-#line 663 "src/libre/parser.act"
+#line 665 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_concat(*flags);
+		(ZInode) = ast_make_expr_concat(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3683 "src/libre/dialect/pcre/parser.c"
+#line 3685 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-concat */
 			p_expr_C_Clist_Hof_Hpieces (flags, lex_state, act_state, err, ZInode);
@@ -3693,14 +3695,14 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 		{
 			/* BEGINNING OF ACTION: ast-make-empty */
 			{
-#line 656 "src/libre/parser.act"
+#line 658 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_empty(*flags);
+		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3704 "src/libre/dialect/pcre/parser.c"
+#line 3706 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-empty */
 		}
@@ -3736,30 +3738,30 @@ p_expr_C_Ctype(flags flags, lex_state lex_state, act_state act_state, err err, t
 		}
 		/* BEGINNING OF ACTION: ast-make-alt */
 		{
-#line 670 "src/libre/parser.act"
+#line 672 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_alt(*flags);
+		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3747 "src/libre/dialect/pcre/parser.c"
+#line 3749 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-alt */
 		/* BEGINNING OF ACTION: ast-add-alt */
 		{
-#line 831 "src/libre/parser.act"
+#line 833 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZInode), (ZIclass))) {
 			goto ZL1;
 		}
 	
-#line 3758 "src/libre/dialect/pcre/parser.c"
+#line 3760 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-add-alt */
 		/* BEGINNING OF ACTION: mark-expr */
 		{
-#line 552 "src/libre/parser.act"
+#line 554 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -3774,7 +3776,7 @@ p_expr_C_Ctype(flags flags, lex_state lex_state, act_state act_state, err err, t
 		(ZInode)->u.class.end   = ast_end;
 */
 	
-#line 3778 "src/libre/dialect/pcre/parser.c"
+#line 3780 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: mark-expr */
 	}
@@ -3788,7 +3790,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 837 "src/libre/parser.act"
+#line 839 "src/libre/parser.act"
 
 
 	static int
@@ -3809,6 +3811,7 @@ ZL0:;
 	struct ast *
 	DIALECT_PARSE(re_getchar_fun *f, void *opaque,
 		const struct fsm_options *opt,
+		struct ast_expr_pool **poolp,
 		enum re_flags flags, int overlap,
 		struct re_err *err)
 	{
@@ -3857,6 +3860,7 @@ ZL0:;
 		act_state = &act_state_s;
 
 		act_state->overlap = overlap;
+		act_state->poolp   = poolp;
 
 		err->e = RE_ESUCCESS;
 
@@ -3928,6 +3932,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 3932 "src/libre/dialect/pcre/parser.c"
+#line 3936 "src/libre/dialect/pcre/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/pcre/parser.h
+++ b/src/libre/dialect/pcre/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 216 "src/libre/parser.act"
+#line 218 "src/libre/parser.act"
 
 
 	#include <re/re.h>
@@ -28,7 +28,7 @@
 extern void p_re__pcre(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 976 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/pcre/parser.h"

--- a/src/libre/dialect/sql/parser.c
+++ b/src/libre/dialect/sql/parser.c
@@ -92,6 +92,8 @@
 	typedef struct ast_endpoint t_endpoint;
 
 	struct act_state {
+		struct ast_expr_pool **poolp;
+
 		enum LX_TOKEN lex_tok;
 		enum LX_TOKEN lex_tok_save;
 		int overlap; /* permit overlap in groups */
@@ -204,7 +206,7 @@
 		return s;
 	}
 
-#line 208 "src/libre/dialect/sql/parser.c"
+#line 210 "src/libre/dialect/sql/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -246,11 +248,11 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: INVERT */
 			{
-#line 231 "src/libre/parser.act"
+#line 233 "src/libre/parser.act"
 
 		ZI191 = '^';
 	
-#line 254 "src/libre/dialect/sql/parser.c"
+#line 256 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: INVERT */
 			ADVANCE_LEXER;
@@ -270,37 +272,37 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 235 "src/libre/parser.act"
+#line 237 "src/libre/parser.act"
 
 		ZIc = '-';
 		ZI99 = lex_state->lx.start;
 		ZI100   = lex_state->lx.end;
 	
-#line 280 "src/libre/dialect/sql/parser.c"
+#line 282 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 677 "src/libre/parser.act"
+#line 679 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_literal(*flags, (ZIc));
+		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 293 "src/libre/dialect/sql/parser.c"
+#line 295 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 			/* BEGINNING OF ACTION: ast-add-alt */
 			{
-#line 831 "src/libre/parser.act"
+#line 833 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((*ZIclass), (ZInode))) {
 			goto ZL1;
 		}
 	
-#line 304 "src/libre/dialect/sql/parser.c"
+#line 306 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 		}
@@ -352,14 +354,14 @@ p_re__sql(flags flags, lex_state lex_state, act_state act_state, err err, t_ast_
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 523 "src/libre/parser.act"
+#line 525 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
 		}
 		goto ZL1;
 	
-#line 363 "src/libre/dialect/sql/parser.c"
+#line 365 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
@@ -395,13 +397,13 @@ ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 				}
 				/* BEGINNING OF ACTION: ast-add-alt */
 				{
-#line 831 "src/libre/parser.act"
+#line 833 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIclass), (ZInode))) {
 			goto ZL4;
 		}
 	
-#line 405 "src/libre/dialect/sql/parser.c"
+#line 407 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: ast-add-alt */
 			}
@@ -410,14 +412,14 @@ ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 			{
 				/* BEGINNING OF ACTION: err-expected-term */
 				{
-#line 460 "src/libre/parser.act"
+#line 462 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXTERM;
 		}
 		goto ZL1;
 	
-#line 421 "src/libre/dialect/sql/parser.c"
+#line 423 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: err-expected-term */
 			}
@@ -471,13 +473,13 @@ ZL2_expr_C_Clist_Hof_Hpieces:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 825 "src/libre/parser.act"
+#line 827 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
 		}
 	
-#line 481 "src/libre/dialect/sql/parser.c"
+#line 483 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-add-concat */
 		/* BEGINNING OF INLINE: 170 */
@@ -517,7 +519,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
-#line 405 "src/libre/parser.act"
+#line 407 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -527,7 +529,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 		ZI193 = lex_state->buf.a[0];
 	
-#line 531 "src/libre/dialect/sql/parser.c"
+#line 533 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
@@ -578,12 +580,12 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		case (TOK_OPENGROUP):
 			/* BEGINNING OF EXTRACT: OPENGROUP */
 			{
-#line 241 "src/libre/parser.act"
+#line 243 "src/libre/parser.act"
 
 		ZIopen__start = lex_state->lx.start;
 		ZIopen__end   = lex_state->lx.end;
 	
-#line 587 "src/libre/dialect/sql/parser.c"
+#line 589 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: OPENGROUP */
 			break;
@@ -593,14 +595,14 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-make-alt */
 		{
-#line 670 "src/libre/parser.act"
+#line 672 "src/libre/parser.act"
 
-		(ZIclass) = ast_make_expr_alt(*flags);
+		(ZIclass) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZIclass) == NULL) {
 			goto ZL1;
 		}
 	
-#line 604 "src/libre/dialect/sql/parser.c"
+#line 606 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-alt */
 		ZItmp = ZIclass;
@@ -618,29 +620,29 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 					/* BEGINNING OF EXTRACT: CLOSEGROUP */
 					{
-#line 261 "src/libre/parser.act"
+#line 263 "src/libre/parser.act"
 
 		ZI139 = ']';
 		ZIclose__start = lex_state->lx.start;
 		ZIclose__end   = lex_state->lx.end;
 	
-#line 628 "src/libre/dialect/sql/parser.c"
+#line 630 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF EXTRACT: CLOSEGROUP */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: mark-group */
 					{
-#line 537 "src/libre/parser.act"
+#line 539 "src/libre/parser.act"
 
 		mark(&act_state->groupstart, &(ZIopen__start));
 		mark(&act_state->groupend,   &(ZIopen__end));
 	
-#line 639 "src/libre/dialect/sql/parser.c"
+#line 641 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: mark-group */
 					/* BEGINNING OF ACTION: mark-expr */
 					{
-#line 552 "src/libre/parser.act"
+#line 554 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -655,7 +657,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		(ZItmp)->u.class.end   = ast_end;
 */
 	
-#line 659 "src/libre/dialect/sql/parser.c"
+#line 661 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: mark-expr */
 					ZInode = ZIclass;
@@ -670,24 +672,24 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 					/* BEGINNING OF EXTRACT: INVERT */
 					{
-#line 231 "src/libre/parser.act"
+#line 233 "src/libre/parser.act"
 
 		ZI143 = '^';
 	
-#line 678 "src/libre/dialect/sql/parser.c"
+#line 680 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF EXTRACT: INVERT */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-alt */
 					{
-#line 670 "src/libre/parser.act"
+#line 672 "src/libre/parser.act"
 
-		(ZImask) = ast_make_expr_alt(*flags);
+		(ZImask) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZImask) == NULL) {
 			goto ZL3;
 		}
 	
-#line 691 "src/libre/dialect/sql/parser.c"
+#line 693 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: ast-make-alt */
 					ZImask__tmp = ZImask;
@@ -708,13 +710,13 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 							case (TOK_CLOSEGROUP):
 								/* BEGINNING OF EXTRACT: CLOSEGROUP */
 								{
-#line 261 "src/libre/parser.act"
+#line 263 "src/libre/parser.act"
 
 		ZI148 = ']';
 		ZIclose__start = lex_state->lx.start;
 		ZIclose__end   = lex_state->lx.end;
 	
-#line 718 "src/libre/dialect/sql/parser.c"
+#line 720 "src/libre/dialect/sql/parser.c"
 								}
 								/* END OF EXTRACT: CLOSEGROUP */
 								break;
@@ -724,12 +726,12 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 							ADVANCE_LEXER;
 							/* BEGINNING OF ACTION: mark-group */
 							{
-#line 537 "src/libre/parser.act"
+#line 539 "src/libre/parser.act"
 
 		mark(&act_state->groupstart, &(ZIclose__start));
 		mark(&act_state->groupend,   &(ZIclose__end));
 	
-#line 733 "src/libre/dialect/sql/parser.c"
+#line 735 "src/libre/dialect/sql/parser.c"
 							}
 							/* END OF ACTION: mark-group */
 						}
@@ -740,14 +742,14 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 							/* BEGINNING OF ACTION: err-expected-closegroup */
 							{
-#line 495 "src/libre/parser.act"
+#line 497 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCLOSEGROUP;
 		}
 		goto ZL3;
 	
-#line 751 "src/libre/dialect/sql/parser.c"
+#line 753 "src/libre/dialect/sql/parser.c"
 							}
 							/* END OF ACTION: err-expected-closegroup */
 							ZIclose__start = ZIopen__end;
@@ -758,7 +760,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 					/* END OF INLINE: 147 */
 					/* BEGINNING OF ACTION: mark-expr */
 					{
-#line 552 "src/libre/parser.act"
+#line 554 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -773,12 +775,12 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		(ZItmp)->u.class.end   = ast_end;
 */
 	
-#line 777 "src/libre/dialect/sql/parser.c"
+#line 779 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: mark-expr */
 					/* BEGINNING OF ACTION: mark-expr */
 					{
-#line 552 "src/libre/parser.act"
+#line 554 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -793,19 +795,19 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		(ZImask__tmp)->u.class.end   = ast_end;
 */
 	
-#line 797 "src/libre/dialect/sql/parser.c"
+#line 799 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: mark-expr */
 					/* BEGINNING OF ACTION: ast-make-subtract */
 					{
-#line 740 "src/libre/parser.act"
+#line 742 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_subtract(*flags, (ZIclass), (ZImask));
+		(ZInode) = ast_make_expr_subtract(act_state->poolp, *flags, (ZIclass), (ZImask));
 		if ((ZInode) == NULL) {
 			goto ZL3;
 		}
 	
-#line 809 "src/libre/dialect/sql/parser.c"
+#line 811 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: ast-make-subtract */
 				}
@@ -821,26 +823,26 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			{
 				/* BEGINNING OF ACTION: err-expected-closegroup */
 				{
-#line 495 "src/libre/parser.act"
+#line 497 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCLOSEGROUP;
 		}
 		goto ZL1;
 	
-#line 832 "src/libre/dialect/sql/parser.c"
+#line 834 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: err-expected-closegroup */
 				/* BEGINNING OF ACTION: ast-make-empty */
 				{
-#line 656 "src/libre/parser.act"
+#line 658 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_empty(*flags);
+		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 844 "src/libre/dialect/sql/parser.c"
+#line 846 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: ast-make-empty */
 			}
@@ -869,42 +871,42 @@ p_192(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 235 "src/libre/parser.act"
+#line 237 "src/libre/parser.act"
 
 		ZIc = '-';
 		ZI102 = lex_state->lx.start;
 		ZI103   = lex_state->lx.end;
 	
-#line 879 "src/libre/dialect/sql/parser.c"
+#line 881 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 677 "src/libre/parser.act"
+#line 679 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_literal(*flags, (ZIc));
+		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 892 "src/libre/dialect/sql/parser.c"
+#line 894 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 			/* BEGINNING OF ACTION: ast-add-alt */
 			{
-#line 831 "src/libre/parser.act"
+#line 833 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((*ZIclass), (ZInode))) {
 			goto ZL1;
 		}
 	
-#line 903 "src/libre/dialect/sql/parser.c"
+#line 905 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 			/* BEGINNING OF ACTION: ast-make-invert */
 			{
-#line 747 "src/libre/parser.act"
+#line 749 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -932,17 +934,17 @@ p_192(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 		 * a better idea.
 		 */
 
-		any = ast_make_expr_named(*flags, &class_any);
+		any = ast_make_expr_named(act_state->poolp, *flags, &class_any);
 		if (any == NULL) {
 			goto ZL1;
 		}
 
-		(*ZIclass) = ast_make_expr_subtract(*flags, any, (*ZIclass));
+		(*ZIclass) = ast_make_expr_subtract(act_state->poolp, *flags, any, (*ZIclass));
 		if ((*ZIclass) == NULL) {
 			goto ZL1;
 		}
 	
-#line 946 "src/libre/dialect/sql/parser.c"
+#line 948 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-invert */
 		}
@@ -951,7 +953,7 @@ p_192(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 		{
 			/* BEGINNING OF ACTION: ast-make-invert */
 			{
-#line 747 "src/libre/parser.act"
+#line 749 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -979,17 +981,17 @@ p_192(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 		 * a better idea.
 		 */
 
-		any = ast_make_expr_named(*flags, &class_any);
+		any = ast_make_expr_named(act_state->poolp, *flags, &class_any);
 		if (any == NULL) {
 			goto ZL1;
 		}
 
-		(*ZIclass) = ast_make_expr_subtract(*flags, any, (*ZIclass));
+		(*ZIclass) = ast_make_expr_subtract(act_state->poolp, *flags, any, (*ZIclass));
 		if ((*ZIclass) == NULL) {
 			goto ZL1;
 		}
 	
-#line 993 "src/libre/dialect/sql/parser.c"
+#line 995 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-invert */
 		}
@@ -1023,21 +1025,21 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 		}
 		/* BEGINNING OF ACTION: ast-make-piece */
 		{
-#line 688 "src/libre/parser.act"
+#line 690 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
-			(ZInode) = ast_make_expr_empty(*flags);
+			(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		} else if ((ZIc).min == 1 && (ZIc).max == 1) {
 			(ZInode) = (ZIe);
 		} else {
-			(ZInode) = ast_make_expr_repeat(*flags, (ZIe), (ZIc));
+			(ZInode) = ast_make_expr_repeat(act_state->poolp, *flags, (ZIe), (ZIc));
 		}
 		if ((ZInode) == NULL) {
 			err->e = RE_EXEOF;
 			goto ZL1;
 		}
 	
-#line 1041 "src/libre/dialect/sql/parser.c"
+#line 1043 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-piece */
 	}
@@ -1060,14 +1062,14 @@ p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__ex
 	{
 		/* BEGINNING OF ACTION: ast-make-alt */
 		{
-#line 670 "src/libre/parser.act"
+#line 672 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_alt(*flags);
+		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1071 "src/libre/dialect/sql/parser.c"
+#line 1073 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-alt */
 		p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, ZInode);
@@ -1081,26 +1083,26 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-alts */
 		{
-#line 481 "src/libre/parser.act"
+#line 483 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXALTS;
 		}
 		goto ZL2;
 	
-#line 1092 "src/libre/dialect/sql/parser.c"
+#line 1094 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 656 "src/libre/parser.act"
+#line 658 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_empty(*flags);
+		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL2;
 		}
 	
-#line 1104 "src/libre/dialect/sql/parser.c"
+#line 1106 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -1122,14 +1124,14 @@ p_196(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		{
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 677 "src/libre/parser.act"
+#line 679 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_literal(*flags, (*ZI193));
+		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (*ZI193));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1133 "src/libre/dialect/sql/parser.c"
+#line 1135 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -1147,23 +1149,23 @@ p_196(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 625 "src/libre/parser.act"
+#line 627 "src/libre/parser.act"
 
 		(ZIa).type = AST_ENDPOINT_LITERAL;
 		(ZIa).u.literal.c = (*ZI193);
 	
-#line 1156 "src/libre/dialect/sql/parser.c"
+#line 1158 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 235 "src/libre/parser.act"
+#line 237 "src/libre/parser.act"
 
 		ZI121 = '-';
 		ZI122 = lex_state->lx.start;
 		ZI123   = lex_state->lx.end;
 	
-#line 1167 "src/libre/dialect/sql/parser.c"
+#line 1169 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
@@ -1171,7 +1173,7 @@ p_196(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			case (TOK_CHAR):
 				/* BEGINNING OF EXTRACT: CHAR */
 				{
-#line 405 "src/libre/parser.act"
+#line 407 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -1181,7 +1183,7 @@ p_196(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 		ZIcz = lex_state->buf.a[0];
 	
-#line 1185 "src/libre/dialect/sql/parser.c"
+#line 1187 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: CHAR */
 				break;
@@ -1191,27 +1193,27 @@ p_196(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 625 "src/libre/parser.act"
+#line 627 "src/libre/parser.act"
 
 		(ZIz).type = AST_ENDPOINT_LITERAL;
 		(ZIz).u.literal.c = (ZIcz);
 	
-#line 1200 "src/libre/dialect/sql/parser.c"
+#line 1202 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF ACTION: mark-range */
 			{
-#line 542 "src/libre/parser.act"
+#line 544 "src/libre/parser.act"
 
 		mark(&act_state->rangestart, &(*ZI194));
 		mark(&act_state->rangeend,   &(ZIend));
 	
-#line 1210 "src/libre/dialect/sql/parser.c"
+#line 1212 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 785 "src/libre/parser.act"
+#line 787 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -1239,12 +1241,12 @@ p_196(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			goto ZL1;
 		}
 
-		(ZInode) = ast_make_expr_range(*flags, &(ZIa), ast_start, &(ZIz), ast_end);
+		(ZInode) = ast_make_expr_range(act_state->poolp, *flags, &(ZIa), ast_start, &(ZIz), ast_end);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1248 "src/libre/dialect/sql/parser.c"
+#line 1250 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -1273,28 +1275,28 @@ p_199(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI1
 
 			/* BEGINNING OF EXTRACT: CLOSECOUNT */
 			{
-#line 272 "src/libre/parser.act"
+#line 274 "src/libre/parser.act"
 
 		ZI163 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1282 "src/libre/dialect/sql/parser.c"
+#line 1284 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: CLOSECOUNT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 547 "src/libre/parser.act"
+#line 549 "src/libre/parser.act"
 
 		mark(&act_state->countstart, &(*ZI197));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 1293 "src/libre/dialect/sql/parser.c"
+#line 1295 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 605 "src/libre/parser.act"
+#line 607 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -1314,7 +1316,7 @@ p_199(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI1
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (*ZIm), &ast_end);
 	
-#line 1318 "src/libre/dialect/sql/parser.c"
+#line 1320 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-range */
 		}
@@ -1330,7 +1332,7 @@ p_199(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI1
 			case (TOK_COUNT):
 				/* BEGINNING OF EXTRACT: COUNT */
 				{
-#line 415 "src/libre/parser.act"
+#line 417 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -1350,7 +1352,7 @@ p_199(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI1
 
 		ZIn = (unsigned int) u;
 	
-#line 1354 "src/libre/dialect/sql/parser.c"
+#line 1356 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -1362,12 +1364,12 @@ p_199(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI1
 			case (TOK_CLOSECOUNT):
 				/* BEGINNING OF EXTRACT: CLOSECOUNT */
 				{
-#line 272 "src/libre/parser.act"
+#line 274 "src/libre/parser.act"
 
 		ZI166 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1371 "src/libre/dialect/sql/parser.c"
+#line 1373 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: CLOSECOUNT */
 				break;
@@ -1377,17 +1379,17 @@ p_199(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI1
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 547 "src/libre/parser.act"
+#line 549 "src/libre/parser.act"
 
 		mark(&act_state->countstart, &(*ZI197));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 1386 "src/libre/dialect/sql/parser.c"
+#line 1388 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 605 "src/libre/parser.act"
+#line 607 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -1407,7 +1409,7 @@ p_199(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI1
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (ZIn), &ast_end);
 	
-#line 1411 "src/libre/dialect/sql/parser.c"
+#line 1413 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-range */
 		}
@@ -1442,13 +1444,13 @@ ZL2_expr_C_Clist_Hof_Halts:;
 		}
 		/* BEGINNING OF ACTION: ast-add-alt */
 		{
-#line 831 "src/libre/parser.act"
+#line 833 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIalts), (ZIa))) {
 			goto ZL1;
 		}
 	
-#line 1452 "src/libre/dialect/sql/parser.c"
+#line 1454 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-add-alt */
 		/* BEGINNING OF INLINE: 176 */
@@ -1473,14 +1475,14 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-alts */
 		{
-#line 481 "src/libre/parser.act"
+#line 483 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXALTS;
 		}
 		goto ZL4;
 	
-#line 1484 "src/libre/dialect/sql/parser.c"
+#line 1486 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
 	}
@@ -1505,12 +1507,12 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 			/* BEGINNING OF EXTRACT: OPENCOUNT */
 			{
-#line 267 "src/libre/parser.act"
+#line 269 "src/libre/parser.act"
 
 		ZI197 = lex_state->lx.start;
 		ZI198   = lex_state->lx.end;
 	
-#line 1514 "src/libre/dialect/sql/parser.c"
+#line 1516 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: OPENCOUNT */
 			ADVANCE_LEXER;
@@ -1518,7 +1520,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			case (TOK_COUNT):
 				/* BEGINNING OF EXTRACT: COUNT */
 				{
-#line 415 "src/libre/parser.act"
+#line 417 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -1538,7 +1540,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		ZIm = (unsigned int) u;
 	
-#line 1542 "src/libre/dialect/sql/parser.c"
+#line 1544 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -1558,11 +1560,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-zero-or-one */
 			{
-#line 597 "src/libre/parser.act"
+#line 599 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, 1, NULL);
 	
-#line 1566 "src/libre/dialect/sql/parser.c"
+#line 1568 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-one */
 		}
@@ -1572,11 +1574,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-one-or-more */
 			{
-#line 593 "src/libre/parser.act"
+#line 595 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 1580 "src/libre/dialect/sql/parser.c"
+#line 1582 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-one-or-more */
 		}
@@ -1586,11 +1588,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-zero-or-more */
 			{
-#line 589 "src/libre/parser.act"
+#line 591 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 1594 "src/libre/dialect/sql/parser.c"
+#line 1596 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 		}
@@ -1599,11 +1601,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 		{
 			/* BEGINNING OF ACTION: count-one */
 			{
-#line 601 "src/libre/parser.act"
+#line 603 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 1607 "src/libre/dialect/sql/parser.c"
+#line 1609 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-one */
 		}
@@ -1616,23 +1618,23 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-count */
 		{
-#line 467 "src/libre/parser.act"
+#line 469 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCOUNT;
 		}
 		goto ZL2;
 	
-#line 1627 "src/libre/dialect/sql/parser.c"
+#line 1629 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: err-expected-count */
 		/* BEGINNING OF ACTION: count-one */
 		{
-#line 601 "src/libre/parser.act"
+#line 603 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 1636 "src/libre/dialect/sql/parser.c"
+#line 1638 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: count-one */
 	}
@@ -1657,24 +1659,24 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: class-any */
 			{
-#line 567 "src/libre/parser.act"
+#line 569 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
 		(ZIa) = &class_any;
 	
-#line 1666 "src/libre/dialect/sql/parser.c"
+#line 1668 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 818 "src/libre/parser.act"
+#line 820 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_named(*flags, (ZIa));
+		(ZIe) = ast_make_expr_named(act_state->poolp, *flags, (ZIa));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1678 "src/libre/dialect/sql/parser.c"
+#line 1680 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 		}
@@ -1687,7 +1689,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
-#line 405 "src/libre/parser.act"
+#line 407 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -1697,20 +1699,20 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 
 		ZIa = lex_state->buf.a[0];
 	
-#line 1701 "src/libre/dialect/sql/parser.c"
+#line 1703 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 677 "src/libre/parser.act"
+#line 679 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_literal(*flags, (ZIa));
+		(ZIe) = ast_make_expr_literal(act_state->poolp, *flags, (ZIa));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1714 "src/libre/dialect/sql/parser.c"
+#line 1716 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -1724,52 +1726,52 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: class-any */
 			{
-#line 567 "src/libre/parser.act"
+#line 569 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
 		(ZIa) = &class_any;
 	
-#line 1733 "src/libre/dialect/sql/parser.c"
+#line 1735 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 818 "src/libre/parser.act"
+#line 820 "src/libre/parser.act"
 
-		(ZIg) = ast_make_expr_named(*flags, (ZIa));
+		(ZIg) = ast_make_expr_named(act_state->poolp, *flags, (ZIa));
 		if ((ZIg) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1745 "src/libre/dialect/sql/parser.c"
+#line 1747 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 			/* BEGINNING OF ACTION: count-zero-or-more */
 			{
-#line 589 "src/libre/parser.act"
+#line 591 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 1754 "src/libre/dialect/sql/parser.c"
+#line 1756 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 			/* BEGINNING OF ACTION: ast-make-piece */
 			{
-#line 688 "src/libre/parser.act"
+#line 690 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
-			(ZIe) = ast_make_expr_empty(*flags);
+			(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
 		} else if ((ZIc).min == 1 && (ZIc).max == 1) {
 			(ZIe) = (ZIg);
 		} else {
-			(ZIe) = ast_make_expr_repeat(*flags, (ZIg), (ZIc));
+			(ZIe) = ast_make_expr_repeat(act_state->poolp, *flags, (ZIg), (ZIc));
 		}
 		if ((ZIe) == NULL) {
 			err->e = RE_EXEOF;
 			goto ZL1;
 		}
 	
-#line 1773 "src/libre/dialect/sql/parser.c"
+#line 1775 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-piece */
 		}
@@ -1786,14 +1788,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			}
 			/* BEGINNING OF ACTION: ast-make-group */
 			{
-#line 702 "src/libre/parser.act"
+#line 704 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_group(*flags, (ZIg));
+		(ZIe) = ast_make_expr_group(act_state->poolp, *flags, (ZIg));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1797 "src/libre/dialect/sql/parser.c"
+#line 1799 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-group */
 			switch (CURRENT_TERMINAL) {
@@ -1824,26 +1826,26 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-atom */
 		{
-#line 474 "src/libre/parser.act"
+#line 476 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXATOM;
 		}
 		goto ZL2;
 	
-#line 1835 "src/libre/dialect/sql/parser.c"
+#line 1837 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 656 "src/libre/parser.act"
+#line 658 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_empty(*flags);
+		(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZIe) == NULL) {
 			goto ZL2;
 		}
 	
-#line 1847 "src/libre/dialect/sql/parser.c"
+#line 1849 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -1872,7 +1874,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed(flags flags, lex_state lex_state, act
 		case (TOK_NAMED__CLASS):
 			/* BEGINNING OF EXTRACT: NAMED_CLASS */
 			{
-#line 435 "src/libre/parser.act"
+#line 437 "src/libre/parser.act"
 
 		ZIid = DIALECT_CLASS(lex_state->buf.a);
 		if (ZIid == NULL) {
@@ -1883,7 +1885,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed(flags flags, lex_state lex_state, act
 		ZI113 = lex_state->lx.start;
 		ZI114   = lex_state->lx.end;
 	
-#line 1887 "src/libre/dialect/sql/parser.c"
+#line 1889 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			break;
@@ -1893,14 +1895,14 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed(flags flags, lex_state lex_state, act
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-make-named */
 		{
-#line 818 "src/libre/parser.act"
+#line 820 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_named(*flags, (ZIid));
+		(ZInode) = ast_make_expr_named(act_state->poolp, *flags, (ZIid));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1904 "src/libre/dialect/sql/parser.c"
+#line 1906 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-named */
 	}
@@ -1923,14 +1925,14 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 		{
 			/* BEGINNING OF ACTION: ast-make-concat */
 			{
-#line 663 "src/libre/parser.act"
+#line 665 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_concat(*flags);
+		(ZInode) = ast_make_expr_concat(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1934 "src/libre/dialect/sql/parser.c"
+#line 1936 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-concat */
 			p_expr_C_Clist_Hof_Hpieces (flags, lex_state, act_state, err, ZInode);
@@ -1944,14 +1946,14 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 		{
 			/* BEGINNING OF ACTION: ast-make-empty */
 			{
-#line 656 "src/libre/parser.act"
+#line 658 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_empty(*flags);
+		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1955 "src/libre/dialect/sql/parser.c"
+#line 1957 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-empty */
 		}
@@ -1969,7 +1971,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 837 "src/libre/parser.act"
+#line 839 "src/libre/parser.act"
 
 
 	static int
@@ -1990,6 +1992,7 @@ ZL0:;
 	struct ast *
 	DIALECT_PARSE(re_getchar_fun *f, void *opaque,
 		const struct fsm_options *opt,
+		struct ast_expr_pool **poolp,
 		enum re_flags flags, int overlap,
 		struct re_err *err)
 	{
@@ -2038,6 +2041,7 @@ ZL0:;
 		act_state = &act_state_s;
 
 		act_state->overlap = overlap;
+		act_state->poolp   = poolp;
 
 		err->e = RE_ESUCCESS;
 
@@ -2109,6 +2113,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 2113 "src/libre/dialect/sql/parser.c"
+#line 2117 "src/libre/dialect/sql/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/sql/parser.h
+++ b/src/libre/dialect/sql/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 216 "src/libre/parser.act"
+#line 218 "src/libre/parser.act"
 
 
 	#include <re/re.h>
@@ -28,7 +28,7 @@
 extern void p_re__sql(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 976 "src/libre/parser.act"
+#line 980 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/sql/parser.h"

--- a/src/libre/libre.syms
+++ b/src/libre/libre.syms
@@ -9,6 +9,7 @@ ast_print_dot
 ast_print_abnf
 ast_print_pcre
 ast_print_tree
+ast_free
 re_parse
 re_strings
 re_strings_new

--- a/src/libre/parser.act
+++ b/src/libre/parser.act
@@ -101,6 +101,8 @@
 	typedef struct ast_endpoint t_endpoint;
 
 	struct act_state {
+		struct ast_expr_pool **poolp;
+
 		enum LX_TOKEN lex_tok;
 		enum LX_TOKEN lex_tok_save;
 		int overlap; /* permit overlap in groups */
@@ -654,28 +656,28 @@
 	 */
 
 	<ast-make-empty>: () -> (node :ast_expr) = @{
-		@node = ast_make_expr_empty(*flags);
+		@node = ast_make_expr_empty(act_state->poolp, *flags);
 		if (@node == NULL) {
 			@!;
 		}
 	@};
 
 	<ast-make-concat>: () -> (node :ast_expr) = @{
-		@node = ast_make_expr_concat(*flags);
+		@node = ast_make_expr_concat(act_state->poolp, *flags);
 		if (@node == NULL) {
 			@!;
 		}
 	@};
 
 	<ast-make-alt>: () -> (node :ast_expr) = @{
-		@node = ast_make_expr_alt(*flags);
+		@node = ast_make_expr_alt(act_state->poolp, *flags);
 		if (@node == NULL) {
 			@!;
 		}
 	@};
 
 	<ast-make-literal>: (c :char) -> (node :ast_expr) = @{
-		@node = ast_make_expr_literal(*flags, @c);
+		@node = ast_make_expr_literal(act_state->poolp, *flags, @c);
 		if (@node == NULL) {
 			@!;
 		}
@@ -687,11 +689,11 @@
 
 	<ast-make-piece>: (e :ast_expr, c :ast_count) -> (node :ast_expr) = @{
 		if (@c.min == 0 && @c.max == 0) {
-			@node = ast_make_expr_empty(*flags);
+			@node = ast_make_expr_empty(act_state->poolp, *flags);
 		} else if (@c.min == 1 && @c.max == 1) {
 			@node = @e;
 		} else {
-			@node = ast_make_expr_repeat(*flags, @e, @c);
+			@node = ast_make_expr_repeat(act_state->poolp, *flags, @e, @c);
 		}
 		if (@node == NULL) {
 			err->e = RE_EXEOF;
@@ -700,7 +702,7 @@
 	@};
 
 	<ast-make-group>: (e :ast_expr) -> (node :ast_expr) = @{
-		@node = ast_make_expr_group(*flags, @e);
+		@node = ast_make_expr_group(act_state->poolp, *flags, @e);
 		if (@node == NULL) {
 			@!;
 		}
@@ -724,21 +726,21 @@
 	@};
 
 	<ast-make-anchor-start>: () -> (node :ast_expr) = @{
-		@node = ast_make_expr_anchor(*flags, AST_ANCHOR_START);
+		@node = ast_make_expr_anchor(act_state->poolp, *flags, AST_ANCHOR_START);
 		if (@node == NULL) {
 			@!;
 		}
 	@};
 
 	<ast-make-anchor-end>: () -> (node :ast_expr) = @{
-		@node = ast_make_expr_anchor(*flags, AST_ANCHOR_END);
+		@node = ast_make_expr_anchor(act_state->poolp, *flags, AST_ANCHOR_END);
 		if (@node == NULL) {
 			@!;
 		}
 	@};
 
 	<ast-make-subtract>: (a :ast_expr, b :ast_expr) -> (node :ast_expr) = @{
-		@node = ast_make_expr_subtract(*flags, @a, @b);
+		@node = ast_make_expr_subtract(act_state->poolp, *flags, @a, @b);
 		if (@node == NULL) {
 			@!;
 		}
@@ -771,12 +773,12 @@
 		 * a better idea.
 		 */
 
-		any = ast_make_expr_named(*flags, &class_any);
+		any = ast_make_expr_named(act_state->poolp, *flags, &class_any);
 		if (any == NULL) {
 			@!;
 		}
 
-		@node = ast_make_expr_subtract(*flags, any, @e);
+		@node = ast_make_expr_subtract(act_state->poolp, *flags, any, @e);
 		if (@node == NULL) {
 			@!;
 		}
@@ -809,14 +811,14 @@
 			@!;
 		}
 
-		@node = ast_make_expr_range(*flags, &@from, ast_start, &@to, ast_end);
+		@node = ast_make_expr_range(act_state->poolp, *flags, &@from, ast_start, &@to, ast_end);
 		if (@node == NULL) {
 			@!;
 		}
 	@};
 
 	<ast-make-named>: (id :ast_class_id) -> (node :ast_expr) = @{
-		@node = ast_make_expr_named(*flags, @id);
+		@node = ast_make_expr_named(act_state->poolp, *flags, @id);
 		if (@node == NULL) {
 			@!;
 		}
@@ -854,6 +856,7 @@
 	struct ast *
 	DIALECT_PARSE(re_getchar_fun *f, void *opaque,
 		const struct fsm_options *opt,
+		struct ast_expr_pool **poolp,
 		enum re_flags flags, int overlap,
 		struct re_err *err)
 	{
@@ -902,6 +905,7 @@
 		act_state = &act_state_s;
 
 		act_state->overlap = overlap;
+		act_state->poolp   = poolp;
 
 		err->e = RE_ESUCCESS;
 

--- a/src/libre/re.c
+++ b/src/libre/re.c
@@ -109,8 +109,8 @@ re_parse(enum re_dialect dialect, int (*getc)(void *opaque), void *opaque,
 
 	flags |= m->flags;
 
-	ast = m->parse(getc, opaque, opt, flags, m->overlap, err);
-	pool = ast_expr_pool_save();
+	ast = m->parse(getc, opaque, opt, &pool, flags, m->overlap, err);
+
 	if (ast == NULL) {
 		ast_pool_free(pool);
 		return NULL;

--- a/src/libre/re.c
+++ b/src/libre/re.c
@@ -168,6 +168,8 @@ re_comp(enum re_dialect dialect, int (*getc)(void *opaque), void *opaque,
 	 */
 	if (unsatisfiable) {
 		ast_expr_free(ast->expr);
+		/* ast_free below frees the pool */
+
 		ast->expr = ast_expr_tombstone;
 	}
 

--- a/src/libre/re_strings.c
+++ b/src/libre/re_strings.c
@@ -38,9 +38,7 @@ re_strings(const struct fsm_options *opt, const char *a[], size_t n,
 	}
 
 	fsm = re_strings_build(g, opt, flags);
-	if (fsm == NULL) {
-		goto error;
-	}
+	re_strings_free(g);
 
 	return fsm;
 

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -478,6 +478,16 @@ endleaf_json(FILE *f, const void *state_opaque, const void *endleaf_opaque)
 	return 0;
 }
 
+static struct fsm *fsm_to_cleanup = NULL;
+
+static void
+do_fsm_cleanup(void)
+{
+	if (fsm_to_cleanup != NULL) {
+		fsm_free(fsm_to_cleanup);
+	}
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -497,6 +507,8 @@ main(int argc, char *argv[])
 	int makevm;
 
 	struct fsm_dfavm *vm;
+
+	atexit(do_fsm_cleanup);
 
 	/* note these defaults are the opposite than for fsm(1) */
 	opt.anonymous_states  = 1;
@@ -680,6 +692,8 @@ main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
+	fsm_to_cleanup = fsm;
+
 	{
 		int i;
 
@@ -785,6 +799,8 @@ main(int argc, char *argv[])
 				perror("fsm_union/concat");
 				return EXIT_FAILURE;
 			}
+
+			fsm_to_cleanup = fsm;
 
 			if (query != NULL) {
 				int r;
@@ -1020,6 +1036,7 @@ main(int argc, char *argv[])
 		/* XXX: free opaques */
 
 		fsm_free(fsm);
+		fsm_to_cleanup = NULL;
 
 		if (vm != NULL) {
 			fsm_vm_free(vm);

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -735,6 +735,8 @@ main(int argc, char *argv[])
 
 		print_ast(stdout, &opt, flags, ast);
 
+		ast_free(ast);
+
 		return 0;
 	}
 

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -251,6 +251,13 @@ xopen(const char *s)
 	return f;
 }
 
+struct matches_list {
+	struct matches_list *next;
+	struct match *head;
+};
+
+static struct matches_list *all_matches = NULL;
+
 static struct match *
 addmatch(struct match **head, int i, const char *s)
 {
@@ -291,6 +298,50 @@ addmatch(struct match **head, int i, const char *s)
 	*head     = new;
 
 	return new;
+}
+
+static void
+add_matches_list(struct match *head)
+{
+	struct matches_list *new;
+
+	if (head == NULL) {
+		return;
+	}
+
+	new = malloc(sizeof *new);
+	if (new == NULL) {
+		perror("allocating matches list");
+		abort();
+	}
+
+	new->next = all_matches;
+	new->head = head;
+	all_matches = new;
+}
+
+static void
+free_all_matches(void)
+{
+	struct matches_list *clst;
+	struct matches_list *nlst;
+
+	for (clst = all_matches; clst != NULL; clst = nlst) {
+		struct match *curr;
+		struct match *next;
+
+		nlst = clst->next;
+
+		for (curr = clst->head; curr != NULL; curr = next) {
+			next = curr->next;
+
+			free(curr);
+		}
+
+		free(clst);
+	}
+
+	all_matches = NULL;
 }
 
 static void
@@ -338,6 +389,7 @@ carryopaque(struct fsm *src_fsm, const fsm_state_t *src_set, size_t n,
 		}
 	}
 
+	add_matches_list(matches);
 	fsm_setopaque(dst_fsm, dst_state, matches);
 
 	return;
@@ -486,6 +538,8 @@ do_fsm_cleanup(void)
 	if (fsm_to_cleanup != NULL) {
 		fsm_free(fsm_to_cleanup);
 	}
+
+	free_all_matches();
 }
 
 int
@@ -776,6 +830,8 @@ main(int argc, char *argv[])
 							perror("addmatch");
 							return EXIT_FAILURE;
 						}
+
+						add_matches_list(matches);
 
 						assert(fsm_getopaque(new, s) == NULL);
 						fsm_setopaque(new, s, matches);

--- a/tests/hashset/hashset0.c
+++ b/tests/hashset/hashset0.c
@@ -36,5 +36,6 @@ int main(void) {
 	assert(hashset_add(s, &a[0]));
 	assert(hashset_add(s, &a[1]));
 	assert(hashset_add(s, &a[2]));
+	hashset_free(s);
 	return 0;
 }

--- a/tests/hashset/hashset1.c
+++ b/tests/hashset/hashset1.c
@@ -90,5 +90,6 @@ int main(void) {
 	assert(hashset_contains(s, &a[14]));
 	assert(hashset_contains(s, &a[15]));
 
+	hashset_free(s);
 	return 0;
 }

--- a/tests/hashset/hashset2.c
+++ b/tests/hashset/hashset2.c
@@ -52,6 +52,7 @@ int main(void) {
 
 	assert(!hashset_contains(s, &a));
 
+	hashset_free(s);
 	return 0;
 }
 

--- a/tests/hashset/hashset3.c
+++ b/tests/hashset/hashset3.c
@@ -61,5 +61,6 @@ int main(void) {
 		assert(seen[i]);
 	}
 
+	hashset_free(s);
 	return 0;
 }

--- a/tests/hashset/hashset4.c
+++ b/tests/hashset/hashset4.c
@@ -59,16 +59,31 @@ int *next_int(int reset) {
 int main(void) {
 	struct hashset *s = hashset_create(NULL, hash_int, cmp_int);
 	size_t i;
+	int **plist;
+
+	plist = malloc(10000 * sizeof *plist);
+	assert(plist != NULL);
+
 	for (i = 0; i < 5000; i++) {
-		assert(hashset_add(s, next_int(0)));
+		int *itm = next_int(0);
+		plist[i] = itm;
+		assert(hashset_add(s, itm));
 	}
 	assert(hashset_count(s) == 5000);
 
 	next_int(1);
 	for (i = 0; i < 5000; i++) {
-		assert(hashset_add(s, next_int(0)));
+		int *itm = next_int(0);
+		plist[5000+i] = itm;
+		assert(hashset_add(s, itm));
 	}
 	assert(hashset_count(s) == 5000);
 
+	for (i=0; i < 10000; i++) {
+		free(plist[i]);
+	}
+	free(plist);
+
+	hashset_free(s);
 	return 0;
 }

--- a/tests/hashset/hashset5.c
+++ b/tests/hashset/hashset5.c
@@ -53,13 +53,29 @@ int main(void) {
 	struct hashset *s = hashset_create(NULL, hash_int, cmp_int);
 	int a[3] = {1200,2400,3600};
 	size_t i;
+	int **plist;
+
+	plist = malloc(5000 * sizeof *plist);
+	assert(plist != NULL);
+
 	for (i = 0; i < 5000; i++) {
-		assert(hashset_add(s, next_int()));
+		int *itm = next_int();
+		plist[i] = itm;
+		assert(hashset_add(s, itm));
 	}
+
 	for (i = 0; i < 3; i++) {
 		assert(hashset_contains(s, &a[i]));
 		hashset_remove(s, &a[i]);
 	}
+
 	assert(hashset_count(s) == 4997);
+
+	for (i=0; i < 5000; i++) {
+		free(plist[i]);
+	}
+	free(plist);
+
+	hashset_free(s);
 	return 0;
 }

--- a/tests/hashset/hashset6.c
+++ b/tests/hashset/hashset6.c
@@ -54,5 +54,11 @@ int main(void) {
 			assert(!hashset_hasnext(&iter));
 		}
 	}
+
+	for (p = hashset_first(s, &iter); p != NULL; p = hashset_next(&iter)) {
+		free(p);
+	}
+
+	hashset_free(s);
 	return 0;
 }

--- a/tests/set/set0.c
+++ b/tests/set/set0.c
@@ -30,5 +30,6 @@ int main(void) {
 	assert(set_add(s, &a[0]));
 	assert(set_add(s, &a[1]));
 	assert(set_add(s, &a[2]));
+	set_free(s);
 	return 0;
 }

--- a/tests/set/set1.c
+++ b/tests/set/set1.c
@@ -33,5 +33,6 @@ int main(void) {
 	assert(set_contains(s, &a[0]));
 	assert(set_contains(s, &a[1]));
 	assert(set_contains(s, &a[2]));
+	set_free(s);
 	return 0;
 }

--- a/tests/set/set2.c
+++ b/tests/set/set2.c
@@ -32,5 +32,6 @@ int main(void) {
 	assert(set_add(s, &a));
 	set_remove(s, &a);
 	assert(!set_contains(s, &a));
+	set_free(s);
 	return 0;
 }

--- a/tests/set/set3.c
+++ b/tests/set/set3.c
@@ -41,5 +41,6 @@ int main(void) {
 	for (i = 0; i < 3; i++) {
 		assert(seen[i]);
 	}
+	set_free(s);
 	return 0;
 }

--- a/tests/set/set4.c
+++ b/tests/set/set4.c
@@ -35,9 +35,23 @@ int *next_int(void) {
 int main(void) {
 	struct set *s = set_create(NULL, cmp_int);
 	size_t i;
+	int **plist;
+
+	plist = malloc(5000 * sizeof *plist);
+	assert(plist != NULL);
+
 	for (i = 0; i < 5000; i++) {
-		assert(set_add(s, next_int()));
+		int *itm = next_int();
+		plist[i] = itm;
+		assert(set_add(s, itm));
 	}
 	assert(set_count(s) == 5000);
+
+	for (i=0; i < 5000; i++) {
+		free(plist[i]);
+	}
+	free(plist);
+
+	set_free(s);
 	return 0;
 }

--- a/tests/set/set5.c
+++ b/tests/set/set5.c
@@ -36,13 +36,27 @@ int main(void) {
 	struct set *s = set_create(NULL, cmp_int);
 	int a[3] = {1200,2400,3600};
 	size_t i;
+	int **plist;
+
+	plist = malloc(5000 * sizeof *plist);
+	assert(plist != NULL);
+
 	for (i = 0; i < 5000; i++) {
-		assert(set_add(s, next_int()));
+		int *itm = next_int();
+		plist[i] = itm;
+		assert(set_add(s, itm));
 	}
 	for (i = 0; i < 3; i++) {
 		assert(set_contains(s, &a[i]));
 		set_remove(s, &a[i]);
 	}
 	assert(set_count(s) == 4997);
+
+	for (i=0; i < 5000; i++) {
+		free(plist[i]);
+	}
+	free(plist);
+
+	set_free(s);
 	return 0;
 }

--- a/tests/set/set6.c
+++ b/tests/set/set6.c
@@ -36,9 +36,16 @@ int main(void) {
 	struct set *s = set_create(NULL, cmp_int);
 	struct set_iter iter;
 	size_t i;
+	int **plist;
+
+	plist = malloc(5000 * sizeof *plist);
+	assert(plist != NULL);
+
 	int *p;
 	for (i = 0; i < 5000; i++) {
-		assert(set_add(s, next_int()));
+		int *itm = next_int();
+		plist[i] = itm;
+		assert(set_add(s, itm));
 	}
 	for (i = 0, p = set_first(s, &iter); i < 5000; i++, set_next(&iter)) {
 		assert(p);
@@ -48,5 +55,12 @@ int main(void) {
 			assert(!set_hasnext(&iter));
 		}
 	}
+
+	for (i=0; i < 5000; i++) {
+		free(plist[i]);
+	}
+	free(plist);
+
+	set_free(s);
 	return 0;
 }

--- a/tests/stateset/stateset0.c
+++ b/tests/stateset/stateset0.c
@@ -17,5 +17,6 @@ int main(void) {
 	assert(state_set_add(&s, NULL, a[0]));
 	assert(state_set_add(&s, NULL, a[1]));
 	assert(state_set_add(&s, NULL, a[2]));
+	state_set_free(s);
 	return 0;
 }

--- a/tests/stateset/stateset1.c
+++ b/tests/stateset/stateset1.c
@@ -34,5 +34,6 @@ int main(void) {
 	assert(state_set_contains(s, a[1]));
 	assert(state_set_contains(s, a[2]));
 
+	state_set_free(s);
 	return 0;
 }

--- a/tests/stateset/stateset2.c
+++ b/tests/stateset/stateset2.c
@@ -19,5 +19,6 @@ int main(void) {
 	assert(state_set_add(&s, NULL, a));
 	state_set_remove(&s, a);
 	assert(!state_set_contains(s, a));
+	state_set_free(s);
 	return 0;
 }

--- a/tests/stateset/stateset3.c
+++ b/tests/stateset/stateset3.c
@@ -28,5 +28,6 @@ int main(void) {
 	for (i = 0; i < 3; i++) {
 		assert(seen[i]);
 	}
+	state_set_free(s);
 	return 0;
 }

--- a/tests/stateset/stateset4.c
+++ b/tests/stateset/stateset4.c
@@ -23,5 +23,6 @@ int main(void) {
 		assert(state_set_add(&s, NULL, next_state()));
 	}
 	assert(state_set_count(s) == 5000);
+	state_set_free(s);
 	return 0;
 }

--- a/tests/stateset/stateset5.c
+++ b/tests/stateset/stateset5.c
@@ -28,5 +28,6 @@ int main(void) {
 		state_set_remove(&s, a[i]);
 	}
 	assert(state_set_count(s) == 4997);
+	state_set_free(s);
 	return 0;
 }

--- a/tests/stateset/stateset6.c
+++ b/tests/stateset/stateset6.c
@@ -26,6 +26,7 @@ static void test(fsm_state_t n) {
 	}
 	assert(i == n);
 	assert(p == (n == 0 ? 999 : n - 1));
+	state_set_free(s);
 }
 
 int main(void) {

--- a/tests/stateset/stateset7.c
+++ b/tests/stateset/stateset7.c
@@ -82,5 +82,6 @@ int main(void) {
 		assert(state_set_contains(s, *all_items[i]));
 	}
 
+	state_set_free(s);
 	return 0;
 }


### PR DESCRIPTION
AST nodes are allocated out of a "pool" which is basically a bump
allocator.  If an error is encountered in parsing, the entire pool is
released.

When the AST is freed, the entire pool is also released.

This version relies on a global pool variable that's later associated
with the `struct ast`, which makes parsing not thread-safe.

This is one potential solution to #251 