### PR TITLE
stateset: make iterator's set argument const

### DIFF
--- a/include/adt/stateset.h
+++ b/include/adt/stateset.h
@@ -55,7 +55,7 @@ size_t
 state_set_count(const struct state_set *set);
 
 void
-state_set_reset(struct state_set *set, struct state_iter *it);
+state_set_reset(const struct state_set *set, struct state_iter *it);
 
 int
 state_set_next(struct state_iter *it, fsm_state_t *state);

--- a/src/adt/stateset.c
+++ b/src/adt/stateset.c
@@ -539,7 +539,7 @@ state_set_count(const struct state_set *set)
 }
 
 void
-state_set_reset(struct state_set *set, struct state_iter *it)
+state_set_reset(const struct state_set *set, struct state_iter *it)
 {
 	it->i = 0;
 	it->set = set;

--- a/tests/capture/captest.c
+++ b/tests/capture/captest.c
@@ -221,8 +221,6 @@ static void captest_carryopaque(const struct fsm *src_fsm,
 			fprintf(stderr, "carryopaque: eo_src ends -> 0x%x\n",
 			    eo_dst->ends);
 		}
-
-		fsm_setopaque(src_fsm, src_set[i], NULL);
 	}
 }
 


### PR DESCRIPTION
The iterator's set argument should probably be const. It looks like this got missed.

This also has a commit to remove a line from test code, which will be removed in an upcoming branch, but here would need casting to modify the now-const pointer -- this would have been another clue that call was actually incorrect.