### PR TITLE
ast: allow for node cloning

### DIFF
--- a/src/libre/ast.h
+++ b/src/libre/ast.h
@@ -198,6 +198,9 @@ void
 ast_expr_free(struct ast_expr *n);
 
 int
+ast_expr_clone(struct ast_expr **n);
+
+int
 ast_expr_cmp(const struct ast_expr *a, const struct ast_expr *b);
 
 int


### PR DESCRIPTION
When constructing an AST directly, as opposed to parsing a regular expression, it may be desirable to clone nodes. This commit adds an ast_expr_clone function for this purpose. It is not yet used anywhere.

It returns 1 if cloning succeeded, or 0 if cloning failed, and modifies the passed in expression pointer directly, rather than returning it by value, so that callers can easily tell whether cloning succeeded. Cloning a null pointer is valid and leaves the node as a null pointer. If this had been returned by value, callers would have no easy way of determining whether the clone operation succeeded.

This is a prerequisite for the PR that will come later to build ASTs that correspond to a given FSM. It should not yet be merged, I have created a separate branch and PR in advance for it for easier review.

I have attempted to follow the existing code style, but PR #253 will change some things. When that goes in, I will update this PR to match.

The API here is not ideal. If there is a better API that still allows callers to easily determine success or failure, please comment and I can update this PR to implement that instead. An alternative would be to have a `struct ast_expr *ast_expr_clone(struct ast_expr *n)` that asserts that its input is not a null pointer, in which case a null pointer can be a special return value that can only be returned on error. Whether that would be a better API depends on what other code might want to call this function.