### PR TITLE
CI with ASAN

### DIFF
--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -1,0 +1,33 @@
+name: ASAN
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest ]
+        cc: [ clang, gcc ]
+        make: [ bmake ]
+    
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: recursive
+
+    - name: dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install bmake pcregrep
+
+    - name: make
+      run: ${{ matrix.make }} -r -j 2 ASAN=1 PKGCONF=pkg-config CC=${{ matrix.cc }}
+
+    - name: test
+      # I don't want to build SID just for sake of its -l test
+      run: ${{ matrix.make }} -r -j 2 ASAN=1 PKGCONF=pkg-config SID='true; echo sid' CC=${{ matrix.cc }} LX=./build/bin/lx test
+

--- a/.github/workflows/asan.yml
+++ b/.github/workflows/asan.yml
@@ -25,9 +25,9 @@ jobs:
         sudo apt-get install bmake pcregrep
 
     - name: make
-      run: ${{ matrix.make }} -r -j 2 ASAN=1 PKGCONF=pkg-config CC=${{ matrix.cc }}
+      run: ${{ matrix.make }} -r -j 2 ASAN=1 DEBUG=1 PKGCONF=pkg-config CC=${{ matrix.cc }}
 
     - name: test
       # I don't want to build SID just for sake of its -l test
-      run: ${{ matrix.make }} -r -j 2 ASAN=1 PKGCONF=pkg-config SID='true; echo sid' CC=${{ matrix.cc }} LX=./build/bin/lx test
+      run: ${{ matrix.make }} -r -j 2 ASAN=1 DEBUG=1 PKGCONF=pkg-config SID='true; echo sid' CC=${{ matrix.cc }} LX=./build/bin/lx test
 

--- a/src/lx/main.c
+++ b/src/lx/main.c
@@ -617,6 +617,8 @@ run_threads(int concurrency, void *(*fn)(void *))
 		}
 	}
 
+	free(tds);
+
 	return 0;
 }
 

--- a/src/lx/main.c
+++ b/src/lx/main.c
@@ -1046,3 +1046,7 @@ main(int argc, char *argv[])
 	return EXIT_SUCCESS;
 }
 
+/* XXX: we're not interested in leaks in lx for the moment; ASAN is applied
+ * for the libraries only. cleanup for lx's own structures should be addressed
+ * at some point; excluding this is sloppy, but it's less important right now. */
+const char * __asan_default_options() { return "detect_leaks=0"; }


### PR DESCRIPTION
I'm adding a run under ASAN, for leak detection.

This is probably annoying because we have a bunch of leaks in tests, and there doesn't seem to be a good way to ignore those. But I figure finding leaks in the libraries is important enough to make it worthwhile.

My intention is to merge this, fix up whatever needs fixing, and then rely on it for spotting leaks in new code.

Here I'm including both gcc and clang, just in case they find anything different. I've removed the `install` target (because we're not testing that), and just one bmake variant (because it's not the makefiles we're testing here).