### PR TITLE
Fix memory error in rewrite_alt.

### DIFF
--- a/src/libre/ast_rewrite.c
+++ b/src/libre/ast_rewrite.c
@@ -272,7 +272,7 @@ rewrite_alt(struct ast_expr *n, enum re_flags flags)
 
 				n->u.alt.n = tmp;
 
-				n->u.alt.alloc = (n->u.alt.count + dead->u.alt.count - 1) * sizeof *n->u.alt.n;
+				n->u.alt.alloc = n->u.alt.count + dead->u.alt.count - 1;
 			}
 
 			/* move along our existing tail to make space */


### PR DESCRIPTION
n->u.alt.alloc is the number of nodes that n->u.alt.n can hold, but was being assigned the number of bytes. This leads later code to conclude enough storage is already available and to write beyond the end of n->u.alt.n.