### PR TITLE
Fix two issues in PCRE printing.

### DIFF
--- a/src/libre/print/pcre.c
+++ b/src/libre/print/pcre.c
@@ -67,6 +67,10 @@ re_flags_print(FILE *f, enum re_flags fl)
 	if (fl & RE_ZONE   ) { fprintf(f, "z"); }
 }
 
+enum {
+	RE_FLAGS_PRINTABLE = RE_ICASE | RE_TEXT | RE_MULTI | RE_REVERSE | RE_SINGLE | RE_ZONE
+};
+
 static void
 print_endpoint(FILE *f, const struct fsm_options *opt, const struct ast_endpoint *e)
 {
@@ -93,10 +97,10 @@ pp_iter(FILE *f, const struct fsm_options *opt, enum re_flags *re_flags, struct 
 
 	if (n == NULL) { return; }
 
-	if (n->re_flags != *re_flags) {
+	if ((n->re_flags ^ *re_flags) & RE_FLAGS_PRINTABLE) {
 		fprintf(f, "(?");
 		re_flags_print(f, n->re_flags & ~*re_flags);
-		if (*re_flags & ~n->re_flags) {
+		if (*re_flags & ~n->re_flags & RE_FLAGS_PRINTABLE) {
 			fprintf(f, "-");
 			re_flags_print(f, *re_flags & ~n->re_flags);
 		}
@@ -133,7 +137,7 @@ pp_iter(FILE *f, const struct fsm_options *opt, enum re_flags *re_flags, struct 
 			} else {
 				enum re_flags localflags = *re_flags;
 				fprintf(f, "(?:");
-				pp_iter(f, opt, re_flags, n->u.alt.n[i]);
+				pp_iter(f, opt, &localflags, n->u.alt.n[i]);
 				fprintf(f, ")");
 			}
 			if (i + 1 < n->u.alt.count) {


### PR DESCRIPTION
Fix unused local variable `localflags`: the idea of PR #249 was to use this variable in the call to `pp_iter`, but this was accidentally still using `re_flags`. This had no effect because we never need to group an operand of `|`, as `|` has the lowest precedence of all operators, but rather than simply remove the code, it is preserved to allow grouping operands of `|` in the future for simpler flag printing, as in `a|(?i:b)|c*`, which currently gets printed as `a|(?i)b|(?-i)c*`.

Fix printing of changed flags to ignore a change in global flags: `RE_ANCHORED` applies to whole regexps only, not individual
subexpressions, and cannot be turned on or off. This cannot occur when constructing ASTs from regexps, as the `RE_ANCHORED` flag will be the same for all AST nodes, but can happen when constructing ASTs from FSMs when additionally using the `-b` option, which should have no effect as FSMs are implicitly anchored.