### PR TITLE
Fixes various compiler warnings

### DIFF
--- a/src/libfsm/print/go.c
+++ b/src/libfsm/print/go.c
@@ -211,7 +211,8 @@ fsm_print_gofrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 static void
 fsm_print_go_complete(FILE *f, const struct ir *ir, const struct fsm_options *opt)
 {
-	const char *cp;
+	/* TODO: currently unused, but must be non-NULL */
+	const char *cp = "";
 
 	assert(f != NULL);
 	assert(ir != NULL);

--- a/src/libfsm/print/vmc.c
+++ b/src/libfsm/print/vmc.c
@@ -228,7 +228,8 @@ fsm_print_cfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 static void
 fsm_print_c_complete(FILE *f, const struct ir *ir, const struct fsm_options *opt)
 {
-	const char *cp;
+	/* TODO: currently unused, but must be non-NULL */
+	const char *cp = "";
 
 	assert(f != NULL);
 	assert(ir != NULL);

--- a/src/libfsm/print/vmdot.c
+++ b/src/libfsm/print/vmdot.c
@@ -300,7 +300,6 @@ void
 fsm_print_vmdot(FILE *f, const struct fsm *fsm)
 {
 	struct ir *ir;
-	const char *prefix;
 
 	assert(f != NULL);
 	assert(fsm != NULL);
@@ -312,12 +311,6 @@ fsm_print_vmdot(FILE *f, const struct fsm *fsm)
 	}
 
 	/* henceforth, no function should be passed struct fsm *, only the ir and options */
-
-	if (fsm->opt->prefix != NULL) {
-		prefix = fsm->opt->prefix;
-	} else {
-		prefix = "fsm_";
-	}
 
 	if (fsm->opt->fragment) {
 		fsm_print_vmdotfrag(f, ir, fsm->opt);

--- a/src/retest/reperf.c
+++ b/src/retest/reperf.c
@@ -1135,7 +1135,18 @@ main(int argc, char *argv[])
 		char buf[128];
 		printf("paused\n");
 		fflush(stdout);
-		fgets(buf, sizeof buf, stdin);
+
+		for (;;) {
+			size_t blen;
+			if (fgets(buf, sizeof buf, stdin) == NULL) {
+				break;
+			}
+
+			blen = strlen(buf);
+			if (blen == 0 || buf[blen-1] == '\n') {
+				break;
+			}
+		}
 	}
 
 	if (tsv) {


### PR DESCRIPTION
This fixes a few compiler warnings that gcc 9.3 identifies.

The biggest change is the `fgets` handling in `reperf`.  gcc issued a warning that the return value was being ignored.  I've replaced it with a loop that correctly handles the full range of `fgets` behavior.
