### PR TITLE
Various improvements to reperf

### DIFF
--- a/src/retest/reperf.c
+++ b/src/retest/reperf.c
@@ -1007,6 +1007,14 @@ usage(void)
 	fprintf(stderr, "        <driverfile> specifies the path to the driver file, or '-' to read it from stdin\n");
 
 	fprintf(stderr, "\n");
+	fprintf(stderr, "        -e\n");
+	fprintf(stderr, "             echo: echos driver script commands and how reperf interprets them\n");
+
+	fprintf(stderr, "\n");
+	fprintf(stderr, "        -C\n");
+	fprintf(stderr, "             disables profiling regexp compile time\n");
+
+	fprintf(stderr, "\n");
 	fprintf(stderr, "        -q\n");
 	fprintf(stderr, "             quiet: elide the regexp from output (useful for long regexps)\n");
 
@@ -1021,6 +1029,10 @@ usage(void)
 	fprintf(stderr, "\n");
 	fprintf(stderr, "        -H <halt>\n");
 	fprintf(stderr, "             halt after compile, glushkovise, determinise, minimise or execute\n");
+
+	fprintf(stderr, "\n");
+	fprintf(stderr, "        -N <cycles>\n");
+	fprintf(stderr, "             executes all tests <cycles> times, overriding any N commands in the script\n");
 
 	fprintf(stderr, "\n");
 	fprintf(stderr, "        -O <olevel>\n");

--- a/src/retest/reperf.c
+++ b/src/retest/reperf.c
@@ -76,6 +76,8 @@
  * 				<test_name>.<subtest_name>, otherwise
  * 				<test_name>
  *
+ * Q                            stops the script, exits, reporting success.
+ *
  * Lines ending with \ are continued to the next line.
  * Both F and S directives may be omitted to measure compilation time only,
  * in which case X should still be given.

--- a/src/retest/reperf.c
+++ b/src/retest/reperf.c
@@ -86,6 +86,7 @@ static struct fsm_vm_compile_opts vm_opts = { 0, FSM_VM_COMPILE_VM_V1, NULL };
 
 static int echo = 0;
 static int disable_comp_timing = 0;
+static int num_cycles = -1;
 
 enum match_type {
 	MATCH_NONE,
@@ -523,6 +524,11 @@ parse_perf_case(FILE *f, enum implementation impl, enum halt halt, int quiet, in
 			}
 
 			t.comp_delta = t.glush_delta = t.det_delta = t.min_delta = t.run_delta = 0.0;
+
+			if (num_cycles > 0) {
+				c.count = num_cycles;
+			}
+
 			err = perf_case_run(&c, halt, &t);
 			if (tsv) {
 				perf_case_report_tsv(&c, halt, err, quiet, &t);
@@ -1106,7 +1112,7 @@ main(int argc, char *argv[])
 	{
 		int c;
 
-		while (c = getopt(argc, argv, "h" "O:L:l:x:" "CepqtH:" ), c != -1) {
+		while (c = getopt(argc, argv, "h" "O:L:l:x:" "CepqtH:N:" ), c != -1) {
 			switch (c) {
 			case 'O':
 				optlevel = strtoul(optarg, NULL, 10);
@@ -1179,6 +1185,24 @@ main(int argc, char *argv[])
 			case 'h':
 				usage();
 				return EXIT_SUCCESS;
+
+			case 'N':
+				{
+					char *end = NULL;
+					long num;
+
+					errno = 0;
+					num = strtol(optarg, &end, 10);
+
+					if (errno != 0 || !end || *end != '\0') {
+						fprintf(stderr, "invalid argument to -N: %s\n", optarg);
+						usage();
+						exit(1);
+					}
+
+					num_cycles = num;
+				}
+				break;
 
 			case '?':
 			default:

--- a/src/retest/reperf.c
+++ b/src/retest/reperf.c
@@ -355,6 +355,7 @@ parse_perf_case(FILE *f, enum implementation impl, enum halt halt, int quiet, in
 		char last;
 		char *b;
 		size_t len;
+		int quit;
 
 		line++;
 		len = strlen(s);
@@ -418,6 +419,7 @@ parse_perf_case(FILE *f, enum implementation impl, enum halt halt, int quiet, in
 			continue;
 		}
 
+		quit = 0;
 		switch (s[0]) {
 		case '#':
 			/* comment, skip */
@@ -530,9 +532,20 @@ parse_perf_case(FILE *f, enum implementation impl, enum halt halt, int quiet, in
 			perf_case_reset(&c);
 			break;
 
+		case 'Q':
+			if (echo) {
+				fprintf(stderr, "ECHO::: QUIT\n");
+			}
+			quit = 1;
+			break;
+
 		default:
 			fprintf(stderr, "line %zu: unknown command '%c': %s\n", line, s[0], s);
 			exit(EXIT_FAILURE);
+		}
+
+		if (quit) {
+			break;
 		}
 	}
 


### PR DESCRIPTION
Adds:
- `-e` option (for echo).  This describes each line read and what it does.  Useful for debugging.
- `Q` script command to quit the script early.
- `-C` flag to disable regexp compile measurements (which can be quite time consuming)
- `-N <cycles>` option to override the `N` commands for each line in the script.
