### PR TITLE
Fix builds for glob, utf8dfa examples

### DIFF
--- a/examples/glob/main.c
+++ b/examples/glob/main.c
@@ -49,7 +49,7 @@ usage(void)
 static int
 match(const struct fsm *fsm, const char *s)
 {
-	const struct fsm_state *state;
+	fsm_state_t state;
 
 	assert(fsm != NULL);
 	assert(fsm_all(fsm, fsm_isdfa));
@@ -68,7 +68,7 @@ static struct fsm *
 compile(const char *glob)
 {
 	struct fsm *fsm;
-	struct fsm_state *state;
+	fsm_state_t state;
 	const char *p;
 
 	assert(glob != NULL);
@@ -79,8 +79,7 @@ compile(const char *glob)
 		exit(2);
 	}
 
-	state = fsm_addstate(fsm);
-	if (!state) {
+	if (!fsm_addstate(fsm, &state)) {
 		perror("fsm_addstate");
 		exit(2);
 	}
@@ -104,11 +103,10 @@ compile(const char *glob)
 	 *     *: 0 -> 1 ?; 1 -> 0;
 	 */
 	for (p = glob; *p; p++) {
-		struct fsm_state *new;
+		fsm_state_t new;
 
 		/* TODO: we could omit this */
-		new = fsm_addstate(fsm);
-		if (!new) {
+		if (!fsm_addstate(fsm, &new)) {
 			perror("fsm_addstate");
 			exit(2);
 		}
@@ -188,6 +186,10 @@ main(int argc, char *argv[])
 
 	fsm = compile(argv[0]);
 	assert(fsm != NULL);
+
+	if (!fsm_determinise(fsm)) {
+		exit(EXIT_FAILURE);
+	}
 
 	if (!fsm_minimise(fsm)) {
 		exit(EXIT_FAILURE);

--- a/examples/utf8dfa/main.c
+++ b/examples/utf8dfa/main.c
@@ -119,7 +119,7 @@ int
 main(int argc, char *argv[])
 {
 	struct fsm *fsm;
-	struct fsm_state *start;
+	fsm_state_t start;
 	fsm_print *print;
 
 	opt.anonymous_states  = 1;
@@ -170,8 +170,7 @@ main(int argc, char *argv[])
 		exit(1);
 	}
 
-	start = fsm_addstate(fsm);
-	if (start == NULL) {
+	if (!fsm_addstate(fsm, &start)) {
 		perror("fsm_addstate");
 		exit(1);
 	}


### PR DESCRIPTION
Convert a few uses of `struct fsm_state *` to `fsm_state_t` in the glob
and utf8dfa examples, particularly around `fsm_addstate`.

Adds an `fsm_determinise` call to the glob example. This is because
it'll still have epsilon edges without it after compiling, causing the
later `fsm_all(fsm, fsm_isdfa)` assertion to fail. This follows the
lead from commit 631c56f3's message. (This doesn't seem to be necessary
for utf8dfa since it only creates literal edges between states.)

Spotted the glob case while reimplementing it using Crystal bindings,
so updated that and utf8dfa (which needed similar changes). The iprange
example also looks like it needs an update but I haven't quite got it
working yet, so it's not part of this change.