### PR TITLE
ast_new_from_fsm: free pool on error

### DIFF
--- a/src/libre/ast_new_from_fsm.c
+++ b/src/libre/ast_new_from_fsm.c
@@ -494,12 +494,15 @@ ast_new_from_fsm(const struct fsm *fsm)
 	assert(fsm);
 
 	expr = ast_expr_new_from_fsm(&pool, fsm);
-	if (!expr)
+	if (!expr) {
+		ast_pool_free(pool);
 		return NULL;
+	}
 
 	ast = ast_new();
 	if (!ast) {
 		ast_expr_free(expr);
+		ast_pool_free(pool);
 		return NULL;
 	}
 


### PR DESCRIPTION
If ast_expr_new_from_fsm or ast_new fails, do not forget to free the pool.