### PR TITLE
Allow freed memory to be reused for AST nodes

### DIFF
--- a/src/libre/ast.c
+++ b/src/libre/ast.c
@@ -33,12 +33,13 @@ ast_expr_pool_new(struct ast_expr_pool **poolp)
 {
 	static const struct ast_expr zero;
 	struct ast_expr_pool *p;
-	size_t i;
+	struct ast_expr *n;
 
 	assert(poolp != NULL);
 
 	p = *poolp;
-	if (p == NULL || p->count >= AST_EXPR_POOL_SIZE) {
+	if (p == NULL ||
+	    (p->nextnode == NULL && p->count >= AST_EXPR_POOL_SIZE)) {
 		p = malloc(sizeof *p);
 		if (p == NULL) {
 			return NULL;
@@ -48,19 +49,30 @@ ast_expr_pool_new(struct ast_expr_pool **poolp)
 		ASAN_POISON_MEMORY_REGION(&p->pool, sizeof p->pool);
 #endif
 
+		p->nextnode = NULL;
+		p->nextpool = *poolp;
 		p->count = 0;
-		p->next = *poolp;
+
 		*poolp = p;
 	}
 
-	assert(p != NULL && p->count < AST_EXPR_POOL_SIZE);
+	assert(p != NULL &&
+	       (p->nextnode != NULL || p->count < AST_EXPR_POOL_SIZE));
 
-	i = p->count++;
+	n = p->nextnode;
+	if (n == NULL) {
+		size_t i = p->count++;
+		n = &p->pool[i].expr;
+	} else {
+		p->nextnode = n->u.free.nextnode;
+	}
+
 #if defined(ASAN)
-	ASAN_UNPOISON_MEMORY_REGION(&p->pool[i].expr, sizeof(p->pool[i].expr));
+	ASAN_UNPOISON_MEMORY_REGION(n, sizeof *n);
 #endif
-	p->pool[i].expr = zero;
-	return &p->pool[i].expr;
+
+	*n = zero;
+	return n;
 }
 
 struct ast *
@@ -86,17 +98,46 @@ void
 ast_pool_free(struct ast_expr_pool *pool)
 {
 	struct ast_expr_pool *curr;
-	for (curr=pool; curr != NULL; curr=curr->next) {
+	for (curr=pool; curr != NULL; curr=curr->nextpool) {
 		unsigned i;
 
+#if defined(ASAN)
+		ASAN_UNPOISON_MEMORY_REGION(&curr->pool, sizeof curr->pool);
+#endif
+
 		for (i=0; i < curr->count; i++) {
-			ast_expr_free(&curr->pool[i].expr);
+			struct ast_expr *n = &curr->pool[i].expr;
+
+			switch (n->type) {
+			case AST_EXPR_EMPTY:
+			case AST_EXPR_LITERAL:
+			case AST_EXPR_CODEPOINT:
+			case AST_EXPR_ANCHOR:
+			case AST_EXPR_RANGE:
+			case AST_EXPR_SUBTRACT:
+			case AST_EXPR_REPEAT:
+			case AST_EXPR_GROUP:
+			case AST_EXPR_TOMBSTONE:
+				break;
+
+			case AST_EXPR_CONCAT:
+				free(n->u.concat.n);
+				break;
+
+			case AST_EXPR_ALT:
+				free(n->u.alt.n);
+				break;
+
+			default:
+				if (n->type)
+					assert(!"unreached");
+			}
 		}
 	}
 
 	while (pool != NULL) {
 		curr = pool;
-		pool = pool->next;
+		pool = pool->nextpool;
 
 		free(curr);
 	}
@@ -105,7 +146,7 @@ ast_pool_free(struct ast_expr_pool *pool)
 void
 ast_free(struct ast *ast)
 {
-	ast_expr_free(ast->expr);
+	ast_expr_free(ast->pool, ast->expr);
 	ast_pool_free(ast->pool);
 	free(ast);
 }
@@ -136,7 +177,7 @@ ast_make_count(unsigned min, const struct ast_pos *start,
  */
 
 void
-ast_expr_free(struct ast_expr *n)
+ast_expr_free(struct ast_expr_pool *pool, struct ast_expr *n)
 {
 	static const struct ast_expr zero;
 
@@ -154,15 +195,15 @@ ast_expr_free(struct ast_expr *n)
 		break;
 
 	case AST_EXPR_SUBTRACT:
-		ast_expr_free(n->u.subtract.a);
-		ast_expr_free(n->u.subtract.b);
+		ast_expr_free(pool, n->u.subtract.a);
+		ast_expr_free(pool, n->u.subtract.b);
 		break;
 
 	case AST_EXPR_CONCAT: {
 		size_t i;
 
 		for (i = 0; i < n->u.concat.count; i++) {
-			ast_expr_free(n->u.concat.n[i]);
+			ast_expr_free(pool, n->u.concat.n[i]);
 		}
 
 		free(n->u.concat.n);
@@ -173,7 +214,7 @@ ast_expr_free(struct ast_expr *n)
 		size_t i;
 
 		for (i = 0; i < n->u.alt.count; i++) {
-			ast_expr_free(n->u.alt.n[i]);
+			ast_expr_free(pool, n->u.alt.n[i]);
 		}
 
 		free(n->u.alt.n);
@@ -181,11 +222,11 @@ ast_expr_free(struct ast_expr *n)
 	}
 
 	case AST_EXPR_REPEAT:
-		ast_expr_free(n->u.repeat.e);
+		ast_expr_free(pool, n->u.repeat.e);
 		break;
 
 	case AST_EXPR_GROUP:
-		ast_expr_free(n->u.group.e);
+		ast_expr_free(pool, n->u.group.e);
 		break;
 
 	case AST_EXPR_TOMBSTONE:
@@ -197,6 +238,8 @@ ast_expr_free(struct ast_expr *n)
 	}
 
 	*n = zero;
+	n->u.free.nextnode = pool->nextnode;
+	pool->nextnode = n;
 }
 
 int
@@ -235,7 +278,7 @@ ast_expr_clone(struct ast_expr_pool **poolp, struct ast_expr **n)
 			break;
 		}
 		if (!ast_expr_clone(poolp, &new->u.subtract.b)) {
-			ast_expr_free(new);
+			ast_expr_free(*poolp, new);
 			new = NULL;
 			break;
 		}
@@ -257,7 +300,7 @@ ast_expr_clone(struct ast_expr_pool **poolp, struct ast_expr **n)
 		for (i = 0; i < old->u.concat.count; i++) {
 			new->u.concat.n[i] = old->u.concat.n[i];
 			if (!ast_expr_clone(poolp, &new->u.concat.n[i])) {
-				ast_expr_free(new);
+				ast_expr_free(*poolp, new);
 				new = NULL;
 				break;
 			}
@@ -281,7 +324,7 @@ ast_expr_clone(struct ast_expr_pool **poolp, struct ast_expr **n)
 		for (i = 0; i < old->u.alt.count; i++) {
 			new->u.alt.n[i] = old->u.alt.n[i];
 			if (!ast_expr_clone(poolp, &new->u.alt.n[i])) {
-				ast_expr_free(new);
+				ast_expr_free(*poolp, new);
 				new = NULL;
 				break;
 			}
@@ -839,12 +882,12 @@ error:
 			break;
 		}
 
-		ast_expr_free(res->u.alt.n[i]);
+		ast_expr_free(*poolp, res->u.alt.n[i]);
 	}
 
 	res->u.alt.count = 0;
 
-	ast_expr_free(res);
+	ast_expr_free(*poolp, res);
 
 	return NULL;
 }

--- a/src/libre/ast.h
+++ b/src/libre/ast.h
@@ -20,7 +20,10 @@ struct ast_pos {
 };
 
 enum ast_expr_type {
-	AST_EXPR_EMPTY,
+	/* Reserve one value (0) indicating a freed expression. This value is
+	 * intentionally unnamed: code that switches on n->type should be able
+	 * to leave it out without triggering a compiler diagnostic. */
+	AST_EXPR_EMPTY = 1,
 	AST_EXPR_CONCAT,
 	AST_EXPR_ALT,
 	AST_EXPR_LITERAL,
@@ -119,6 +122,10 @@ struct ast_expr {
 	enum re_flags re_flags;
 
 	union {
+		struct {
+			struct ast_expr *nextnode;
+		} free;
+
 		/* ordered sequence */
 		struct {
 			size_t count; /* used */
@@ -187,8 +194,9 @@ struct ast_expr_pool {
 #endif
 	} pool[AST_EXPR_POOL_SIZE];
 
-	struct ast_expr_pool *next;
-	unsigned count;
+	struct ast_expr *nextnode;
+	struct ast_expr_pool *nextpool;
+	size_t count;
 };
 
 struct ast_expr *
@@ -227,7 +235,7 @@ ast_make_count(unsigned min, const struct ast_pos *start,
  */
 
 void
-ast_expr_free(struct ast_expr *n);
+ast_expr_free(struct ast_expr_pool *pool, struct ast_expr *n);
 
 int
 ast_expr_clone(struct ast_expr_pool **poolp, struct ast_expr **n);

--- a/src/libre/dialect/comp.h
+++ b/src/libre/dialect/comp.h
@@ -16,7 +16,6 @@
 typedef struct ast *
 re_dialect_parse_fun(re_getchar_fun *getchar, void *opaque,
 	const struct fsm_options *opt,
-	struct ast_expr_pool **poolp,
 	enum re_flags flags, int overlap,
 	struct re_err *err);
 

--- a/src/libre/dialect/glob/parser.c
+++ b/src/libre/dialect/glob/parser.c
@@ -557,7 +557,6 @@ ZL0:;
 	struct ast *
 	DIALECT_PARSE(re_getchar_fun *f, void *opaque,
 		const struct fsm_options *opt,
-		struct ast_expr_pool **poolp,
 		enum re_flags flags, int overlap,
 		struct re_err *err)
 	{
@@ -606,7 +605,7 @@ ZL0:;
 		act_state = &act_state_s;
 
 		act_state->overlap = overlap;
-		act_state->poolp   = poolp;
+		act_state->poolp   = &ast->pool;
 
 		err->e = RE_ESUCCESS;
 
@@ -678,6 +677,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 682 "src/libre/dialect/glob/parser.c"
+#line 681 "src/libre/dialect/glob/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/glob/parser.h
+++ b/src/libre/dialect/glob/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__glob(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 1014 "src/libre/parser.act"
+#line 1013 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/glob/parser.h"

--- a/src/libre/dialect/like/parser.c
+++ b/src/libre/dialect/like/parser.c
@@ -557,7 +557,6 @@ ZL0:;
 	struct ast *
 	DIALECT_PARSE(re_getchar_fun *f, void *opaque,
 		const struct fsm_options *opt,
-		struct ast_expr_pool **poolp,
 		enum re_flags flags, int overlap,
 		struct re_err *err)
 	{
@@ -606,7 +605,7 @@ ZL0:;
 		act_state = &act_state_s;
 
 		act_state->overlap = overlap;
-		act_state->poolp   = poolp;
+		act_state->poolp   = &ast->pool;
 
 		err->e = RE_ESUCCESS;
 
@@ -678,6 +677,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 682 "src/libre/dialect/like/parser.c"
+#line 681 "src/libre/dialect/like/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/like/parser.h
+++ b/src/libre/dialect/like/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__like(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 1014 "src/libre/parser.act"
+#line 1013 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/like/parser.h"

--- a/src/libre/dialect/literal/parser.c
+++ b/src/libre/dialect/literal/parser.c
@@ -470,7 +470,6 @@ ZL0:;
 	struct ast *
 	DIALECT_PARSE(re_getchar_fun *f, void *opaque,
 		const struct fsm_options *opt,
-		struct ast_expr_pool **poolp,
 		enum re_flags flags, int overlap,
 		struct re_err *err)
 	{
@@ -519,7 +518,7 @@ ZL0:;
 		act_state = &act_state_s;
 
 		act_state->overlap = overlap;
-		act_state->poolp   = poolp;
+		act_state->poolp   = &ast->pool;
 
 		err->e = RE_ESUCCESS;
 
@@ -591,6 +590,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 595 "src/libre/dialect/literal/parser.c"
+#line 594 "src/libre/dialect/literal/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/literal/parser.h
+++ b/src/libre/dialect/literal/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__literal(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 1014 "src/libre/parser.act"
+#line 1013 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/literal/parser.h"

--- a/src/libre/dialect/native/parser.c
+++ b/src/libre/dialect/native/parser.c
@@ -2920,7 +2920,6 @@ ZL0:;
 	struct ast *
 	DIALECT_PARSE(re_getchar_fun *f, void *opaque,
 		const struct fsm_options *opt,
-		struct ast_expr_pool **poolp,
 		enum re_flags flags, int overlap,
 		struct re_err *err)
 	{
@@ -2969,7 +2968,7 @@ ZL0:;
 		act_state = &act_state_s;
 
 		act_state->overlap = overlap;
-		act_state->poolp   = poolp;
+		act_state->poolp   = &ast->pool;
 
 		err->e = RE_ESUCCESS;
 
@@ -3041,6 +3040,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 3045 "src/libre/dialect/native/parser.c"
+#line 3044 "src/libre/dialect/native/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/native/parser.h
+++ b/src/libre/dialect/native/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__native(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 1014 "src/libre/parser.act"
+#line 1013 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/native/parser.h"

--- a/src/libre/dialect/pcre/parser.c
+++ b/src/libre/dialect/pcre/parser.c
@@ -3883,7 +3883,6 @@ ZL0:;
 	struct ast *
 	DIALECT_PARSE(re_getchar_fun *f, void *opaque,
 		const struct fsm_options *opt,
-		struct ast_expr_pool **poolp,
 		enum re_flags flags, int overlap,
 		struct re_err *err)
 	{
@@ -3932,7 +3931,7 @@ ZL0:;
 		act_state = &act_state_s;
 
 		act_state->overlap = overlap;
-		act_state->poolp   = poolp;
+		act_state->poolp   = &ast->pool;
 
 		err->e = RE_ESUCCESS;
 
@@ -4004,6 +4003,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 4008 "src/libre/dialect/pcre/parser.c"
+#line 4007 "src/libre/dialect/pcre/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/pcre/parser.h
+++ b/src/libre/dialect/pcre/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__pcre(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 1014 "src/libre/parser.act"
+#line 1013 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/pcre/parser.h"

--- a/src/libre/dialect/sql/parser.c
+++ b/src/libre/dialect/sql/parser.c
@@ -1992,7 +1992,6 @@ ZL0:;
 	struct ast *
 	DIALECT_PARSE(re_getchar_fun *f, void *opaque,
 		const struct fsm_options *opt,
-		struct ast_expr_pool **poolp,
 		enum re_flags flags, int overlap,
 		struct re_err *err)
 	{
@@ -2041,7 +2040,7 @@ ZL0:;
 		act_state = &act_state_s;
 
 		act_state->overlap = overlap;
-		act_state->poolp   = poolp;
+		act_state->poolp   = &ast->pool;
 
 		err->e = RE_ESUCCESS;
 
@@ -2113,6 +2112,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 2117 "src/libre/dialect/sql/parser.c"
+#line 2116 "src/libre/dialect/sql/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/sql/parser.h
+++ b/src/libre/dialect/sql/parser.h
@@ -28,7 +28,7 @@
 extern void p_re__sql(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 1014 "src/libre/parser.act"
+#line 1013 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/sql/parser.h"

--- a/src/libre/parser.act
+++ b/src/libre/parser.act
@@ -890,7 +890,6 @@
 	struct ast *
 	DIALECT_PARSE(re_getchar_fun *f, void *opaque,
 		const struct fsm_options *opt,
-		struct ast_expr_pool **poolp,
 		enum re_flags flags, int overlap,
 		struct re_err *err)
 	{
@@ -939,7 +938,7 @@
 		act_state = &act_state_s;
 
 		act_state->overlap = overlap;
-		act_state->poolp   = poolp;
+		act_state->poolp   = &ast->pool;
 
 		err->e = RE_ESUCCESS;
 

--- a/src/libre/re.c
+++ b/src/libre/re.c
@@ -96,7 +96,6 @@ re_parse(enum re_dialect dialect, int (*getc)(void *opaque), void *opaque,
 {
 	const struct dialect *m;
 	struct ast *ast = NULL;
-	struct ast_expr_pool *pool = NULL;
 	enum ast_analysis_res res;
 	
 	assert(getc != NULL);
@@ -109,19 +108,16 @@ re_parse(enum re_dialect dialect, int (*getc)(void *opaque), void *opaque,
 
 	flags |= m->flags;
 
-	ast = m->parse(getc, opaque, opt, &pool, flags, m->overlap, err);
+	ast = m->parse(getc, opaque, opt, flags, m->overlap, err);
 
 	if (ast == NULL) {
-		ast_pool_free(pool);
 		return NULL;
 	}
 
 	if (!ast_rewrite(ast, flags)) {
-		ast_pool_free(pool);
+		ast_free(ast);
 		return NULL;
 	}
-
-	ast->pool = pool;
 
 	/* Do a complete pass over the AST, filling in other details. */
 	res = ast_analysis(ast);
@@ -167,7 +163,7 @@ re_comp(enum re_dialect dialect, int (*getc)(void *opaque), void *opaque,
 	 * that unioning it with other regexes will still work.
 	 */
 	if (unsatisfiable) {
-		ast_expr_free(ast->expr);
+		ast_expr_free(ast->pool, ast->expr);
 		/* ast_free below frees the pool */
 
 		ast->expr = ast_expr_tombstone;


### PR DESCRIPTION
When ast_expr_free frees a node, it allows the memory used for that
node to be reused by a subsequent ast_make_expr_* call. During normal
parsing this will have no effect as memory will only be allocated, never
freed, but ast_new_from_fsm does mix allocations and deallocations.
ast_rewrite currently never allocates, only deallocates, but if future
improvements there do allocate, they will automatically benefit from
this as well.

Clearly marking already freed nodes this way also allows double frees to
be caught and reported. This commit contains a fix for a double free in
ast_rewrite.c's rewrite_concat function.