### PR TITLE
Code generation to awk

### DIFF
--- a/include/fsm/print.h
+++ b/include/fsm/print.h
@@ -16,6 +16,7 @@ struct fsm;
  * specified. The available formats are:
  *
  *  fsm_print_api    - C code which calls the fsm(3) API
+ *  fsm_print_awk    - awk code (gawk dialect)
  *  fsm_print_c      - ISO C90 code
  *  fsm_print_dot    - Graphviz Dot format, intended for rendering graphically
  *  fsm_print_fsm    - fsm(5) .fsm format, suitable for parsing by fsm(1)
@@ -37,6 +38,7 @@ struct fsm;
 typedef void (fsm_print)(FILE *f, const struct fsm *fsm);
 
 fsm_print fsm_print_api;
+fsm_print fsm_print_awk;
 fsm_print fsm_print_c;
 fsm_print fsm_print_dot;
 fsm_print fsm_print_fsm;

--- a/include/print/esc.h
+++ b/include/print/esc.h
@@ -11,6 +11,7 @@ struct fsm_options;
 
 typedef int (escputc)(FILE *f, const struct fsm_options *opt, char c);
 
+escputc awk_escputc;
 escputc c_escputc_char;
 escputc c_escputc_str;
 escputc abnf_escputc;
@@ -21,6 +22,9 @@ escputc json_escputc;
 escputc pcre_escputc;
 escputc rust_escputc_char;
 escputc rust_escputc_str;
+
+void
+awk_escputcharlit(FILE *f, const struct fsm_options *opt, char c);
 
 void
 c_escputcharlit(FILE *f, const struct fsm_options *opt, char c);

--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -156,6 +156,7 @@ print_name(const char *name)
 		fsm_print *f;
 	} a[] = {
 		{ "api",   fsm_print_api   },
+		{ "awk",   fsm_print_awk   },
 		{ "c",     fsm_print_c     },
 		{ "dot",   fsm_print_dot   },
 		{ "fsm",   fsm_print_fsm   },

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -32,6 +32,7 @@ fsm_parse
 
 # <fsm/print.h>
 fsm_print_api
+fsm_print_awk
 fsm_print_c
 fsm_print_dot
 fsm_print_fsm

--- a/src/libfsm/print/Makefile
+++ b/src/libfsm/print/Makefile
@@ -1,6 +1,7 @@
 .include "../../../share/mk/top.mk"
 
 SRC += src/libfsm/print/api.c
+SRC += src/libfsm/print/awk.c
 SRC += src/libfsm/print/c.c
 SRC += src/libfsm/print/dot.c
 SRC += src/libfsm/print/fsm.c
@@ -15,7 +16,7 @@ SRC += src/libfsm/print/vmc.c
 SRC += src/libfsm/print/vmdot.c
 SRC += src/libfsm/print/vmasm.c
 
-.for src in ${SRC:Msrc/libfsm/print/vmc.c} ${SRC:Msrc/libfsm/print/rust.c} ${SRC:Msrc/libfsm/print/sh.c} ${SRC:Msrc/libfsm/print/go.c} ${SRC:Msrc/libfsm/print/vmasm.c} ${SRC:Msrc/libfsm/print/vmdot.c}
+.for src in ${SRC:Msrc/libfsm/print/awk.c} ${SRC:Msrc/libfsm/print/vmc.c} ${SRC:Msrc/libfsm/print/rust.c} ${SRC:Msrc/libfsm/print/sh.c} ${SRC:Msrc/libfsm/print/go.c} ${SRC:Msrc/libfsm/print/vmasm.c} ${SRC:Msrc/libfsm/print/vmdot.c}
 CFLAGS.${src} += -std=c99 # XXX: for ir.h
 DFLAGS.${src} += -std=c99 # XXX: for ir.h
 .endfor

--- a/src/libfsm/print/awk.c
+++ b/src/libfsm/print/awk.c
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2008-2020 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdint.h>
+#include <errno.h>
+#include <stdio.h>
+
+#include <print/esc.h>
+
+#include <adt/set.h>
+
+#include <fsm/fsm.h>
+#include <fsm/pred.h>
+#include <fsm/walk.h>
+#include <fsm/print.h>
+#include <fsm/options.h>
+#include <fsm/vm.h>
+
+#include "libfsm/internal.h"
+
+#include "libfsm/vm/vm.h"
+
+#include "ir.h"
+
+#define START UINT32_MAX
+
+static int
+leaf(FILE *f, const void *state_opaque, const void *leaf_opaque)
+{
+	assert(f != NULL);
+	assert(leaf_opaque == NULL);
+
+	(void) state_opaque;
+	(void) leaf_opaque;
+
+	/* XXX: this should be FSM_UNKNOWN or something non-EOF,
+	 * maybe user defined */
+	fprintf(f, "return -1;");
+
+	return 0;
+}
+
+static const char *
+cmp_operator(int cmp)
+{
+	switch (cmp) {
+	case VM_CMP_LT: return "<";
+	case VM_CMP_LE: return "<=";
+	case VM_CMP_EQ: return "==";
+	case VM_CMP_GE: return ">=";
+	case VM_CMP_GT: return ">";
+	case VM_CMP_NE: return "!=";
+
+	case VM_CMP_ALWAYS:
+	default:
+		assert("unreached");
+		return NULL;
+	}
+}
+
+static void
+print_label(FILE *f, const struct dfavm_op_ir *op)
+{
+	if (op->index == START) {
+		fprintf(f, "\"\"");
+	} else {
+		fprintf(f, "%lu", (unsigned long) op->index);
+	}
+}
+
+static void
+print_cond(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt)
+{
+	if (op->cmp == VM_CMP_ALWAYS) {
+		return;
+	}
+
+	fprintf(f, "if (c %s ", cmp_operator(op->cmp));
+	awk_escputcharlit(f, opt, op->cmp_arg);
+	fprintf(f, ") ");
+}
+
+static void
+print_end(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt,
+	enum dfavm_op_end end_bits, const struct ir *ir)
+{
+	if (end_bits == VM_END_FAIL) {
+		fprintf(f, "return -1");
+		return;
+	}
+
+	if (opt->endleaf != NULL) {
+		opt->endleaf(f, op->ir_state->opaque, opt->endleaf_opaque);
+	} else {
+		fprintf(f, "return %lu", (unsigned long) (op->ir_state - ir->states));
+	}
+}
+
+static void
+print_jump(FILE *f, const struct dfavm_op_ir *op, const char *prefix)
+{
+	fprintf(f, "return %smain(s, ", prefix);
+	print_label(f, op);
+	fprintf(f, ")");
+}
+
+static void
+print_branch(FILE *f, const struct dfavm_op_ir *op, const char *prefix)
+{
+	print_jump(f, op->u.br.dest_arg, prefix);
+}
+
+/* TODO: eventually to be non-static */
+static int
+fsm_print_awkfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
+	const char *cp, const char *prefix,
+	int (*leaf)(FILE *, const void *state_opaque, const void *leaf_opaque),
+	const void *leaf_opaque)
+{
+	static const struct dfavm_assembler_ir zero;
+	struct dfavm_assembler_ir a;
+	struct dfavm_op_ir *op;
+
+	static const struct fsm_vm_compile_opts vm_opts = { FSM_VM_COMPILE_DEFAULT_FLAGS, FSM_VM_COMPILE_VM_V1, NULL };
+
+	assert(f != NULL);
+	assert(ir != NULL);
+	assert(opt != NULL);
+	assert(cp != NULL);
+	assert(prefix != NULL);
+
+	a = zero;
+
+	/* TODO: we don't currently have .opaque information attached to struct dfavm_op_ir.
+	 * We'll need that in order to be able to use the leaf callback here. */
+	(void) leaf;
+	(void) leaf_opaque;
+
+	/* TODO: we'll need to heed cp for e.g. lx's codegen */
+	(void) cp;
+
+	if (!dfavm_compile_ir(&a, ir, vm_opts)) {
+		return -1;
+	}
+
+	/*
+	 * We only output labels for ops which are branched to. This gives
+	 * gaps in the sequence for ops which don't need a label.
+	 * So here we renumber just the ones we use.
+	 */
+	{
+		uint32_t l;
+
+		l = START;
+
+		for (op = a.linked; op != NULL; op = op->next) {
+			if (op == a.linked || op->num_incoming > 0) {
+				op->index = l++;
+			}
+		}
+	}
+
+	fprintf(f, "    switch (l) {\n");
+
+	for (op = a.linked; op != NULL; op = op->next) {
+		if (op == a.linked || op->num_incoming > 0) {
+			if (op != a.linked) {
+				fprintf(f, "\n");
+			}
+
+			fprintf(f, "    case ");
+			print_label(f, op);
+			fprintf(f, ":");
+
+			if (op->ir_state->example != NULL) {
+				fprintf(f, " /* e.g. \"");
+				escputs(f, opt, c_escputc_str, op->ir_state->example);
+				fprintf(f, "\" */");
+			}
+
+			fprintf(f, "\n");
+		}
+
+		fprintf(f, "        ");
+
+		switch (op->instr) {
+		case VM_OP_STOP:
+			print_cond(f, op, opt);
+			print_end(f, op, opt, op->u.stop.end_bits, ir);
+			fprintf(f, ";");
+			break;
+
+		case VM_OP_FETCH: {
+			fprintf(f, "if (s == \"\") ");
+			print_end(f, op, opt, op->u.fetch.end_bits, ir);
+			fprintf(f, "\n");
+
+			fprintf(f, "        ");
+			fprintf(f, "c = substr(s, 1, 1)");
+			fprintf(f, "\n");
+
+			fprintf(f, "        ");
+			fprintf(f, "s = substr(s, 2)");
+			fprintf(f, "\n");
+
+			break;
+		}
+
+		case VM_OP_BRANCH:
+			print_cond(f, op, opt);
+			print_branch(f, op, prefix);
+			break;
+
+		default:
+			assert(!"unreached");
+			break;
+		}
+
+		fprintf(f, "\n");
+	}
+
+	fprintf(f, "    }\n");
+
+	dfavm_opasm_finalize_op(&a);
+
+	return 0;
+}
+
+void
+fsm_print_awk_complete(FILE *f, const struct ir *ir,
+	const struct fsm_options *opt, const char *prefix, const char *cp)
+{
+	assert(f != NULL);
+	assert(ir != NULL);
+	assert(opt != NULL);
+
+	if (opt->fragment) {
+		fsm_print_awkfrag(f, ir, opt, cp, prefix,
+			opt->leaf != NULL ? opt->leaf : leaf, opt->leaf_opaque);
+		return;
+	}
+
+	fprintf(f, "\n");
+
+	fprintf(f, "function %smain(", prefix);
+
+	switch (opt->io) {
+	case FSM_IO_STR:
+		fprintf(f, "s");
+		break;
+
+	case FSM_IO_GETC:
+	case FSM_IO_PAIR:
+	default:
+		fprintf(stderr, "unsupported IO API\n");
+		break;
+	}
+
+	fprintf(f, ",    l, c) {\n");
+
+	fsm_print_awkfrag(f, ir, opt, cp, prefix,
+		opt->leaf != NULL ? opt->leaf : leaf, opt->leaf_opaque);
+
+	fprintf(f, "}\n");
+	fprintf(f, "\n");
+
+}
+
+void
+fsm_print_awk(FILE *f, const struct fsm *fsm)
+{
+	struct ir *ir;
+	const char *prefix;
+	const char *cp;
+
+	assert(f != NULL);
+	assert(fsm != NULL);
+	assert(fsm->opt != NULL);
+
+	ir = make_ir(fsm);
+	if (ir == NULL) {
+		return;
+	}
+
+	if (fsm->opt->prefix != NULL) {
+		prefix = fsm->opt->prefix;
+	} else {
+		prefix = "fsm_";
+	}
+
+	if (fsm->opt->cp != NULL) {
+		cp = fsm->opt->cp;
+	} else {
+		cp = "c"; /* XXX */
+	}
+
+	fsm_print_awk_complete(f, ir, fsm->opt, prefix, cp);
+
+	free_ir(fsm, ir);
+}
+

--- a/src/print/Makefile
+++ b/src/print/Makefile
@@ -1,5 +1,6 @@
 .include "../../share/mk/top.mk"
 
+SRC += src/print/awk.c
 SRC += src/print/c.c
 SRC += src/print/dot.c
 SRC += src/print/abnf.c

--- a/src/print/awk.c
+++ b/src/print/awk.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2008-2017 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <ctype.h>
+#include <assert.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <fsm/fsm.h>
+#include <fsm/options.h>
+
+#include <print/esc.h>
+
+int
+awk_escputc_char(FILE *f, const struct fsm_options *opt, char c)
+{
+	assert(f != NULL);
+	assert(opt != NULL);
+
+	if (opt->always_hex) {
+		return fprintf(f, "\\x%02x", (unsigned char) c);
+	}
+
+	switch (c) {
+	case '\\': return fputs("\\\\", f);
+	case '\'': return fputs("\\\'", f);
+
+	case '\a': return fputs("\\a", f);
+	case '\b': return fputs("\\b", f);
+	case '\f': return fputs("\\f", f);
+	case '\n': return fputs("\\n", f);
+	case '\r': return fputs("\\r", f);
+	case '\t': return fputs("\\t", f);
+	case '\v': return fputs("\\v", f);
+
+	default:
+		break;
+	}
+
+	if (!isprint((unsigned char) c)) {
+		return fprintf(f, "\\x%02x", (unsigned char) c);
+	}
+
+	return fprintf(f, "%c", c);
+}
+
+void
+awk_escputcharlit(FILE *f, const struct fsm_options *opt, char c)
+{
+	assert(f != NULL);
+	assert(opt != NULL);
+
+	if (opt->always_hex || (unsigned char) c > SCHAR_MAX) {
+		fprintf(f, "0x%02x", (unsigned char) c);
+		return;
+	}
+
+	fprintf(f, "\"");
+	awk_escputc_char(f, opt, c);
+	fprintf(f, "\"");
+}
+

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -107,6 +107,7 @@ print_name(const char *name,
 		ast_print *print_ast;
 	} a[] = {
 		{ "api",    fsm_print_api,    NULL },
+		{ "awk",    fsm_print_awk,    NULL },
 		{ "c",      fsm_print_c,      NULL },
 		{ "dot",    fsm_print_dot,    NULL },
 		{ "fsm",    fsm_print_fsm,    NULL },


### PR DESCRIPTION
Here I'm adding code generation to awk. it's unfortunately gawk dialect, because of the switch.

I'm also using recursion to change state (rather than simulating a label as in the Rust codegen, #234). Perhaps that's more suitable for other languages; it's not a great idea in awk. Unlike the Rust codegen, I'm able to fall through between cases.

For a survey of TCO (or the lack of) in awk implementations, see https://blog.0branch.com/posts/2016-05-13-awk-tco.html

Here's how the generated code looks:
![image](https://user-images.githubusercontent.com/1371085/100293962-3f355300-2f3a-11eb-8478-af471e2bfa0c.png)

And the corresponding CFG of VM ops:
![image](https://user-images.githubusercontent.com/1371085/100293993-54aa7d00-2f3a-11eb-8e56-e161e89b7d78.png)
