### PR TITLE
Missing const for src_fsm in carryopaque callbacks

### DIFF
--- a/examples/iprange/main.c
+++ b/examples/iprange/main.c
@@ -421,7 +421,7 @@ important(unsigned n)
 }
 
 static void
-carryopaque(struct fsm *src_fsm, const fsm_state_t *src_set, size_t n,
+carryopaque(const struct fsm *src_fsm, const fsm_state_t *src_set, size_t n,
 	struct fsm *dst_fsm, struct fsm_state *dst_state)
 {
 	void *o = NULL;

--- a/include/fsm/options.h
+++ b/include/fsm/options.h
@@ -65,7 +65,7 @@ struct fsm_options {
 	void *endleaf_opaque;
 
 	/* TODO: explain */
-	void (*carryopaque)(struct fsm *src_fsm, const fsm_state_t *src_set, size_t n,
+	void (*carryopaque)(const struct fsm *src_fsm, const fsm_state_t *src_set, size_t n,
 		struct fsm *dst_fsm, fsm_state_t dst_state);
 
 	/* custom allocation functions */

--- a/src/libfsm/fsm.c
+++ b/src/libfsm/fsm.c
@@ -125,7 +125,7 @@ fsm_move(struct fsm *dst, struct fsm *src)
 }
 
 void
-fsm_carryopaque_array(struct fsm *src_fsm, const fsm_state_t *src_set, size_t n,
+fsm_carryopaque_array(const struct fsm *src_fsm, const fsm_state_t *src_set, size_t n,
 	struct fsm *dst_fsm, fsm_state_t dst_state)
 {
 	assert(src_fsm != NULL);
@@ -173,7 +173,7 @@ fsm_carryopaque_array(struct fsm *src_fsm, const fsm_state_t *src_set, size_t n,
 }
 
 void
-fsm_carryopaque(struct fsm *src_fsm, const struct state_set *src_set,
+fsm_carryopaque(const struct fsm *src_fsm, const struct state_set *src_set,
 	struct fsm *dst_fsm, fsm_state_t dst_state)
 {
 	fsm_state_t src_state;

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -78,11 +78,11 @@ struct fsm {
 };
 
 void
-fsm_carryopaque_array(struct fsm *src_fsm, const fsm_state_t *src_set, size_t n,
+fsm_carryopaque_array(const struct fsm *src_fsm, const fsm_state_t *src_set, size_t n,
     struct fsm *dst_fsm, fsm_state_t dst_state);
 
 void
-fsm_carryopaque(struct fsm *fsm, const struct state_set *set,
+fsm_carryopaque(const struct fsm *fsm, const struct state_set *set,
 	struct fsm *new, fsm_state_t state);
 
 struct fsm *

--- a/src/lx/main.c
+++ b/src/lx/main.c
@@ -251,7 +251,7 @@ lang_exclude(const char *name)
 }
 
 static void
-carryopaque(struct fsm *src_fsm, const fsm_state_t *src_set, size_t n,
+carryopaque(const struct fsm *src_fsm, const fsm_state_t *src_set, size_t n,
 	struct fsm *dst_fsm, fsm_state_t dst_state)
 {
 	struct mapping_set *conflict;

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -345,7 +345,7 @@ free_all_matches(void)
 }
 
 static void
-carryopaque(struct fsm *src_fsm, const fsm_state_t *src_set, size_t n,
+carryopaque(const struct fsm *src_fsm, const fsm_state_t *src_set, size_t n,
 	struct fsm *dst_fsm, fsm_state_t dst_state)
 {
 	struct match *matches;

--- a/tests/capture/captest.c
+++ b/tests/capture/captest.c
@@ -166,7 +166,7 @@ cleanup:
 
 static struct fsm_options options;
 
-static void captest_carryopaque(struct fsm *src_fsm,
+static void captest_carryopaque(const struct fsm *src_fsm,
     const fsm_state_t *src_set, size_t n,
     struct fsm *dst_fsm, fsm_state_t dst_state)
 {

--- a/theft/fuzz_capture_string_set.c
+++ b/theft/fuzz_capture_string_set.c
@@ -511,7 +511,7 @@ check_captures_for_false_positives(const struct check_env *env,
 
 static struct fsm_options options;
 
-static void css_carryopaque(struct fsm *src_fsm,
+static void css_carryopaque(const struct fsm *src_fsm,
     const fsm_state_t *src_set, size_t n,
     struct fsm *dst_fsm, fsm_state_t dst_state)
 {

--- a/theft/fuzz_literals.c
+++ b/theft/fuzz_literals.c
@@ -15,7 +15,7 @@ add_literal(struct fsm *fsm, const uint8_t *string, size_t size, intptr_t id);
 static bool
 check_literal(struct fsm *fsm, struct fsm_literal_scen *scen, intptr_t id);
 static void
-carryopaque_cb(struct fsm *src_fsm, const fsm_state_t *set, size_t count,
+carryopaque_cb(const struct fsm *src_fsm, const fsm_state_t *set, size_t count,
 	struct fsm *dst_fsm, fsm_state_t state);
 
 static const struct fsm_options opt = {


### PR DESCRIPTION
I'm not sure why this was missing, perhaps as a side effect from some previous arrangement. In any case the intention is that `src_fsm` is immutable. const does not guarantee that, but it's the closest thing we have.