### PR TITLE
Fix various leaks exposed by ASAN when running tests and reperf

### DIFF
--- a/reperf/boost.scr
+++ b/reperf/boost.scr
@@ -1,0 +1,59 @@
+# simple matches from Boost
+
+- test 1
+M abc
+D pcre
+S abc
+N 1000000
+R 1
+X
+
+- test 2
+M ^([0-9]+)(-| |$)(.*)$
+D pcre
+S 100- this is a line of ftp response which contains a message string
+N 1000000
+R 1
+X
+
+- test 3
+M ([[:digit:]]{4}[- ]){3}[[:digit:]]{3,4}
+D pcre
+S 1234-5678-1234-456
+N 1000000
+R 1
+X
+
+- test 4
+M ^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$
+D pcre
+S john@johnmaddock.co.uk
+N 1000000
+R 1
+X
+
+- test 5
+M ^([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)$
+D pcre
+S foo12@foo.edu
+N 1000000
+R 1
+X
+Q
+
+- gutten 3
+M [[:alpha:]]+ing
+D pcre
+F mtent/mtent12.txt
+N 10
+R 1
+X
+
+- gutten 6
+M (Tom|Sawyer|Huckleberry|Finn).{0,30}river|river.{0,30}(Tom|Sawyer|Huckleberry|Finn)
+D pcre
+F mtent/mtent12.txt
+N 10
+R 1
+X
+

--- a/src/libfsm/capture.c
+++ b/src/libfsm/capture.c
@@ -39,6 +39,7 @@ fsm_capture_free(struct fsm *fsm)
 	if (ci == NULL) {
 		return;
 	}
+	f_free(fsm->opt->alloc, ci->buckets);
 	f_free(fsm->opt->alloc, ci);
 	fsm->capture_info = NULL;
 }

--- a/src/libfsm/fsm.c
+++ b/src/libfsm/fsm.c
@@ -34,6 +34,8 @@ free_contents(struct fsm *fsm)
 		edge_set_free(fsm->opt->alloc, fsm->states[i].edges);
 	}
 
+	fsm_capture_free(fsm);
+
 	f_free(fsm->opt->alloc, fsm->states);
 }
 

--- a/src/libfsm/vm.c
+++ b/src/libfsm/vm.c
@@ -127,7 +127,7 @@ fsm_vm_compile(const struct fsm *fsm)
 void
 fsm_vm_free(struct fsm_dfavm *vm)
 {
-	(void)vm;
+	dfavm_free_vm(vm);
 }
 
 static enum dfavm_state

--- a/src/libfsm/vm/v1.c
+++ b/src/libfsm/vm/v1.c
@@ -415,3 +415,11 @@ vm_match_v1(const struct dfavm_v1 *vm, struct vm_state *st, const char *buf, siz
 	return VM_FAIL;
 }
 
+void
+dfavm_v1_finalize(struct dfavm_v1 *vm)
+{
+	free(vm->ops);
+	vm->ops = NULL;
+	vm->len = 0;
+}
+

--- a/src/libfsm/vm/v2.c
+++ b/src/libfsm/vm/v2.c
@@ -319,3 +319,15 @@ vm_match_v2(const struct dfavm_v2 *vm, struct vm_state *st, const char *buf, siz
 	return VM_FAIL;
 }
 
+void
+dfavm_v2_finalize(struct dfavm_v2 *vm)
+{
+	free(vm->abuf);
+	vm->abuf = NULL;
+	vm->alen = 0;
+
+	free(vm->ops);
+	vm->ops = NULL;
+	vm->len = 0;
+}
+

--- a/src/libfsm/vm/vm.c
+++ b/src/libfsm/vm/vm.c
@@ -473,3 +473,18 @@ error:
 	return NULL;
 }
 
+void
+dfavm_free_vm(struct fsm_dfavm *vm)
+{
+	if (vm->version_major == DFAVM_VARENC_MAJOR && vm->version_minor == DFAVM_VARENC_MINOR) {
+		dfavm_v1_finalize(&vm->u.v1);
+	} else if (vm->version_major == DFAVM_FIXEDENC_MAJOR && vm->version_minor == DFAVM_FIXEDENC_MINOR) {
+		dfavm_v2_finalize(&vm->u.v2);
+	} else {
+		/* invalid VM version! */
+		/* XXX - should we do something? */
+	}
+
+	free(vm);
+}
+

--- a/src/libfsm/vm/vm.c
+++ b/src/libfsm/vm/vm.c
@@ -477,6 +477,10 @@ error:
 void
 dfavm_free_vm(struct fsm_dfavm *vm)
 {
+	if (vm == NULL) {
+		return;
+	}
+
 	if (vm->version_major == DFAVM_VARENC_MAJOR && vm->version_minor == DFAVM_VARENC_MINOR) {
 		dfavm_v1_finalize(&vm->u.v1);
 	} else if (vm->version_major == DFAVM_FIXEDENC_MAJOR && vm->version_minor == DFAVM_FIXEDENC_MINOR) {

--- a/src/libfsm/vm/vm.c
+++ b/src/libfsm/vm/vm.c
@@ -5,6 +5,7 @@
  */
 
 #include <assert.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -482,7 +483,7 @@ dfavm_free_vm(struct fsm_dfavm *vm)
 		dfavm_v2_finalize(&vm->u.v2);
 	} else {
 		/* invalid VM version! */
-		/* XXX - should we do something? */
+		assert(false && "unsupported version passed in");
 	}
 
 	free(vm);

--- a/src/libfsm/vm/vm.h
+++ b/src/libfsm/vm/vm.h
@@ -197,6 +197,9 @@ struct fsm_dfavm *
 dfavm_compile_vm(const struct dfavm_assembler_ir *a, struct fsm_vm_compile_opts opts);
 
 void
+dfavm_free_vm(struct fsm_dfavm *vm);
+
+void
 dfavm_opasm_finalize_op(struct dfavm_assembler_ir *a);
 
 /* v1 */
@@ -219,6 +222,12 @@ void
 running_print_op_v2(const struct dfavm_v2 *vm, uint32_t pc, const char *sp, const char *buf, size_t n, char ch, FILE *f);
 enum dfavm_state
 vm_match_v2(const struct dfavm_v2 *vm, struct vm_state *st, const char *buf, size_t n);
+
+void
+dfavm_v1_finalize(struct dfavm_v1 *vm);
+
+void
+dfavm_v2_finalize(struct dfavm_v2 *vm);
 
 #endif
 

--- a/src/retest/reperf.c
+++ b/src/retest/reperf.c
@@ -696,12 +696,12 @@ perf_case_run(struct perf_case *c, enum halt halt,
 		}
 	}
 
+	ret = ERROR_NONE;
+
 	if (c->mt != MATCH_NONE) {
 		struct timespec t0, t1;
 
 		xclock_gettime(&t0);
-
-		ret = ERROR_NONE;
 
 		for (iter=0; iter < c->count; iter++) {
 			int r;
@@ -721,21 +721,18 @@ perf_case_run(struct perf_case *c, enum halt halt,
 			str_free(&contents);
 		}
 
-		if (ret != ERROR_NONE) {
-			fsm_runner_finalize(&runner);
-			return ret;
+		if (ret == ERROR_NONE) {
+			xclock_gettime(&t1);
+
+			report_delta(&t->run_delta, &t0, &t1);
 		}
-
-		xclock_gettime(&t1);
-
-		report_delta(&t->run_delta, &t0, &t1);
 	}
 
 done:
 
 	fsm_runner_finalize(&runner);
 
-	return ERROR_NONE;
+	return ret;
 }
 
 static void

--- a/src/retest/reperf.c
+++ b/src/retest/reperf.c
@@ -302,6 +302,14 @@ perf_case_init(struct perf_case *c, enum implementation impl)
 	c->expected_matches = 1;
 }
 
+static void
+perf_case_finalize(struct perf_case *c)
+{
+	str_free(&c->test_name);
+	str_free(&c->regexp);
+	str_free(&c->match);
+}
+
 static enum error_type
 perf_case_run(struct perf_case *c, enum halt halt,
 	struct timing *t);
@@ -492,6 +500,7 @@ parse_perf_case(FILE *f, enum implementation impl, enum halt halt, int quiet, in
 	}
 
 	free(buf);
+	perf_case_finalize(&c);
 
 	return 0;
 }

--- a/src/retest/reperf.c
+++ b/src/retest/reperf.c
@@ -626,6 +626,10 @@ perf_case_run(struct perf_case *c, enum halt halt,
 			if (fsm == NULL) {
 				return ERROR_PARSING_REGEXP;
 			}
+
+			if (iter < c->count-1) {
+				fsm_free(fsm);
+			}
 		}
 
 		xclock_gettime(&c1);

--- a/tests/capture/captest.h
+++ b/tests/capture/captest.h
@@ -55,4 +55,10 @@ captest_fsm_with_options(void);
 struct fsm *
 captest_fsm_of_string(const char *string, unsigned end_id);
 
+struct captest_end_opaque *
+captest_new_opaque(void);
+
+void
+captest_free_all_end_opaques(void);
+
 #endif

--- a/tests/capture/capture3.c
+++ b/tests/capture/capture3.c
@@ -143,7 +143,9 @@ int main(void) {
 	check(f_all, "cde", 1, bases[1].capture);
 	check(f_all, "fghi", 2, bases[2].capture);
 
+
 	fsm_free(f_all);
+	captest_free_all_end_opaques();
 
 	return 0;
 }

--- a/tests/capture/capture4.c
+++ b/tests/capture/capture4.c
@@ -66,6 +66,7 @@ int main(void) {
 	    cb_ab_c, 0, 4);
 
 	fsm_free(f_all);
+	captest_free_all_end_opaques();
 
 	return 0;
 }
@@ -175,7 +176,7 @@ build_ab_c(void)
 	struct fsm *fsm = captest_fsm_with_options();
 	assert(fsm != NULL);
 
-	eo = calloc(1, sizeof(*eo));
+	eo = captest_new_opaque();
 	if (eo == NULL) { goto fail; }
 
 	eo->tag = CAPTEST_END_OPAQUE_TAG;

--- a/tests/capture/capture5.c
+++ b/tests/capture/capture5.c
@@ -53,6 +53,8 @@ int main(void) {
 	    3, 4);
 
 	fsm_free(f);
+	captest_free_all_end_opaques();
+
 	return 0;
 }
 

--- a/tests/capture/capture_concat1.c
+++ b/tests/capture/capture_concat1.c
@@ -34,6 +34,8 @@ int main(void) {
 	    cb_cde, 2, 5);
 
 	fsm_free(abcde);
+	captest_free_all_end_opaques();
+
 	return EXIT_SUCCESS;
 }
 

--- a/tests/capture/capture_concat2.c
+++ b/tests/capture/capture_concat2.c
@@ -34,6 +34,8 @@ int main(void) {
 	    cb_de, 3, 5);
 
 	fsm_free(abcde);
+	captest_free_all_end_opaques();
+
 	return EXIT_SUCCESS;
 }
 

--- a/tests/capture/capture_union1.c
+++ b/tests/capture/capture_union1.c
@@ -34,6 +34,8 @@ int main(void) {
 	check(abcde, "cde", 1, cb_cde, 0, 3);
 
 	fsm_free(abcde);
+	captest_free_all_end_opaques();
+
 	return EXIT_SUCCESS;
 }
 

--- a/tests/capture/capture_union2.c
+++ b/tests/capture/capture_union2.c
@@ -34,6 +34,8 @@ int main(void) {
 	check(fsm, "abed", 1, cb_abed, 0, 4);
 
 	fsm_free(fsm);
+	captest_free_all_end_opaques();
+
 	return EXIT_SUCCESS;
 }
 


### PR DESCRIPTION
Running the usual tests and reperf with the leak detector in ASAN found a bunch of leaks:

- `fsm_vm_free()` was previously a stub that did nothing but leak VM data.  Now it actually frees the VM data (faf8abd)
- `reperf` itself had a number of leaks (b1d2c45, 963e0c5, f8e7d96)
- Capture data was not freed in `fsm_free()`, and now is (2480033 and fb4afee)  ping: @silentbicycle 
- The "opaque" data used by capture tests (see below).  ping: @silentbicycle 

This PR also includes an example `reperf` script (f13522b).

A note about the opaque data used by the capture tests:
As mentioned in the comment in [captest.c](https://github.com/katef/libfsm/commit/06dedbec7d72b6e069759d3d0af4a4a3d8be5cb9#diff-bd9ad04eaafdcbeab4448632ca77b3b835490c23f77fc4caf95ae065b8145aa2R16-R24):
```/* Pool allocator for opaque data to eliminates inadvertent memory leaks.
 *
 * XXX - this isn't great, but it's quite hard to keep track of opaque
 *       data through the various fsm operations.
 *
 *       The right solution is probably to have each fsm keep an opaque
 *       "destructor" that it calls when the states of an FSM are
 *       destroyed.
 */
```
The pool allocator is a hack here.  It would be much better to give libfsm a opaque destructor callback to inform the client whenever a piece of opaque data is no longer referenced.  However, that's far beyond the scope of this PR.