### PR TITLE
Fix some misc. lingering issues in the capture code

### DIFF
--- a/src/libfsm/capture.c
+++ b/src/libfsm/capture.c
@@ -505,6 +505,11 @@ step_trail_iter_edges(struct capture_set_path_env *env)
 	}
 
 #if LOG_CAPTURE > 0
+	fprintf(stderr, " -- marking %u as seen\n", e.state);
+#endif
+	MARK_SEEN(env, e.state);
+
+#if LOG_CAPTURE > 0
 	fprintf(stderr, "    -- not seen (%u), exploring\n", e.state);
 #endif
 	env->trail_i++;

--- a/src/libfsm/capture.c
+++ b/src/libfsm/capture.c
@@ -383,6 +383,27 @@ grow_capture_action_buckets(const struct fsm_alloc *alloc,
 }
 
 static int
+grow_trail(struct capture_set_path_env *env)
+{
+	struct trail_cell *ntrail;
+	unsigned nceil;
+	assert(env != NULL);
+
+	nceil = 2 * env->trail_ceil;
+	assert(nceil > env->trail_ceil);
+
+	ntrail = f_realloc(env->fsm->opt->alloc, env->trail,
+	    nceil * sizeof(env->trail[0]));
+	if (ntrail == NULL) {
+		return 0;
+	}
+
+	env->trail = ntrail;
+	env->trail_ceil = nceil;
+	return 1;
+}
+
+static int
 step_trail_start(struct capture_set_path_env *env)
 {
 	struct trail_cell *tc = &env->trail[env->trail_i - 1];
@@ -478,7 +499,9 @@ step_trail_iter_edges(struct capture_set_path_env *env)
 	}
 
 	if (env->trail_i == env->trail_ceil) {
-		assert(!"TODO: grow trail"); /* FIXME exercise this */
+		if (!grow_trail(env)) {
+			return 0;
+		}
 	}
 
 #if LOG_CAPTURE > 0

--- a/src/libfsm/capture_internal.h
+++ b/src/libfsm/capture_internal.h
@@ -78,6 +78,7 @@ struct capture_set_path_env {
 	struct trail_cell {
 		fsm_state_t state;
 		enum trail_step step;
+		char has_self_edge;
 		struct edge_iter iter;
 	} *trail;
 

--- a/src/libfsm/capture_internal.h
+++ b/src/libfsm/capture_internal.h
@@ -100,6 +100,9 @@ grow_capture_action_buckets(const struct fsm_alloc *alloc,
     struct fsm_capture_info *ci);
 
 static int
+grow_trail(struct capture_set_path_env *env);
+
+static int
 step_trail_start(struct capture_set_path_env *env);
 static int
 step_trail_iter_edges(struct capture_set_path_env *env);

--- a/tests/capture/captest.h
+++ b/tests/capture/captest.h
@@ -19,7 +19,10 @@
 #define MAX_TEST_CAPTURES 8
 
 #define CAPTEST_RUN_SINGLE_LOG 0
+
+#ifndef LOG_INTERMEDIATE_FSMS
 #define LOG_INTERMEDIATE_FSMS 0
+#endif
 
 struct captest_single_fsm_test_info {
 	const char *string;

--- a/tests/capture/capture5.c
+++ b/tests/capture/capture5.c
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2020 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <fsm/fsm.h>
+#include <fsm/bool.h>
+#include <fsm/capture.h>
+#include <fsm/pred.h>
+#include <fsm/print.h>
+
+#define LOG_INTERMEDIATE_FSMS 0
+#include "captest.h"
+
+/* Check that self edges are handled properly in the
+ * capture action analysis.
+ *
+ * The DFA corresponds to /a(b*)(c)/. */
+
+static struct fsm *
+build(void);
+
+static void
+check(struct fsm *f, const char *input,
+    unsigned pa_0, unsigned pa_1,
+    unsigned pb_0, unsigned pb_1);
+
+int main(void) {
+	struct fsm *f = build();
+	unsigned captures;
+	assert(f != NULL);
+
+	captures = fsm_countcaptures(f);
+	if (captures != 2) {
+		fprintf(stderr, "expected 2 captures, got %u\n", captures);
+		exit(EXIT_FAILURE);
+	}
+
+	check(f, "ac",
+	    1, 1,
+	    1, 2);
+	check(f, "abc",
+	    1, 2,
+	    2, 3);
+	check(f, "abbc",
+	    1, 3,
+	    3, 4);
+
+	fsm_free(f);
+	return 0;
+}
+
+static struct fsm *
+build(void)
+{
+	struct fsm *fsm = captest_fsm_with_options();
+
+	if (!fsm_addstate_bulk(fsm, 4)) { goto fail; }
+
+	fsm_setstart(fsm, 0);
+	if (!fsm_addedge_literal(fsm, 0, 1, 'a')) { goto fail; }
+
+	if (!fsm_addedge_literal(fsm, 1, 1, 'b')) { goto fail; }
+	if (!fsm_addedge_literal(fsm, 1, 2, 'c')) { goto fail; }
+
+	fsm_setend(fsm, 2, 1);
+
+	if (!fsm_capture_set_path(fsm, 0, 1, 1)) { goto fail; }
+	if (!fsm_capture_set_path(fsm, 1, 1, 2)) { goto fail; }
+
+#if LOG_INTERMEDIATE_FSMS
+	fprintf(stderr, "==== built\n");
+	fsm_print_fsm(stderr, fsm);
+	fsm_capture_dump(stderr, "built", fsm);
+#endif
+
+	if (!fsm_determinise(fsm)) {
+		fprintf(stderr, "Failed to determise\n");
+		exit(EXIT_FAILURE);
+	}
+
+#if LOG_INTERMEDIATE_FSMS
+	fprintf(stderr, "==== after det\n");
+	fsm_print_fsm(stderr, fsm);
+	fsm_capture_dump(stderr, "after det", fsm);
+#endif
+
+	if (!fsm_minimise(fsm)) {
+		fprintf(stderr, "Failed to minimise\n");
+		exit(EXIT_FAILURE);
+	}
+
+#if LOG_INTERMEDIATE_FSMS
+	fprintf(stderr, "==== after min\n");
+	fsm_print_fsm(stderr, fsm);
+	fsm_capture_dump(stderr, "after min", fsm);
+#endif
+	return fsm;
+
+fail:
+	exit(EXIT_FAILURE);
+}
+
+static void
+check(struct fsm *fsm, const char *string,
+    unsigned pa_0, unsigned pa_1,
+    unsigned pb_0, unsigned pb_1)
+{
+	int exec_res;
+	size_t i;
+	struct captest_input input;
+	fsm_state_t end;
+	struct fsm_capture captures[MAX_TEST_CAPTURES];
+
+	fprintf(stderr, "#### check '%s', exp: c%u: (%u, %u), c%u: %u, %u)\n",
+	    string,
+	    0, pa_0, pa_1,
+	    1, pb_0, pb_1);
+
+	input.string = string;
+	input.pos = 0;
+
+	for (i = 0; i < MAX_TEST_CAPTURES; i++) {
+		captures[i].pos[0] = FSM_CAPTURE_NO_POS;
+		captures[i].pos[1] = FSM_CAPTURE_NO_POS;
+	}
+
+	exec_res = fsm_exec(fsm, captest_getc, &input, &end, captures);
+	if (exec_res != 1) {
+		fprintf(stderr, "fsm_exec: %d\n", exec_res);
+		exit(EXIT_FAILURE);
+	}
+
+	/* check captures */
+	fprintf(stderr, "captures for '%s': [%ld, %ld], [%ld, %ld]\n",
+	    string,
+	    captures[0].pos[0], captures[0].pos[1],
+	    captures[1].pos[0], captures[1].pos[1]);
+	assert(captures[0].pos[0] == pa_0);
+	assert(captures[0].pos[1] == pa_1);
+	assert(captures[1].pos[0] == pb_0);
+	assert(captures[1].pos[1] == pb_1);
+}

--- a/tests/capture/capture_long_trail.c
+++ b/tests/capture/capture_long_trail.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <fsm/fsm.h>
+#include <fsm/capture.h>
+
+#include "captest.h"
+/* a(bcdefghijklmnopqrstuvwxy)z
+ * This is long enough to exercise growing the trail for
+ * capture action analysis. */
+
+int main(void) {
+	struct captest_single_fsm_test_info test_info = {
+		"abcdefghijklmnopqrstuvwxyz",
+		{
+			{ 1, 25 },
+		}
+	};
+	return captest_run_single(&test_info);
+}

--- a/theft/fuzz_capture_string_set.c
+++ b/theft/fuzz_capture_string_set.c
@@ -553,7 +553,7 @@ static void css_carryopaque(const struct fsm *src_fsm,
 		/* FIXME: freeing here leads to a use after free */
 		/* f_free(opt->alloc, eo_src); */
 
-		fsm_setopaque(src_fsm, src_set[i], NULL);
+		/* fsm_setopaque(src_fsm, src_set[i], NULL); */
 	}
 }
 

--- a/theft/fuzz_literals.c
+++ b/theft/fuzz_literals.c
@@ -189,7 +189,7 @@ check_literal(struct fsm *fsm, struct fsm_literal_scen *scen, intptr_t id)
 }
 
 static void
-carryopaque_cb(struct fsm *src_fsm, const fsm_state_t *set, size_t count,
+carryopaque_cb(const struct fsm *src_fsm, const fsm_state_t *set, size_t count,
 	struct fsm *dst_fsm, fsm_state_t state)
 {
 	const intptr_t NONE = -1;


### PR DESCRIPTION
- Remove a flag that I thought was necessary to handle the logic properly for PCRE anchors. It wasn't actually necessary, but didn't removed, and still had a silly temporary name.
- Actually grow the capture action trail. Add a test that exercises this. This got missed, and would lead to an assert failure with any capture more than 8 characters long.
- Mark the seen edges during the capture action graph search. This was missing, and while it probably wouldn't affect correctness, it could cause exponential behavior in pathological cases (because of backtracking).
- Add a special case for states with self-edges, so they get appropriate `EXTEND` capture actions added to the DFA. This is necessary for cases like `a(b*)(c)`, where it would handle "ac" correctly (capturing the empty string and "c"), but "abbbc" would not extend the existing capture as it encountered each "b", erroneously leading to "a()bbb(c)" rather than "a(bbb)(c)". Add a test for this (capture5.c). I _think_ this is correct, but it has very subtle interactions with anything else. Only applying captures to DFAs means that we can avoid the inherently ambiguous cases I can think of, such as `a(b*)(b)`, and property testing isn't finding anything else, but it needs more thought. 
- Minor interface changes in the property test code, which is not built by default, and was broken by other interface changes (refining const-ness).

I found most of these by searching for `FIXME`; usually I do that before posting PRs, but these got missed.

Should `step_trail_iter_epsilons`'s " /* skipping this for now */" in `capture.c` be an assert? We currently only support DFAs (it just skips checking epsilon edges), but the interface doesn't really enforce that clearly (such as an `fsm_all(fsm, fsm_isdfa)` check upfront), it just ignores the epsilons.