### PR TITLE
Implementing DFA-based group capture matching, part 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ SUBDIR += src/retest
 SUBDIR += src/lx/print
 SUBDIR += src/lx
 SUBDIR += src
+SUBDIR += tests/capture
 SUBDIR += tests/complement
 SUBDIR += tests/intersect
 SUBDIR += tests/ir

--- a/include/fsm/Makefile
+++ b/include/fsm/Makefile
@@ -2,11 +2,11 @@
 
 STAGE_COPY += include/fsm/alloc.h
 STAGE_COPY += include/fsm/bool.h
-STAGE_COPY += include/fsm/capture.h
 STAGE_COPY += include/fsm/cost.h
 STAGE_COPY += include/fsm/fsm.h
 STAGE_COPY += include/fsm/options.h
 STAGE_COPY += include/fsm/pred.h
 STAGE_COPY += include/fsm/print.h
+STAGE_COPY += include/fsm/subgraph.h
 STAGE_COPY += include/fsm/walk.h
 

--- a/include/fsm/bool.h
+++ b/include/fsm/bool.h
@@ -30,7 +30,8 @@ int
 fsm_complement(struct fsm *fsm);
 
 struct fsm *
-fsm_union(struct fsm *a, struct fsm *b);
+fsm_union(struct fsm *a, struct fsm *b,
+	struct fsm_combine_info *combine_info);
 
 struct fsm *
 fsm_intersect(struct fsm *a, struct fsm *b);

--- a/include/fsm/bool.h
+++ b/include/fsm/bool.h
@@ -19,11 +19,13 @@
 struct fsm;
 
 /* When combining two FSMs, it can sometimes be useful to know the
- * offsets to their original start states.
+ * offsets to their original start states and captures.
  * If passed in, this struct will be updated with those details. */
 struct fsm_combine_info {
 	fsm_state_t base_a;
 	fsm_state_t base_b;
+	unsigned capture_base_a;
+	unsigned capture_base_b;
 };
 
 int

--- a/include/fsm/bool.h
+++ b/include/fsm/bool.h
@@ -18,6 +18,14 @@
 
 struct fsm;
 
+/* When combining two FSMs, it can sometimes be useful to know the
+ * offsets to their original start states.
+ * If passed in, this struct will be updated with those details. */
+struct fsm_combine_info {
+	fsm_state_t base_a;
+	fsm_state_t base_b;
+};
+
 int
 fsm_complement(struct fsm *fsm);
 

--- a/include/fsm/bool.h
+++ b/include/fsm/bool.h
@@ -28,12 +28,29 @@ struct fsm_combine_info {
 	unsigned capture_base_b;
 };
 
+struct fsm_combined_base_pair {
+	fsm_state_t state;
+	unsigned capture;
+};
+
 int
 fsm_complement(struct fsm *fsm);
 
 struct fsm *
 fsm_union(struct fsm *a, struct fsm *b,
 	struct fsm_combine_info *combine_info);
+
+/* Union an array of FSMs, keeping track of the offsets to their
+ * starting states and (if used) capture bases.
+ *
+ * bases[] is expected to have the same count as fsms[], and
+ * will be initialized by the function.
+ *
+ * On success, returns the unioned fsm and updates bases[].
+ * On failure, returns NULL; all fsms are freed. */
+struct fsm *
+fsm_union_array(size_t fsm_count,
+    struct fsm **fsms, struct fsm_combined_base_pair *bases);
 
 struct fsm *
 fsm_intersect(struct fsm *a, struct fsm *b);

--- a/include/fsm/capture.h
+++ b/include/fsm/capture.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#ifndef FSM_CAPTURE_H
+#define FSM_CAPTURE_H
+
+#include <stdlib.h>
+#include <fsm/fsm.h>
+
+/*
+ * Offsets for a capturing match group. The first position is the
+ * offset to the start of the match within the string, the second
+ * position is after the end. pos[1] will always be >= pos[0].
+ * The match length is equal to pos[1] - pos[0], and for a
+ * zero-character match, pos[0] == pos[1].
+ *
+ * If there is no match, both will be set to FSM_CAPTURE_NO_POS. */
+#define FSM_CAPTURE_NO_POS ((size_t)-1)
+struct fsm_capture {
+	size_t pos[2];
+};
+
+/* How many captures does the FSM use? */
+unsigned
+fsm_countcaptures(const struct fsm *fsm);
+
+/* Does a specific state have any capture actions? */
+int
+fsm_capture_has_capture_actions(const struct fsm *fsm, fsm_state_t state);
+
+/* Set a capture path on an FSM. This means that during matching, the
+ * portion of a match between the path's START and END states will be
+ * captured. As the FSM is transformed (determinisation, minimisation,
+ * unioning, etc.), the path will be converted to refer to the pair(s)
+ * of new states instead. If the path's END state is no longer reachable
+ * from its START state, then the capture path will be ignored.
+ * Multiple instances of the same capture_id and path are ignored. */
+int
+fsm_capture_set_path(struct fsm *fsm, unsigned capture_id,
+    fsm_state_t start, fsm_state_t end);
+
+/* Increase the base capture ID for all captures in an fsm.
+ * This could be used before combining multiple FSMs -- for
+ * example, before unioning a and b, where a has 3 captures
+ * and b has 2, b may be rebase'd to 3 -- so a has captures
+ * 0-2 and b has 3-4. */
+void
+fsm_capture_rebase_capture_id(struct fsm *fsm, unsigned base);
+
+/* Allocate a capture buffer with enough space for
+ * the current FSM's captures. */
+struct fsm_capture *
+fsm_capture_alloc(const struct fsm *fsm);
+
+#ifndef NDEBUG
+#include <stdio.h>
+
+/* Dump capture metadata about an FSM. */
+void
+fsm_capture_dump(FILE *f, const char *tag, const struct fsm *fsm);
+#endif
+
+#endif

--- a/include/fsm/capture.h
+++ b/include/fsm/capture.h
@@ -50,6 +50,10 @@ fsm_capture_set_path(struct fsm *fsm, unsigned capture_id,
 void
 fsm_capture_rebase_capture_id(struct fsm *fsm, unsigned base);
 
+/* Same, but for capture action states. */
+void
+fsm_capture_rebase_capture_action_states(struct fsm *fsm, fsm_state_t base);
+
 /* Allocate a capture buffer with enough space for
  * the current FSM's captures. */
 struct fsm_capture *

--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -18,6 +18,7 @@
 struct fsm;
 struct fsm_options;
 struct path; /* XXX */
+struct fsm_capture;
 struct fsm_combine_info;
 
 /*
@@ -391,7 +392,7 @@ fsm_shortest(const struct fsm *fsm,
  */
 int
 fsm_exec(const struct fsm *fsm, int (*fsm_getc)(void *opaque), void *opaque,
-	fsm_state_t *end);
+	fsm_state_t *end, struct fsm_capture *captures);
 
 /*
  * Callbacks which may be passed to fsm_exec(). These are conveniences for

--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -18,6 +18,7 @@
 struct fsm;
 struct fsm_options;
 struct path; /* XXX */
+struct fsm_combine_info;
 
 /*
  * States in libfsm are referred to by a 0-based numeric index.
@@ -75,12 +76,20 @@ fsm_move(struct fsm *dst, struct fsm *src);
 /*
  * Merge states from a and b. This is a memory-management operation only;
  * the storage for the two sets of states is combined, but no edges are added.
+ * a and b can appear in the merged FSM in either order.
  *
  * The resulting FSM has two disjoint sets, and no start state.
+ *
+ * If non-NULL, the combine_info struct will be updated to note the new
+ * base offsets for the pair of FSMs.
  */
+struct fsm_merge_update_info {
+	fsm_state_t base_a;
+	fsm_state_t base_b;
+};
 struct fsm *
 fsm_merge(struct fsm *a, struct fsm *b,
-	fsm_state_t *base_a, fsm_state_t *base_b);
+	struct fsm_combine_info *combine_info);
 
 /*
  * Add a state.

--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -338,7 +338,8 @@ fsm_minimise(struct fsm *fsm);
  * Concatenate b after a. This is not commutative.
  */
 struct fsm *
-fsm_concat(struct fsm *a, struct fsm *b);
+fsm_concat(struct fsm *a, struct fsm *b,
+	struct fsm_combine_info *combine_info);
 
 /*
  * Return 1 if the fsm does not match anything;

--- a/include/fsm/subgraph.h
+++ b/include/fsm/subgraph.h
@@ -4,28 +4,28 @@
  * See LICENCE for the full copyright terms.
  */
 
-#ifndef FSM_CAPTURE_H
-#define FSM_CAPTURE_H
+#ifndef FSM_SUBGRAPH_H
+#define FSM_SUBGRAPH_H
 
 /*
- * Captures nodes added between fsm_capture_start() and
- * fsm_capture_end()
+ * Spans nodes added between fsm_subgraph_start() and
+ * fsm_subgraph_end()
  *
- * Can be used by fsm_capture_duplicate() to make copies of the subgraph.
+ * Can be used by fsm_subgraph_duplicate() to make copies of the subgraph.
  *
  * The subgraph capture is only valid as long as no nodes are deleted after
- * fsm_capture_start() is called.
+ * fsm_subgraph_start() is called.
  */
-struct fsm_capture {
+struct fsm_subgraph {
 	fsm_state_t start;
 	fsm_state_t end;
 };
 
 void
-fsm_capture_start(struct fsm *fsm, struct fsm_capture *capture);
+fsm_subgraph_start(struct fsm *fsm, struct fsm_subgraph *subgraph);
 
 void
-fsm_capture_stop(struct fsm *fsm, struct fsm_capture *capture);
+fsm_subgraph_stop(struct fsm *fsm, struct fsm_subgraph *subgraph);
 
 /*
  * Duplicate a captured sub-graph.
@@ -38,8 +38,8 @@ fsm_capture_stop(struct fsm *fsm, struct fsm_capture *capture);
  * The start of the subgraph is output to *q.
  */
 int
-fsm_capture_duplicate(struct fsm *fsm,
-	const struct fsm_capture *capture,
+fsm_subgraph_duplicate(struct fsm *fsm,
+	const struct fsm_subgraph *subgraph,
 	fsm_state_t *x,
 	fsm_state_t *q);
 

--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -634,7 +634,7 @@ main(int argc, char *argv[])
 
 				f = xopen(argv[0]);
 
-				e = fsm_exec(fsm, fsm_fgetc, f, &state);
+				e = fsm_exec(fsm, fsm_fgetc, f, &state, NULL);
 
 				fclose(f);
 			} else {
@@ -642,7 +642,7 @@ main(int argc, char *argv[])
 
 				s = argv[i];
 
-				e = fsm_exec(fsm, fsm_sgetc, &s, &state);
+				e = fsm_exec(fsm, fsm_sgetc, &s, &state, NULL);
 			}
 
 			if (e != 1) {

--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -507,8 +507,8 @@ main(int argc, char *argv[])
 		    FSM_TRIM_START_AND_END_REACHABLE, NULL);
 			break;
 
-		case OP_CONCAT:      q = fsm_concat(a, b);    break;
-		case OP_UNION:       q = fsm_union(a, b);     break;
+		case OP_CONCAT:      q = fsm_concat(a, b, NULL); break;
+		case OP_UNION:       q = fsm_union(a, b, NULL); break;
 		case OP_INTERSECT:   q = fsm_intersect(a, b); break;
 		case OP_SUBTRACT:    q = fsm_subtract(a, b);  break;
 

--- a/src/libfsm/Makefile
+++ b/src/libfsm/Makefile
@@ -1,5 +1,6 @@
 .include "../../share/mk/top.mk"
 
+SRC += src/libfsm/capture.c
 SRC += src/libfsm/collate.c
 SRC += src/libfsm/complete.c
 SRC += src/libfsm/consolidate.c

--- a/src/libfsm/Makefile
+++ b/src/libfsm/Makefile
@@ -21,7 +21,7 @@ SRC += src/libfsm/vm.c
 
 # graph things
 SRC += src/libfsm/mergestates.c
-SRC += src/libfsm/capture.c
+SRC += src/libfsm/subgraph.c
 
 # search
 SRC += src/libfsm/shortest.c

--- a/src/libfsm/capture.c
+++ b/src/libfsm/capture.c
@@ -354,14 +354,14 @@ grow_capture_action_buckets(const struct fsm_alloc *alloc,
 	for (i = 0; i < ci->bucket_count; i++) {
 		const struct fsm_capture_action_bucket *src_b = &ci->buckets[i];
 		unsigned h;
-		size_t b_i, mask;
+		const size_t mask = ncount - 1;
+		size_t b_i;
 
 		if (src_b->state == CAPTURE_NO_STATE) {
 			continue;
 		}
 
 		h = PHI32 * src_b->state;
-		mask = ci->bucket_count - 1;
 		for (b_i = 0; b_i < ncount; b_i++) {
 			struct fsm_capture_action_bucket *dst_b;
 			dst_b = &nbuckets[(h + b_i) & mask];

--- a/src/libfsm/capture.c
+++ b/src/libfsm/capture.c
@@ -9,53 +9,567 @@
 int
 fsm_capture_init(struct fsm *fsm)
 {
-	(void)fsm;
+	struct fsm_capture_info *ci = NULL;
+	size_t i;
+
+	ci = f_calloc(fsm->opt->alloc,
+	    1, sizeof(*ci));
+	if (ci == NULL) {
+		goto cleanup;
+	}
+	fsm->capture_info = ci;
+
+	for (i = 0; i < fsm->statealloc; i++) {
+		fsm->states[i].has_capture_actions = 0;
+	}
+
+	return 1;
+
+cleanup:
+	if (ci != NULL) {
+		f_free(fsm->opt->alloc, ci);
+	}
 	return 0;
 }
 
 void
 fsm_capture_free(struct fsm *fsm)
 {
-	(void)fsm;
+	struct fsm_capture_info *ci = fsm->capture_info;
+	if (ci == NULL) {
+		return;
+	}
+	f_free(fsm->opt->alloc, ci);
+	fsm->capture_info = NULL;
 }
 
 unsigned
 fsm_countcaptures(const struct fsm *fsm)
 {
 	(void)fsm;
-	return 0;
+	if (fsm->capture_info == NULL) {
+		return 0;
+	}
+	if (fsm->capture_info->buckets_used == 0) {
+		return 0;
+	}
+
+	/* check actual */
+#if EXPENSIVE_CHECKS
+	{
+		struct fsm_capture_info *ci = fsm->capture_info;
+		size_t i;
+		for (i = 0; i < ci->bucket_count; i++) {
+			struct fsm_capture_action_bucket *b = &ci->buckets[i];
+			if (b->state == CAPTURE_NO_STATE) { /* empty */
+				continue;
+			}
+			assert(ci->max_capture_id >= b->action.id);
+		}
+	}
+#endif
+
+	return fsm->capture_info->max_capture_id + 1;
 }
 
 int
 fsm_capture_has_capture_actions(const struct fsm *fsm, fsm_state_t state)
 {
-	(void)fsm;
-	(void)state;
-	return 0;
+	assert(state < fsm->statecount);
+	return fsm->states[state].has_capture_actions;
 }
 
 int
 fsm_capture_set_path(struct fsm *fsm, unsigned capture_id,
     fsm_state_t start, fsm_state_t end)
 {
-	(void)fsm;
-	(void)capture_id;
-	(void)start;
-	(void)end;
+	struct fsm_capture_info *ci;
+	struct capture_set_path_env env;
+	size_t seen_words;
+	int res = 0;
+
+	assert(fsm != NULL);
+	assert(start < fsm->statecount);
+	assert(end < fsm->statecount);
+
+	ci = fsm->capture_info;
+	assert(ci != NULL);
+
+	/* captures should no longer be stored as paths -- instead, set
+	 * the info on the states _here_, and convert it as necessary. */
+
+#if LOG_CAPTURE > 0
+	fprintf(stderr, "fsm_capture_set_path: capture %u: <%u, %u>\n",
+	    capture_id, start, end);
+#endif
+
+	if (capture_id > FSM_CAPTURE_MAX) {
+		return 0;	/* ID out of range */
+	}
+
+	if (!init_capture_action_htab(fsm, ci)) {
+		return 0;
+	}
+
+	/* This will create a trail and do a depth-first search from the
+	 * start state, marking every unique path to the end state. */
+	env.fsm = fsm;
+	env.capture_id = capture_id;
+	env.start = start;
+	env.end = end;
+
+	env.trail_ceil = 0;
+	env.trail = NULL;
+	env.seen = NULL;
+
+	env.trail = f_malloc(fsm->opt->alloc,
+	    DEF_TRAIL_CEIL * sizeof(env.trail[0]));
+	if (env.trail == NULL) {
+		goto cleanup;
+	}
+	env.trail_ceil = DEF_TRAIL_CEIL;
+
+	seen_words = fsm->statecount/64 + 1;
+	env.seen = f_malloc(fsm->opt->alloc,
+	    seen_words * sizeof(env.seen[0]));
+
+	if (!mark_capture_path(&env)) {
+		goto cleanup;
+	}
+
+	if (capture_id >= ci->max_capture_id) {
+		ci->max_capture_id = capture_id;
+	}
+
+	res = 1;
+	/* fall through */
+
+cleanup:
+	f_free(fsm->opt->alloc, env.trail);
+	f_free(fsm->opt->alloc, env.seen);
+	return res;
+}
+
+static int
+init_capture_action_htab(struct fsm *fsm, struct fsm_capture_info *ci)
+{
+	size_t count, i;
+	assert(fsm != NULL);
+	assert(ci != NULL);
+
+	if (ci->bucket_count > 0) {
+		assert(ci->buckets != NULL);
+		return 1;	/* done */
+	}
+
+	assert(ci->buckets == NULL);
+	assert(ci->buckets_used == 0);
+
+	count = DEF_CAPTURE_ACTION_BUCKET_COUNT;
+	ci->buckets = f_malloc(fsm->opt->alloc,
+	    count * sizeof(ci->buckets[0]));
+	if (ci->buckets == NULL) {
+		return 0;
+	}
+
+	/* Init buckets to CAPTURE_NO_STATE -> empty. */
+	for (i = 0; i < count; i++) {
+		ci->buckets[i].state = CAPTURE_NO_STATE;
+	}
+
+	ci->bucket_count = count;
+	return 1;
+}
+
+static int
+mark_capture_path(struct capture_set_path_env *env)
+{
+	const size_t seen_words = env->fsm->statecount/64 + 1;
+
+#if LOG_CAPTURE > 0
+	fprintf(stderr, "mark_capture_path: path [id %u, %u - %u]\n",
+	    env->capture_id, env->start, env->end);
+#endif
+
+	if (env->start == env->end) {
+		struct fsm_capture_action action;
+		action.type = CAPTURE_ACTION_COMMIT_ZERO_STEP;
+		action.id = env->capture_id;
+		action.to = CAPTURE_NO_STATE;
+		if (!add_capture_action(env->fsm, env->fsm->capture_info,
+			env->start, &action)) {
+			return 0;
+		}
+		return 1;
+	}
+
+	memset(env->seen, 0x00,
+	    seen_words * sizeof(env->seen[0]));
+
+	/* initialize to starting node */
+	env->trail_i = 1;
+	env->trail[0].state = env->start;
+	env->trail[0].step = TRAIL_STEP_START;
+
+	while (env->trail_i > 0) {
+		const enum trail_step step = env->trail[env->trail_i - 1].step;
+#if LOG_CAPTURE > 0
+		fprintf(stderr, "mark_capture_path: trail %u/%u, cur %u, step %d\n",
+		    env->trail_i, env->trail_ceil,
+		    env->trail[env->trail_i - 1].state,
+		    step);
+#endif
+
+		switch (step) {
+		case TRAIL_STEP_START:
+			if (!step_trail_start(env)) {
+				return 0;
+			}
+			break;
+		case TRAIL_STEP_ITER_EDGES:
+			if (!step_trail_iter_edges(env)) {
+				return 0;
+			}
+			break;
+		case TRAIL_STEP_ITER_EPSILONS:
+			if (!step_trail_iter_epsilons(env)) {
+				return 0;
+			}
+			break;
+		case TRAIL_STEP_DONE:
+			if (!step_trail_done(env)) {
+				return 0;
+			}
+			break;
+		default:
+			assert(!"match fail");
+		}
+	}
+
+	return 1;
+}
+
+static int
+cmp_action(const struct fsm_capture_action *a,
+    const struct fsm_capture_action *b) {
+	/* could use memcmp here, provided padding is always zeroed. */
+	return a->id < b->id ? -1
+	    : a->id > b->id ? 1
+	    : a->type < b->type ? -1
+	    : a->type > b->type ? 1
+	    : a->to < b->to ? -1
+	    : a->to > b->to ? 1
+	    : 0;
+}
+
+int
+fsm_capture_add_action(struct fsm *fsm,
+    fsm_state_t state, enum capture_action_type type,
+    unsigned id, fsm_state_t to)
+{
+	struct fsm_capture_action action;
+	assert(fsm->capture_info != NULL);
+
+	action.type = type;
+	action.id = id;
+	action.to = to;
+	return add_capture_action(fsm, fsm->capture_info,
+	    state, &action);
+}
+
+static int
+add_capture_action(struct fsm *fsm, struct fsm_capture_info *ci,
+    fsm_state_t state, const struct fsm_capture_action *action)
+{
+	unsigned h;
+	size_t b_i, mask;
+
+	assert(state < fsm->statecount);
+	assert(action->to == CAPTURE_NO_STATE || action->to < fsm->statecount);
+
+#if LOG_CAPTURE > 0
+	fprintf(stderr, "add_capture_action: state %u, type %s, ID %u, TO %d\n",
+	    state, fsm_capture_action_type_name[action->type],
+	    action->id, action->to);
+#endif
+
+	if (ci->bucket_count == 0) {
+		if (!init_capture_action_htab(fsm, ci)) {
+			return 0;
+		}
+	} else if (ci->buckets_used >= ci->bucket_count/2) { /* grow */
+		if (!grow_capture_action_buckets(fsm->opt->alloc, ci)) {
+			return 0;
+		}
+	}
+
+	h = PHI32 * state;
+	mask = ci->bucket_count - 1;
+
+	for (b_i = 0; b_i < ci->bucket_count; b_i++) {
+		struct fsm_capture_action_bucket *b = &ci->buckets[(h + b_i) & mask];
+		if (b->state == CAPTURE_NO_STATE) { /* empty */
+			b->state = state;
+			memcpy(&b->action, action, sizeof(*action));
+			ci->buckets_used++;
+			fsm->states[state].has_capture_actions = 1;
+			if (action->id > ci->max_capture_id) {
+				ci->max_capture_id = action->id;
+			}
+			return 1;
+		} else if (b->state == state &&
+		    0 == cmp_action(action, &b->action)) {
+			/* already present, ignore duplicate */
+			assert(fsm->states[state].has_capture_actions);
+			assert(ci->max_capture_id >= action->id);
+			return 1;
+		} else {
+			continue; /* skip past collision */
+		}
+	}
+
+	assert(!"unreachable");
 	return 0;
+}
+
+static int
+grow_capture_action_buckets(const struct fsm_alloc *alloc,
+    struct fsm_capture_info *ci)
+{
+	const size_t ncount = 2 * ci->bucket_count;
+	struct fsm_capture_action_bucket *nbuckets;
+	size_t nused = 0;
+	size_t i;
+
+	assert(ncount != 0);
+	nbuckets = f_malloc(alloc, ncount * sizeof(nbuckets[0]));
+	if (nbuckets == NULL) {
+		return 0;
+	}
+
+	for (i = 0; i < ncount; i++) {
+		nbuckets[i].state = CAPTURE_NO_STATE;
+	}
+
+	for (i = 0; i < ci->bucket_count; i++) {
+		const struct fsm_capture_action_bucket *src_b = &ci->buckets[i];
+		unsigned h;
+		size_t b_i, mask;
+
+		if (src_b->state == CAPTURE_NO_STATE) {
+			continue;
+		}
+
+		h = PHI32 * src_b->state;
+		mask = ci->bucket_count - 1;
+		for (b_i = 0; b_i < ncount; b_i++) {
+			struct fsm_capture_action_bucket *dst_b;
+			dst_b = &nbuckets[(h + b_i) & mask];
+			if (dst_b->state == CAPTURE_NO_STATE) {
+				memcpy(dst_b, src_b, sizeof(*src_b));
+				nused++;
+				break;
+			} else {
+				continue;
+			}
+		}
+	}
+
+	assert(nused == ci->buckets_used);
+	f_free(alloc, ci->buckets);
+	ci->buckets = nbuckets;
+	ci->bucket_count = ncount;
+	return 1;
+}
+
+static int
+step_trail_start(struct capture_set_path_env *env)
+{
+	struct trail_cell *tc = &env->trail[env->trail_i - 1];
+	const fsm_state_t cur = tc->state;
+	size_t i;
+	struct edge_set *edge_set = NULL;
+
+	/* check if node is endpoint, if so mark trail,
+	 * then pop trail and continue */
+	if (cur == env->end) {
+		struct fsm_capture_action action;
+#if LOG_CAPTURE > 0
+		fprintf(stderr, " -- GOT END at %u\n", cur);
+#endif
+		action.id = env->capture_id;
+
+		for (i = 0; i < env->trail_i; i++) {
+			fsm_state_t state = env->trail[i].state;
+#if LOG_CAPTURE > 0
+			fprintf(stderr, " -- %lu: %d\n",
+			    i, state);
+#endif
+
+			if (i == 0) {
+				action.type = CAPTURE_ACTION_START;
+			} else {
+				action.type = (i < env->trail_i - 1
+				    ? CAPTURE_ACTION_EXTEND
+				    : CAPTURE_ACTION_COMMIT);
+			}
+
+			if (i < env->trail_i - 1) {
+				action.to = env->trail[i + 1].state;
+			} else {
+				action.to = CAPTURE_NO_STATE;
+			}
+
+			if (!add_capture_action(env->fsm,
+				env->fsm->capture_info,
+				state, &action)) {
+				return 0;
+			}
+		}
+
+		tc->step = TRAIL_STEP_DONE;
+		return 1;
+	}
+
+#if LOG_CAPTURE > 0
+	fprintf(stderr, " -- resetting edge iterator\n");
+#endif
+	edge_set = env->fsm->states[cur].edges;
+
+	MARK_SEEN(env, cur);
+#if LOG_CAPTURE > 0
+	fprintf(stderr, " -- marking %u as seen\n", cur);
+#endif
+
+	edge_set_reset(edge_set, &tc->iter);
+	tc->step = TRAIL_STEP_ITER_EDGES;
+	return 1;
+}
+
+static int
+step_trail_iter_edges(struct capture_set_path_env *env)
+{
+	struct trail_cell *tc = &env->trail[env->trail_i - 1];
+	struct trail_cell *next_tc = NULL;
+
+	struct fsm_edge e;
+
+	if (!edge_set_next(&tc->iter, &e)) {
+#if LOG_CAPTURE > 0
+		fprintf(stderr, " -- ITER_EDGE_NEXT: DONE %u\n", tc->state);
+#endif
+		tc->step = TRAIL_STEP_ITER_EPSILONS;
+		return 1;
+	}
+
+#if LOG_CAPTURE > 0
+	fprintf(stderr, " -- ITER_EDGE_NEXT: %u -- NEXT %u\n",
+	    tc->state, e.state);
+#endif
+
+	/* FIXME: the seen filtering means it misses self edges,
+	 * should those be special-cased here? */
+
+	if (CHECK_SEEN(env, e.state)) {
+#if LOG_CAPTURE > 0
+		fprintf(stderr, "    -- seen, skipping\n");
+#endif
+		return 1;	/* continue */
+	}
+
+	if (env->trail_i == env->trail_ceil) {
+		assert(!"TODO: grow trail"); /* FIXME exercise this */
+	}
+
+#if LOG_CAPTURE > 0
+	fprintf(stderr, "    -- not seen (%u), exploring\n", e.state);
+#endif
+	env->trail_i++;
+	next_tc = &env->trail[env->trail_i - 1];
+	next_tc->state = e.state;
+	next_tc->step = TRAIL_STEP_START;
+
+	return 1;
+}
+
+static int
+step_trail_iter_epsilons(struct capture_set_path_env *env)
+{
+	struct trail_cell *tc = &env->trail[env->trail_i - 1];
+
+	/* skipping this for now */
+
+#if LOG_CAPTURE > 0
+	fprintf(stderr, " -- ITER_EPSILONS: %u\n", tc->state);
+#endif
+
+	tc->step = TRAIL_STEP_DONE;
+	return 1;
+}
+
+static int
+step_trail_done(struct capture_set_path_env *env)
+{
+	struct trail_cell *tc;
+
+	/* 0-step paths already handled outside loop */
+	assert(env->trail_i > 0);
+
+	tc = &env->trail[env->trail_i - 1];
+#if LOG_CAPTURE > 0
+	fprintf(stderr, " -- DONE: %u\n", tc->state);
+#endif
+	CLEAR_SEEN(env, tc->state);
+
+	env->trail_i--;
+	return 1;
 }
 
 void
 fsm_capture_rebase_capture_id(struct fsm *fsm, unsigned base)
 {
-	(void)fsm;
-	(void)base;
+	size_t i;
+	struct fsm_capture_info *ci = fsm->capture_info;
+	assert(ci != NULL);
+
+	for (i = 0; i < ci->bucket_count; i++) {
+		struct fsm_capture_action_bucket *b = &ci->buckets[i];
+		if (b->state == CAPTURE_NO_STATE) {
+			continue;
+		}
+
+		b->action.id += base;
+		if (b->action.id > ci->max_capture_id) {
+			ci->max_capture_id = b->action.id;
+		}
+	}
+}
+
+void
+fsm_capture_rebase_capture_action_states(struct fsm *fsm, fsm_state_t base)
+{
+	size_t i;
+	struct fsm_capture_info *ci = fsm->capture_info;
+	assert(ci != NULL);
+
+	for (i = 0; i < ci->bucket_count; i++) {
+		struct fsm_capture_action_bucket *b = &ci->buckets[i];
+		if (b->state == CAPTURE_NO_STATE) {
+			continue;
+		}
+
+		b->state += base;
+		if (b->action.to != CAPTURE_NO_STATE) {
+			b->action.to += base;
+		}
+	}
 }
 
 struct fsm_capture *
 fsm_capture_alloc(const struct fsm *fsm)
 {
 	(void)fsm;
+	assert(!"todo");
 	return NULL;
 }
 
@@ -64,26 +578,182 @@ fsm_capture_update_captures(const struct fsm *fsm,
     fsm_state_t cur_state, fsm_state_t next_state, size_t offset,
     struct fsm_capture *captures)
 {
-	(void)fsm;
-	(void)cur_state;
-	(void)next_state;
-	(void)offset;
-	(void)captures;
+	const struct fsm_capture_info *ci;
+	unsigned h;
+	size_t b_i, mask;
+
+	assert(cur_state < fsm->statecount);
+	assert(fsm->states[cur_state].has_capture_actions);
+
+	ci = fsm->capture_info;
+	assert(ci != NULL);
+
+	h = PHI32 * cur_state;
+	mask = ci->bucket_count - 1;
+
+#if LOG_CAPTURE > 0
+	fprintf(stderr, "-- updating captures at state %u, to %d, offset %lu\n",
+	    cur_state, next_state, offset);
+#endif
+
+	for (b_i = 0; b_i < ci->bucket_count; b_i++) {
+		struct fsm_capture_action_bucket *b = &ci->buckets[(h + b_i) & mask];
+		unsigned capture_id;
+		if (b->state == CAPTURE_NO_STATE) {
+			break;	/* no more for this state */
+		} else if (b->state != cur_state) {
+			continue; /* skip collision */
+		}
+
+		assert(b->state == cur_state);
+		capture_id = b->action.id;
+
+		switch (b->action.type) {
+		case CAPTURE_ACTION_START:
+#if LOG_CAPTURE > 0
+			fprintf(stderr, "START [%u, %u]\n",
+			    b->action.id, b->action.to);
+#endif
+			if (next_state == b->action.to && captures[capture_id].pos[0] != FSM_CAPTURE_NO_POS) {
+				captures[capture_id].pos[0] = offset;
+#if LOG_CAPTURE > 0
+				fprintf(stderr, " -- set capture[%u].[0] to %lu\n", b->action.id, offset);
+#endif
+			} else {
+				/* filtered, ignore */
+			}
+			break;
+		case CAPTURE_ACTION_EXTEND:
+#if LOG_CAPTURE > 0
+			fprintf(stderr, "EXTEND [%u, %u]\n",
+			    b->action.id, b->action.to);
+#endif
+			if (captures[capture_id].pos[0] != FSM_CAPTURE_NO_POS) {
+				if (next_state == b->action.to) {
+					captures[capture_id].pos[1] = offset;
+#if LOG_CAPTURE > 0
+				fprintf(stderr, " -- set capture[%u].[1] to %lu\n", b->action.id, offset);
+#endif
+				} else {
+					/* filtered, ignore */
+				}
+			}
+			break;
+		case CAPTURE_ACTION_COMMIT_ZERO_STEP:
+#if LOG_CAPTURE > 0
+			fprintf(stderr, "COMMIT_ZERO_STEP [%u]\n",
+			    b->action.id);
+#endif
+
+			if (captures[capture_id].pos[0] == FSM_CAPTURE_NO_POS) {
+				captures[capture_id].pos[0] = offset;
+				captures[capture_id].pos[1] = offset | COMMITTED_CAPTURE_FLAG;
+			}
+
+#if LOG_CAPTURE > 0
+			fprintf(stderr, " -- set capture[%u].[0] and [1] to %lu (with COMMIT flag)\n", b->action.id, offset);
+#endif
+			break;
+		case CAPTURE_ACTION_COMMIT:
+#if LOG_CAPTURE > 0
+			fprintf(stderr, "COMMIT [%u]\n",
+			    b->action.id);
+#endif
+			captures[capture_id].pos[1] = offset | COMMITTED_CAPTURE_FLAG;
+#if LOG_CAPTURE > 0
+			fprintf(stderr, " -- set capture[%u].[1] to %lu (with COMMIT flag)\n", b->action.id, offset);
+#endif
+			break;
+		default:
+			assert(!"matchfail");
+		}
+	}
 }
 
 void
 fsm_capture_finalize_captures(const struct fsm *fsm,
-    size_t capture_count, struct fsm_capture *captures);
+    size_t capture_count, struct fsm_capture *captures)
+{
+	size_t i;
+
+	/* If either pos[] is FSM_CAPTURE_NO_POS or the
+	 * COMMITTED_CAPTURE_FLAG isn't set on pos[1], then the capture
+	 * wasn't finalized; clear it. Otherwise, clear that bit so the
+	 * pos[1] offset is meaningful. */
+	(void)fsm;
+
+	/* FIXME: this should also take the end state(s) associated
+	 * with a capture into account, when that information is available;
+	 * otherwise there will be false positives for zero-width captures
+	 * where the paths have a common prefix. */
+
+	for (i = 0; i < capture_count; i++) {
+		if (captures[i].pos[0] == FSM_CAPTURE_NO_POS
+		    || captures[i].pos[1] == FSM_CAPTURE_NO_POS
+		    || (0 == (captures[i].pos[1] & COMMITTED_CAPTURE_FLAG))) {
+			captures[i].pos[0] = FSM_CAPTURE_NO_POS;
+			captures[i].pos[1] = FSM_CAPTURE_NO_POS;
+		} else if (captures[i].pos[1] & COMMITTED_CAPTURE_FLAG) {
+			captures[i].pos[1] &=~ COMMITTED_CAPTURE_FLAG;
+		}
+	}
+}
+
+void
+fsm_capture_action_iter(const struct fsm *fsm,
+    fsm_capture_action_iter_cb *cb, void *opaque)
+{
+	size_t i;
+	struct fsm_capture_info *ci = fsm->capture_info;
+	assert(ci != NULL);
+
+	for (i = 0; i < ci->bucket_count; i++) {
+		struct fsm_capture_action_bucket *b = &ci->buckets[i];
+		if (b->state == CAPTURE_NO_STATE) {
+			continue;
+		}
+
+		if (!cb(b->state, b->action.type,
+			b->action.id, b->action.to, opaque)) {
+			break;
+		}
+	}
+}
+
+const char *fsm_capture_action_type_name[] = {
+	"START", "EXTEND",
+	"COMMIT_ZERO_STEP", "COMMIT"
+};
 
 #ifndef NDEBUG
 #include <stdio.h>
+
+static int
+dump_iter_cb(fsm_state_t state,
+    enum capture_action_type type, unsigned capture_id, fsm_state_t to,
+    void *opaque)
+{
+	FILE *f = opaque;
+	fprintf(f, " - state %u, %s [capture_id: %u, to: %d]\n",
+	    state, fsm_capture_action_type_name[type], capture_id, to);
+	return 1;
+}
 
 /* Dump capture metadata about an FSM. */
 void
 fsm_capture_dump(FILE *f, const char *tag, const struct fsm *fsm)
 {
-	(void)f;
-	(void)tag;
-	(void)fsm;
+	struct fsm_capture_info *ci;
+
+	assert(fsm != NULL);
+	ci = fsm->capture_info;
+	if (ci == NULL || ci->bucket_count == 0) {
+		fprintf(f, "==== %s -- no captures\n", tag);
+		return;
+	}
+
+	fprintf(f, "==== %s -- capture action hash table (%u buckets)\n",
+	    tag, ci->bucket_count);
+	fsm_capture_action_iter(fsm, dump_iter_cb, f);
 }
 #endif

--- a/src/libfsm/capture.c
+++ b/src/libfsm/capture.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include "capture_internal.h"
+
+int
+fsm_capture_init(struct fsm *fsm)
+{
+	(void)fsm;
+	return 0;
+}
+
+void
+fsm_capture_free(struct fsm *fsm)
+{
+	(void)fsm;
+}
+
+unsigned
+fsm_countcaptures(const struct fsm *fsm)
+{
+	(void)fsm;
+	return 0;
+}
+
+int
+fsm_capture_has_capture_actions(const struct fsm *fsm, fsm_state_t state)
+{
+	(void)fsm;
+	(void)state;
+	return 0;
+}
+
+int
+fsm_capture_set_path(struct fsm *fsm, unsigned capture_id,
+    fsm_state_t start, fsm_state_t end)
+{
+	(void)fsm;
+	(void)capture_id;
+	(void)start;
+	(void)end;
+	return 0;
+}
+
+void
+fsm_capture_rebase_capture_id(struct fsm *fsm, unsigned base)
+{
+	(void)fsm;
+	(void)base;
+}
+
+struct fsm_capture *
+fsm_capture_alloc(const struct fsm *fsm)
+{
+	(void)fsm;
+	return NULL;
+}
+
+void
+fsm_capture_update_captures(const struct fsm *fsm,
+    fsm_state_t cur_state, fsm_state_t next_state, size_t offset,
+    struct fsm_capture *captures)
+{
+	(void)fsm;
+	(void)cur_state;
+	(void)next_state;
+	(void)offset;
+	(void)captures;
+}
+
+void
+fsm_capture_finalize_captures(const struct fsm *fsm,
+    size_t capture_count, struct fsm_capture *captures);
+
+#ifndef NDEBUG
+#include <stdio.h>
+
+/* Dump capture metadata about an FSM. */
+void
+fsm_capture_dump(FILE *f, const char *tag, const struct fsm *fsm)
+{
+	(void)f;
+	(void)tag;
+	(void)fsm;
+}
+#endif

--- a/src/libfsm/capture.h
+++ b/src/libfsm/capture.h
@@ -5,6 +5,26 @@
 #include <fsm/fsm.h>
 #include <fsm/capture.h>
 
+#define NEXT_STATE_END ((fsm_state_t)-1)
+
+#define CAPTURE_NO_STATE ((fsm_state_t)-1)
+
+/* Capture interface -- functions internal to libfsm.
+ * The public interface should not depend on any of these details. */
+
+enum capture_action_type {
+	/* Start an active capture if transitioning to TO. */
+	CAPTURE_ACTION_START,
+	/* Continue an active capture if transitioning to TO,
+	 * otherwise deactivate it. */
+	CAPTURE_ACTION_EXTEND,
+	/* Write a zero-step capture (i.e., the start and
+	 * end state are the same). */
+	CAPTURE_ACTION_COMMIT_ZERO_STEP,
+	/* Write an active capture's endpoints. */
+	CAPTURE_ACTION_COMMIT
+};
+
 int
 fsm_capture_init(struct fsm *fsm);
 
@@ -21,5 +41,27 @@ fsm_capture_update_captures(const struct fsm *fsm,
 void
 fsm_capture_finalize_captures(const struct fsm *fsm,
     size_t capture_count, struct fsm_capture *captures);
+
+/* Add a capture action. This is used to update capture actions
+ * in the destination FSM when combining/transforming other FSMs. */
+int
+fsm_capture_add_action(struct fsm *fsm,
+    fsm_state_t state, enum capture_action_type type,
+    unsigned id, fsm_state_t to);
+
+/* Callback for iterating over capture actions.
+ * Return 1 to continue, return 0 to halt.
+ * If TO is not meaningful for a particular type, it will be
+ * set to NEXT_STATE_END. */
+typedef int
+fsm_capture_action_iter_cb(fsm_state_t state,
+    enum capture_action_type type, unsigned capture_id, fsm_state_t to,
+    void *opaque);
+
+void
+fsm_capture_action_iter(const struct fsm *fsm,
+    fsm_capture_action_iter_cb *cb, void *opaque);
+
+extern const char *fsm_capture_action_type_name[];
 
 #endif

--- a/src/libfsm/capture.h
+++ b/src/libfsm/capture.h
@@ -1,0 +1,25 @@
+#ifndef LIBFSM_CAPTURE_H
+#define LIBFSM_CAPTURE_H
+
+#include <stdlib.h>
+#include <fsm/fsm.h>
+#include <fsm/capture.h>
+
+int
+fsm_capture_init(struct fsm *fsm);
+
+void
+fsm_capture_free(struct fsm *fsm);
+
+/* Update captures, called when exiting or ending on a state.
+ * If ending on a state, use NEXT_STATE_END for next_state. */
+void
+fsm_capture_update_captures(const struct fsm *fsm,
+    fsm_state_t cur_state, fsm_state_t next_state, size_t offset,
+    struct fsm_capture *captures);
+
+void
+fsm_capture_finalize_captures(const struct fsm *fsm,
+    size_t capture_count, struct fsm_capture *captures);
+
+#endif

--- a/src/libfsm/capture_internal.h
+++ b/src/libfsm/capture_internal.h
@@ -1,0 +1,20 @@
+#ifndef CAPTURE_INTERNAL_H
+#define CAPTURE_INTERNAL_H
+
+#include <stdlib.h>
+#include <stdint.h>
+
+#include <fsm/alloc.h>
+#include <fsm/capture.h>
+#include <fsm/fsm.h>
+
+#include <adt/edgeset.h>
+
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+
+#include "internal.h"
+#include "capture.h"
+
+#endif

--- a/src/libfsm/capture_internal.h
+++ b/src/libfsm/capture_internal.h
@@ -17,4 +17,99 @@
 #include "internal.h"
 #include "capture.h"
 
+/* Bucket count for capture action hash table.
+ * Must be a power of 2. */
+
+#define DEF_CAPTURE_ACTION_BUCKET_COUNT 32
+#define DEF_TRAIL_CEIL 8
+
+#define LOG_CAPTURE 0
+
+/* 32-bit approximation of golden ratio, used for hashing */
+#define PHI32 0x9e3779b9
+
+/* Most significant bit of a size_t. */
+#define COMMITTED_CAPTURE_FLAG ((SIZE_MAX) ^ (SIZE_MAX >> 1))
+
+#define EXPENSIVE_CHECKS 1
+
+struct fsm_capture_info {
+	unsigned max_capture_id;
+
+	/* Add-only hash table. */
+	unsigned bucket_count;
+	unsigned buckets_used; /* grow if >= 1/2 used */
+
+	/* Hash buckets. If state is CAPTURE_NO_STATE,
+	 * the bucket is empty. */
+	struct fsm_capture_action_bucket {
+		fsm_state_t state; /* key */
+		struct fsm_capture_action {
+			enum capture_action_type type;
+			unsigned id;
+			/* only used by START and EXTEND */
+			fsm_state_t to;
+		} action;
+	} *buckets;
+};
+
+enum trail_step {
+	TRAIL_STEP_START,
+	TRAIL_STEP_ITER_EDGES,
+	TRAIL_STEP_ITER_EPSILONS,
+	TRAIL_STEP_DONE
+};
+
+/* env->seen is used as a bit set for tracking which states have already
+ * been processed. These macros set/check/clear the bits. */
+#define SEEN_BITOP(ENV, STATE, OP) ENV->seen[STATE/64] OP ((uint64_t)1 << (STATE&63))
+#define MARK_SEEN(ENV, STATE) SEEN_BITOP(ENV, STATE, |=)
+#define CHECK_SEEN(ENV, STATE) SEEN_BITOP(ENV, STATE, &)
+#define CLEAR_SEEN(ENV, STATE) SEEN_BITOP(ENV, STATE, &=~)
+
+struct capture_set_path_env {
+	struct fsm *fsm;
+	unsigned capture_id;
+	fsm_state_t start;
+	fsm_state_t end;
+
+	unsigned trail_i;
+	unsigned trail_ceil;
+	struct trail_cell {
+		fsm_state_t state;
+		enum trail_step step;
+		struct edge_iter iter;
+	} *trail;
+
+	/* bitset for which states have already been seen. */
+	uint64_t *seen;
+};
+
+static int
+init_capture_action_htab(struct fsm *fsm, struct fsm_capture_info *ci);
+
+static int
+mark_capture_path(struct capture_set_path_env *env);
+
+static int
+add_capture_action(struct fsm *fsm, struct fsm_capture_info *ci,
+    fsm_state_t state, const struct fsm_capture_action *action);
+
+static int
+grow_capture_action_buckets(const struct fsm_alloc *alloc,
+    struct fsm_capture_info *ci);
+
+static int
+step_trail_start(struct capture_set_path_env *env);
+static int
+step_trail_iter_edges(struct capture_set_path_env *env);
+static int
+step_trail_iter_epsilons(struct capture_set_path_env *env);
+static int
+step_trail_done(struct capture_set_path_env *env);
+
+static int
+cmp_action(const struct fsm_capture_action *a,
+    const struct fsm_capture_action *b);
+
 #endif

--- a/src/libfsm/concat.c
+++ b/src/libfsm/concat.c
@@ -18,12 +18,17 @@
 #include "internal.h"
 
 struct fsm *
-fsm_concat(struct fsm *a, struct fsm *b)
+fsm_concat(struct fsm *a, struct fsm *b,
+	struct fsm_combine_info *combine_info)
 {
 	struct fsm *q;
 	fsm_state_t ea, sb;
 	fsm_state_t sq;
-	struct fsm_combine_info combine_info;
+	struct fsm_combine_info combine_info_internal;
+
+	if (combine_info == NULL) {
+		combine_info = &combine_info_internal;
+	}
 
 	assert(a != NULL);
 	assert(b != NULL);
@@ -52,12 +57,12 @@ fsm_concat(struct fsm *a, struct fsm *b)
 
 	fsm_setend(a, ea, 1);
 
-	q = fsm_merge(a, b, &combine_info);
+	q = fsm_merge(a, b, combine_info);
 	assert(q != NULL);
 
-	sq += combine_info.base_a;
-	ea += combine_info.base_a;
-	sb += combine_info.base_b;
+	sq += combine_info->base_a;
+	ea += combine_info->base_a;
+	sb += combine_info->base_b;
 
 	fsm_setend(q, ea, 0);
 

--- a/src/libfsm/concat.c
+++ b/src/libfsm/concat.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 
 #include <fsm/fsm.h>
+#include <fsm/bool.h>
 #include <fsm/pred.h>
 #include <fsm/walk.h>
 #include <fsm/options.h>
@@ -22,7 +23,7 @@ fsm_concat(struct fsm *a, struct fsm *b)
 	struct fsm *q;
 	fsm_state_t ea, sb;
 	fsm_state_t sq;
-	fsm_state_t base_a, base_b;
+	struct fsm_combine_info combine_info;
 
 	assert(a != NULL);
 	assert(b != NULL);
@@ -51,12 +52,12 @@ fsm_concat(struct fsm *a, struct fsm *b)
 
 	fsm_setend(a, ea, 1);
 
-	q = fsm_merge(a, b, &base_a, &base_b);
+	q = fsm_merge(a, b, &combine_info);
 	assert(q != NULL);
 
-	sq += base_a;
-	ea += base_a;
-	sb += base_b;
+	sq += combine_info.base_a;
+	ea += combine_info.base_a;
+	sb += combine_info.base_b;
 
 	fsm_setend(q, ea, 0);
 

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -24,6 +24,7 @@
 #include "capture.h"
 
 #define DUMP_MAPPING 0
+#define LOG_DETERMINISE_CLOSURES 0
 #define LOG_DETERMINISE_CAPTURES 0
 
 /*
@@ -248,7 +249,9 @@ fsm_determinise(struct fsm *nfa)
 			goto error;
 		}
 
-		/* fprintf(stderr, "#### Adding mapping for start state %u -> 0\n", start); */
+#if LOG_DETERMINISE_CAPTURES
+		fprintf(stderr, "#### Adding mapping for start state %u -> 0\n", start);
+#endif
 
 		curr = mapping_add(mappings, nfa->opt->alloc, dfacount++, set);
 		if (curr == NULL) {
@@ -284,7 +287,6 @@ fsm_determinise(struct fsm *nfa)
 					/* TODO: free mappings, sclosures, stack */
 					goto error;
 				}
-				/* fprintf(stderr, "*** cur %u, s %u\n", curr->dfastate, s); */
 			}
 		}
 
@@ -295,17 +297,19 @@ fsm_determinise(struct fsm *nfa)
 				continue;
 			}
 
-			/* fprintf(stderr, "fsm_determinise: cur (dfa %u) label '%c': %p:", */
-			/*     curr->dfastate, (char)i, (void *)sclosures[i]); */
+#if LOG_DETERMINISE_CLOSURES
+			fprintf(stderr, "fsm_determinise: cur (dfa %u) label '%c': %p:",
+			    curr->dfastate, (char)i, (void *)sclosures[i]);
 			{
 				struct state_iter it;
 				fsm_state_t s;
 
 				for (state_set_reset(sclosures[i], &it); state_set_next(&it, &s); ) {
-					/* fprintf(stderr, " %u", s); */
+					fprintf(stderr, " %u", s);
 				}
-				/* fprintf(stderr, "\n"); */
+				fprintf(stderr, "\n");
 			}
+#endif
 
 			/*
 			 * The set of NFA states sclosures[i] represents a single DFA state.

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -453,10 +453,12 @@ remap_capture_actions(struct mapping_hashset *mappings,
 	struct reverse_mapping *reverse_mappings;
 	fsm_state_t state;
 	const size_t capture_count = fsm_countcaptures(src_nfa);
-	size_t i,j;
+	size_t i, j;
 	int res = 0;
 
-	(void)j;
+	if (capture_count == 0) {
+		return 1;
+	}
 
 	/* This is not 1 to 1 -- if state X is now represented by multiple
 	 * states Y in the DFA, and state X has action(s) when transitioning
@@ -469,11 +471,6 @@ remap_capture_actions(struct mapping_hashset *mappings,
 	reverse_mappings = f_calloc(dst_dfa->opt->alloc, src_nfa->statecount, sizeof(reverse_mappings[0]));
 	if (reverse_mappings == NULL) {
 		return 0;
-	}
-
-	if (capture_count == 0) {
-		/* fprintf(stderr, "zero captures, could bail early\n"); */
-		/* return 1; */
 	}
 
 	/* build reverse mappings table: for every NFA state X, if X is part
@@ -500,6 +497,8 @@ remap_capture_actions(struct mapping_hashset *mappings,
 		}
 		fprintf(stderr, "\n");
 	}
+#else
+	(void)j;
 #endif
 
 	if (!det_copy_capture_actions(reverse_mappings, dst_dfa, src_nfa)) {

--- a/src/libfsm/exec.c
+++ b/src/libfsm/exec.c
@@ -21,6 +21,8 @@
 #include "internal.h"
 #include "capture.h"
 
+#define LOG_EXEC 0
+
 static int
 transition(const struct fsm *fsm, fsm_state_t state, int c,
 	size_t offset, struct fsm_capture *captures,
@@ -77,10 +79,22 @@ fsm_exec(const struct fsm *fsm,
 		captures[i].pos[1] = FSM_CAPTURE_NO_POS;
 	}
 
+#if LOG_EXEC
+	fprintf(stderr, "fsm_exec: starting at %d\n", state);
+#endif
+
 	while (c = fsm_getc(opaque), c != EOF) {
 		if (!transition(fsm, state, c, offset, captures, &state)) {
+#if LOG_EXEC
+			fprintf(stderr, "fsm_exec: edge not found\n");
+#endif
 			return 0;
 		}
+
+#if LOG_EXEC
+		fprintf(stderr, "fsm_exec: @ %zu, input '%c', new state %u\n",
+		    offset, c, state);
+#endif
 		offset++;
 	}
 

--- a/src/libfsm/exec.c
+++ b/src/libfsm/exec.c
@@ -36,7 +36,7 @@ transition(const struct fsm *fsm, fsm_state_t state, int c,
 int
 fsm_exec(const struct fsm *fsm,
 	int (*fsm_getc)(void *opaque), void *opaque,
-	fsm_state_t *end)
+	fsm_state_t *end, struct fsm_capture *captures)
 {
 	fsm_state_t state;
 	int c;
@@ -44,6 +44,8 @@ fsm_exec(const struct fsm *fsm,
 	assert(fsm != NULL);
 	assert(fsm_getc != NULL);
 	assert(end != NULL);
+
+	(void)captures;
 
 	/* TODO: check prerequisites; that it has literal edges, DFA, etc */
 

--- a/src/libfsm/exec.c
+++ b/src/libfsm/exec.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 
 #include <fsm/fsm.h>
+#include <fsm/capture.h>
 #include <fsm/pred.h>
 #include <fsm/walk.h>
 
@@ -18,9 +19,11 @@
 #include <adt/edgeset.h>
 
 #include "internal.h"
+#include "capture.h"
 
 static int
 transition(const struct fsm *fsm, fsm_state_t state, int c,
+	size_t offset, struct fsm_capture *captures,
 	fsm_state_t *next)
 {
 	assert(state < fsm->statecount);
@@ -28,6 +31,11 @@ transition(const struct fsm *fsm, fsm_state_t state, int c,
 
 	if (!edge_set_transition(fsm->states[state].edges, c, next)) {
 		return 0;
+	}
+
+	if (captures != NULL && fsm_capture_has_capture_actions(fsm, state)) {
+		fsm_capture_update_captures(fsm, state, *next,
+		    offset, captures);
 	}
 
 	return 1;
@@ -40,12 +48,15 @@ fsm_exec(const struct fsm *fsm,
 {
 	fsm_state_t state;
 	int c;
+	size_t offset = 0;
+	unsigned i;
+	size_t capture_count;
 
 	assert(fsm != NULL);
 	assert(fsm_getc != NULL);
 	assert(end != NULL);
 
-	(void)captures;
+	capture_count = fsm_countcaptures(fsm);
 
 	/* TODO: check prerequisites; that it has literal edges, DFA, etc */
 
@@ -61,15 +72,29 @@ fsm_exec(const struct fsm *fsm,
 		return -1;
 	}
 
+	for (i = 0; i < capture_count; i++) {
+		captures[i].pos[0] = FSM_CAPTURE_NO_POS;
+		captures[i].pos[1] = FSM_CAPTURE_NO_POS;
+	}
+
 	while (c = fsm_getc(opaque), c != EOF) {
-		if (!transition(fsm, state, c, &state)) {
+		if (!transition(fsm, state, c, offset, captures, &state)) {
 			return 0;
 		}
+		offset++;
 	}
 
 	if (!fsm_isend(fsm, state)) {
 		return 0;
 	}
+
+	/* Check for capture actions on end state */
+	if (captures != NULL && fsm_capture_has_capture_actions(fsm, state)) {
+		fsm_capture_update_captures(fsm, state, NEXT_STATE_END,
+		    offset, captures);
+	}
+
+	fsm_capture_finalize_captures(fsm, capture_count, captures);
 
 	*end = state;
 	return 1;

--- a/src/libfsm/fsm.c
+++ b/src/libfsm/fsm.c
@@ -20,6 +20,7 @@
 #include <adt/edgeset.h>
 
 #include "internal.h"
+#include "capture.h"
 
 void
 free_contents(struct fsm *fsm)
@@ -56,6 +57,7 @@ fsm_new(const struct fsm_options *opt)
 	new->statealloc = 128; /* guess */
 	new->statecount = 0;
 	new->endcount   = 0;
+	new->capture_info = NULL;
 
 	new->states = f_malloc(f.opt->alloc, new->statealloc * sizeof *new->states);
 	if (new->states == NULL) {
@@ -66,6 +68,12 @@ fsm_new(const struct fsm_options *opt)
 	fsm_clearstart(new);
 
 	new->opt = opt;
+
+	if (!fsm_capture_init(new)) {
+		f_free(f.opt->alloc, new->states);
+		f_free(f.opt->alloc, new);
+		return NULL;
+	}
 
 	return new;
 }
@@ -110,6 +118,8 @@ fsm_move(struct fsm *dst, struct fsm *src)
 	dst->statecount = src->statecount;
 	dst->statealloc = src->statealloc;
 	dst->endcount   = src->endcount;
+
+	dst->capture_info = src->capture_info;
 
 	f_free(src->opt->alloc, src);
 }

--- a/src/libfsm/glushkovise.c
+++ b/src/libfsm/glushkovise.c
@@ -17,6 +17,34 @@
 #include <adt/stateset.h>
 
 #include "internal.h"
+#include "capture.h"
+
+#define DUMP_EPSILON_CLOSURES 0
+#define DEF_PENDING_CAPTURE_ACTIONS_CEIL 2
+
+struct remap_env {
+	char tag;
+	const struct fsm_alloc *alloc;
+	struct state_set **rmap;
+	int ok;
+
+	size_t count;
+	size_t ceil;
+	struct remap_action {
+		fsm_state_t state;
+		enum capture_action_type type;
+		unsigned capture_id;
+		fsm_state_t to;
+	} *actions;
+};
+
+static int
+remap_capture_actions(struct fsm *nfa, struct state_set **eclosures);
+
+static int
+remap_capture_action_cb(fsm_state_t state,
+    enum capture_action_type type, unsigned capture_id, fsm_state_t to,
+    void *opaque);
 
 int
 fsm_glushkovise(struct fsm *nfa)
@@ -30,6 +58,22 @@ fsm_glushkovise(struct fsm *nfa)
 	if (eclosures == NULL) {
 		return 0;
 	}
+
+#if DUMP_EPSILON_CLOSURES
+	{
+		struct state_iter kt;
+		fsm_state_t es;
+		fprintf(stderr, "# ==== epsilon_closures\n");
+		for (s = 0; s < nfa->statecount; s++) {
+			if (eclosures[s] == NULL) { continue; }
+			fprintf(stderr, " -- %u:", s);
+			for (state_set_reset(eclosures[s], &kt); state_set_next(&kt, &es); ) {
+				fprintf(stderr, " %u", es);
+			}
+			fprintf(stderr, "\n");
+		}
+	}
+#endif
 
 	for (s = 0; s < nfa->statecount; s++) {
 		struct state_set *sclosures[FSM_SIGMA_COUNT] = { NULL };
@@ -101,7 +145,10 @@ fsm_glushkovise(struct fsm *nfa)
 		 * known to have been an end state.
 		 */
 		fsm_carryopaque(nfa, eclosures[s], nfa, s);
+	}
 
+	if (!remap_capture_actions(nfa, eclosures)) {
+		goto error;
 	}
 
 	closure_free(eclosures, nfa->statecount);
@@ -116,3 +163,149 @@ error:
 	return 0;
 }
 
+static int
+remap_capture_actions(struct fsm *nfa, struct state_set **eclosures)
+{
+	int res = 0;
+	fsm_state_t s, i;
+	struct state_set **rmap;
+	struct state_iter si;
+	fsm_state_t si_s;
+	struct remap_env env = { 'R', NULL, NULL, 1, 0, 0, NULL };
+	env.alloc = nfa->opt->alloc;
+
+	/* build a reverse mapping */
+	rmap = f_calloc(nfa->opt->alloc, nfa->statecount, sizeof(rmap[0]));
+	if (rmap == NULL) {
+		goto cleanup;
+	}
+
+	for (s = 0; s < nfa->statecount; s++) {
+		if (eclosures[s] == NULL) { continue; }
+		for (state_set_reset(eclosures[s], &si); state_set_next(&si, &si_s); ) {
+			if (si_s == s) {
+				continue; /* ignore identical states */
+			}
+			/* fprintf(stderr, "remap_capture_actions: %u <- %u\n", */
+			/*     s, si_s); */
+			if (!state_set_add(&rmap[si_s], nfa->opt->alloc, s)) {
+				goto cleanup;
+			}
+		}
+	}
+	env.rmap = rmap;
+
+	/* Iterate over the current set of actions with the reverse
+	 * mapping (containing only states which will be skipped,
+	 * collecting info about every new capture action that will need
+	 * to be added.
+	 *
+	 * It can't be added during the iteration, because that would
+	 * modify the hash table as it's being iterated over. */
+	fsm_capture_action_iter(nfa, remap_capture_action_cb, &env);
+
+	/* Now that we're done iterating, add those actions. */
+	for (i = 0; i < env.count; i++) {
+		const struct remap_action *a = &env.actions[i];
+		if (!fsm_capture_add_action(nfa, a->state, a->type,
+			a->capture_id, a->to)) {
+			goto cleanup;
+		}
+	}
+
+	res = 1;
+
+cleanup:
+	if (env.actions != NULL) {
+		f_free(nfa->opt->alloc, env.actions);
+	}
+
+	if (rmap != NULL) {
+		for (i = 0; i < nfa->statecount; i++) {
+			state_set_free(rmap[i]);
+		}
+		f_free(nfa->opt->alloc, rmap);
+	}
+	return res;
+
+}
+
+static int
+add_pending_capture_action(struct remap_env *env,
+    fsm_state_t state, enum capture_action_type type,
+    unsigned capture_id, fsm_state_t to)
+{
+	struct remap_action *a;
+	if (env->count == env->ceil) {
+		struct remap_action *nactions;
+		const size_t nceil = (env->ceil == 0
+		    ? DEF_PENDING_CAPTURE_ACTIONS_CEIL : 2*env->ceil);
+		assert(nceil > 0);
+		nactions = f_realloc(env->alloc,
+		    env->actions,
+		    nceil * sizeof(nactions[0]));
+		if (nactions == NULL) {
+			return 0;
+		}
+
+		env->ceil = nceil;
+		env->actions = nactions;
+	}
+
+	a = &env->actions[env->count];
+	/* fprintf(stderr, "add_pending_capture_action: state %d, type %s, capture_id %u, to %d\n", */
+	/*     state, fsm_capture_action_type_name[type], capture_id, to); */
+	a->state = state;
+	a->type = type;
+	a->capture_id = capture_id;
+	a->to = to;
+	env->count++;
+	return 1;
+}
+
+static int
+remap_capture_action_cb(fsm_state_t state,
+    enum capture_action_type type, unsigned capture_id, fsm_state_t to,
+    void *opaque)
+{
+	struct state_iter si;
+	fsm_state_t si_s;
+	struct remap_env *env = opaque;
+	assert(env->tag == 'R');
+
+	/* fprintf(stderr, "remap_capture_action_cb: state %d, type %s, capture_id %u, to %d\n", */
+	/*     state, fsm_capture_action_type_name[type], capture_id, to); */
+
+	for (state_set_reset(env->rmap[state], &si); state_set_next(&si, &si_s); ) {
+		struct state_iter si_to;
+		fsm_state_t si_tos;
+
+		/* fprintf(stderr, " -- rcac: state %d -> %d\n", state, si_s); */
+
+		if (!add_pending_capture_action(env, si_s, type, capture_id, to)) {
+			goto fail;
+		}
+
+		if (to == CAPTURE_NO_STATE) {
+			continue;
+		}
+
+		for (state_set_reset(env->rmap[to], &si_to); state_set_next(&si, &si_tos); ) {
+			/* fprintf(stderr, " -- rcac:     to %d -> %d\n", to, si_tos); */
+			/* if (!add_pending_capture_action(env, si_s, type, capture_id, si_tos)) { */
+			/* 	goto fail; */
+			/* } */
+
+			if (!add_pending_capture_action(env, si_tos, type, capture_id, to)) {
+				goto fail;
+			}
+
+		}
+	}
+
+	return 1;
+
+fail:
+	env->ok = 0;
+	return 0;
+}

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -40,6 +40,8 @@ struct state_array;
 
 #define FSM_ENDCOUNT_MAX ULONG_MAX
 
+#define FSM_CAPTURE_MAX INT_MAX
+
 struct fsm_edge {
 	fsm_state_t state; /* destination */
 	unsigned char symbol;
@@ -47,6 +49,10 @@ struct fsm_edge {
 
 struct fsm_state {
 	unsigned int end:1;
+
+	/* If 0, then this state has no need for checking
+	 * the fsm->capture_info struct. */
+	unsigned int has_capture_actions:1;
 
 	/* meaningful within one particular transformation only */
 	unsigned int visited:1;
@@ -67,6 +73,7 @@ struct fsm {
 	fsm_state_t start;
 	unsigned int hasstart:1;
 
+	struct fsm_capture_info *capture_info;
 	const struct fsm_options *opt;
 };
 

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -118,3 +118,10 @@ fsm_vm_free
 fsm_vm_match_buffer
 fsm_vm_match_file
 
+# <fsm/capture.h>
+fsm_countcaptures
+fsm_capture_has_capture_actions
+fsm_capture_set_path
+fsm_capture_rebase_capture_id
+fsm_capture_alloc
+fsm_capture_dump

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -1,6 +1,7 @@
 # <fsm/bool.h>
 fsm_complement
 fsm_union
+fsm_union_array
 fsm_intersect
 
 # <fsm/cost.h>

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -67,9 +67,9 @@ fsm_findmode
 fsm_collate
 fsm_mergestates
 
-fsm_capture_start
-fsm_capture_stop
-fsm_capture_duplicate
+fsm_subgraph_start
+fsm_subgraph_stop
+fsm_subgraph_duplicate
 
 fsm_setstart
 fsm_getstart

--- a/src/libfsm/merge.c
+++ b/src/libfsm/merge.c
@@ -107,12 +107,14 @@ fsm_mergeab(struct fsm *a, struct fsm *b,
 
 struct fsm *
 fsm_merge(struct fsm *a, struct fsm *b,
-	fsm_state_t *base_a, fsm_state_t *base_b)
+	struct fsm_combine_info *combine_info)
 {
+	int a_dst;
+	struct fsm *res;
+
 	assert(a != NULL);
 	assert(b != NULL);
-	assert(base_a != NULL);
-	assert(base_b != NULL);
+	assert(combine_info != NULL);
 
 	if (a->opt != b->opt) {
 		errno = EINVAL;
@@ -126,17 +128,27 @@ fsm_merge(struct fsm *a, struct fsm *b,
 	 */
 
 	if (a->statealloc > b->statealloc) {
-		return merge(a, b, base_a, base_b);
+		a_dst = 1;
 	} else if (a->statealloc < b->statealloc) {
-		return merge(b, a, base_b, base_a);
-	}
-
-	if (a->statecount > b->statecount) {
-		return merge(a, b, base_a, base_b);
+		a_dst = 0;
+	} else if (a->statecount > b->statecount) {
+		a_dst = 1;
 	} else if (a->statecount < b->statecount) {
-		return merge(b, a, base_b, base_a);
+		a_dst = 0;
+	} else {
+		a_dst = 1;
 	}
 
-	return merge(a, b, base_a, base_b);
+	if (a_dst) {
+		res = merge(a, b,
+		    &combine_info->base_a,
+		    &combine_info->base_b);
+	} else {
+		res = merge(b, a,
+		    &combine_info->base_b,
+		    &combine_info->base_a);
+	}
+
+	return res;
 }
 

--- a/src/libfsm/state.c
+++ b/src/libfsm/state.c
@@ -32,11 +32,16 @@ fsm_addstate(struct fsm *fsm, fsm_state_t *state)
 	if (fsm->statecount == fsm->statealloc) {
 		const size_t factor = 2; /* a guess */
 		const size_t n = fsm->statealloc * factor;
-		void *tmp;
+		struct fsm_state *tmp;
+		size_t i;
 
 		tmp = f_realloc(fsm->opt->alloc, fsm->states, n * sizeof *fsm->states);
 		if (tmp == NULL) {
 			return 0;
+		}
+
+		for (i = fsm->statealloc; i < n; i++) {
+			tmp[i].has_capture_actions = 0;
 		}
 
 		fsm->statealloc = n;

--- a/src/libfsm/subgraph.c
+++ b/src/libfsm/subgraph.c
@@ -10,7 +10,7 @@
 
 #include <fsm/fsm.h>
 #include <fsm/pred.h>
-#include <fsm/capture.h>
+#include <fsm/subgraph.h>
 
 #include <adt/alloc.h>
 #include <adt/set.h>
@@ -21,26 +21,26 @@
 #include "internal.h"
 
 void
-fsm_capture_start(struct fsm *fsm, struct fsm_capture *capture)
+fsm_subgraph_start(struct fsm *fsm, struct fsm_subgraph *subgraph)
 {
 	assert(fsm != NULL);
-	assert(capture != NULL);
+	assert(subgraph != NULL);
 
-	capture->start = fsm_countstates(fsm);
+	subgraph->start = fsm_countstates(fsm);
 }
 
 void
-fsm_capture_stop(struct fsm *fsm, struct fsm_capture *capture)
+fsm_subgraph_stop(struct fsm *fsm, struct fsm_subgraph *subgraph)
 {
 	assert(fsm != NULL);
-	assert(capture != NULL);
+	assert(subgraph != NULL);
 
-	capture->end = fsm_countstates(fsm);
+	subgraph->end = fsm_countstates(fsm);
 }
 
 int
-fsm_capture_duplicate(struct fsm *fsm,
-	const struct fsm_capture *capture,
+fsm_subgraph_duplicate(struct fsm *fsm,
+	const struct fsm_subgraph *subgraph,
 	fsm_state_t *x,
 	fsm_state_t *q)
 {
@@ -48,13 +48,13 @@ fsm_capture_duplicate(struct fsm *fsm,
 	fsm_state_t new_start, new_end;
 	fsm_state_t ind;
 
-	assert(fsm     != NULL);
-	assert(capture != NULL);
-	assert(q       != NULL);
-	assert(x == NULL || (*x >= capture->start && *x < capture->end));
+	assert(fsm      != NULL);
+	assert(subgraph != NULL);
+	assert(q        != NULL);
+	assert(x == NULL || (*x >= subgraph->start && *x < subgraph->end));
 
-	old_start = capture->start;
-	old_end   = capture->end;
+	old_start = subgraph->start;
+	old_end   = subgraph->end;
 
 	if (old_start >= old_end) {
 		return 0;

--- a/src/libfsm/union.c
+++ b/src/libfsm/union.c
@@ -6,6 +6,7 @@
 
 #include <assert.h>
 #include <stddef.h>
+#include <string.h>
 #include <limits.h>
 #include <errno.h>
 
@@ -16,6 +17,8 @@
 #include <fsm/options.h>
 
 #include "internal.h"
+
+#define LOG_UNION_ARRAY 0
 
 struct fsm *
 fsm_union(struct fsm *a, struct fsm *b,
@@ -86,3 +89,52 @@ error:
 	return NULL;
 }
 
+struct fsm *
+fsm_union_array(size_t fsm_count,
+    struct fsm **fsms, struct fsm_combined_base_pair *bases)
+{
+	size_t i;
+	struct fsm *res = fsms[0];
+
+	fsms[0] = NULL;
+	memset(bases, 0x00, fsm_count * sizeof(bases[0]));
+
+	for (i = 1; i < fsm_count; i++) {
+		struct fsm_combine_info ci;
+		struct fsm *combined = fsm_union(res, fsms[i], &ci);
+		fsms[i] = NULL;
+		if (combined == NULL) {
+			while (i < fsm_count) {
+				fsm_free(fsms[i]);
+				i++;
+			}
+
+			fsm_free(res);
+			return NULL;
+		}
+
+		bases[i].state = ci.base_b;
+		bases[i].capture = ci.capture_base_b;
+		res = combined;
+
+		/* If the first argument didn't get its states put first
+		 * in the union, then shift the bases for everything
+		 * that has been combined into it so far. */
+		if (ci.capture_base_a > 0) {
+			size_t shift_i;
+			for (shift_i = 0; shift_i < i; shift_i++) {
+				bases[shift_i].state += ci.base_a;
+				bases[shift_i].capture += ci.capture_base_a;
+			}
+		}
+	}
+
+#if LOG_UNION_ARRAY
+	for (i = 0; i < fsm_count; i++) {
+		fprintf(stderr, "union_array: bases %u: %zu, %zu\n",
+		    i, bases[i].state, bases[i].capture);
+	}
+#endif
+
+	return res;
+}

--- a/src/libfsm/union.c
+++ b/src/libfsm/union.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 
 #include <fsm/fsm.h>
+#include <fsm/capture.h>
 #include <fsm/bool.h>
 #include <fsm/pred.h>
 #include <fsm/options.h>

--- a/src/libfsm/union.c
+++ b/src/libfsm/union.c
@@ -22,7 +22,7 @@ fsm_union(struct fsm *a, struct fsm *b)
 	struct fsm *q;
 	fsm_state_t sa, sb;
 	fsm_state_t sq;
-	fsm_state_t base_a, base_b;
+	struct fsm_combine_info combine_info;
 
 	assert(a != NULL);
 	assert(b != NULL);
@@ -40,11 +40,11 @@ fsm_union(struct fsm *a, struct fsm *b)
 		return NULL;
 	}
 
-	q = fsm_merge(a, b, &base_a, &base_b);
+	q = fsm_merge(a, b, &combine_info);
 	assert(q != NULL);
 
-	sa += base_a;
-	sb += base_b;
+	sa += combine_info.base_a;
+	sb += combine_info.base_b;
 
 	/*
 	 * The canonical approach is to create a new start state, with epsilon

--- a/src/libfsm/union.c
+++ b/src/libfsm/union.c
@@ -17,12 +17,17 @@
 #include "internal.h"
 
 struct fsm *
-fsm_union(struct fsm *a, struct fsm *b)
+fsm_union(struct fsm *a, struct fsm *b,
+	struct fsm_combine_info *combine_info)
 {
 	struct fsm *q;
 	fsm_state_t sa, sb;
 	fsm_state_t sq;
-	struct fsm_combine_info combine_info;
+	struct fsm_combine_info combine_info_internal;
+
+	if (combine_info == NULL) {
+		combine_info = &combine_info_internal;
+	}
 
 	assert(a != NULL);
 	assert(b != NULL);
@@ -40,11 +45,11 @@ fsm_union(struct fsm *a, struct fsm *b)
 		return NULL;
 	}
 
-	q = fsm_merge(a, b, &combine_info);
+	q = fsm_merge(a, b, combine_info);
 	assert(q != NULL);
 
-	sa += combine_info.base_a;
-	sb += combine_info.base_b;
+	sa += combine_info->base_a;
+	sb += combine_info->base_b;
 
 	/*
 	 * The canonical approach is to create a new start state, with epsilon

--- a/src/libre/ast_compile.c
+++ b/src/libre/ast_compile.c
@@ -16,7 +16,7 @@
 #include <fsm/fsm.h>
 #include <fsm/bool.h>
 #include <fsm/pred.h>
-#include <fsm/capture.h>
+#include <fsm/subgraph.h>
 
 #include <re/re.h>
 
@@ -546,10 +546,10 @@ comp_iter_repeated(struct comp_env *env,
 		 * build its NFA, and link to its head.
 		 */
 
-		struct fsm_capture capture;
+		struct fsm_subgraph subgraph;
 		fsm_state_t tail;
 
-		fsm_capture_start(env->fsm, &capture);
+		fsm_subgraph_start(env->fsm, &subgraph);
 
 		NEWSTATE(na);
 		NEWSTATE(nz);
@@ -562,7 +562,7 @@ comp_iter_repeated(struct comp_env *env,
 		if (min == 0) {
 			EPSILON(na, nz);
 		}
-		fsm_capture_stop(env->fsm, &capture);
+		fsm_subgraph_stop(env->fsm, &subgraph);
 		tail = nz;
 
 		if (max != AST_COUNT_UNBOUNDED) {
@@ -572,7 +572,7 @@ comp_iter_repeated(struct comp_env *env,
 				 */
 				b = tail;
 
-				if (!fsm_capture_duplicate(env->fsm, &capture, &b, &a)) {
+				if (!fsm_subgraph_duplicate(env->fsm, &subgraph, &b, &a)) {
 					return 0;
 				}
 
@@ -593,7 +593,7 @@ comp_iter_repeated(struct comp_env *env,
 				 */
 				b = tail;
 
-				if (!fsm_capture_duplicate(env->fsm, &capture, &b, &a)) {
+				if (!fsm_subgraph_duplicate(env->fsm, &subgraph, &b, &a)) {
 					return 0;
 				}
 

--- a/src/lx/ast.c
+++ b/src/lx/ast.c
@@ -130,7 +130,7 @@ ast_addmapping(struct ast_zone *z, struct fsm *fsm,
 
 	/* TODO: re_addcolour(fsm, m) */
 
-	m->fsm = fsm_union(m->fsm, fsm);
+	m->fsm = fsm_union(m->fsm, fsm, NULL);
 	if (m->fsm == NULL) {
 		return NULL;
 	}

--- a/src/lx/main.c
+++ b/src/lx/main.c
@@ -402,7 +402,7 @@ zone_equal(const struct ast_zone *a, const struct ast_zone *b)
 		return -1;
 	}
 
-	q = fsm_union(x, y);
+	q = fsm_union(x, y, NULL);
 	if (q == NULL) {
 		fsm_free(x);
 		fsm_free(y);

--- a/src/lx/main.c
+++ b/src/lx/main.c
@@ -489,7 +489,7 @@ zone_minimise(void *arg)
 
 		for (m = z->ml; m != NULL; m = m->next) {
 			fsm_state_t ms;
-			fsm_state_t base_z, base_m;
+			struct fsm_combine_info combine_info;
 
 			assert(m->fsm != NULL);
 
@@ -513,7 +513,7 @@ zone_minimise(void *arg)
 
 			(void) fsm_getstart(m->fsm, &ms);
 
-			z->fsm = fsm_merge(z->fsm, m->fsm, &base_z, &base_m);
+			z->fsm = fsm_merge(z->fsm, m->fsm, &combine_info);
 			if (z->fsm == NULL) {
 				pthread_mutex_lock(&zmtx);
 				zerror = errno;
@@ -525,8 +525,8 @@ zone_minimise(void *arg)
 			m->fsm = NULL;
 #endif
 
-			ms    += base_m;
-			start += base_z;
+			ms    += combine_info.base_b;
+			start += combine_info.base_a;
 
 			if (!fsm_addedge_epsilon(z->fsm, start, ms)) {
 				pthread_mutex_lock(&zmtx);

--- a/src/lx/parser.act
+++ b/src/lx/parser.act
@@ -329,8 +329,8 @@
 
 		for (m = @z->ml; m != NULL; m = m->next) {
 			struct fsm *fsm;
-			fsm_state_t base_r, base_fsm;
 			fsm_state_t ms;
+			struct fsm_combine_info combine_info;
 
 			if (m->token == NULL) {
 				continue;
@@ -355,14 +355,14 @@
 			 */
 			fsm_setendopaque(fsm, NULL);
 
-			@r = fsm_merge(@r, fsm, &base_r, &base_fsm);
+			@r = fsm_merge(@r, fsm, &combine_info);
 			if (@r == NULL) {
 				perror("fsm_union");
 				@!;
 			}
 
-			ms    += base_fsm;
-			start += base_r;
+			ms    += combine_info.base_b;
+			start += combine_info.base_a;
 
 			if (!fsm_addedge_epsilon(@r, start, ms)) {
 				perror("fsm_addedge_epsilon");

--- a/src/lx/parser.act
+++ b/src/lx/parser.act
@@ -701,7 +701,7 @@
 		assert(@a != NULL);
 		assert(@b != NULL);
 
-		@q = fsm_concat(@a, @b);
+		@q = fsm_concat(@a, @b, NULL);
 		if (@q == NULL) {
 			perror("fsm_concat");
 			@!;
@@ -740,7 +740,7 @@
 		assert(@a != NULL);
 		assert(@b != NULL);
 
-		@q = fsm_union(@a, @b);
+		@q = fsm_union(@a, @b, NULL);
 		if (@q == NULL) {
 			perror("fsm_union");
 			@!;

--- a/src/lx/parser.c
+++ b/src/lx/parser.c
@@ -293,8 +293,8 @@ p_pattern(lex_state lex_state, act_state act_state, zone ZIz, fsm *ZOr)
 
 		for (m = (ZIz)->ml; m != NULL; m = m->next) {
 			struct fsm *fsm;
-			fsm_state_t base_r, base_fsm;
 			fsm_state_t ms;
+			struct fsm_combine_info combine_info;
 
 			if (m->token == NULL) {
 				continue;
@@ -319,14 +319,14 @@ p_pattern(lex_state lex_state, act_state act_state, zone ZIz, fsm *ZOr)
 			 */
 			fsm_setendopaque(fsm, NULL);
 
-			(ZIr) = fsm_merge((ZIr), fsm, &base_r, &base_fsm);
+			(ZIr) = fsm_merge((ZIr), fsm, &combine_info);
 			if ((ZIr) == NULL) {
 				perror("fsm_union");
 				goto ZL1;
 			}
 
-			ms    += base_fsm;
-			start += base_r;
+			ms    += combine_info.base_b;
+			start += combine_info.base_a;
 
 			if (!fsm_addedge_epsilon((ZIr), start, ms)) {
 				perror("fsm_addedge_epsilon");
@@ -741,8 +741,8 @@ p_list_Hof_Hthings_C_Cthing(lex_state lex_state, act_state act_state, ast ZIa, z
 
 		for (m = (ZIz)->ml; m != NULL; m = m->next) {
 			struct fsm *fsm;
-			fsm_state_t base_r, base_fsm;
 			fsm_state_t ms;
+			struct fsm_combine_info combine_info;
 
 			if (m->token == NULL) {
 				continue;
@@ -767,14 +767,14 @@ p_list_Hof_Hthings_C_Cthing(lex_state lex_state, act_state act_state, ast ZIa, z
 			 */
 			fsm_setendopaque(fsm, NULL);
 
-			(ZI254) = fsm_merge((ZI254), fsm, &base_r, &base_fsm);
+			(ZI254) = fsm_merge((ZI254), fsm, &combine_info);
 			if ((ZI254) == NULL) {
 				perror("fsm_union");
 				goto ZL1;
 			}
 
-			ms    += base_fsm;
-			start += base_r;
+			ms    += combine_info.base_b;
+			start += combine_info.base_a;
 
 			if (!fsm_addedge_epsilon((ZI254), start, ms)) {
 				perror("fsm_addedge_epsilon");

--- a/src/lx/parser.c
+++ b/src/lx/parser.c
@@ -1247,7 +1247,7 @@ ZL2_180:;
 		assert((ZI177) != NULL);
 		assert((ZIb) != NULL);
 
-		(ZIq) = fsm_union((ZI177), (ZIb));
+		(ZIq) = fsm_union((ZI177), (ZIb), NULL);
 		if ((ZIq) == NULL) {
 			perror("fsm_union");
 			goto ZL1;
@@ -1491,7 +1491,7 @@ ZL2_list_Hof_Hthings_C_Czone_Hthing_C_Clist_Hof_Hzone_Hto_Hmappings_C_Clist_Hof_
 		assert((ZIold_Hexit) != NULL);
 		assert((ZInew_Hexit) != NULL);
 
-		(*ZIexit) = fsm_union((ZIold_Hexit), (ZInew_Hexit));
+		(*ZIexit) = fsm_union((ZIold_Hexit), (ZInew_Hexit), NULL);
 		if ((*ZIexit) == NULL) {
 			perror("fsm_union");
 			goto ZL1;
@@ -1906,7 +1906,7 @@ p_208(lex_state lex_state, act_state act_state, zone *ZIz, fsm *ZI206, fsm *ZOq)
 		assert((*ZI206) != NULL);
 		assert((ZIb) != NULL);
 
-		(ZIq) = fsm_concat((*ZI206), (ZIb));
+		(ZIq) = fsm_concat((*ZI206), (ZIb), NULL);
 		if ((ZIq) == NULL) {
 			perror("fsm_concat");
 			goto ZL1;

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -546,7 +546,8 @@ do_fsm_cleanup(void)
 int
 main(int argc, char *argv[])
 {
-	struct fsm *(*join)(struct fsm *, struct fsm *);
+	struct fsm *(*join)(struct fsm *, struct fsm *,
+	    struct fsm_combine_info *);
 	int (*query)(const struct fsm *, const struct fsm *);
 	fsm_print *print_fsm;
 	ast_print *print_ast;
@@ -853,7 +854,7 @@ main(int argc, char *argv[])
 				}
 			}
 
-			fsm = join(fsm, new);
+			fsm = join(fsm, new, NULL);
 			if (fsm == NULL) {
 				perror("fsm_union/concat");
 				return EXIT_FAILURE;

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -1059,7 +1059,7 @@ main(int argc, char *argv[])
 					if (vm != NULL) {
 						e = fsm_vm_match_file(vm, f);
 					} else {
-						e = fsm_exec(fsm, fsm_fgetc, f, &state);
+						e = fsm_exec(fsm, fsm_fgetc, f, &state, NULL);
 					}
 
 					fclose(f);
@@ -1071,7 +1071,7 @@ main(int argc, char *argv[])
 					if (vm != NULL) {
 						e = fsm_vm_match_buffer(vm, s, strlen(s));
 					} else {
-						e = fsm_exec(fsm, fsm_sgetc, &s, &state);
+						e = fsm_exec(fsm, fsm_sgetc, &s, &state, NULL);
 					}
 				}
 

--- a/tests/capture/Makefile
+++ b/tests/capture/Makefile
@@ -1,0 +1,26 @@
+.include "../../share/mk/top.mk"
+
+TEST.tests/capture != ls -1 tests/capture/capture*.c
+TEST_SRCDIR.tests/capture = tests/capture
+TEST_OUTDIR.tests/capture = ${BUILD}/tests/capture
+
+.for n in ${TEST.tests/capture:T:R:C/^capture//}
+test:: ${TEST_OUTDIR.tests/capture}/res${n}
+SRC += ${TEST_SRCDIR.tests/capture}/capture${n}.c
+CFLAGS.${TEST_SRCDIR.tests/capture}/capture${n}.c = -UNDEBUG
+
+# FIXME: using `bulid/lib/libfsm.a` directly here isn't ideal
+
+${TEST_OUTDIR.tests/capture}/run${n}: ${TEST_OUTDIR.tests/capture}/capture${n}.o ${TEST_OUTDIR.tests/capture}/captest.o
+	${CC} ${CFLAGS} -o ${TEST_OUTDIR.tests/capture}/run${n} ${TEST_OUTDIR.tests/capture}/capture${n}.o ${TEST_OUTDIR.tests/capture}/captest.o build/lib/libfsm.a
+
+${TEST_OUTDIR.tests/capture}/res${n}: ${TEST_OUTDIR.tests/capture}/run${n}
+	( ${TEST_OUTDIR.tests/capture}/run${n} 1>&2 && echo PASS || echo FAIL ) > ${TEST_OUTDIR.tests/capture}/res${n}
+
+.for lib in ${LIB:Mlibfsm} ${LIB:Mlibre}
+${TEST_OUTDIR.tests/capture}/run${n}: ${BUILD}/lib/${lib:R}.a
+.endfor
+.endfor
+
+${TEST_OUTDIR.tests/capture}/captest.o: tests/capture/captest.c
+	${CC} ${CFLAGS} -c -o ${TEST_OUTDIR.tests/capture}/captest.o tests/capture/captest.c

--- a/tests/capture/Makefile
+++ b/tests/capture/Makefile
@@ -9,15 +9,13 @@ test:: ${TEST_OUTDIR.tests/capture}/res${n}
 SRC += ${TEST_SRCDIR.tests/capture}/capture${n}.c
 CFLAGS.${TEST_SRCDIR.tests/capture}/capture${n}.c = -UNDEBUG
 
-# FIXME: using `bulid/lib/libfsm.a` directly here isn't ideal
-
 ${TEST_OUTDIR.tests/capture}/run${n}: ${TEST_OUTDIR.tests/capture}/capture${n}.o ${TEST_OUTDIR.tests/capture}/captest.o
-	${CC} ${CFLAGS} -o ${TEST_OUTDIR.tests/capture}/run${n} ${TEST_OUTDIR.tests/capture}/capture${n}.o ${TEST_OUTDIR.tests/capture}/captest.o build/lib/libfsm.a
+	${CC} ${CFLAGS} -o ${TEST_OUTDIR.tests/capture}/run${n} ${TEST_OUTDIR.tests/capture}/capture${n}.o ${TEST_OUTDIR.tests/capture}/captest.o ${BUILD}/lib/libfsm.a
 
 ${TEST_OUTDIR.tests/capture}/res${n}: ${TEST_OUTDIR.tests/capture}/run${n}
 	( ${TEST_OUTDIR.tests/capture}/run${n} 1>&2 && echo PASS || echo FAIL ) > ${TEST_OUTDIR.tests/capture}/res${n}
 
-.for lib in ${LIB:Mlibfsm} ${LIB:Mlibre}
+.for lib in ${LIB:Mlibfsm}
 ${TEST_OUTDIR.tests/capture}/run${n}: ${BUILD}/lib/${lib:R}.a
 .endfor
 .endfor

--- a/tests/capture/captest.c
+++ b/tests/capture/captest.c
@@ -198,9 +198,6 @@ static void captest_carryopaque(struct fsm *src_fsm,
 	if (eo_old_dst != NULL) {
 		assert(eo_old_dst->tag == CAPTEST_END_OPAQUE_TAG);
 		eo_dst->ends |= eo_old_dst->ends;
-
-		/* FIXME: freeing here leads to a use after free */
-		/* f_free(opt->alloc, eo_old_dst); */
 	}
 
 	fsm_setopaque(dst_fsm, dst_state, eo_dst);
@@ -217,9 +214,6 @@ static void captest_carryopaque(struct fsm *src_fsm,
 		}
 		assert(eo_src->tag == CAPTEST_END_OPAQUE_TAG);
 		eo_dst->ends |= eo_src->ends;
-
-		/* FIXME: freeing here leads to a use after free */
-		/* f_free(opt->alloc, eo_src); */
 
 		fsm_setopaque(src_fsm, src_set[i], NULL);
 	}

--- a/tests/capture/captest.c
+++ b/tests/capture/captest.c
@@ -1,0 +1,213 @@
+#include "captest.h"
+
+#include <fsm/alloc.h>
+#include <fsm/capture.h>
+
+#define FAIL(MSG)					\
+	fprintf(stderr, "FAIL: %s:%d -- %s\n",	\
+	    __FILE__, __LINE__, MSG);		\
+	exit(EXIT_FAILURE)
+
+int
+captest_getc(void *opaque)
+{
+	struct captest_input *input = opaque;
+	int res = input->string[input->pos];
+	input->pos++;
+	return res == 0 ? EOF : res;
+}
+
+int
+captest_run_single(const struct captest_single_fsm_test_info *info)
+{
+	size_t i;
+	struct captest_input input;
+	fsm_state_t end;
+	int exec_res;
+	struct fsm_capture got_captures[MAX_TEST_CAPTURES];
+	struct fsm_capture exp_captures[MAX_TEST_CAPTURES];
+	size_t capture_count = 0;
+	struct fsm *fsm = captest_fsm_of_string(info->string, 0);
+
+	input.string = info->string;
+	input.pos = 0;
+
+	if (fsm == NULL) {
+		FAIL("fsm_of_string");
+	}
+
+	for (i = 0; i < MAX_TEST_CAPTURES; i++) {
+		exp_captures[i].pos[0] = FSM_CAPTURE_NO_POS;
+		exp_captures[i].pos[1] = FSM_CAPTURE_NO_POS;
+	}
+
+	for (i = 0; i < MAX_SINGLE_FSM_TEST_PATHS; i++) {
+		const struct captest_single_fsm_test_path *path =
+		    &info->paths[i];
+		if (path->start == 0 && path->end == 0 && i > 0) {
+			break;	/* end of list */
+		}
+		if (!fsm_capture_set_path(fsm, i,
+			path->start, path->end)) {
+			fprintf(stderr,
+			    "failed to set capture path %lu\n", i);
+			FAIL("fsm_capture_set_path");
+		}
+
+		exp_captures[i].pos[0] = path->start;
+		exp_captures[i].pos[1] = path->end;
+
+		capture_count = i + 1;
+	}
+
+	{
+		const unsigned count = fsm_countcaptures(fsm);
+		const unsigned expected = capture_count;
+		if (count != expected) {
+			fprintf(stderr, "expected %u, got %u\n",
+			    expected, count);
+			FAIL("countcaptures");
+		}
+	}
+
+	exec_res = fsm_exec(fsm, captest_getc, &input, &end, got_captures);
+	if (exec_res != 1) { FAIL("exec_res"); }
+	if (end != strlen(info->string)) { FAIL("exec end pos"); }
+
+	{
+		struct captest_end_opaque *eo = fsm_getopaque(fsm, end);
+		assert(eo != NULL);
+		assert(eo->tag == CAPTEST_END_OPAQUE_TAG);
+		if (!(eo->ends & (1U << 0))) {
+			FAIL("end ID not set in opaque");
+		}
+	}
+
+	for (i = 0; i < capture_count; i++) {
+		if (got_captures[i].pos[0] != exp_captures[i].pos[0]) {
+			fprintf(stderr, "capture[%lu].pos[0]: exp %lu, got %lu\n",
+			    i, exp_captures[i].pos[0],
+			    got_captures[i].pos[0]);
+			FAIL("capture mismatch");
+		}
+		if (got_captures[i].pos[1] != exp_captures[i].pos[1]) {
+			fprintf(stderr, "capture[%lu].pos[1]: exp %lu, got %lu\n",
+			    i, exp_captures[i].pos[1],
+			    got_captures[i].pos[1]);
+			FAIL("capture mismatch");
+		}
+	}
+
+	fsm_free(fsm);
+	return 0;
+}
+
+struct fsm *
+captest_fsm_of_string(const char *string, unsigned end_id)
+{
+	struct fsm *fsm = captest_fsm_with_options();
+	const size_t length = strlen(string);
+	size_t i;
+	struct captest_end_opaque *eo = NULL;
+
+	if (fsm == NULL) {
+		return NULL;
+	}
+
+	eo = calloc(1, sizeof(*eo));
+	if (eo == NULL) {
+		goto cleanup;
+	}
+
+	eo->tag = CAPTEST_END_OPAQUE_TAG;
+
+	/* set bit for end state */
+	assert(end_id < 8*sizeof(eo->ends));
+	eo->ends |= (1U << end_id);
+
+	if (!fsm_addstate_bulk(fsm, length + 1)) {
+		goto cleanup;
+	}
+	fsm_setstart(fsm, 0);
+
+	for (i = 0; i < length; i++) {
+		if (!fsm_addedge_literal(fsm, i, i + 1, string[i])) {
+			goto cleanup;
+		}
+	}
+	fsm_setend(fsm, length, 1);
+	fsm_setopaque(fsm, length, eo);
+	fprintf(stderr, "fsm_of_string: set opaque to %p for \"%s\"\n",
+	    (void *)eo, string);
+
+	return fsm;
+
+cleanup:
+	if (eo != NULL) { free(eo); }
+	fsm_free(fsm);
+	return NULL;
+}
+
+static struct fsm_options options;
+
+static void captest_carryopaque(struct fsm *src_fsm,
+    const fsm_state_t *src_set, size_t n,
+    struct fsm *dst_fsm, fsm_state_t dst_state)
+{
+	struct captest_end_opaque *eo_src = NULL;
+	struct captest_end_opaque *eo_dst = NULL;
+	struct captest_end_opaque *eo_old_dst = NULL;
+	size_t i;
+
+	fprintf(stderr, "captest_carryopaque: src_fsm %p, src_set %p, n %lu, dst_fsm %p, dst_state %u\n",
+	    (void *)src_fsm, (void *)src_set, n,
+	    (void *)dst_fsm, dst_state);
+
+	eo_old_dst = fsm_getopaque(dst_fsm, dst_state);
+
+	eo_dst = calloc(1, sizeof(*eo_dst));
+	/* FIXME: no way to handle an alloc error in carryopaque? */
+	assert(eo_dst != NULL);
+	eo_dst->tag = CAPTEST_END_OPAQUE_TAG;
+	fprintf(stderr, "captest_carryopaque: new opaque %p (eo_dst)\n",
+	    (void *)eo_dst);
+
+	if (eo_old_dst != NULL) {
+		assert(eo_old_dst->tag == CAPTEST_END_OPAQUE_TAG);
+		eo_dst->ends |= eo_old_dst->ends;
+
+		/* FIXME: freeing here leads to a use after free */
+		/* f_free(opt->alloc, eo_old_dst); */
+	}
+
+	fsm_setopaque(dst_fsm, dst_state, eo_dst);
+
+	/* union bits set in eo_src->ends into eo_dst->ends and free */
+	for (i = 0; i < n; i++) {
+		eo_src = fsm_getopaque(src_fsm, src_set[i]);
+		if (eo_src == NULL) {
+			continue;
+		}
+		fprintf(stderr, "carryopaque: dst %p <- src[%lu] %p\n",
+		    (void *)eo_dst, i, (void *)eo_src);
+		assert(eo_src->tag == CAPTEST_END_OPAQUE_TAG);
+		eo_dst->ends |= eo_src->ends;
+
+		/* FIXME: freeing here leads to a use after free */
+		/* f_free(opt->alloc, eo_src); */
+
+		fsm_setopaque(src_fsm, src_set[i], NULL);
+	}
+}
+
+struct fsm *
+captest_fsm_with_options(void)
+{
+	struct fsm *fsm = NULL;
+	if (options.carryopaque == NULL) { /* initialize */
+		options.carryopaque = captest_carryopaque;
+	}
+
+	fsm = fsm_new(&options);
+	return fsm;
+}

--- a/tests/capture/captest.c
+++ b/tests/capture/captest.c
@@ -155,8 +155,6 @@ captest_fsm_of_string(const char *string, unsigned end_id)
 	}
 	fsm_setend(fsm, length, 1);
 	fsm_setopaque(fsm, length, eo);
-	/* fprintf(stderr, "fsm_of_string: set opaque to %p for \"%s\"\n", */
-	/*     (void *)eo, string); */
 
 	return fsm;
 
@@ -198,22 +196,31 @@ static void captest_carryopaque(struct fsm *src_fsm,
 	if (eo_old_dst != NULL) {
 		assert(eo_old_dst->tag == CAPTEST_END_OPAQUE_TAG);
 		eo_dst->ends |= eo_old_dst->ends;
+		if (log_level > 0) {
+			fprintf(stderr, "carryopaque: old_dst (%d) ends 0x%x\n",
+			    dst_state, eo_dst->ends);
+		}
 	}
 
 	fsm_setopaque(dst_fsm, dst_state, eo_dst);
 
-	/* union bits set in eo_src->ends into eo_dst->ends and free */
+	/* union bits set in eo_src->ends into eo_dst->ends */
 	for (i = 0; i < n; i++) {
 		eo_src = fsm_getopaque(src_fsm, src_set[i]);
 		if (eo_src == NULL) {
 			continue;
 		}
 		if (log_level > 0) {
-			fprintf(stderr, "carryopaque: dst %p <- src[%lu] %p\n",
-			    (void *)eo_dst, i, (void *)eo_src);
+			fprintf(stderr, "carryopaque: dst %p (%d) <- src[%lu] (%d) %p\n",
+			    (void *)eo_dst, dst_state, i, src_set[i],
+			    (void *)eo_src);
 		}
 		assert(eo_src->tag == CAPTEST_END_OPAQUE_TAG);
 		eo_dst->ends |= eo_src->ends;
+		if (log_level > 0) {
+			fprintf(stderr, "carryopaque: eo_src ends -> 0x%x\n",
+			    eo_dst->ends);
+		}
 
 		fsm_setopaque(src_fsm, src_set[i], NULL);
 	}

--- a/tests/capture/captest.c
+++ b/tests/capture/captest.c
@@ -137,8 +137,8 @@ captest_fsm_of_string(const char *string, unsigned end_id)
 	}
 	fsm_setend(fsm, length, 1);
 	fsm_setopaque(fsm, length, eo);
-	fprintf(stderr, "fsm_of_string: set opaque to %p for \"%s\"\n",
-	    (void *)eo, string);
+	/* fprintf(stderr, "fsm_of_string: set opaque to %p for \"%s\"\n", */
+	/*     (void *)eo, string); */
 
 	return fsm;
 
@@ -158,10 +158,13 @@ static void captest_carryopaque(struct fsm *src_fsm,
 	struct captest_end_opaque *eo_dst = NULL;
 	struct captest_end_opaque *eo_old_dst = NULL;
 	size_t i;
+	const int log_level = 0;
 
-	fprintf(stderr, "captest_carryopaque: src_fsm %p, src_set %p, n %lu, dst_fsm %p, dst_state %u\n",
-	    (void *)src_fsm, (void *)src_set, n,
-	    (void *)dst_fsm, dst_state);
+	if (log_level > 0) {
+		fprintf(stderr, "captest_carryopaque: src_fsm %p, src_set %p, n %lu, dst_fsm %p, dst_state %u\n",
+		    (void *)src_fsm, (void *)src_set, n,
+		    (void *)dst_fsm, dst_state);
+	}
 
 	eo_old_dst = fsm_getopaque(dst_fsm, dst_state);
 
@@ -169,8 +172,10 @@ static void captest_carryopaque(struct fsm *src_fsm,
 	/* FIXME: no way to handle an alloc error in carryopaque? */
 	assert(eo_dst != NULL);
 	eo_dst->tag = CAPTEST_END_OPAQUE_TAG;
-	fprintf(stderr, "captest_carryopaque: new opaque %p (eo_dst)\n",
-	    (void *)eo_dst);
+	if (log_level > 0) {
+		fprintf(stderr, "captest_carryopaque: new opaque %p (eo_dst)\n",
+		    (void *)eo_dst);
+	}
 
 	if (eo_old_dst != NULL) {
 		assert(eo_old_dst->tag == CAPTEST_END_OPAQUE_TAG);
@@ -188,8 +193,10 @@ static void captest_carryopaque(struct fsm *src_fsm,
 		if (eo_src == NULL) {
 			continue;
 		}
-		fprintf(stderr, "carryopaque: dst %p <- src[%lu] %p\n",
-		    (void *)eo_dst, i, (void *)eo_src);
+		if (log_level > 0) {
+			fprintf(stderr, "carryopaque: dst %p <- src[%lu] %p\n",
+			    (void *)eo_dst, i, (void *)eo_src);
+		}
 		assert(eo_src->tag == CAPTEST_END_OPAQUE_TAG);
 		eo_dst->ends |= eo_src->ends;
 

--- a/tests/capture/captest.h
+++ b/tests/capture/captest.h
@@ -18,6 +18,9 @@
 #define MAX_SINGLE_FSM_TEST_PATHS 8
 #define MAX_TEST_CAPTURES 8
 
+#define CAPTEST_RUN_SINGLE_LOG 0
+#define LOG_INTERMEDIATE_FSMS 0
+
 struct captest_single_fsm_test_info {
 	const char *string;
 	struct captest_single_fsm_test_path {

--- a/tests/capture/captest.h
+++ b/tests/capture/captest.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+#ifndef CAPTEST_H
+#define CAPTEST_H
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <fsm/fsm.h>
+#include <fsm/capture.h>
+#include <fsm/options.h>
+
+#define MAX_SINGLE_FSM_TEST_PATHS 8
+#define MAX_TEST_CAPTURES 8
+
+struct captest_single_fsm_test_info {
+	const char *string;
+	struct captest_single_fsm_test_path {
+		fsm_state_t start;
+		fsm_state_t end;
+	} paths[MAX_SINGLE_FSM_TEST_PATHS];
+};
+
+struct captest_end_opaque {
+#define CAPTEST_END_OPAQUE_TAG 'E'
+	unsigned char tag;
+	unsigned ends;		/* bit set */
+};
+
+struct captest_input {
+	const char *string;
+	size_t pos;
+};
+
+int
+captest_run_single(const struct captest_single_fsm_test_info *info);
+
+int
+captest_getc(void *opaque);
+
+struct fsm *
+captest_fsm_with_options(void);
+
+struct fsm *
+captest_fsm_of_string(const char *string, unsigned end_id);
+
+#endif

--- a/tests/capture/capture0.c
+++ b/tests/capture/capture0.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <fsm/fsm.h>
+#include <fsm/capture.h>
+
+#include "captest.h"
+
+/* /a(bcd)e/ */
+
+int main(void) {
+	struct captest_single_fsm_test_info test_info = {
+		"abcde",
+		{
+			{ 1, 4 },
+		}
+	};
+	return captest_run_single(&test_info);
+}

--- a/tests/capture/capture1.c
+++ b/tests/capture/capture1.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <fsm/fsm.h>
+#include <fsm/capture.h>
+
+#include "captest.h"
+/* /()a()b()()(c)()/ */
+
+int main(void) {
+	struct captest_single_fsm_test_info test_info = {
+		"abc",
+		{
+			{ 0, 0 },
+			{ 1, 1 },
+			{ 2, 2 },
+			{ 2, 2 },
+			{ 2, 3 },
+			{ 3, 3 },
+		}
+	};
+	return captest_run_single(&test_info);
+}

--- a/tests/capture/capture1.c
+++ b/tests/capture/capture1.c
@@ -13,18 +13,15 @@
 #include <fsm/capture.h>
 
 #include "captest.h"
-/* /()a()b()()(c)()/ */
+/* (a(b(c))) */
 
 int main(void) {
 	struct captest_single_fsm_test_info test_info = {
 		"abc",
 		{
-			{ 0, 0 },
-			{ 1, 1 },
-			{ 2, 2 },
-			{ 2, 2 },
+			{ 0, 3 },
+			{ 1, 3 },
 			{ 2, 3 },
-			{ 3, 3 },
 		}
 	};
 	return captest_run_single(&test_info);

--- a/tests/capture/capture2.c
+++ b/tests/capture/capture2.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <fsm/fsm.h>
+#include <fsm/capture.h>
+
+#include "captest.h"
+
+/* /()(a(b()c)d)()/ */
+
+int main(void) {
+	struct captest_single_fsm_test_info test_info = {
+		"abcd",
+		{
+			{ 0, 0 },
+			{ 0, 4 },
+			{ 1, 3 },
+			{ 2, 2 },
+			{ 4, 4 },
+		}
+	};
+	return captest_run_single(&test_info);
+}

--- a/tests/capture/capture2.c
+++ b/tests/capture/capture2.c
@@ -14,17 +14,17 @@
 
 #include "captest.h"
 
-/* /()(a(b()c)d)()/ */
+/* (a(b((c))(d))) */
 
 int main(void) {
 	struct captest_single_fsm_test_info test_info = {
 		"abcd",
 		{
-			{ 0, 0 },
 			{ 0, 4 },
-			{ 1, 3 },
-			{ 2, 2 },
-			{ 4, 4 },
+			{ 1, 4 },
+			{ 2, 3 },
+			{ 2, 3 },
+			{ 3, 4 },
 		}
 	};
 	return captest_run_single(&test_info);

--- a/tests/capture/capture3.c
+++ b/tests/capture/capture3.c
@@ -22,8 +22,11 @@
  * - 1: "(cd(e))"
  * - 2: "(fgh(i))"
  *
- * Shift the captures for 1 and 2 forward and used/combine
- * opaques on them to track which one(s) matched. */
+ * Shift the captures for 1 and 2 forward and use/combine
+ * opaques on them to track which one(s) matched.
+ *
+ * This tracking of which DFA matched should be more directly
+ * supported by the API later. */
 
 static void
 check(const struct fsm *fsm, const char *string,
@@ -129,19 +132,6 @@ int main(void) {
 	fsm_print_fsm(stderr, f_all);
 	fsm_capture_dump(stderr, "#### f_all", f_all);
 #endif
-
-	if (0) {		/* don't minimize */
-		if (!fsm_minimise(f_all)) {
-			fprintf(stderr, "NOPE %d\n", __LINE__);
-			exit(EXIT_FAILURE);
-		}
-
-#if LOG_INTERMEDIATE_FSMS
-		fprintf(stderr, "==== after minimise\n");
-		fsm_print_fsm(stderr, f_all);
-		fsm_capture_dump(stderr, "#### f_all", f_all);
-#endif
-	}
 
 	captures = fsm_countcaptures(f_all);
 	if (captures != 6) {

--- a/tests/capture/capture3.c
+++ b/tests/capture/capture3.c
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2020 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <fsm/fsm.h>
+#include <fsm/bool.h>
+#include <fsm/capture.h>
+#include <fsm/print.h>
+
+#include "captest.h"
+
+#define LOG_INTERMEDIATE_FSMS 0
+
+/* Combine 3 fully disjoint FSMs:
+ *
+ * - 0: "(ab)()"
+ * - 1: "(cde)()"
+ * - 2: "(fghi)()"
+ *
+ * Shift the captures for 1 and 2 forward and used/combine
+ * opaques on them to track which one(s) matched. */
+
+static void
+check(const struct fsm *fsm, const char *string,
+    unsigned end_id, unsigned capture_base);
+
+int main(void) {
+	struct fsm *f_ab = captest_fsm_of_string("ab", 0);
+	struct fsm *f_cde = captest_fsm_of_string("cde", 1);
+	struct fsm *f_fghi = captest_fsm_of_string("fghi", 2);
+	struct fsm *f_all = NULL;
+	unsigned captures;
+	struct fsm_combine_info ci;
+	unsigned cb_ab, cb_cde, cb_fghi; /* capture base */
+
+	assert(f_ab);
+	assert(f_cde);
+	assert(f_fghi);
+
+	/* set captures */
+#define SET_CAPTURE(FSM, STATE, CAPTURE, TYPE)				\
+	if (!fsm_set_capture_action(FSM, STATE, CAPTURE, TYPE)) {	\
+		fprintf(stderr, "failed to set capture on line %d\n",	\
+		    __LINE__);						\
+		exit(EXIT_FAILURE);					\
+	}
+
+	/* (ab)() */
+	if (!fsm_capture_set_path(f_ab, 0, 0, 2)) {
+		exit(EXIT_FAILURE);
+	}
+	if (!fsm_capture_set_path(f_ab, 1, 2, 2)) {
+		exit(EXIT_FAILURE);
+	}
+
+	/* (cde)() */
+	if (!fsm_capture_set_path(f_cde, 0, 0, 3)) {
+		exit(EXIT_FAILURE);
+	}
+	if (!fsm_capture_set_path(f_cde, 1, 3, 3)) {
+		exit(EXIT_FAILURE);
+	}
+
+	/* (fghi)() */
+	if (!fsm_capture_set_path(f_fghi, 0, 0, 4)) {
+		exit(EXIT_FAILURE);
+	}
+	if (!fsm_capture_set_path(f_fghi, 1, 4, 4)) {
+		exit(EXIT_FAILURE);
+	}
+
+#if LOG_INTERMEDIATE_FSMS
+	fprintf(stderr, "\n=== f_ab...\n");
+	fsm_print_fsm(stderr, f_ab);
+	fsm_capture_dump(stderr, "#### f_ab", f_ab);
+
+	fprintf(stderr, "\n=== f_cde...\n");
+	fsm_print_fsm(stderr, f_cde);
+	fsm_capture_dump(stderr, "#### f_cde", f_cde);
+
+	fprintf(stderr, "\n=== f_fghi...\n");
+	fsm_print_fsm(stderr, f_fghi);
+	fsm_capture_dump(stderr, "#### f_fghi", f_fghi);
+#endif
+
+	/* union them */
+	f_all = fsm_union(f_ab, f_cde, &ci);
+	assert(f_all != NULL);
+	cb_ab = ci.capture_base_a;
+	cb_cde = ci.capture_base_b;
+
+#if LOG_INTERMEDIATE_FSMS
+	fprintf(stderr, "=== unioned f_ab with f_cde... (CB ab: %u, cde: %u)\n",
+	    cb_ab, cb_cde);
+	fsm_print_fsm(stderr, f_all);
+	fsm_capture_dump(stderr, "#### f_all", f_all);
+#endif
+
+	f_all = fsm_union(f_all, f_fghi, &ci);
+	assert(f_all != NULL);
+	cb_fghi = ci.capture_base_b;
+
+#if LOG_INTERMEDIATE_FSMS
+	fprintf(stderr, "=== unioned f_all with f_fghi... (CB all: %u, fghi: %u)\n",
+	    ci.capture_base_a, cb_fghi);
+	fsm_print_fsm(stderr, f_all);
+	fsm_capture_dump(stderr, "#### f_all #2", f_all);
+#endif
+
+	if (!fsm_determinise(f_all)) {
+		fprintf(stderr, "NOPE %d\n", __LINE__);
+		exit(EXIT_FAILURE);
+	}
+
+	if (!fsm_minimise(f_all)) {
+		fprintf(stderr, "NOPE %d\n", __LINE__);
+		exit(EXIT_FAILURE);
+	}
+
+#if LOG_INTERMEDIATE_FSMS
+	fprintf(stderr, "==== after building\n");
+	fsm_print_fsm(stderr, f_all);
+	fsm_capture_dump(stderr, "#### f_all", f_all);
+#endif
+
+	captures = fsm_countcaptures(f_all);
+	if (captures != 6) {
+		fprintf(stderr, "expected 6 captures, got %u\n", captures);
+		exit(EXIT_FAILURE);
+	}
+
+	check(f_all, "ab", 0, cb_ab);
+	check(f_all, "cde", 1, cb_cde);
+	check(f_all, "fghi", 2, cb_fghi);
+
+	fsm_free(f_all);
+
+	return 0;
+}
+
+static void
+check(const struct fsm *fsm, const char *string,
+    unsigned end_id, unsigned capture_base)
+{
+	int exec_res;
+	size_t i;
+	struct captest_input input;
+	fsm_state_t end;
+	struct fsm_capture captures[MAX_TEST_CAPTURES];
+	struct captest_end_opaque *eo = NULL;
+	const size_t length = strlen(string);
+	const unsigned cb = capture_base; /* alias */
+
+	input.string = string;
+	input.pos = 0;
+
+	for (i = 0; i < MAX_TEST_CAPTURES; i++) {
+		captures[i].pos[0] = FSM_CAPTURE_NO_POS;
+		captures[i].pos[1] = FSM_CAPTURE_NO_POS;
+	}
+
+	exec_res = fsm_exec(fsm, captest_getc, &input, &end, captures);
+	if (exec_res != 1) {
+		fprintf(stderr, "fsm_exec: %d for '%s', expected 1\n",
+		    exec_res, string);
+		exit(EXIT_FAILURE);
+	}
+
+	/* check opaque end ID */
+	eo = fsm_getopaque(fsm, end);
+	fprintf(stderr, "exec: end %d -> %p\n", end, (void *)eo);
+
+	assert(eo != NULL);
+	assert(eo->tag == CAPTEST_END_OPAQUE_TAG);
+	assert(eo->ends & (1U << end_id));
+
+	/* check captures */
+	fprintf(stderr, "captures for '%s': [%ld, %ld], [%ld, %ld]\n",
+	    string,
+	    captures[0 + cb].pos[0], captures[0 + cb].pos[1],
+	    captures[1 + cb].pos[0], captures[1 + cb].pos[1]);
+	assert(captures[0 + cb].pos[0] == 0);
+	assert(captures[0 + cb].pos[1] == length);
+	assert(captures[1 + cb].pos[0] == length);
+	assert(captures[1 + cb].pos[1] == length);
+}

--- a/tests/capture/capture4.c
+++ b/tests/capture/capture4.c
@@ -27,6 +27,9 @@
 static struct fsm *
 build_and_combine(unsigned *cb_a, unsigned *cb_b);
 
+static void
+det_and_min(const char *tag, struct fsm *fsm);
+
 static struct fsm *
 build_ab_c(void);
 
@@ -96,6 +99,9 @@ build_and_combine(unsigned *cb_a, unsigned *cb_b)
 	fsm_capture_dump(stderr, "ab*c", f_ab_c);
 #endif
 
+	det_and_min("abc", f_abc);
+	det_and_min("ab*c", f_ab_c);
+
 	/* union them */
 	f_all = fsm_union(f_abc, f_ab_c, &ci);
 	assert(f_all != NULL);
@@ -121,18 +127,28 @@ build_and_combine(unsigned *cb_a, unsigned *cb_b)
 	fprintf(stderr, "====================\n");
 #endif
 
-	if (!fsm_minimise(f_all)) {
+	return f_all;
+}
+
+static void
+det_and_min(const char *tag, struct fsm *fsm)
+{
+	if (!fsm_determinise(fsm)) {
+		fprintf(stderr, "Failed to determise '%s'\n", tag);
+		exit(EXIT_FAILURE);
+	}
+
+	if (!fsm_minimise(fsm)) {
+		fprintf(stderr, "Failed to minimise '%s'\n", tag);
 		exit(EXIT_FAILURE);
 	}
 
 #if LOG_INTERMEDIATE_FSMS
-	fprintf(stderr, "==================== post-min \n");
-	fsm_print_fsm(stderr, f_all);
-	fsm_capture_dump(stderr, "capture_actions", f_all);
-	fprintf(stderr, "====================\n");
+	fprintf(stderr, "==== after det_and_min: '%s'\n", tag);
+	fsm_print_fsm(stderr, fsm);
+	fsm_capture_dump(stderr, tag, fsm);
 #endif
 
-	return f_all;
 }
 
 static struct fsm *

--- a/tests/capture/capture4.c
+++ b/tests/capture/capture4.c
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2020 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <fsm/fsm.h>
+#include <fsm/bool.h>
+#include <fsm/capture.h>
+#include <fsm/print.h>
+
+#include "captest.h"
+
+#define LOG_INTERMEDIATE_FSMS 0
+
+/* Combine 2 mostly overlapping FSMs:
+ * - 0: "(abc)"
+ * - 1: "(ab*c)"
+ * and check for false positives in the match.
+ */
+
+static struct fsm *
+build_and_combine(unsigned *cb_a, unsigned *cb_b);
+
+static struct fsm *
+build_ab_c(void);
+
+static void
+check(const struct fsm *fsm, const char *string,
+    unsigned expected_ends,
+    unsigned cb_a, size_t pa_0, size_t pa_1,
+    unsigned cb_b, size_t pb_0, size_t pb_1);
+
+int main(void) {
+	unsigned cb_abc, cb_ab_c;
+	struct fsm *f_all = build_and_combine(&cb_abc, &cb_ab_c);
+	unsigned captures;
+	const unsigned exp_0 = 1U << 0;
+	const unsigned exp_1 = 1U << 1;
+
+	captures = fsm_countcaptures(f_all);
+	if (captures != 2) {
+		fprintf(stderr, "expected 2 captures, got %u\n", captures);
+		exit(EXIT_FAILURE);
+	}
+
+	#define NO_POS FSM_CAPTURE_NO_POS
+	check(f_all, "abc",	/* captures 0 and 1 */
+	    exp_0 | exp_1,
+	    cb_abc, 0, 3,
+	    cb_ab_c, 0, 3);
+	check(f_all, "ac",	/* only capture 1 */
+	    exp_1,
+	    cb_abc, NO_POS, NO_POS,
+	    cb_ab_c, 0, 2);
+	check(f_all, "abbc",	/* only capture 1 */
+	    exp_1,
+	    cb_abc, NO_POS, NO_POS,
+	    cb_ab_c, 0, 4);
+
+	fsm_free(f_all);
+
+	return 0;
+}
+
+static struct fsm *
+build_and_combine(unsigned *cb_a, unsigned *cb_b)
+{
+	struct fsm *f_abc = captest_fsm_of_string("abc", 0);
+	struct fsm *f_ab_c = build_ab_c();
+	struct fsm *f_all;
+	struct fsm_combine_info ci;
+
+	assert(f_abc);
+	assert(f_ab_c);
+
+	if (!fsm_capture_set_path(f_abc, 0, 0, 3)) {
+		exit(EXIT_FAILURE);
+	}
+	if (!fsm_capture_set_path(f_ab_c, 0, 0, 3)) {
+		exit(EXIT_FAILURE);
+	}
+
+#if LOG_INTERMEDIATE_FSMS
+	fprintf(stderr, "==================== abc \n");
+	fsm_print_fsm(stderr, f_abc);
+	fsm_capture_dump(stderr, "abc", f_abc);
+
+	fprintf(stderr, "==================== ab*c \n");
+	fsm_print_fsm(stderr, f_ab_c);
+	fsm_capture_dump(stderr, "ab*c", f_ab_c);
+#endif
+
+	/* union them */
+	f_all = fsm_union(f_abc, f_ab_c, &ci);
+	assert(f_all != NULL);
+
+	*cb_a = ci.capture_base_a;
+	*cb_b = ci.capture_base_b;
+
+#if LOG_INTERMEDIATE_FSMS
+	fprintf(stderr, "==================== post-union \n");
+	fsm_print_fsm(stderr, f_all);
+	fsm_capture_dump(stderr, "capture_actions", f_all);
+	fprintf(stderr, "====================\n");
+#endif
+
+	if (!fsm_determinise(f_all)) {
+		exit(EXIT_FAILURE);
+	}
+
+#if LOG_INTERMEDIATE_FSMS
+	fprintf(stderr, "==================== post-det \n");
+	fsm_print_fsm(stderr, f_all);
+	fsm_capture_dump(stderr, "capture_actions", f_all);
+	fprintf(stderr, "====================\n");
+#endif
+
+	if (!fsm_minimise(f_all)) {
+		exit(EXIT_FAILURE);
+	}
+
+#if LOG_INTERMEDIATE_FSMS
+	fprintf(stderr, "==================== post-min \n");
+	fsm_print_fsm(stderr, f_all);
+	fsm_capture_dump(stderr, "capture_actions", f_all);
+	fprintf(stderr, "====================\n");
+#endif
+
+	return f_all;
+}
+
+static struct fsm *
+build_ab_c(void)
+{
+	struct captest_end_opaque *eo = NULL;
+	struct fsm *fsm = captest_fsm_with_options();
+	assert(fsm != NULL);
+
+	eo = calloc(1, sizeof(*eo));
+	if (eo == NULL) { goto fail; }
+
+	eo->tag = CAPTEST_END_OPAQUE_TAG;
+	eo->ends |= (1U << 1);
+
+	if (!fsm_addstate_bulk(fsm, 4)) { goto fail; }
+
+	fsm_setstart(fsm, 0);
+	if (!fsm_addedge_literal(fsm, 0, 1, 'a')) { goto fail; }
+
+	if (!fsm_addedge_literal(fsm, 1, 2, 'b')) { goto fail; }
+	if (!fsm_addedge_literal(fsm, 1, 3, 'c')) { goto fail; }
+
+	if (!fsm_addedge_literal(fsm, 2, 2, 'b')) { goto fail; }
+	if (!fsm_addedge_literal(fsm, 2, 3, 'c')) { goto fail; }
+
+	fsm_setend(fsm, 3, 1);
+	fsm_setopaque(fsm, 3, eo);
+	return fsm;
+
+fail:
+	exit(EXIT_FAILURE);
+}
+
+static void
+check(const struct fsm *fsm, const char *string,
+    unsigned expected_ends,
+    unsigned cb_a, size_t pa_0, size_t pa_1,
+    unsigned cb_b, size_t pb_0, size_t pb_1)
+{
+	int exec_res;
+	size_t i;
+	struct captest_input input;
+	fsm_state_t end;
+	struct fsm_capture captures[MAX_TEST_CAPTURES];
+	struct captest_end_opaque *eo = NULL;
+
+	fprintf(stderr, "#### check '%s', exp: ends 0x%u, c%u: (%ld, %ld), c%u: %ld, %ld)\n",
+	    string, expected_ends,
+	    cb_a, pa_0, pa_1,
+	    cb_b, pb_0, pb_1);
+
+	input.string = string;
+	input.pos = 0;
+
+	for (i = 0; i < MAX_TEST_CAPTURES; i++) {
+		captures[i].pos[0] = FSM_CAPTURE_NO_POS;
+		captures[i].pos[1] = FSM_CAPTURE_NO_POS;
+	}
+
+	exec_res = fsm_exec(fsm, captest_getc, &input, &end, captures);
+	if (exec_res != 1) {
+		fprintf(stderr, "fsm_exec: %d\n", exec_res);
+		exit(EXIT_FAILURE);
+	}
+
+	/* check opaque end ID */
+	eo = fsm_getopaque(fsm, end);
+	fprintf(stderr, "exec: end %d -> %p\n", end, (void *)eo);
+
+	assert(eo != NULL);
+	assert(eo->tag == CAPTEST_END_OPAQUE_TAG);
+	if (eo->ends != expected_ends) {
+		fprintf(stderr, "Expected ends 0x%x, got 0x%x\n",
+		    expected_ends, eo->ends);
+		/* exit(EXIT_FAILURE); */
+	}
+
+	/* check captures */
+	fprintf(stderr, "captures for '%s': [%ld, %ld], [%ld, %ld]\n",
+	    string,
+	    captures[0].pos[0], captures[0].pos[1],
+	    captures[1].pos[0], captures[1].pos[1]);
+	assert(captures[cb_a].pos[0] == pa_0);
+	assert(captures[cb_a].pos[1] == pa_1);
+	assert(captures[cb_b].pos[0] == pb_0);
+	assert(captures[cb_b].pos[1] == pb_1);
+}

--- a/tests/capture/capture4.c
+++ b/tests/capture/capture4.c
@@ -16,8 +16,6 @@
 
 #include "captest.h"
 
-#define LOG_INTERMEDIATE_FSMS 0
-
 /* Combine 2 mostly overlapping FSMs:
  * - 0: "(abc)"
  * - 1: "(ab*c)"

--- a/tests/capture/capture_concat1.c
+++ b/tests/capture/capture_concat1.c
@@ -11,11 +11,123 @@
 
 #include <fsm/fsm.h>
 #include <fsm/capture.h>
+#include <fsm/bool.h>
 
 #include "captest.h"
 
 /* concat /(ab)/ and /(cde)/ */
 
+static struct fsm *
+build(unsigned *cb_a, unsigned *cb_b);
+
+static void
+check(const struct fsm *fsm, const char *input, unsigned end_id,
+    unsigned cb_ab, size_t exp_start_ab, size_t exp_end_ab,
+    unsigned cb_cde, size_t exp_start_cde, size_t exp_end_cde);
+
 int main(void) {
-	return EXIT_FAILURE;
+	unsigned cb_ab, cb_cde; /* capture base */
+	struct fsm *abcde = build(&cb_ab, &cb_cde);
+
+	check(abcde, "abcde", 1,
+	    cb_ab, 0, 2,
+	    cb_cde, 2, 5);
+
+	fsm_free(abcde);
+	return EXIT_SUCCESS;
+}
+
+static struct fsm *
+build(unsigned *cb_a, unsigned *cb_b)
+{
+	struct fsm *ab = captest_fsm_of_string("ab", 0);
+	struct fsm *cde = captest_fsm_of_string("cde", 1);
+	struct fsm *abcde;
+	struct fsm_combine_info ci;
+	size_t cc_ab, cc_cde, cc_abcde;
+
+	assert(ab);
+	assert(cde);
+
+	if (!fsm_capture_set_path(ab, 0, 0, 2)) {
+		assert(!"path 0");
+	}
+	if (!fsm_capture_set_path(cde, 0, 0, 3)) {
+		assert(!"path 1");
+	}
+
+	cc_ab = fsm_countcaptures(ab);
+	assert(cc_ab == 1);
+
+	cc_cde = fsm_countcaptures(cde);
+	assert(cc_cde == 1);
+
+	abcde = fsm_concat(ab, cde, &ci);
+	assert(abcde);
+	*cb_a = ci.capture_base_a;
+	*cb_b = ci.capture_base_b;
+
+	cc_abcde = fsm_countcaptures(abcde);
+	assert(cc_abcde == cc_ab + cc_cde);
+
+#if LOG_INTERMEDIATE_FSMS
+	fprintf(stderr, "==== after concat: cb_ab %u, cb_cde %u\n",
+	    *cb_a, *cb_b);
+	fsm_print_fsm(stderr, abcde);
+
+	fsm_capture_dump(stderr, "#### after concat", abcde);
+
+	fprintf(stderr, "==== determinise\n");
+#endif
+
+	if (!fsm_determinise(abcde)) {
+		assert(!"determinise");
+	}
+
+#if LOG_INTERMEDIATE_FSMS
+	fprintf(stderr, "==== after determinise\n");
+	fsm_print_fsm(stderr, abcde);
+
+	assert(fsm_countcaptures(abcde) == cc_abcde);
+
+	fsm_capture_dump(stderr, "#### after det", abcde);
+#endif
+
+	assert(fsm_countcaptures(abcde) == cc_abcde);
+	return abcde;
+}
+
+static void
+check(const struct fsm *fsm, const char *input, unsigned end_id,
+    unsigned cb_ab, size_t exp_start_ab, size_t exp_end_ab,
+    unsigned cb_cde, size_t exp_start_cde, size_t exp_end_cde)
+{
+	struct captest_input ci;
+	fsm_state_t end;
+	int exec_res;
+	struct fsm_capture captures[MAX_TEST_CAPTURES];
+
+	ci.string = input;
+	ci.pos = 0;
+
+	exec_res = fsm_exec(fsm, captest_getc, &ci, &end, captures);
+	if (exec_res != 1) {
+		fprintf(stderr, "exec_res: %d\n", exec_res);
+		exit(EXIT_FAILURE);
+	}
+
+	{
+		struct captest_end_opaque *eo = fsm_getopaque(fsm, end);
+		assert(eo != NULL);
+		assert(eo->tag == CAPTEST_END_OPAQUE_TAG);
+		if (!(eo->ends & (1U << end_id))) {
+			assert(!"end mismatch");
+		}
+	}
+
+	assert(captures[cb_ab].pos[0] == exp_start_ab);
+	assert(captures[cb_ab].pos[1] == exp_end_ab);
+
+	assert(captures[cb_cde].pos[0] == exp_start_cde);
+	assert(captures[cb_cde].pos[1] == exp_end_cde);
 }

--- a/tests/capture/capture_concat1.c
+++ b/tests/capture/capture_concat1.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <fsm/fsm.h>
+#include <fsm/capture.h>
+
+#include "captest.h"
+
+/* concat /(ab)/ and /(cde)/ */
+
+int main(void) {
+	return EXIT_FAILURE;
+}

--- a/tests/capture/capture_concat2.c
+++ b/tests/capture/capture_concat2.c
@@ -11,11 +11,123 @@
 
 #include <fsm/fsm.h>
 #include <fsm/capture.h>
+#include <fsm/bool.h>
 
 #include "captest.h"
 
 /* concat /(abc)/ and /(de)/ */
 
+static struct fsm *
+build(unsigned *cb_a, unsigned *cb_b);
+
+static void
+check(const struct fsm *fsm, const char *input, unsigned end_id,
+    unsigned cb_ab, size_t exp_start_ab, size_t exp_end_ab,
+    unsigned cb_cde, size_t exp_start_cde, size_t exp_end_cde);
+
 int main(void) {
-	return EXIT_FAILURE;
+	unsigned cb_abc, cb_de; /* capture base */
+	struct fsm *abcde = build(&cb_abc, &cb_de);
+
+	check(abcde, "abcde", 1,
+	    cb_abc, 0, 3,
+	    cb_de, 3, 5);
+
+	fsm_free(abcde);
+	return EXIT_SUCCESS;
+}
+
+static struct fsm *
+build(unsigned *cb_a, unsigned *cb_b)
+{
+	struct fsm *abc = captest_fsm_of_string("abc", 0);
+	struct fsm *de = captest_fsm_of_string("de", 1);
+	struct fsm *abcde;
+	struct fsm_combine_info ci;
+	size_t cc_abc, cc_de, cc_abcde;
+
+	assert(abc);
+	assert(de);
+
+	if (!fsm_capture_set_path(abc, 0, 0, 3)) {
+		assert(!"path 0");
+	}
+	if (!fsm_capture_set_path(de, 0, 0, 2)) {
+		assert(!"path 1");
+	}
+
+	cc_abc = fsm_countcaptures(abc);
+	assert(cc_abc == 1);
+
+	cc_de = fsm_countcaptures(de);
+	assert(cc_de == 1);
+
+	abcde = fsm_concat(abc, de, &ci);
+	assert(abcde);
+	*cb_a = ci.capture_base_a;
+	*cb_b = ci.capture_base_b;
+
+	cc_abcde = fsm_countcaptures(abcde);
+	assert(cc_abcde == cc_abc + cc_de);
+
+#if LOG_INTERMEDIATE_FSMS
+	fprintf(stderr, "==== after concat: cb_abc %u, cb_de %u\n",
+	    *cb_a, *cb_b);
+	fsm_print_fsm(stderr, abcde);
+
+	fsm_capture_dump(stderr, "#### after concat", abcde);
+
+	fprintf(stderr, "==== determinise\n");
+#endif
+
+	if (!fsm_determinise(abcde)) {
+		assert(!"determinise");
+	}
+
+#if LOG_INTERMEDIATE_FSMS
+	fprintf(stderr, "==== after determinise\n");
+	fsm_print_fsm(stderr, abcde);
+
+	assert(fsm_countcaptures(abcde) == cc_abcde);
+
+	fsm_capture_dump(stderr, "#### after det", abcde);
+#endif
+
+	assert(fsm_countcaptures(abcde) == cc_abcde);
+	return abcde;
+}
+
+static void
+check(const struct fsm *fsm, const char *input, unsigned end_id,
+    unsigned cb_abc, size_t exp_start_abc, size_t exp_end_abc,
+    unsigned cb_de, size_t exp_start_de, size_t exp_end_de)
+{
+	struct captest_input ci;
+	fsm_state_t end;
+	int exec_res;
+	struct fsm_capture captures[MAX_TEST_CAPTURES];
+
+	ci.string = input;
+	ci.pos = 0;
+
+	exec_res = fsm_exec(fsm, captest_getc, &ci, &end, captures);
+	if (exec_res != 1) {
+		fprintf(stderr, "exec_res: %d\n", exec_res);
+		exit(EXIT_FAILURE);
+	}
+
+	{
+		struct captest_end_opaque *eo = fsm_getopaque(fsm, end);
+		assert(eo != NULL);
+		assert(eo->tag == CAPTEST_END_OPAQUE_TAG);
+		if (!(eo->ends & (1U << end_id))) {
+			assert(!"end mismatch");
+		}
+	}
+
+	assert(captures[cb_abc].pos[0] == exp_start_abc);
+	assert(captures[cb_abc].pos[1] == exp_end_abc);
+
+	assert(captures[cb_de].pos[0] == exp_start_de);
+	assert(captures[cb_de].pos[1] == exp_end_de);
 }

--- a/tests/capture/capture_concat2.c
+++ b/tests/capture/capture_concat2.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <fsm/fsm.h>
+#include <fsm/capture.h>
+
+#include "captest.h"
+
+/* concat /(abc)/ and /(de)/ */
+
+int main(void) {
+	return EXIT_FAILURE;
+}

--- a/tests/capture/capture_union1.c
+++ b/tests/capture/capture_union1.c
@@ -44,6 +44,7 @@ build(unsigned *cb_a, unsigned *cb_b)
 	struct fsm *cde = captest_fsm_of_string("cde", 1);
 	struct fsm *abcde;
 	struct fsm_combine_info ci;
+	size_t cc_ab, cc_cde, cc_abcde;
 
 	assert(ab);
 	assert(cde);
@@ -55,11 +56,21 @@ build(unsigned *cb_a, unsigned *cb_b)
 		assert(!"path 1");
 	}
 
+	cc_ab = fsm_countcaptures(ab);
+	assert(cc_ab == 1);
+
+	cc_cde = fsm_countcaptures(cde);
+	assert(cc_cde == 1);
+
 	abcde = fsm_union(ab, cde, &ci);
 	assert(abcde);
 	*cb_a = ci.capture_base_a;
 	*cb_b = ci.capture_base_b;
 
+	cc_abcde = fsm_countcaptures(abcde);
+	assert(cc_abcde == cc_ab + cc_cde);
+
+#if LOG_INTERMEDIATE_FSMS
 	fprintf(stderr, "==== after union: cb_ab %u, cb_cde %u\n",
 	    *cb_a, *cb_b);
 	fsm_print_fsm(stderr, abcde);
@@ -67,24 +78,22 @@ build(unsigned *cb_a, unsigned *cb_b)
 	fsm_capture_dump(stderr, "#### after union", abcde);
 
 	fprintf(stderr, "==== determinise\n");
+#endif
+
 	if (!fsm_determinise(abcde)) {
 		assert(!"determinise");
 	}
 
+#if LOG_INTERMEDIATE_FSMS
 	fprintf(stderr, "==== after determinise\n");
 	fsm_print_fsm(stderr, abcde);
 
+	assert(fsm_countcaptures(abcde) == cc_abcde);
+
 	fsm_capture_dump(stderr, "#### after det", abcde);
+#endif
 
-	if (!fsm_minimise(abcde)) {
-		assert(!"minimise");
-	}
-
-	fprintf(stderr, "==== after minimise\n");
-	fsm_print_fsm(stderr, abcde);
-
-	fsm_capture_dump(stderr, "#### after min", abcde);
-
+	assert(fsm_countcaptures(abcde) == cc_abcde);
 	return abcde;
 }
 

--- a/tests/capture/capture_union1.c
+++ b/tests/capture/capture_union1.c
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2020 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <fsm/fsm.h>
+#include <fsm/bool.h>
+#include <fsm/capture.h>
+#include <fsm/print.h>
+
+#include "captest.h"
+
+/* union /(ab)/ and /(cde)/ */
+
+static struct fsm *
+build(unsigned *cb_a, unsigned *cb_b);
+
+static void
+check(const struct fsm *fsm, const char *input,
+    unsigned end_id, unsigned exp_capture_id,
+    size_t exp_start, size_t exp_end);
+
+int main(void) {
+	unsigned cb_ab, cb_cde; /* capture base */
+	struct fsm *abcde = build(&cb_ab, &cb_cde);
+
+	check(abcde, "ab", 0, cb_ab, 0, 2);
+	check(abcde, "cde", 1, cb_cde, 0, 3);
+
+	fsm_free(abcde);
+	return EXIT_SUCCESS;
+}
+
+static struct fsm *
+build(unsigned *cb_a, unsigned *cb_b)
+{
+	struct fsm *ab = captest_fsm_of_string("ab", 0);
+	struct fsm *cde = captest_fsm_of_string("cde", 1);
+	struct fsm *abcde;
+	struct fsm_combine_info ci;
+
+	assert(ab);
+	assert(cde);
+
+	if (!fsm_capture_set_path(ab, 0, 0, 2)) {
+		assert(!"path 0");
+	}
+	if (!fsm_capture_set_path(cde, 0, 0, 3)) {
+		assert(!"path 1");
+	}
+
+	abcde = fsm_union(ab, cde, &ci);
+	assert(abcde);
+	*cb_a = ci.capture_base_a;
+	*cb_b = ci.capture_base_b;
+
+	fprintf(stderr, "==== after union: cb_ab %u, cb_cde %u\n",
+	    *cb_a, *cb_b);
+	fsm_print_fsm(stderr, abcde);
+
+	fsm_capture_dump(stderr, "#### after union", abcde);
+
+	fprintf(stderr, "==== determinise\n");
+	if (!fsm_determinise(abcde)) {
+		assert(!"determinise");
+	}
+
+	fprintf(stderr, "==== after determinise\n");
+	fsm_print_fsm(stderr, abcde);
+
+	fsm_capture_dump(stderr, "#### after det", abcde);
+
+	if (!fsm_minimise(abcde)) {
+		assert(!"minimise");
+	}
+
+	fprintf(stderr, "==== after minimise\n");
+	fsm_print_fsm(stderr, abcde);
+
+	fsm_capture_dump(stderr, "#### after min", abcde);
+
+	return abcde;
+}
+
+static void
+check(const struct fsm *fsm, const char *input,
+    unsigned end_id, unsigned exp_capture_id,
+    size_t exp_start, size_t exp_end)
+{
+	struct captest_input ci;
+	fsm_state_t end;
+	int exec_res;
+	struct fsm_capture got_captures[MAX_TEST_CAPTURES];
+
+	ci.string = input;
+	ci.pos = 0;
+
+	exec_res = fsm_exec(fsm, captest_getc, &ci, &end, got_captures);
+	if (exec_res != 1) {
+		fprintf(stderr, "exec_res: %d\n", exec_res);
+		exit(EXIT_FAILURE);
+	}
+
+	{
+		struct captest_end_opaque *eo = fsm_getopaque(fsm, end);
+		assert(eo != NULL);
+		assert(eo->tag == CAPTEST_END_OPAQUE_TAG);
+		if (!(eo->ends & (1U << end_id))) {
+			assert(!"end mismatch");
+		}
+	}
+
+	if (got_captures[exp_capture_id].pos[0] != exp_start) {
+		fprintf(stderr, "capture[%u].pos[0]: exp %lu, got %lu\n",
+		    exp_capture_id, exp_start,
+		    got_captures[exp_capture_id].pos[0]);
+		exit(EXIT_FAILURE);
+	}
+	if (got_captures[exp_capture_id].pos[1] != exp_end) {
+		fprintf(stderr, "capture[%u].pos[1]: exp %lu, got %lu\n",
+		    exp_capture_id, exp_end,
+		    got_captures[exp_capture_id].pos[1]);
+		exit(EXIT_FAILURE);
+	}
+}

--- a/tests/capture/capture_union2.c
+++ b/tests/capture/capture_union2.c
@@ -43,7 +43,6 @@ build(unsigned *cb_a, unsigned *cb_b)
 	struct fsm *abcd = captest_fsm_of_string("abcd", 0);
 	struct fsm *abed = captest_fsm_of_string("abed", 1);
 	struct fsm *res;
-	struct fsm_combine_info ci;
 
 	assert(abcd);
 	assert(abed);
@@ -55,18 +54,22 @@ build(unsigned *cb_a, unsigned *cb_b)
 		assert(!"path 1");
 	}
 
-	res = fsm_union(abcd, abed, &ci);
-	assert(res);
-	*cb_a = ci.capture_base_a;
-	*cb_b = ci.capture_base_b;
+	{
+		struct fsm *fsms[2];
+		struct fsm_combined_base_pair bases[2];
+		fsms[0] = abcd;
+		fsms[1] = abed;
+		res = fsm_union_array(2, fsms, bases);
+		assert(res);
+		*cb_a = bases[0].capture;
+		*cb_b = bases[1].capture;
+	}
 
 	if (!fsm_determinise(res)) {
 		assert(!"determinise");
 	}
 
-	if (!fsm_minimise(res)) {
-		assert(!"minimise");
-	}
+	assert(fsm_countcaptures(res) == 2);
 
 	return res;
 }

--- a/theft/Makefile
+++ b/theft/Makefile
@@ -8,6 +8,7 @@ SRC += theft/wrap.c
 SRC += theft/fuzz_adt_edge_set.c
 SRC += theft/fuzz_adt_priq.c
 SRC += theft/fuzz_adt_set.c
+SRC += theft/fuzz_capture_string_set.c
 SRC += theft/fuzz_literals.c
 SRC += theft/fuzz_minimise.c
 SRC += theft/fuzz_nfa.c
@@ -17,6 +18,7 @@ SRC += theft/fuzz_re_parser_pcre.c
 SRC += theft/fuzz_trim.c
 
 SRC += theft/type_info_adt_edge_set.c
+SRC += theft/type_info_capture_string_set.c
 SRC += theft/type_info_dfa.c
 SRC += theft/type_info_fsm_literal.c
 SRC += theft/type_info_nfa.c

--- a/theft/fuzz_capture_string_set.c
+++ b/theft/fuzz_capture_string_set.c
@@ -1,0 +1,1144 @@
+#include "type_info_capture_string_set.h"
+
+#include <fsm/capture.h>
+#include <fsm/print.h>
+
+#define LOG_LEVEL 2
+
+static enum theft_trial_res
+prop_css_invariants(struct theft *t, void *arg1);
+
+static enum theft_trial_res
+check_capstring_set(struct capture_env *env,
+    const struct capture_string_set *css,
+    const char *input, struct fsm_capture *captures);
+
+static struct fsm *
+build_capstring_dfa(const struct capstring *cs, uint8_t end_id);
+
+struct check_env {
+	struct fsm *combined;
+	struct fsm **copies;
+	const size_t *capture_bases;
+	const unsigned *capture_counts;
+	size_t copies_count;
+	uint8_t letter_count;
+	uint8_t string_maxlen;
+	size_t checks;
+};
+
+struct css_input {
+	const char *string;
+	size_t pos;
+};
+
+static int
+css_getc(void *opaque);
+
+static enum theft_trial_res
+check_fsms_for_single_input(struct check_env *env, struct fsm_capture *captures,
+    const char *input_str);
+
+static enum theft_trial_res
+check_fsms_for_inputs(struct check_env *env, struct fsm_capture *captures);
+
+static enum theft_trial_res
+check_iter(struct check_env *env,
+    char *buf, size_t offset, struct fsm_capture *captures);
+
+static bool
+compare_captures(const struct check_env *env,
+    const struct fsm_capture *captures_combined,
+    size_t nth_fsm, const struct fsm_capture *captures);
+
+static bool
+test_css_invariants(theft_seed seed)
+{
+	enum theft_run_res res;
+
+	struct capture_env env = {
+		.tag = 'c',
+		.letter_count = 2,
+		.string_maxlen = 7,
+	};
+
+
+	seed = theft_seed_of_time();
+	fprintf(stderr, "==== seed %lu\n", seed);
+
+	/* theft_generate(stdout, seed, &type_info_capture_string_set, &env); */
+	/* exit(EXIT_SUCCESS); */
+
+	struct theft_run_config config = {
+		.name = __func__,
+		.prop1 = prop_css_invariants,
+		.type_info = { &type_info_capture_string_set, },
+		.hooks = {
+			.trial_pre = theft_hook_first_fail_halt,
+			/* .trial_post = repeat_with_verbose, */
+			.env = &env,
+		},
+		.seed = seed,
+		.trials = 100000,
+		.fork = {
+			/* .enable = true, */
+			.timeout = 10000,
+		},
+	};
+
+	res = theft_run(&config);
+	printf("%s: %s\n", __func__, theft_run_res_str(res));
+
+	return res == THEFT_RUN_PASS;
+}
+
+static enum theft_trial_res
+prop_css_invariants(struct theft *t, void *arg1)
+{
+	/* build DFAs for every string (alphanumeric literals or '*'),
+	 * save match groups, then combine copies of them and check that
+	 * the combined version behaves the same as matching each in
+	 * sequence for all possible strings letter_count x string_maxlen.
+	 *
+	 * optionally skip them all if the combined one doesn't match;
+	 * that mostly checks fsm_union, not captures. */
+	struct capture_env *env = theft_hook_get_env(t);
+	assert(env && env->tag == 'c');
+
+	struct fsm_capture captures[MAX_TOTAL_CAPTURES];
+	const struct capture_string_set *css = arg1;
+	return check_capstring_set(env, css, NULL, captures);
+}
+
+static enum theft_trial_res
+check_capstring_set(struct capture_env *env,
+    const struct capture_string_set *css,
+    const char *input, struct fsm_capture *captures)
+{
+	const int verbosity = LOG_LEVEL;
+
+	if (css->count == 0) {
+		return THEFT_TRIAL_SKIP;
+	}
+
+	size_t capture_bases[MAX_CAPTURE_STRINGS] = { 0 };
+	unsigned capture_counts[MAX_CAPTURE_STRINGS] = { 0 };
+	struct fsm *fsm_copies[MAX_CAPTURE_STRINGS] = { NULL };
+	struct fsm *combined = NULL;
+
+	for (size_t cs_i = 0; cs_i < css->count; cs_i++) {
+		const struct capstring *cs = &css->capture_strings[cs_i];
+
+		for (size_t i = 0; i < cs->capture_count; i++) {
+			/* if (cs->captures[i].length == 0) { */
+			/* 	return THEFT_TRIAL_SKIP; */
+			/* } */
+		}
+
+		struct fsm *dfa = build_capstring_dfa(cs, (uint8_t)cs_i);
+
+		if (dfa == NULL) {
+			return THEFT_TRIAL_ERROR;
+		}
+
+		const size_t capture_count = fsm_countcaptures(dfa);
+
+		if (verbosity > 2) {
+			fprintf(stderr, "==== cs '%s'\n", cs->string);
+			fsm_print_fsm(stderr, dfa);
+		}
+
+		struct fsm *cp = fsm_clone(dfa);
+		if (cp == NULL) {
+			return THEFT_TRIAL_ERROR;
+		}
+		assert(cp != NULL);
+		fsm_copies[cs_i] = cp;
+
+		const size_t cp_capture_count = fsm_countcaptures(cp);
+		if (verbosity > 2) {
+			fprintf(stderr, "==== min(det(cp))\n");
+			fsm_print_fsm(stderr, cp);
+			fprintf(stderr, "capture_count: %lu\n", cp_capture_count);
+		}
+
+		if (cp_capture_count != capture_count) {
+			fprintf(stderr, "expected %lu but got %lu captures for cp\n",
+			    capture_count, cp_capture_count);
+			return THEFT_TRIAL_FAIL;
+		}
+
+		if (cs_i == 0) {
+			combined = dfa;
+			/* fsm_capture_dump(stderr, "pre-union", combined); */
+			capture_counts[0] = capture_count;
+		} else {
+			struct fsm_combine_info ci;
+			combined = fsm_union(combined, dfa, &ci);
+			if (combined == NULL) {
+				return THEFT_TRIAL_ERROR;
+			}
+
+			/* FIXME: the way we track capture bases is problematic
+			 * here, because everything before may get shifted --
+			 * if _a is > 0, we need to increment everything up to
+			 * now by that, right? */
+			if (LOG_LEVEL > 2) {
+				fprintf(stderr, "union'd, bases %u and %u, cs_i %lu\n",
+				    ci.capture_base_a,
+				    ci.capture_base_b, cs_i);
+			}
+
+			if (cs_i == 1) {
+				capture_bases[0] = ci.capture_base_a;
+			}
+			capture_bases[cs_i] = ci.capture_base_b;
+			capture_counts[cs_i] = cp_capture_count;
+
+			if (ci.capture_base_a > 0 && cs_i > 1) {
+				size_t i;
+				for (i = 0; i < cs_i; i++) {
+					capture_bases[i] += ci.capture_base_a;
+
+					if (LOG_LEVEL > 2) {
+						fprintf(stderr, " -- *** capture_bases[%lu] now %lu\n", i, capture_bases[i]);
+					}
+				}
+			}
+
+			if (capture_counts[cs_i] < capture_count) {
+				fprintf(stderr, "FAIL: combined has %u captures but dfa has %zu\n",
+				    capture_counts[cs_i], capture_count);
+				return THEFT_TRIAL_FAIL;
+			}
+
+			if (verbosity > 2) {
+				fsm_capture_dump(stderr, "unioned", combined);
+				fsm_print_fsm(stderr, combined);
+			}
+
+		}
+
+		if (verbosity > 2) {
+			fprintf(stderr, "==== combined with %zu:\n", cs_i);
+			fsm_print_fsm(stderr, combined);
+		}
+	}
+
+	if (verbosity > 2) {
+		fsm_capture_dump(stderr, "pre-det", combined);
+		fsm_print_fsm(stderr, combined);
+	}
+
+	if (!fsm_determinise(combined)) {
+		return THEFT_TRIAL_ERROR;
+	}
+
+	/* (do not minimise) */
+	/* if (!fsm_minimise(combined)) { */
+	/* 	return THEFT_TRIAL_ERROR; */
+	/* } */
+
+	if (!fsm_complement(combined)) {
+		return THEFT_TRIAL_ERROR;
+	}
+	if (!fsm_complement(combined)) {
+		return THEFT_TRIAL_ERROR;
+	}
+
+	if (verbosity > 2) {
+		fprintf(stderr, "==== det(combined)\n");
+		fsm_print_fsm(stderr, combined);
+		fsm_capture_dump(stderr, "det(combined)", combined);
+	}
+
+	struct check_env check_env = {
+		.combined = combined,
+		.copies = fsm_copies,
+		.copies_count = css->count,
+		.capture_bases = capture_bases,
+		.capture_counts = capture_counts,
+		.letter_count = env->letter_count,
+		.string_maxlen = env->string_maxlen,
+	};
+
+	enum theft_trial_res res;
+
+	if (input == NULL) {
+		res = check_fsms_for_inputs(&check_env, captures);
+		/* fprintf(stderr, "-- checked %zu\n", check_env.checks); */
+	} else {
+		res = check_fsms_for_single_input(&check_env, captures, input);
+	}
+
+	for (size_t cs_i = 0; cs_i < css->count; cs_i++) {
+		fsm_free(fsm_copies[cs_i]);
+	}
+	fsm_free(combined);
+
+	return res;
+}
+
+static enum theft_trial_res
+check_fsms_for_single_input(struct check_env *env, struct fsm_capture *captures,
+	const char *input_str)
+{
+	/* check it: if the combined one matches, then
+	 * at least one of the original strings must match,
+	 * and then check the captures. */
+	struct css_input input = { .string = input_str, };
+	fsm_state_t end;
+	assert(env->combined);
+
+	for (size_t i = 0; i < MAX_TOTAL_CAPTURES; i++) {
+		captures[i].pos[0] = (size_t)-3;
+		captures[i].pos[1] = (size_t)-3;
+	}
+
+	int exec_res = fsm_exec(env->combined, css_getc,
+	    &input, &end, captures);
+	if (exec_res < 0) {
+		fprintf(stderr, "!!! '%s', res %d\n",
+		    input_str, exec_res);
+	}
+
+	assert(exec_res >= 0);
+	if (exec_res == 1) {
+		if (LOG_LEVEL > 0) {
+			const size_t combined_capture_count = fsm_countcaptures(env->combined);
+			for (size_t i = 0; i < combined_capture_count; i++) {
+				fprintf(stderr, "capture[%zu/%zu]: (%ld, %ld)\n",
+				    i, combined_capture_count,
+				    captures[i].pos[0], captures[i].pos[1]);
+			}
+		}
+
+		bool found = false;
+		for (size_t i = 0; i < env->copies_count; i++) {
+			struct fsm_capture captures2[MAX_TOTAL_CAPTURES];
+			for (size_t i = 0; i < MAX_TOTAL_CAPTURES; i++) {
+				captures2[i].pos[0] = (size_t)-2;
+				captures2[i].pos[1] = (size_t)-2;
+			}
+
+			struct css_input input2 = { .string = input_str, };
+			fsm_state_t end2;
+			if (env->copies[i] == NULL) {
+				fprintf(stderr, "env->copies[%zu]: null\n", i);
+			}
+
+			if (LOG_LEVEL > 1) {
+				fprintf(stderr, "=== executing env->copies[%lu]\n", i);
+			}
+
+			assert(env->copies[i] != NULL);
+			int exec_res2 = fsm_exec(env->copies[i],
+			    css_getc, &input2, &end2, captures2);
+			if (exec_res2 == 1) {
+				found = true;
+				if (!compare_captures(env, captures,
+					i, captures2)) {
+					return THEFT_TRIAL_FAIL;
+				}
+			}
+		}
+
+		if (!found) {
+			fprintf(stderr, "combined matched but not originals\n");
+			return THEFT_TRIAL_FAIL;
+		}
+	}
+	return THEFT_TRIAL_PASS;
+}
+
+static enum theft_trial_res
+check_fsms_for_inputs(struct check_env *env, struct fsm_capture *captures)
+{
+	char buf[MAX_CAPTURE_STRING_LENGTH] = { 0 };
+
+	/* exhaustively check inputs up to env->string_maxlen */
+	return check_iter(env, buf, 0, captures);
+}
+
+static int
+css_getc(void *opaque)
+{
+	struct css_input *input = opaque;
+	int res = input->string[input->pos];
+	input->pos++;
+	return res == 0 ? EOF : res;
+}
+
+static enum theft_trial_res
+check_iter(struct check_env *env,
+    char *buf, size_t offset, struct fsm_capture *captures)
+{
+	const int verbosity = LOG_LEVEL;
+
+	if (verbosity > 2) {
+		fprintf(stderr, "buf -- [%zu]: '%s'\n",
+		    offset, buf);
+	}
+
+	if (offset == env->string_maxlen) {
+		return THEFT_TRIAL_PASS;
+	} else {
+
+		if (verbosity > 1) {
+			fprintf(stderr, "buf -- [%zu]: '%s' (executing)\n",
+			    offset, buf);
+		}
+
+		enum theft_trial_res res;
+		res = check_fsms_for_single_input(env, captures, buf);
+		if (res != THEFT_TRIAL_PASS) {
+			return res;
+		}
+
+#if 0
+		/* check it: if the combined one matches, then
+		 * at least one of the original strings must match,
+		 * and then check the captures. */
+		struct css_input input = { .string = buf, };
+		fsm_state_t end;
+		assert(env->combined);
+
+		for (size_t i = 0; i < MAX_TOTAL_CAPTURES; i++) {
+			captures[i].pos[0] = (size_t)-3;
+			captures[i].pos[1] = (size_t)-3;
+		}
+
+		int exec_res = fsm_exec(env->combined, css_getc,
+		    &input, &end, captures);
+		if (exec_res < 0) {
+			fprintf(stderr, "!!! '%s', res %d\n",
+			    buf, exec_res);
+		}
+
+		assert(exec_res >= 0);
+		if (exec_res == 1) {
+			if (LOG_LEVEL > 0) {
+				const size_t combined_capture_count = fsm_countcaptures(env->combined);
+				for (size_t i = 0; i < combined_capture_count; i++) {
+					fprintf(stderr, "capture[%zu/%zu]: (%ld, %ld)\n",
+					    i, combined_capture_count,
+					    captures[i].pos[0], captures[i].pos[1]);
+				}
+			}
+
+			bool found = false;
+			for (size_t i = 0; i < env->copies_count; i++) {
+				struct fsm_capture captures2[MAX_TOTAL_CAPTURES];
+				for (size_t i = 0; i < MAX_TOTAL_CAPTURES; i++) {
+					captures2[i].pos[0] = (size_t)-2;
+					captures2[i].pos[1] = (size_t)-2;
+				}
+
+				struct css_input input2 = { .string = buf, };
+				fsm_state_t end2;
+				if (env->copies[i] == NULL) {
+					fprintf(stderr, "env->copies[%zu]: null\n", i);
+				}
+
+				if (LOG_LEVEL > 1) {
+					fprintf(stderr, "=== executing env->copies[%lu]\n", i);
+				}
+
+				assert(env->copies[i] != NULL);
+				int exec_res2 = fsm_exec(env->copies[i],
+				    css_getc, &input2, &end2, captures2);
+				if (exec_res2 == 1) {
+					found = true;
+					if (!compare_captures(env, captures,
+						i, captures2)) {
+						return THEFT_TRIAL_FAIL;
+					}
+				}
+			}
+
+			if (!found) {
+				fprintf(stderr, "combined matched but not originals\n");
+				return THEFT_TRIAL_FAIL;
+			}
+		}
+#endif
+	}
+
+	env->checks++;
+
+	for (uint8_t i = 0; i < env->letter_count; i++) {
+		buf[offset] = 'a' + i;
+		buf[offset + 1] = '\0';
+		enum theft_trial_res res = check_iter(env,
+		    buf, offset + 1, captures);
+		if (res != THEFT_TRIAL_PASS) {
+			return res;
+		}
+	}
+
+	return THEFT_TRIAL_PASS;
+}
+
+static bool
+compare_captures(const struct check_env *env,
+    const struct fsm_capture *captures_combined,
+    size_t nth_fsm, const struct fsm_capture *captures)
+{
+	const size_t combined_capture_count = fsm_countcaptures(env->combined);
+	if (combined_capture_count == 0) {
+		return true;	/* no captures */
+	}
+
+	const size_t capture_count = env->capture_counts[nth_fsm];
+	const size_t base = env->capture_bases[nth_fsm];
+
+	if (combined_capture_count < capture_count) {
+		fprintf(stderr, "expected %lu captures, got %lu\n",
+		    capture_count, combined_capture_count);
+		return false;
+	}
+
+#if LOG_LEVEL > 1
+	fprintf(stderr, "compare_captures: combined_capture_count %zu, capture_count %lu\n",
+	    combined_capture_count, capture_count);
+
+	for (size_t i = 0; i < MAX_TOTAL_CAPTURES; i++) {
+		fprintf(stderr, "captures[%zu]: (%ld, %ld)\n",
+		    i, captures[i].pos[0], captures[i].pos[1]);
+	}
+
+	for (size_t i = 0; i < MAX_TOTAL_CAPTURES; i++) {
+		fprintf(stderr, "captures_combined[%zu]: (%ld, %ld)\n",
+		    i, captures_combined[i].pos[0], captures_combined[i].pos[1]);
+	}
+#endif
+
+	for (size_t i = 0; i < capture_count; i++) {
+		if (LOG_LEVEL > 0) {
+			fprintf(stderr, "cc[%zu/%zu]: (%ld, %ld) <-> (%ld, %ld) (base %lu)\n",
+			    i, capture_count,
+			    captures[i].pos[0], captures[i].pos[1],
+			    captures_combined[i + base].pos[0],
+			    captures_combined[i + base].pos[1], base);
+		}
+
+		for (size_t p = 0; p < 2; p++) {
+			/* fprintf(stderr, "?? captures[%zu].pos[%lu] = %zu\n", i, p, captures[i].pos[p]); */
+			/* fprintf(stderr, "?? captures_combined[%zu + %lu].pos[%lu] = %zu\n", i, base, p, captures_combined[i + base].pos[p]); */
+
+			if (captures[i].pos[p] != captures_combined[i + base].pos[p]) {
+				fprintf(stderr, "bad capture %zu: exp (%ld - %ld), got (%ld - %ld)\n",
+				    i,
+				    captures[i].pos[0], captures[i].pos[1],
+				    captures_combined[i + base].pos[0],
+				    captures_combined[i + base].pos[1]);
+
+				return false;
+
+				/* if (captures[i].pos[0] != FSM_CAPTURE_NO_POS */
+				/*     && captures[i].pos[1] != FSM_CAPTURE_NO_POS) { */
+				/* 	return false; */
+				/* } */
+			}
+		}
+	}
+
+	if (combined_capture_count == 0) {
+		fprintf(stderr, "Zero captures...\n");
+	}
+
+	if (LOG_LEVEL > 0) {
+		fprintf(stderr, "%zu captures...matched\n", combined_capture_count);
+	}
+	return true;
+}
+
+static struct fsm_options options;
+
+static void css_carryopaque(struct fsm *src_fsm,
+    const fsm_state_t *src_set, size_t n,
+    struct fsm *dst_fsm, fsm_state_t dst_state)
+{
+	struct css_end_opaque *eo_src = NULL;
+	struct css_end_opaque *eo_dst = NULL;
+	struct css_end_opaque *eo_old_dst = NULL;
+	size_t i;
+
+	eo_old_dst = fsm_getopaque(dst_fsm, dst_state);
+
+	eo_dst = calloc(1, sizeof(*eo_dst));
+	assert(eo_dst != NULL);
+	eo_dst->tag = CSS_END_OPAQUE_TAG;
+
+	if (eo_old_dst != NULL) {
+		assert(eo_old_dst->tag == CSS_END_OPAQUE_TAG);
+		eo_dst->ends |= eo_old_dst->ends;
+		/* FIXME: freeing here leads to a use after free */
+		/* f_free(opt->alloc, eo_old_dst); */
+	}
+
+	fsm_setopaque(dst_fsm, dst_state, eo_dst);
+
+	/* FIXME: set captures */
+
+	/* union bits set in eo_src->ends into eo_dst->ends and free */
+	for (i = 0; i < n; i++) {
+		if (!fsm_isend(src_fsm, src_set[i])) {
+			continue;
+		}
+
+		eo_src = fsm_getopaque(src_fsm, src_set[i]);
+		if (eo_src == NULL) {
+			continue;
+		}
+		assert(eo_src->tag == CSS_END_OPAQUE_TAG);
+		eo_dst->ends |= eo_src->ends;
+
+		/* FIXME: freeing here leads to a use after free */
+		/* f_free(opt->alloc, eo_src); */
+
+		fsm_setopaque(src_fsm, src_set[i], NULL);
+	}
+}
+
+static struct fsm *
+build_capstring_dfa(const struct capstring *cs, uint8_t end_id)
+{
+	struct fsm *fsm = NULL;
+	size_t i;
+	struct css_end_opaque *eo = NULL;
+	const size_t length = strlen(cs->string);
+	size_t states = 0;
+	fsm_state_t state, prev;
+
+	if (options.carryopaque == NULL) { /* initialize */
+		options.carryopaque = css_carryopaque;
+	}
+
+	fsm = fsm_new(&options);
+	if (fsm == NULL) { goto cleanup; }
+
+	eo = calloc(1, sizeof(*eo));
+	assert(eo != NULL);
+
+	eo->tag = CSS_END_OPAQUE_TAG;
+
+	/* set bit for end state */
+	assert(end_id < 8*sizeof(eo->ends));
+	eo->ends |= (1U << end_id);
+
+	if (!fsm_addstate(fsm, &state)) {
+		goto cleanup;
+	}
+	fsm_setstart(fsm, state);
+	prev = state;
+
+	i = 0;
+	while (i < length) {
+		const char c = cs->string[i];
+		assert(c != '*');
+
+		if (!fsm_addstate(fsm, &state)) {
+			goto cleanup;
+		}
+		states++;
+
+		if (!fsm_addedge_literal(fsm, prev, state, c)) {
+			goto cleanup;
+		}
+
+		if (i + 1 < length && cs->string[i + 1] == '*') {
+			if (!fsm_addedge_epsilon(fsm, prev, state)) {
+				goto cleanup;
+			}
+			if (!fsm_addedge_literal(fsm, state, state, c)) {
+				goto cleanup;
+			}
+			i++;
+		}
+
+		prev = state;
+		i++;
+	}
+
+	for (i = 0; i < cs->capture_count; i++) {
+		const fsm_state_t start = cs->captures[i].offset;
+		const fsm_state_t end = start + cs->captures[i].length;
+
+		if (!fsm_capture_set_path(fsm, i, start, end)) {
+			goto cleanup;
+		}
+	}
+
+	fsm_setend(fsm, state, 1);
+	fsm_setopaque(fsm, state, eo);
+
+	if (!fsm_determinise(fsm)) {
+		goto cleanup;
+	}
+
+	if (!fsm_minimise(fsm)) {
+		goto cleanup;
+	}
+
+	if (fsm_countcaptures(fsm) != cs->capture_count) {
+		goto cleanup;
+	}
+
+	return fsm;
+
+cleanup:
+	free(eo);
+	fsm_free(fsm);
+	return NULL;
+}
+
+static bool
+regression0(theft_seed seed)
+{
+	(void)seed;
+
+	struct capture_env env = {
+		.tag = 'c',
+		.letter_count = 3,
+		.string_maxlen = 5,
+	};
+
+	const struct capture_string_set css = {
+		.count = 3,
+		.capture_strings = {
+			{
+				.string = "",
+				.capture_count = 0,
+			},
+			{
+				.string = "",
+				.capture_count = 0,
+			},
+			{
+				.string = "aaa",
+				.capture_count = 0,
+			},
+		},
+	};
+
+	return THEFT_TRIAL_PASS ==
+	    check_capstring_set(&env, &css, NULL, NULL);
+}
+
+static bool
+regression1(theft_seed seed)
+{
+	(void)seed;
+
+	struct capture_env env = {
+		.tag = 'c',
+		.letter_count = 3,
+		.string_maxlen = 5,
+	};
+
+	const struct capture_string_set css = {
+		.count = 1,
+		.capture_strings = {
+			{
+				.string = "a",
+				.capture_count = 1,
+				.captures = {
+					{ 0, 0 },
+				},
+			},
+		},
+	};
+
+	return THEFT_TRIAL_PASS ==
+	    check_capstring_set(&env, &css, NULL, NULL);
+}
+
+static bool
+regression2(theft_seed seed)
+{
+	(void)seed;
+
+	struct capture_env env = {
+		.tag = 'c',
+		.letter_count = 3,
+		.string_maxlen = 5,
+	};
+
+	/* enough actions to force hash table growth */
+	const struct capture_string_set css = {
+		.count = 2,
+		.capture_strings = {
+			{
+				.string = "bbbbb",
+				.capture_count = 1,
+				.captures = {
+					{ 0, 0 },
+				},
+			},
+			{
+				.string = "b*bba",
+				.capture_count = 2,
+				.captures = {
+					{ 0, 2 },
+					{ 1, 3 },
+				},
+			},
+		},
+	};
+
+	return THEFT_TRIAL_PASS ==
+	    check_capstring_set(&env, &css, NULL, NULL);
+}
+
+static bool
+regression3(theft_seed seed)
+{
+	(void)seed;
+
+	struct capture_env env = {
+		.tag = 'c',
+		.letter_count = 3,
+		.string_maxlen = 5,
+	};
+
+	const struct capture_string_set css = {
+		.count = 2,
+		.capture_strings = {
+			{
+				.string = "aaaaaaa",
+				.capture_count = 2,
+				.captures = {
+					{ 0, 2 },
+					{ 0, 0 },
+				},
+			},
+			{
+				.string = "d*a*bbd",
+				.capture_count = 2,
+				.captures = {
+					{ 0, 0 },
+					{ 0, 2 },
+				},
+			},
+		},
+	};
+
+	return THEFT_TRIAL_PASS ==
+	    check_capstring_set(&env, &css, NULL, NULL);
+}
+
+static bool
+regression4(theft_seed seed)
+{
+	(void)seed;
+
+	struct capture_env env = {
+		.tag = 'c',
+		.letter_count = 3,
+		.string_maxlen = 5,
+	};
+
+	/* enough actions to force hash table growth */
+	const struct capture_string_set css = {
+		.count = 2,
+		.capture_strings = {
+			{
+				.string = "aa",
+				.capture_count = 0,
+			},
+			{
+				.string = "",
+				.capture_count = 1,
+				.captures = {
+					{ 0, 0 },
+				},
+			},
+		},
+	};
+
+	return THEFT_TRIAL_PASS ==
+	    check_capstring_set(&env, &css, NULL, NULL);
+}
+
+static bool
+regression5(theft_seed seed)
+{
+	(void)seed;
+
+	struct capture_env env = {
+		.tag = 'c',
+		.letter_count = 3,
+		.string_maxlen = 5,
+	};
+
+	/* enough actions to force hash table growth */
+	const struct capture_string_set css = {
+		.count = 3,
+		.capture_strings = {
+			{
+				.string = "",
+				.capture_count = 0,
+			},
+			{
+				.string = "",
+				.capture_count = 1,
+				.captures = {
+					{ 0, 0 },
+				},
+			},
+			{
+				.string = "aaaa",
+				.capture_count = 1,
+				.captures = {
+					{ 0, 2 },
+				},
+			},
+		},
+	};
+
+	return THEFT_TRIAL_PASS ==
+	    check_capstring_set(&env, &css, NULL, NULL);
+}
+
+static bool
+regression_fp(theft_seed seed)
+{
+	(void)seed;
+
+	struct capture_env env = {
+		.tag = 'c',
+		.letter_count = 3,
+		.string_maxlen = 5,
+	};
+
+	const struct capture_string_set css = {
+		.count = 2,
+		.capture_strings = {
+			{
+				.string = "abc",
+				.capture_count = 2,
+				.captures = {
+					{ 0, 3 },
+					{ 3, 0 },
+				},
+			},
+			{
+				.string = "ab*c",
+				.capture_count = 2,
+				.captures = {
+					{ 0, 3 },
+					{ 3, 0 },
+				},
+			},
+		},
+	};
+
+	return THEFT_TRIAL_PASS ==
+	    check_capstring_set(&env, &css, NULL, NULL);
+}
+
+static bool
+regression6(theft_seed seed)
+{
+	(void)seed;
+
+	struct capture_env env = {
+		.tag = 'c',
+		.letter_count = 3,
+		.string_maxlen = 5,
+	};
+
+	/* enough actions to force hash table growth */
+	const struct capture_string_set css = {
+		.count = 2,
+		.capture_strings = {
+			{
+				.string = "",
+				.capture_count = 1,
+				.captures = {
+					{ 0, 0 },
+				},
+			},
+			{
+				.string = "a",
+				.capture_count = 1,
+				.captures = {
+					{ 0, 0 },
+				},
+			},
+		},
+	};
+
+	return THEFT_TRIAL_PASS ==
+	    check_capstring_set(&env, &css, NULL, NULL);
+}
+
+static bool
+regression7(theft_seed seed)
+{
+	(void)seed;
+
+	struct capture_env env = {
+		.tag = 'c',
+		.letter_count = 3,
+		.string_maxlen = 5,
+	};
+
+	const struct capture_string_set css = {
+		.count = 3,
+		.capture_strings = {
+			{
+				.string = "bb",
+				.capture_count = 0,
+			},
+			{
+				.string = "a",
+				.capture_count = 0,
+			},
+			{
+				.string = "b*a",
+				.capture_count = 2,
+				.captures = {
+					{ 0, 0 },
+					{ 0, 1 },
+				},
+			},
+		},
+	};
+
+	return THEFT_TRIAL_PASS ==
+	    check_capstring_set(&env, &css, NULL, NULL);
+}
+
+static bool
+regression8(theft_seed seed)
+{
+	(void)seed; // 0x5d58a83011ff1d39
+
+	struct capture_env env = {
+		.tag = 'c',
+		.letter_count = 3,
+		.string_maxlen = 5,
+	};
+
+#if 0
+	const struct capture_string_set css = {
+		.count = 2,
+		.capture_strings = {
+			{	/* "()aa" */
+				.string = "aa",
+				.capture_count = 1,
+				.captures = {
+					{ 0, 0 },
+				},
+			},
+			{	/* "()a*(a)a()a" */
+				.string = "a*aaa*",
+				.capture_count = 3,
+				.captures = {
+					{ 0, 0 },
+					{ 3, 0 },
+					{ 1, 1 },
+				},
+			},
+		},
+	};
+#else
+
+	/* echo "bananas" | pcregrep --om-separator="#" -o1 -o2 ".*(an).*(ana).*" */
+	/* echo "aa" | pcregrep --om-separator="#" -o1 -o2 "a*(a)()" */
+	/* -> [(0,1); (-1,-1)] */
+
+	const struct capture_string_set css = {
+		.count = 2,
+		.capture_strings = {
+			{	/* "aa" */
+				.string = "aa",
+				.capture_count = 0,
+			},
+			{	/* "a*(a)()" */
+				.string = "a*a",
+				.capture_count = 2,
+				.captures = {
+					{ 1, 1 },
+					{ 2, 0 },
+				},
+			},
+		},
+	};
+#endif
+	return THEFT_TRIAL_PASS ==
+	    check_capstring_set(&env, &css, NULL, NULL);
+
+}
+
+
+
+static bool
+regression_n_1(theft_seed seed)
+{
+	(void)seed;
+
+	struct capture_env env = {
+		.tag = 'c',
+		.letter_count = 2,
+		.string_maxlen = 5,
+	};
+
+	const struct capture_string_set css = {
+		.count = 2,
+		.capture_strings = {
+			{	/* a*(b) */
+				.string = "a*b",
+				.capture_count = 1,
+				.captures = {
+					{ 1, 1 },
+				},
+			},
+			{	/* (a)b* */
+				.string = "ab*",
+				.capture_count = 1,
+				.captures = {
+					{ 0, 1 },
+				},
+			},
+		},
+	};
+
+	struct fsm_capture captures[MAX_TOTAL_CAPTURES];
+
+	if (THEFT_TRIAL_PASS !=
+	    check_capstring_set(&env, &css, "ab", captures)) {
+		return false;
+	}
+
+	/* FIXME: check captures, need base info */
+	fprintf(stderr, "%ld, %ld, %ld, %ld\n",
+	    captures[0].pos[0], captures[0].pos[1],
+	    captures[1].pos[0], captures[1].pos[1]);
+	/* assert(captures[0].pos[0] ==  */
+
+	return true;
+}
+
+void
+register_test_capture_string_set(void)
+{
+	reg_test("capture_string_set_regression_false_positive", regression_fp);
+	reg_test("capture_string_set_regression0", regression0);
+	reg_test("capture_string_set_regression1", regression1);
+	reg_test("capture_string_set_regression2", regression2);
+	reg_test("capture_string_set_regression3", regression3);
+	reg_test("capture_string_set_regression4", regression4);
+	reg_test("capture_string_set_regression5", regression5);
+	reg_test("capture_string_set_regression6", regression6);
+	reg_test("capture_string_set_regression7", regression7);
+	reg_test("capture_string_set_regression8", regression8);
+
+	reg_test("capture_string_set_nonempty_regression1", regression_n_1);
+
+
+	reg_test("capture_string_set_invariants",
+	    test_css_invariants);
+}

--- a/theft/fuzz_literals.c
+++ b/theft/fuzz_literals.c
@@ -139,7 +139,7 @@ add_literal(struct fsm *fsm, const uint8_t *string, size_t size, intptr_t id)
 
 	fsm_setendopaque(new, (void *) id);
 
-	res = fsm_union(fsm, new);
+	res = fsm_union(fsm, new, NULL);
 	if (res == NULL) {
 		return NULL;
 	}

--- a/theft/main.c
+++ b/theft/main.c
@@ -240,6 +240,7 @@ main(int argc, char **argv)
 	register_test_re();
 	register_test_adt_priq();
 	register_test_adt_set();
+	register_test_capture_string_set();
 	register_test_nfa();
 	register_test_trim();
 	register_test_minimise();

--- a/theft/theft_libfsm.h
+++ b/theft/theft_libfsm.h
@@ -70,6 +70,7 @@ void register_test_literals(void);
 void register_test_re(void);
 void register_test_adt_priq(void);
 void register_test_adt_set(void);
+void register_test_capture_string_set(void);
 void register_test_nfa(void);
 void register_test_adt_edge_set(void);
 void register_test_trim(void);

--- a/theft/type_info_capture_string_set.c
+++ b/theft/type_info_capture_string_set.c
@@ -1,0 +1,116 @@
+#include "type_info_capture_string_set.h"
+
+#include <adt/xalloc.h>
+
+#define IGNORE_ZERO_LENGTH_CAPTURES 1
+
+static void
+gen_string(struct theft *t,
+    uint8_t letter_count, uint8_t string_maxlen,
+    size_t *length, char *buf);
+
+static enum theft_alloc_res
+cs_alloc(struct theft *t, void *unused, void **output)
+{
+	struct capture_string_set *res;
+	struct capture_env *env = theft_hook_get_env(t);
+	assert(env && env->tag == 'c');
+	(void)unused;
+
+	res = calloc(1, sizeof(*res));
+	if (res == NULL) { return THEFT_ALLOC_ERROR; }
+
+	const uint8_t cs_ceil = 1 + theft_random_choice(t, MAX_CAPTURE_STRINGS - 1);
+	for (size_t cs_i = 0; cs_i < cs_ceil; cs_i++) {
+		struct capstring *cs = &res->capture_strings[res->count];
+		memset(cs, 0x00, sizeof(*cs));
+
+		size_t length;
+		gen_string(t, env->letter_count, env->string_maxlen,
+		    &length, cs->string);
+
+		const uint8_t capture_count_ceil = theft_random_choice(t, MAX_CAPTURES);
+		for (size_t c_i = 0; c_i < capture_count_ceil; c_i++) {
+			struct capture *c = &cs->captures[cs->capture_count];
+			c->offset = theft_random_choice(t, length);
+			c->length = theft_random_choice(t, length - c->offset);
+			if (theft_random_bits(t, 4) > 0
+#if IGNORE_ZERO_LENGTH_CAPTURES
+			    && c->length > 0
+#endif
+				) {
+				cs->capture_count++; /* keep */
+			}
+		}
+
+		if (theft_random_bits(t, 3) > 0) {
+			res->count++; /* keep */
+		}
+	}
+
+	*output = res;
+	return THEFT_ALLOC_OK;
+}
+
+static void
+gen_string(struct theft *t,
+    uint8_t letter_count, uint8_t string_maxlen,
+    size_t *length, char *buf)
+{
+	/* Generate a string 'a' .. (letter_count - 1), with
+	 * optional, nonconsecutive '*'s after letters. */
+	size_t i = 0;
+	size_t stars = 0;
+
+	for (i = 0; i < string_maxlen; i++) {
+		/* While this ordering is a bit confusing
+		 * ('\0', 'a' .. letter_count, '*'), this ensures
+		 * that the simplest option is first and thus theft
+		 * is able to shrink the string. */
+		char c = theft_random_choice(t, letter_count + 2);
+		if (c == 0) {
+			break;	/* '\0' */
+		} else if (c == letter_count + 1) {
+			/* disallow multiple consecutive '*'s */
+			if (i == 0 || buf[i - 1] == '*') {
+				c = 'a';
+			} else {
+				c = '*';
+				stars++;
+			}
+		} else {
+			c += 'a' - 1;
+		}
+		buf[i] = c;
+	}
+	assert(stars <= i);
+	*length = i - stars;
+}
+
+static void
+cs_print(FILE *f, const void *instance, void *env)
+{
+	const struct capture_string_set *css = instance;
+	(void)env;
+
+	fprintf(f, "capture_string_set[%u]:\n", css->count);
+	for (size_t cs_i = 0; cs_i < css->count; cs_i++) {
+		const struct capstring *cs = &css->capture_strings[cs_i];
+		fprintf(f, " -- %zu: '%s'", cs_i, cs->string);
+		for (size_t c_i = 0; c_i < cs->capture_count;  c_i++) {
+			const uint8_t offset = cs->captures[c_i].offset;
+			const uint8_t length = cs->captures[c_i].length;
+			fprintf(f, " (%u,%u)", offset, offset + length);
+		}
+		fprintf(f, "\n");
+	}
+}
+
+const struct theft_type_info type_info_capture_string_set = {
+	.alloc = cs_alloc,
+	.free  = theft_generic_free_cb,
+	.print = cs_print,
+	.autoshrink_config = {
+		.enable = true,
+	}
+};

--- a/theft/type_info_capture_string_set.h
+++ b/theft/type_info_capture_string_set.h
@@ -1,0 +1,39 @@
+#ifndef TYPE_INFO_CAPTURE_STRING_SET_H
+#define TYPE_INFO_CAPTURE_STRING_SET_H
+
+#include "theft_libfsm.h"
+
+#define MAX_CAPTURE_STRINGS 8
+#define MAX_CAPTURES 4
+#define MAX_CAPTURE_STRING_LENGTH 16
+#define MAX_TOTAL_CAPTURES (MAX_CAPTURE_STRINGS * MAX_CAPTURES)
+
+/* abcd* */
+
+struct capture_env {
+	char tag;
+	uint8_t letter_count;	/* e.g. 4 = "abcd"; 0 < count <= 26 */
+	uint8_t string_maxlen;	/* must be < MAX_CAPTURE_STRING_LENGTH */
+};
+
+struct css_end_opaque {
+#define CSS_END_OPAQUE_TAG 'C'
+	unsigned char tag;
+	unsigned ends;		/* bit set */
+};
+
+struct capture_string_set {
+	uint8_t count;
+	struct capstring {
+		char string[MAX_CAPTURE_STRING_LENGTH];
+		uint8_t capture_count;
+		struct capture {
+			uint8_t offset;
+			uint8_t length;
+		} captures[MAX_CAPTURES];
+	} capture_strings[MAX_CAPTURE_STRINGS];
+};
+
+extern const struct theft_type_info type_info_capture_string_set;
+
+#endif

--- a/theft/wrap.c
+++ b/theft/wrap.c
@@ -48,7 +48,7 @@ wrap_fsm_exec(struct fsm *fsm, const struct string_pair *pair, fsm_state_t *stat
 		.offset = 0
 	};
 
-	e = fsm_exec(fsm, scanner_next, &s, state);
+	e = fsm_exec(fsm, scanner_next, &s, state, NULL);
 
 	assert(s.str == pair->string);
 	assert(s.magic == &s.magic);


### PR DESCRIPTION
This is the first pass of work adding support for capture actions in the DFAs.

When multiple DFAs with captures are unioned and then determinised (but not minimised after), we can track info about captures for them. (Minimisation after is not supported because it combines states in a way that leads to false positives)

- Add `fsm_union_array` to the public interface. This supports unioning an array of fsms, internally tracking the fsms' start states and base capture offsets in the combined fsm.

- Update the interfaces related to merge, union, and concat, so the base/capture_base info is populated.

- The combined DFA will have some capture false positives -- it may set captures for other DFAs executed on the same path, but there's currently no association between end states and the original DFAs, so they cannot be filtered out. Work in a future PR should add this; for now, a flag in the `capture_string_set_invariants` and some other regression tests enables/disables checking for these false positives. Some of those tests have pending work to track this better once implemented, but for now the minimal case that triggers this is unioning `aaa` and `(a)a` and giving the input string "aaa" (`capture_string_set_regression_false_positive2`).

- Similarly, there is a temporarily ignored ambiguity in `tests/capture/capture4.c`: determinization loses the information that "abc" matches both `ab*c` AND `abc`. This is noted in the test, and will be worked on next, but this pass is focused on the capture action mechanism itself.

- Zero-width captures (such as `ab()cd()e`) are explicitly not supported. They lead to ambiguities when they're preceded by other greedy matches. Fortunately, PCRE also does not support them.