### PR TITLE
Lots of fixes to various memory leaks

### DIFF
--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -349,6 +349,15 @@ gen_words(FILE *f, const struct fsm *fsm)
 }
 #endif /* 0 */
 
+static struct fsm *fsm_to_cleanup = NULL;
+
+static void
+do_fsm_cleanup(void)
+{
+	if (fsm_to_cleanup != NULL) {
+		fsm_free(fsm_to_cleanup);
+	}
+}
 
 int
 main(int argc, char *argv[])
@@ -364,6 +373,8 @@ main(int argc, char *argv[])
 	int (*query)(const struct fsm *, fsm_state_t);
 	int (*walk )(const struct fsm *,
 		 int (*)(const struct fsm *, fsm_state_t));
+
+	atexit(do_fsm_cleanup);
 
 	opt.comments = 1;
 	opt.io       = FSM_IO_GETC;
@@ -523,6 +534,8 @@ main(int argc, char *argv[])
 			q = NULL;
 		}
 
+		fsm_to_cleanup = q;
+
 		if (-1 == clock_gettime(CLOCK_MONOTONIC, &post)) {
 			perror("clock_gettime");
 			exit(EXIT_FAILURE);
@@ -645,6 +658,7 @@ main(int argc, char *argv[])
 	}
 
 	fsm_free(fsm);
+	fsm_to_cleanup = NULL;
 
 	return r;
 }

--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -356,6 +356,7 @@ do_fsm_cleanup(void)
 {
 	if (fsm_to_cleanup != NULL) {
 		fsm_free(fsm_to_cleanup);
+		fsm_to_cleanup = NULL;
 	}
 }
 

--- a/src/fsm/parser.act
+++ b/src/fsm/parser.act
@@ -427,6 +427,7 @@
 		ADVANCE_LEXER; /* XXX: what if the first token is unrecognised? */
 		p_fsm(new, lex_state, act_state);
 
+		free(act_state_s.states.buckets);
 		lx->free(lx->buf_opaque);
 
 		return new;

--- a/src/fsm/parser.c
+++ b/src/fsm/parser.c
@@ -1256,11 +1256,12 @@ ZL1:;
 		ADVANCE_LEXER; /* XXX: what if the first token is unrecognised? */
 		p_fsm(new, lex_state, act_state);
 
+		free(act_state_s.states.buckets);
 		lx->free(lx->buf_opaque);
 
 		return new;
 	}
 
-#line 1265 "src/fsm/parser.c"
+#line 1266 "src/fsm/parser.c"
 
 /* END OF FILE */

--- a/src/fsm/parser.h
+++ b/src/fsm/parser.h
@@ -26,7 +26,7 @@
 extern void p_fsm(fsm, lex_state, act_state);
 /* BEGINNING OF TRAILER */
 
-#line 435 "src/fsm/parser.act"
+#line 436 "src/fsm/parser.act"
 
 #line 32 "src/fsm/parser.h"
 

--- a/src/libfsm/closure.c
+++ b/src/libfsm/closure.c
@@ -258,5 +258,7 @@ closure_free(struct state_set **closures, size_t n)
 	for (s = 0; s < n; s++) {
 		state_set_free(closures[s]);
 	}
+
+	free(closures);
 }
 

--- a/src/libfsm/closure.c
+++ b/src/libfsm/closure.c
@@ -116,6 +116,8 @@ start:
 		fsm->states[p].visited = 0;
 	}
 
+	queue_free(q);
+
 	return 1;
 
 error:

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -356,11 +356,14 @@ fsm_determinise(struct fsm *nfa)
 		}
 	}
 
+	mapping_hashset_free(mappings);
+
 	return 1;
 
 error:
 
 	/* TODO: free stuff */
+	mapping_hashset_free(mappings);
 
 	return 0;
 }

--- a/src/libfsm/glushkovise.c
+++ b/src/libfsm/glushkovise.c
@@ -111,6 +111,7 @@ fsm_glushkovise(struct fsm *nfa)
 error:
 
 	/* TODO: free stuff */
+	closure_free(eclosures, nfa->statecount);
 
 	return 0;
 }

--- a/src/libfsm/minimise.c
+++ b/src/libfsm/minimise.c
@@ -72,7 +72,8 @@ fsm_minimise(struct fsm *fsm)
 	}
 
 	if (fsm->statecount == 0) {
-		return 1;	/* empty -- no-op */
+		r = 1;
+		goto cleanup;
 	}
 
 	TIME(tv_pre);
@@ -81,7 +82,8 @@ fsm_minimise(struct fsm *fsm)
 	LOG_TIME_DELTA("collect_labels");
 
 	if (label_count == 0) {
-		return 1;	/* no edges -- no-op */
+		r = 1;
+		goto cleanup;
 	}
 
 	mapping = f_malloc(fsm->opt->alloc,

--- a/src/libfsm/state.c
+++ b/src/libfsm/state.c
@@ -211,6 +211,9 @@ fsm_compact_states(struct fsm *fsm,
 	for (i = 0, dst = 0, removed_count = 0; i < orig_statecount; i++) {
 		assert(dst <= i);
 		if (mapping[i] == FSM_STATE_REMAP_NO_STATE) { /* dead */
+			state_set_free(fsm->states[i].epsilons);
+			edge_set_free(fsm->opt->alloc, fsm->states[i].edges);
+
 			fsm->statecount--;
 			removed_count++;
 		} else {				      /* keep */

--- a/src/libfsm/union.c
+++ b/src/libfsm/union.c
@@ -32,8 +32,8 @@ fsm_union(struct fsm *a, struct fsm *b)
 		return NULL;
 	}
 
-	if (a->statecount == 0) { return b; }
-	if (b->statecount == 0) { return a; }
+	if (a->statecount == 0) { fsm_free(a); return b; }
+	if (b->statecount == 0) { fsm_free(b); return a; }
 
 	if (!fsm_getstart(a, &sa) || !fsm_getstart(b, &sb)) {
 		errno = EINVAL;

--- a/src/libre/ast.c
+++ b/src/libre/ast.c
@@ -443,7 +443,7 @@ ast_make_expr_concat(enum re_flags re_flags)
 	res->u.concat.alloc = 8; /* arbitrary initial value */
 	res->u.concat.count = 0;
 
-	res->u.concat.n = malloc(res->u.concat.alloc * sizeof *res->u.concat.n);
+	res->u.concat.n = calloc(res->u.concat.alloc, sizeof *res->u.concat.n);
 	if (res->u.concat.n == NULL) {
 		return NULL;
 	}
@@ -490,7 +490,7 @@ ast_make_expr_alt(enum re_flags re_flags)
 	res->u.alt.alloc = 8; /* arbitrary initial value */
 	res->u.alt.count = 0;
 
-	res->u.alt.n = malloc(res->u.alt.alloc * sizeof *res->u.alt.n);
+	res->u.alt.n = calloc(res->u.alt.alloc, sizeof *res->u.alt.n);
 	if (res->u.alt.n == NULL) {
 		return NULL;
 	}

--- a/src/libre/ast.c
+++ b/src/libre/ast.c
@@ -678,7 +678,7 @@ ast_make_expr_named(enum re_flags re_flags, const struct class *class)
 	res->u.alt.alloc = class->count;
 	res->u.alt.count = class->count;
 
-	res->u.alt.n = malloc(res->u.alt.alloc * sizeof *res->u.alt.n);
+	res->u.alt.n = calloc(res->u.alt.alloc, sizeof *res->u.alt.n);
 	if (res->u.alt.n == NULL) {
 		return NULL;
 	}

--- a/src/libre/ast.h
+++ b/src/libre/ast.h
@@ -174,7 +174,30 @@ struct ast_expr {
 	} u;
 };
 
+enum { AST_EXPR_POOL_SIZE = 64 };
+
+struct ast_expr_pool {
+	struct ast_expr_pool *next;
+	unsigned count;
+	struct ast_expr pool[AST_EXPR_POOL_SIZE];
+};
+
+struct ast_expr *
+ast_expr_pool_new(struct ast_expr_pool **poolp);
+
+void
+ast_pool_free(struct ast_expr_pool *pool);
+
+/* Returns current global expression pool, setting
+ * global to NULL.
+ *
+ * This is a hack.
+ */
+struct ast_expr_pool *
+ast_expr_pool_save(void);
+
 struct ast {
+	struct ast_expr_pool *pool;
 	struct ast_expr *expr;
 };
 

--- a/src/libre/ast_rewrite.c
+++ b/src/libre/ast_rewrite.c
@@ -205,6 +205,7 @@ rewrite_concat(struct ast_expr *n, enum re_flags flags)
 
 	if (n->u.concat.count == 0) {
 		free(n->u.concat.n);
+		n->u.concat.n = NULL;
 
 		goto empty;
 	}
@@ -233,6 +234,7 @@ tombstone:
 	}
 
 	free(n->u.concat.n);
+	n->u.concat.n = NULL;
 
 	n->type = AST_EXPR_TOMBSTONE;
 
@@ -314,6 +316,7 @@ rewrite_alt(struct ast_expr *n, enum re_flags flags)
 
 	if (n->u.alt.count == 0) {
 		free(n->u.alt.n);
+		n->u.alt.n = NULL;
 
 		goto empty;
 	}

--- a/src/libre/ast_rewrite.c
+++ b/src/libre/ast_rewrite.c
@@ -228,6 +228,12 @@ empty:
 
 tombstone:
 
+	for (i = 0; i < n->u.concat.count; i++) {
+		ast_expr_free(n->u.concat.n[i]);
+	}
+
+	free(n->u.concat.n);
+
 	n->type = AST_EXPR_TOMBSTONE;
 
 	return 1;

--- a/src/libre/ast_rewrite.c
+++ b/src/libre/ast_rewrite.c
@@ -117,6 +117,7 @@ compile_subexpr(struct ast_expr *e, enum re_flags flags)
 static int
 rewrite_concat(struct ast_expr *n, enum re_flags flags)
 {
+	static const struct ast_expr zero;
 	size_t i;
 
 	assert(n != NULL);
@@ -209,10 +210,11 @@ rewrite_concat(struct ast_expr *n, enum re_flags flags)
 	}
 
 	if (n->u.concat.count == 1) {
-		void *p = n->u.concat.n, *q = n->u.concat.n[0];
-		*n = *n->u.concat.n[0];
+		void *p = n->u.concat.n;
+		struct ast_expr *q = n->u.concat.n[0];
+		*n = *q;
+		*q = zero;
 		free(p);
-		free(q);
 		return 1;
 	}
 
@@ -234,6 +236,7 @@ tombstone:
 static int
 rewrite_alt(struct ast_expr *n, enum re_flags flags)
 {
+	static const struct ast_expr zero;
 	size_t i;
 
 	assert(n != NULL);
@@ -310,10 +313,11 @@ rewrite_alt(struct ast_expr *n, enum re_flags flags)
 	}
 
 	if (n->u.alt.count == 1) {
-		void *p = n->u.alt.n, *q = n->u.alt.n[0];
-		*n = *n->u.alt.n[0];
+		void *p = n->u.alt.n;
+		struct ast_expr *q = n->u.alt.n[0];
+		*n = *q;
+		*q = zero;
 		free(p);
-		free(q);
 		return 1;
 	}
 

--- a/src/libre/re.c
+++ b/src/libre/re.c
@@ -168,6 +168,8 @@ re_comp(enum re_dialect dialect, int (*getc)(void *opaque), void *opaque,
 	 */
 	if (unsatisfiable) {
 		ast_expr_free(ast->expr);
+		/* ast_free below frees the pool */
+
 		ast->expr = ast_expr_tombstone;
 	}
 

--- a/src/libre/re_strings.c
+++ b/src/libre/re_strings.c
@@ -38,9 +38,7 @@ re_strings(const struct fsm_options *opt, const char *a[], size_t n,
 	}
 
 	fsm = re_strings_build(g, opt, flags);
-	if (fsm == NULL) {
-		goto error;
-	}
+	re_strings_free(g);
 
 	return fsm;
 

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -535,6 +535,7 @@ do_fsm_cleanup(void)
 {
 	if (fsm_to_cleanup != NULL) {
 		fsm_free(fsm_to_cleanup);
+		fsm_to_cleanup = NULL;
 	}
 
 	free_all_matches();

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -476,6 +476,16 @@ endleaf_json(FILE *f, const void *state_opaque, const void *endleaf_opaque)
 	return 0;
 }
 
+static struct fsm *fsm_to_cleanup = NULL;
+
+static void
+do_fsm_cleanup(void)
+{
+	if (fsm_to_cleanup != NULL) {
+		fsm_free(fsm_to_cleanup);
+	}
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -494,6 +504,8 @@ main(int argc, char *argv[])
 	int makevm;
 
 	struct fsm_dfavm *vm;
+
+	atexit(do_fsm_cleanup);
 
 	/* note these defaults are the opposite than for fsm(1) */
 	opt.anonymous_states  = 1;
@@ -656,6 +668,8 @@ main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
+	fsm_to_cleanup = fsm;
+
 	{
 		int i;
 
@@ -753,6 +767,8 @@ main(int argc, char *argv[])
 				perror("fsm_union/concat");
 				return EXIT_FAILURE;
 			}
+
+			fsm_to_cleanup = fsm;
 
 			if (query != NULL) {
 				int r;
@@ -988,6 +1004,7 @@ main(int argc, char *argv[])
 		/* XXX: free opaques */
 
 		fsm_free(fsm);
+		fsm_to_cleanup = NULL;
 
 		if (vm != NULL) {
 			fsm_vm_free(vm);

--- a/tests/hashset/hashset0.c
+++ b/tests/hashset/hashset0.c
@@ -33,9 +33,13 @@ hash_int(const void *a)
 int main(void) {
 	struct hashset *s = hashset_create(NULL, hash_int, cmp_int);
 	int a[3] = {1, 2, 3};
+
+	assert(s != NULL);
+
 	assert(hashset_add(s, &a[0]));
 	assert(hashset_add(s, &a[1]));
 	assert(hashset_add(s, &a[2]));
+
 	hashset_free(s);
 	return 0;
 }

--- a/tests/hashset/hashset0.c
+++ b/tests/hashset/hashset0.c
@@ -36,5 +36,6 @@ int main(void) {
 	assert(hashset_add(s, &a[0]));
 	assert(hashset_add(s, &a[1]));
 	assert(hashset_add(s, &a[2]));
+	hashset_free(s);
 	return 0;
 }

--- a/tests/hashset/hashset1.c
+++ b/tests/hashset/hashset1.c
@@ -90,5 +90,6 @@ int main(void) {
 	assert(hashset_contains(s, &a[14]));
 	assert(hashset_contains(s, &a[15]));
 
+	hashset_free(s);
 	return 0;
 }

--- a/tests/hashset/hashset1.c
+++ b/tests/hashset/hashset1.c
@@ -48,6 +48,8 @@ int main(void) {
 	 */
 	int a[] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
 
+	assert(s != NULL);
+
 	/* add 'em in */
 	assert(hashset_add(s, &a[0]));
 	assert(hashset_add(s, &a[1]));

--- a/tests/hashset/hashset2.c
+++ b/tests/hashset/hashset2.c
@@ -44,6 +44,9 @@ hashset_contains(const struct hashset *set, const void *item)
 int main(void) {
 	struct hashset *s = hashset_create(NULL, hash_int, cmp_int);
 	int a = 1;
+
+	assert(s != NULL);
+
 	assert(hashset_add(s, &a));
 	assert(hashset_add(s, &a));
 	assert(hashset_add(s, &a));

--- a/tests/hashset/hashset2.c
+++ b/tests/hashset/hashset2.c
@@ -52,6 +52,7 @@ int main(void) {
 
 	assert(!hashset_contains(s, &a));
 
+	hashset_free(s);
 	return 0;
 }
 

--- a/tests/hashset/hashset3.c
+++ b/tests/hashset/hashset3.c
@@ -61,5 +61,6 @@ int main(void) {
 		assert(seen[i]);
 	}
 
+	hashset_free(s);
 	return 0;
 }

--- a/tests/hashset/hashset3.c
+++ b/tests/hashset/hashset3.c
@@ -48,6 +48,9 @@ int main(void) {
 	int a[3] = {1, 2, 3};
 	int seen[3] = {0, 0, 0};
 	int i;
+
+	assert(s != NULL);
+
 	assert(hashset_add(s, &a[0]));
 	assert(hashset_add(s, &a[1]));
 	assert(hashset_add(s, &a[2]));

--- a/tests/hashset/hashset4.c
+++ b/tests/hashset/hashset4.c
@@ -59,16 +59,31 @@ int *next_int(int reset) {
 int main(void) {
 	struct hashset *s = hashset_create(NULL, hash_int, cmp_int);
 	size_t i;
+	int **plist;
+
+	plist = malloc(10000 * sizeof *plist);
+	assert(plist != NULL);
+
 	for (i = 0; i < 5000; i++) {
-		assert(hashset_add(s, next_int(0)));
+		int *itm = next_int(0);
+		plist[i] = itm;
+		assert(hashset_add(s, itm));
 	}
 	assert(hashset_count(s) == 5000);
 
 	next_int(1);
 	for (i = 0; i < 5000; i++) {
-		assert(hashset_add(s, next_int(0)));
+		int *itm = next_int(0);
+		plist[5000+i] = itm;
+		assert(hashset_add(s, itm));
 	}
 	assert(hashset_count(s) == 5000);
 
+	for (i=0; i < 10000; i++) {
+		free(plist[i]);
+	}
+	free(plist);
+
+	hashset_free(s);
 	return 0;
 }

--- a/tests/hashset/hashset4.c
+++ b/tests/hashset/hashset4.c
@@ -41,6 +41,7 @@ hashset_contains(const struct hashset *set, const void *item)
 	return finditem(set, h, item, &b);
 }
 
+enum { VALUE=0, RESET=1 };
 int *next_int(int reset) {
 	static int n = 0;
 	int *p;
@@ -56,30 +57,45 @@ int *next_int(int reset) {
 	return p;
 }
 
+enum { COUNT = 5000U };
+
 int main(void) {
 	struct hashset *s = hashset_create(NULL, hash_int, cmp_int);
 	size_t i;
 	int **plist;
 
-	plist = malloc(10000 * sizeof *plist);
+	assert(s != NULL);
+
+	/* need 2*COUNT because we allocate items twice in two
+	 * separate loops
+	 */
+	plist = calloc(2*COUNT, sizeof *plist);
 	assert(plist != NULL);
 
-	for (i = 0; i < 5000; i++) {
-		int *itm = next_int(0);
+	for (i = 0; i < COUNT; i++) {
+		int *itm = next_int(VALUE);
+		assert(itm != NULL);
+
 		plist[i] = itm;
 		assert(hashset_add(s, itm));
 	}
-	assert(hashset_count(s) == 5000);
+	assert(hashset_count(s) == COUNT);
 
-	next_int(1);
-	for (i = 0; i < 5000; i++) {
-		int *itm = next_int(0);
-		plist[5000+i] = itm;
+	/* reset counter and add items again.  size of hash set should
+	 * stay the same since these are duplicates.
+	 */
+	next_int(RESET);
+
+	for (i = 0; i < COUNT; i++) {
+		int *itm = next_int(VALUE);
+		assert(itm != NULL);
+
+		plist[COUNT+i] = itm;
 		assert(hashset_add(s, itm));
 	}
-	assert(hashset_count(s) == 5000);
+	assert(hashset_count(s) == COUNT);
 
-	for (i=0; i < 10000; i++) {
+	for (i=0; i < 2*COUNT; i++) {
 		free(plist[i]);
 	}
 	free(plist);

--- a/tests/hashset/hashset5.c
+++ b/tests/hashset/hashset5.c
@@ -49,29 +49,37 @@ int *next_int(void) {
 	return p;
 }
 
+enum { COUNT = 5000U };
+
 int main(void) {
 	struct hashset *s = hashset_create(NULL, hash_int, cmp_int);
-	int a[3] = {1200,2400,3600};
 	size_t i;
 	int **plist;
 
-	plist = malloc(5000 * sizeof *plist);
+	int a[3] = {1200,2400,3600};
+	const unsigned num_a = sizeof a / sizeof *a;
+
+	assert(s != NULL);
+
+	plist = calloc(COUNT, sizeof *plist);
 	assert(plist != NULL);
 
-	for (i = 0; i < 5000; i++) {
+	for (i = 0; i < COUNT; i++) {
 		int *itm = next_int();
+		assert(itm != NULL);
+
 		plist[i] = itm;
 		assert(hashset_add(s, itm));
 	}
 
-	for (i = 0; i < 3; i++) {
+	for (i = 0; i < num_a; i++) {
 		assert(hashset_contains(s, &a[i]));
 		hashset_remove(s, &a[i]);
 	}
 
-	assert(hashset_count(s) == 4997);
+	assert(hashset_count(s) == COUNT-num_a);
 
-	for (i=0; i < 5000; i++) {
+	for (i=0; i < COUNT; i++) {
 		free(plist[i]);
 	}
 	free(plist);

--- a/tests/hashset/hashset5.c
+++ b/tests/hashset/hashset5.c
@@ -53,13 +53,29 @@ int main(void) {
 	struct hashset *s = hashset_create(NULL, hash_int, cmp_int);
 	int a[3] = {1200,2400,3600};
 	size_t i;
+	int **plist;
+
+	plist = malloc(5000 * sizeof *plist);
+	assert(plist != NULL);
+
 	for (i = 0; i < 5000; i++) {
-		assert(hashset_add(s, next_int()));
+		int *itm = next_int();
+		plist[i] = itm;
+		assert(hashset_add(s, itm));
 	}
+
 	for (i = 0; i < 3; i++) {
 		assert(hashset_contains(s, &a[i]));
 		hashset_remove(s, &a[i]);
 	}
+
 	assert(hashset_count(s) == 4997);
+
+	for (i=0; i < 5000; i++) {
+		free(plist[i]);
+	}
+	free(plist);
+
+	hashset_free(s);
 	return 0;
 }

--- a/tests/hashset/hashset6.c
+++ b/tests/hashset/hashset6.c
@@ -38,17 +38,26 @@ int *next_int(void) {
 	return p;
 }
 
+enum { COUNT = 5000U };
+
 int main(void) {
 	struct hashset *s = hashset_create(NULL, hash_int, cmp_int);
 	struct hashset_iter iter;
 	size_t i;
 	int *p;
-	for (i = 0; i < 5000; i++) {
-		assert(hashset_add(s, next_int()));
+
+	assert(s != NULL);
+
+	for (i = 0; i < COUNT; i++) {
+		int *itm = next_int();
+		assert(itm != NULL);
+
+		assert(hashset_add(s, itm));
 	}
-	for (i = 0, p = hashset_first(s, &iter); i < 5000; i++, hashset_next(&iter)) {
+
+	for (i = 0, p = hashset_first(s, &iter); i < COUNT; i++, hashset_next(&iter)) {
 		assert(p);
-		if (i < 4999) {
+		if (i < COUNT-1) {
 			assert(hashset_hasnext(&iter));
 		} else {
 			assert(!hashset_hasnext(&iter));

--- a/tests/hashset/hashset6.c
+++ b/tests/hashset/hashset6.c
@@ -54,5 +54,11 @@ int main(void) {
 			assert(!hashset_hasnext(&iter));
 		}
 	}
+
+	for (p = hashset_first(s, &iter); p != NULL; p = hashset_next(&iter)) {
+		free(p);
+	}
+
+	hashset_free(s);
 	return 0;
 }

--- a/tests/set/set0.c
+++ b/tests/set/set0.c
@@ -27,9 +27,14 @@ cmp_int(const void *a, const void *b)
 int main(void) {
 	struct set *s = set_create(NULL, cmp_int);
 	int a[3] = {1, 2, 3};
+
+	assert(s != NULL);
+
 	assert(set_add(s, &a[0]));
 	assert(set_add(s, &a[1]));
 	assert(set_add(s, &a[2]));
+
 	set_free(s);
+
 	return 0;
 }

--- a/tests/set/set0.c
+++ b/tests/set/set0.c
@@ -30,5 +30,6 @@ int main(void) {
 	assert(set_add(s, &a[0]));
 	assert(set_add(s, &a[1]));
 	assert(set_add(s, &a[2]));
+	set_free(s);
 	return 0;
 }

--- a/tests/set/set1.c
+++ b/tests/set/set1.c
@@ -33,5 +33,6 @@ int main(void) {
 	assert(set_contains(s, &a[0]));
 	assert(set_contains(s, &a[1]));
 	assert(set_contains(s, &a[2]));
+	set_free(s);
 	return 0;
 }

--- a/tests/set/set1.c
+++ b/tests/set/set1.c
@@ -27,12 +27,17 @@ cmp_int(const void *a, const void *b)
 int main(void) {
 	struct set *s = set_create(NULL, cmp_int);
 	int a[3] = {1, 2, 3};
+
+	assert(s != NULL);
+
 	assert(set_add(s, &a[0]));
 	assert(set_add(s, &a[1]));
 	assert(set_add(s, &a[2]));
+
 	assert(set_contains(s, &a[0]));
 	assert(set_contains(s, &a[1]));
 	assert(set_contains(s, &a[2]));
+
 	set_free(s);
 	return 0;
 }

--- a/tests/set/set2.c
+++ b/tests/set/set2.c
@@ -27,11 +27,17 @@ cmp_int(const void *a, const void *b)
 int main(void) {
 	struct set *s = set_create(NULL, cmp_int);
 	int a = 1;
+
+	assert(s != NULL);
+
 	assert(set_add(s, &a));
 	assert(set_add(s, &a));
 	assert(set_add(s, &a));
+
 	set_remove(s, &a);
 	assert(!set_contains(s, &a));
+
 	set_free(s);
+
 	return 0;
 }

--- a/tests/set/set2.c
+++ b/tests/set/set2.c
@@ -32,5 +32,6 @@ int main(void) {
 	assert(set_add(s, &a));
 	set_remove(s, &a);
 	assert(!set_contains(s, &a));
+	set_free(s);
 	return 0;
 }

--- a/tests/set/set3.c
+++ b/tests/set/set3.c
@@ -41,5 +41,6 @@ int main(void) {
 	for (i = 0; i < 3; i++) {
 		assert(seen[i]);
 	}
+	set_free(s);
 	return 0;
 }

--- a/tests/set/set3.c
+++ b/tests/set/set3.c
@@ -31,16 +31,22 @@ int main(void) {
 	int a[3] = {1, 2, 3};
 	int seen[3] = {0, 0, 0};
 	int i;
+
+	assert(s != NULL);
+
 	assert(set_add(s, &a[0]));
 	assert(set_add(s, &a[1]));
 	assert(set_add(s, &a[2]));
+
 	for (p = set_first(s, &iter); p != NULL; p = set_next(&iter)) {
 		assert(*p == 1 || *p == 2 || *p == 3);
 		seen[*p - 1] = 1;
 	}
+
 	for (i = 0; i < 3; i++) {
 		assert(seen[i]);
 	}
+
 	set_free(s);
 	return 0;
 }

--- a/tests/set/set4.c
+++ b/tests/set/set4.c
@@ -32,22 +32,26 @@ int *next_int(void) {
 	return p;
 }
 
+enum { COUNT = 5000U };
+
 int main(void) {
 	struct set *s = set_create(NULL, cmp_int);
 	size_t i;
 	int **plist;
 
-	plist = malloc(5000 * sizeof *plist);
+	assert(s != NULL);
+
+	plist = calloc(COUNT, sizeof *plist);
 	assert(plist != NULL);
 
-	for (i = 0; i < 5000; i++) {
+	for (i = 0; i < COUNT; i++) {
 		int *itm = next_int();
 		plist[i] = itm;
 		assert(set_add(s, itm));
 	}
-	assert(set_count(s) == 5000);
+	assert(set_count(s) == COUNT);
 
-	for (i=0; i < 5000; i++) {
+	for (i=0; i < COUNT; i++) {
 		free(plist[i]);
 	}
 	free(plist);

--- a/tests/set/set4.c
+++ b/tests/set/set4.c
@@ -35,9 +35,23 @@ int *next_int(void) {
 int main(void) {
 	struct set *s = set_create(NULL, cmp_int);
 	size_t i;
+	int **plist;
+
+	plist = malloc(5000 * sizeof *plist);
+	assert(plist != NULL);
+
 	for (i = 0; i < 5000; i++) {
-		assert(set_add(s, next_int()));
+		int *itm = next_int();
+		plist[i] = itm;
+		assert(set_add(s, itm));
 	}
 	assert(set_count(s) == 5000);
+
+	for (i=0; i < 5000; i++) {
+		free(plist[i]);
+	}
+	free(plist);
+
+	set_free(s);
 	return 0;
 }

--- a/tests/set/set5.c
+++ b/tests/set/set5.c
@@ -32,27 +32,35 @@ int *next_int(void) {
 	return p;
 }
 
+enum { COUNT = 5000U };
+
 int main(void) {
 	struct set *s = set_create(NULL, cmp_int);
-	int a[3] = {1200,2400,3600};
 	size_t i;
 	int **plist;
 
-	plist = malloc(5000 * sizeof *plist);
+	int a[3] = {1200,2400,3600};
+	const unsigned num_a = sizeof a / sizeof *a;
+
+	assert(s != NULL);
+
+	plist = calloc(COUNT, sizeof *plist);
 	assert(plist != NULL);
 
-	for (i = 0; i < 5000; i++) {
+	for (i = 0; i < COUNT; i++) {
 		int *itm = next_int();
 		plist[i] = itm;
 		assert(set_add(s, itm));
 	}
-	for (i = 0; i < 3; i++) {
+
+	for (i = 0; i < num_a; i++) {
 		assert(set_contains(s, &a[i]));
 		set_remove(s, &a[i]);
 	}
-	assert(set_count(s) == 4997);
 
-	for (i=0; i < 5000; i++) {
+	assert(set_count(s) == COUNT-num_a);
+
+	for (i=0; i < COUNT; i++) {
 		free(plist[i]);
 	}
 	free(plist);

--- a/tests/set/set5.c
+++ b/tests/set/set5.c
@@ -36,13 +36,27 @@ int main(void) {
 	struct set *s = set_create(NULL, cmp_int);
 	int a[3] = {1200,2400,3600};
 	size_t i;
+	int **plist;
+
+	plist = malloc(5000 * sizeof *plist);
+	assert(plist != NULL);
+
 	for (i = 0; i < 5000; i++) {
-		assert(set_add(s, next_int()));
+		int *itm = next_int();
+		plist[i] = itm;
+		assert(set_add(s, itm));
 	}
 	for (i = 0; i < 3; i++) {
 		assert(set_contains(s, &a[i]));
 		set_remove(s, &a[i]);
 	}
 	assert(set_count(s) == 4997);
+
+	for (i=0; i < 5000; i++) {
+		free(plist[i]);
+	}
+	free(plist);
+
+	set_free(s);
 	return 0;
 }

--- a/tests/set/set6.c
+++ b/tests/set/set6.c
@@ -36,9 +36,16 @@ int main(void) {
 	struct set *s = set_create(NULL, cmp_int);
 	struct set_iter iter;
 	size_t i;
+	int **plist;
+
+	plist = malloc(5000 * sizeof *plist);
+	assert(plist != NULL);
+
 	int *p;
 	for (i = 0; i < 5000; i++) {
-		assert(set_add(s, next_int()));
+		int *itm = next_int();
+		plist[i] = itm;
+		assert(set_add(s, itm));
 	}
 	for (i = 0, p = set_first(s, &iter); i < 5000; i++, set_next(&iter)) {
 		assert(p);
@@ -48,5 +55,12 @@ int main(void) {
 			assert(!set_hasnext(&iter));
 		}
 	}
+
+	for (i=0; i < 5000; i++) {
+		free(plist[i]);
+	}
+	free(plist);
+
+	set_free(s);
 	return 0;
 }

--- a/tests/set/set6.c
+++ b/tests/set/set6.c
@@ -43,7 +43,7 @@ int main(void) {
 
 	assert(s != NULL);
 
-	plist = calloc(5000, sizeof *plist);
+	plist = calloc(COUNT, sizeof *plist);
 	assert(plist != NULL);
 
 	for (i = 0; i < COUNT; i++) {

--- a/tests/set/set6.c
+++ b/tests/set/set6.c
@@ -32,31 +32,36 @@ int *next_int(void) {
 	return p;
 }
 
+enum { COUNT = 5000U };
+
 int main(void) {
 	struct set *s = set_create(NULL, cmp_int);
 	struct set_iter iter;
 	size_t i;
 	int **plist;
+	int *p;
 
-	plist = malloc(5000 * sizeof *plist);
+	assert(s != NULL);
+
+	plist = calloc(5000, sizeof *plist);
 	assert(plist != NULL);
 
-	int *p;
-	for (i = 0; i < 5000; i++) {
+	for (i = 0; i < COUNT; i++) {
 		int *itm = next_int();
 		plist[i] = itm;
 		assert(set_add(s, itm));
 	}
-	for (i = 0, p = set_first(s, &iter); i < 5000; i++, set_next(&iter)) {
+
+	for (i = 0, p = set_first(s, &iter); i < COUNT; i++, set_next(&iter)) {
 		assert(p);
-		if (i < 4999) {
+		if (i < COUNT-1) {
 			assert(set_hasnext(&iter));
 		} else {
 			assert(!set_hasnext(&iter));
 		}
 	}
 
-	for (i=0; i < 5000; i++) {
+	for (i=0; i < COUNT; i++) {
 		free(plist[i]);
 	}
 	free(plist);

--- a/tests/stateset/stateset0.c
+++ b/tests/stateset/stateset0.c
@@ -17,5 +17,6 @@ int main(void) {
 	assert(state_set_add(&s, NULL, a[0]));
 	assert(state_set_add(&s, NULL, a[1]));
 	assert(state_set_add(&s, NULL, a[2]));
+	state_set_free(s);
 	return 0;
 }

--- a/tests/stateset/stateset1.c
+++ b/tests/stateset/stateset1.c
@@ -34,5 +34,6 @@ int main(void) {
 	assert(state_set_contains(s, a[1]));
 	assert(state_set_contains(s, a[2]));
 
+	state_set_free(s);
 	return 0;
 }

--- a/tests/stateset/stateset2.c
+++ b/tests/stateset/stateset2.c
@@ -19,5 +19,6 @@ int main(void) {
 	assert(state_set_add(&s, NULL, a));
 	state_set_remove(&s, a);
 	assert(!state_set_contains(s, a));
+	state_set_free(s);
 	return 0;
 }

--- a/tests/stateset/stateset3.c
+++ b/tests/stateset/stateset3.c
@@ -28,5 +28,6 @@ int main(void) {
 	for (i = 0; i < 3; i++) {
 		assert(seen[i]);
 	}
+	state_set_free(s);
 	return 0;
 }

--- a/tests/stateset/stateset4.c
+++ b/tests/stateset/stateset4.c
@@ -23,5 +23,6 @@ int main(void) {
 		assert(state_set_add(&s, NULL, next_state()));
 	}
 	assert(state_set_count(s) == 5000);
+	state_set_free(s);
 	return 0;
 }

--- a/tests/stateset/stateset5.c
+++ b/tests/stateset/stateset5.c
@@ -28,5 +28,6 @@ int main(void) {
 		state_set_remove(&s, a[i]);
 	}
 	assert(state_set_count(s) == 4997);
+	state_set_free(s);
 	return 0;
 }

--- a/tests/stateset/stateset6.c
+++ b/tests/stateset/stateset6.c
@@ -26,6 +26,7 @@ static void test(fsm_state_t n) {
 	}
 	assert(i == n);
 	assert(p == (n == 0 ? 999 : n - 1));
+	state_set_free(s);
 }
 
 int main(void) {

--- a/tests/stateset/stateset7.c
+++ b/tests/stateset/stateset7.c
@@ -82,5 +82,6 @@ int main(void) {
 		assert(state_set_contains(s, *all_items[i]));
 	}
 
+	state_set_free(s);
 	return 0;
 }


### PR DESCRIPTION
So... I made the mistake of compiling with ASAN on Linux (running under WSLv2, but still Linux) and ... wow.  LSAN detects a ton of memory leaks in the standard test suite.

Here's an attempt to plug them, stacking on #252.

This isn't quite ready to merge yet.  There are some issues to resolve with #252 first.  But given the breadth of changes here, I wanted to raise them earlier rather than later.
