### PR TITLE
fsm.h: Remove incorrect header comment -- fsm_merge can return NULL.

### DIFF
--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -77,7 +77,6 @@ fsm_move(struct fsm *dst, struct fsm *src);
  * the storage for the two sets of states is combined, but no edges are added.
  *
  * The resulting FSM has two disjoint sets, and no start state.
- * Cannot return NULL.
  */
 struct fsm *
 fsm_merge(struct fsm *a, struct fsm *b,


### PR DESCRIPTION
It will return NULL if the two fsm structs have mismatched options or if realloc fails.