### PR TITLE
DFA match group part two, end IDs

### DIFF
--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -223,12 +223,16 @@ fsm_setendid(struct fsm *fsm, fsm_end_id_t id);
  * If id_buf has enough cells to store all the end IDs (according
  * to id_buf_count) then they are written into id_buf[] and
  * *ids_written is set to the number of IDs. The end IDs in the
- * buffer will be in ascending order (FIXME: not currently
- * enforced).
+ * buffer may appear in any order, but should not have duplicates.
  *
  * Returns 0 if there is not enough space in id_buf for the
  * end IDs, or 1 if zero or more end IDs were returned. */
-int
+enum fsm_getendids_res {
+	FSM_GETENDIDS_NOT_FOUND,
+	FSM_GETENDIDS_FOUND,
+	FSM_GETENDIDS_ERROR_INSUFFICIENT_SPACE = -1
+};
+enum fsm_getendids_res
 fsm_getendids(const struct fsm *fsm, fsm_state_t end_state,
     size_t id_buf_count, fsm_end_id_t *id_buf,
     size_t *ids_written);

--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -222,7 +222,9 @@ fsm_setendid(struct fsm *fsm, fsm_end_id_t id);
 /* Get the end IDs associated with an end state, if any.
  * If id_buf has enough cells to store all the end IDs (according
  * to id_buf_count) then they are written into id_buf[] and
- * *ids_written is set to the number of IDs.
+ * *ids_written is set to the number of IDs. The end IDs in the
+ * buffer will be in ascending order (FIXME: not currently
+ * enforced).
  *
  * Returns 0 if there is not enough space in id_buf for the
  * end IDs, or 1 if zero or more end IDs were returned. */

--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -28,6 +28,11 @@ struct fsm_combine_info;
  */
 typedef unsigned int fsm_state_t;
 
+/* FSMs can have an opaque numeric identifier associated with
+ * their end states. These can be used to determine which of the
+ * original FSM(s) matched when executing a combined FSM. */
+typedef unsigned int fsm_end_id_t;
+
 /*
  * Create a new FSM. This is to be freed with fsm_free(). A structure allocated
  * from fsm_new() is expected to be passed as the "fsm" argument to the
@@ -200,6 +205,35 @@ fsm_setopaque(struct fsm *fsm, fsm_state_t state, void *opaque);
  */
 void *
 fsm_getopaque(const struct fsm *fsm, fsm_state_t state);
+
+/* Associate a numeric ID with the end states in an fsm.
+ * This can be used to track which of the original fsms matched
+ * input when multiple fsms are combined.
+ *
+ * These will be preserved through the following operations:
+ * - determinise
+ * - union
+ * - concat
+ * - ...
+ * */
+int
+fsm_setendid(struct fsm *fsm, fsm_end_id_t id);
+
+/* Get the end IDs associated with an end state, if any.
+ * If id_buf has enough cells to store all the end IDs (according
+ * to id_buf_count) then they are written into id_buf[] and
+ * *ids_written is set to the number of IDs.
+ *
+ * Returns 0 if there is not enough space in id_buf for the
+ * end IDs, or 1 if zero or more end IDs were returned. */
+int
+fsm_getendids(const struct fsm *fsm, fsm_state_t end_state,
+    size_t id_buf_count, fsm_end_id_t *id_buf,
+    size_t *ids_written);
+
+/* Get the number of end IDs associated with an end state. */
+size_t
+fsm_getendidcount(const struct fsm *fsm, fsm_state_t end_state);
 
 /*
  * Find the state (if there is just one), or add epsilon edges from all states,

--- a/src/libfsm/Makefile
+++ b/src/libfsm/Makefile
@@ -9,6 +9,7 @@ SRC += src/libfsm/closure.c
 SRC += src/libfsm/edge.c
 SRC += src/libfsm/empty.c
 SRC += src/libfsm/end.c
+SRC += src/libfsm/endids.c
 SRC += src/libfsm/equal.c
 SRC += src/libfsm/exec.c
 SRC += src/libfsm/fsm.c

--- a/src/libfsm/capture_internal.h
+++ b/src/libfsm/capture_internal.h
@@ -25,9 +25,6 @@
 
 #define LOG_CAPTURE 0
 
-/* 32-bit approximation of golden ratio, used for hashing */
-#define PHI32 0x9e3779b9
-
 /* Most significant bit of a size_t. */
 #define COMMITTED_CAPTURE_FLAG ((SIZE_MAX) ^ (SIZE_MAX >> 1))
 

--- a/src/libfsm/clone.c
+++ b/src/libfsm/clone.c
@@ -16,9 +16,15 @@
 
 #include "internal.h"
 #include "capture.h"
+#include "endids.h"
+
+#define LOG_CLONE_ENDIDS 0
 
 static int
 copy_capture_actions(struct fsm *dst, const struct fsm *src);
+
+static int
+copy_end_ids(struct fsm *dst, const struct fsm *src);
 
 struct fsm *
 fsm_clone(const struct fsm *fsm)
@@ -69,6 +75,11 @@ fsm_clone(const struct fsm *fsm)
 			fsm_free(new);
 			return NULL;
 		}
+
+		if (!copy_end_ids(new, fsm)) {
+			fsm_free(new);
+			return NULL;
+		}
 	}
 
 	return new;
@@ -106,3 +117,43 @@ copy_capture_actions(struct fsm *dst, const struct fsm *src)
 	return env.ok;
 }
 
+struct copy_end_ids_env {
+	char tag;
+	struct fsm *dst;
+	const struct fsm *src;
+	int ok;
+};
+
+static int
+copy_end_ids_cb(fsm_state_t state, const fsm_end_id_t id, void *opaque)
+{
+	struct copy_end_ids_env *env = opaque;
+	enum fsm_endid_set_res sres;
+	assert(env->tag == 'c');
+
+#if LOG_CLONE_ENDIDS
+	fprintf(stderr, "clone[%d] <- %d\n", state, id);
+#endif
+
+	sres = fsm_endid_set(env->dst, state, id);
+	if (sres == FSM_ENDID_SET_ERROR_ALLOC_FAIL) {
+		env->ok = 0;
+		return 0;
+	}
+
+	return 1;
+}
+
+static int
+copy_end_ids(struct fsm *dst, const struct fsm *src)
+{
+	struct copy_end_ids_env env;
+	env.tag = 'c';		/* for clone */
+	env.dst = dst;
+	env.src = src;
+	env.ok = 1;
+
+	fsm_endid_iter(src, copy_end_ids_cb, &env);
+
+	return env.ok;
+}

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -22,6 +22,7 @@
 
 #include "internal.h"
 #include "capture.h"
+#include "endids.h"
 
 #define DUMP_MAPPING 0
 #define LOG_DETERMINISE_CLOSURES 0
@@ -274,7 +275,7 @@ fsm_determinise(struct fsm *nfa)
 
 		/*
 		 * The closure of a set is equivalent to the union of closures of
-		 * each item. Here we iteratively build up sclosures[] in-situ
+		 * each item. Here we iteratively build up closures[] in-situ
 		 * to avoid needing to create a state set to store the union.
 		 */
 		{
@@ -416,6 +417,10 @@ fsm_determinise(struct fsm *nfa)
 			 * known to have been an end state.
 			 */
 			fsm_carryopaque(nfa, m->closure, dfa, m->dfastate);
+
+			if (!fsm_endid_carry(nfa, m->closure, dfa, m->dfastate)) {
+				goto error;
+			}
 		}
 
 		if (!remap_capture_actions(mappings, dfa, nfa)) {

--- a/src/libfsm/endids.c
+++ b/src/libfsm/endids.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include "endids_internal.h"
+
+struct fsm_endid_info *
+fsm_endid_alloc(struct fsm_alloc *alloc)
+{
+	(void)alloc;
+	return NULL;
+}
+
+void
+fsm_endid_free(struct fsm_endid_info *ei)
+{
+	(void)ei;
+}
+
+int
+fsm_endid_set(struct fsm_endid_info *ei,
+    fsm_state_t state, fsm_end_id_t id)
+{
+	(void)ei;
+	(void)state;
+	(void)id;
+	return 0;
+}
+
+size_t
+fsm_endid_count(const struct fsm_endid_info *ei,
+    fsm_state_t state)
+{
+	(void)ei;
+	(void)state;
+	return 0;
+}
+
+int
+fsm_endid_get(const struct fsm_endid_info *ei, fsm_state_t end_state,
+    size_t id_buf_count, fsm_end_id_t *id_buf,
+    size_t *ids_written)
+{
+	(void)ei;
+	(void)end_state;
+	(void)id_buf;
+	(void)id_buf_count;
+	(void)ids_written;
+	return 0;
+}

--- a/src/libfsm/endids.c
+++ b/src/libfsm/endids.c
@@ -6,6 +6,25 @@
 
 #include "endids_internal.h"
 
+#define LOG_ENDIDS 0
+
+static void
+dump_buckets(const char *tag, const struct endid_info *ei)
+{
+#if LOG_ENDIDS > 3
+	size_t j;
+	for (j = 0; j < ei->bucket_count; j++) {
+		struct endid_info_bucket *b = &ei->buckets[j];
+		fprintf(stderr, "%s[%lu/%u]: %d (on %p)\n",
+		    tag,
+		    j, ei->bucket_count, b->state, (void *)ei->buckets);
+	}
+#else
+	(void)tag;
+	(void)ei;
+#endif
+}
+
 int
 fsm_setendid(struct fsm *fsm, fsm_end_id_t id)
 {
@@ -14,7 +33,13 @@ fsm_setendid(struct fsm *fsm, fsm_end_id_t id)
 	/* for every end state */
 	for (i = 0; i < fsm->statecount; i++) {
 		if (fsm_isend(fsm, i)) {
-			if (!fsm_endid_set(fsm, i, id)) {
+			enum fsm_endid_set_res sres;
+#if LOG_ENDIDS > 3
+			fprintf(stderr, "fsm_setendid: setting id %u on state %d\n",
+			    id, i);
+#endif
+			sres = fsm_endid_set(fsm, i, id);
+			if (sres == FSM_ENDID_SET_ERROR_ALLOC_FAIL) {
 				return 0;
 			}
 		}
@@ -23,7 +48,7 @@ fsm_setendid(struct fsm *fsm, fsm_end_id_t id)
 	return 1;
 }
 
-int
+enum fsm_getendids_res
 fsm_getendids(const struct fsm *fsm, fsm_state_t end_state,
     size_t id_buf_count, fsm_end_id_t *id_buf,
     size_t *ids_written)
@@ -41,84 +66,302 @@ fsm_getendidcount(const struct fsm *fsm, fsm_state_t end_state)
 int
 fsm_endid_init(struct fsm *fsm)
 {
-	struct fsm_endid_info *res = f_calloc(fsm->opt->alloc, 1, sizeof(*res));
-	assert(res != NULL);
+	struct endid_info_bucket *buckets = NULL;
+	size_t i;
+	struct endid_info *res = f_calloc(fsm->opt->alloc, 1, sizeof(*res));
+	if (res == NULL) {
+		return 0;
+	}
 
-	res->alloc = fsm->opt->alloc;
+	buckets = f_malloc(fsm->opt->alloc,
+	    DEF_BUCKET_COUNT * sizeof(buckets[0]));
+	if (buckets == NULL) {
+		f_free(fsm->opt->alloc, res);
+		return 0;
+	}
+
+	/* initialize the hash table's buckets to empty */
+	for (i = 0; i < DEF_BUCKET_COUNT; i++) {
+		buckets[i].state = BUCKET_NO_STATE;
+	}
+
+	res->buckets = buckets;
+	res->bucket_count = DEF_BUCKET_COUNT;
+	res->buckets_used = 0;
+
 	fsm->endid_info = res;
+
+#if LOG_ENDIDS > 3
+	fprintf(stderr, "fsm_endid_init: initialized with %u buckets\n",
+	    res->bucket_count);
+#endif
+
 	return 1;
 }
 
 void
 fsm_endid_free(struct fsm *fsm)
 {
+	size_t i;
 	if (fsm == NULL || fsm->endid_info == NULL) {
 		return;
 	}
 
+	for (i = 0; i < fsm->endid_info->bucket_count; i++) {
+		struct endid_info_bucket *b = &fsm->endid_info->buckets[i];
+		if (b->state == BUCKET_NO_STATE) {
+			continue;
+		}
+		f_free(fsm->opt->alloc, fsm->endid_info->buckets[i].ids);
+	}
+	f_free(fsm->opt->alloc, fsm->endid_info->buckets);
 	f_free(fsm->opt->alloc, fsm->endid_info);
 }
 
-int
+static int
+grow_endid_buckets(const struct fsm_alloc *alloc, struct endid_info *info)
+{
+	size_t old_i, new_i;
+	struct endid_info_bucket *old_buckets, *new_buckets;
+	size_t new_count, new_used = 0, new_mask;
+	const size_t old_count = info->bucket_count;
+
+	new_count = 2*info->bucket_count;
+	assert(new_count > old_count);
+	old_buckets = info->buckets;
+	new_mask = new_count - 1;
+	assert((new_mask & new_count) == 0); /* power of 2 */
+
+#if LOG_ENDIDS > 3
+	fprintf(stderr, "grow_endid_buckets: growing from %lu to %lu buckets\n",
+	    old_count, new_count);
+	    res->bucket_count);
+#endif
+
+	new_buckets = f_malloc(alloc, new_count * sizeof(new_buckets[0]));
+	if (new_buckets == NULL) {
+		return 0;
+	}
+
+	for (new_i = 0; new_i < new_count; new_i++) {
+		new_buckets[new_i].state = BUCKET_NO_STATE;
+	}
+
+	for (old_i = 0; old_i < old_count; old_i++) {
+		struct endid_info_bucket *src_b = &old_buckets[old_i];
+		struct endid_info_bucket *dst_b;
+		unsigned hash;
+		int copied = 0;
+		if (src_b->state == BUCKET_NO_STATE) {
+			continue;
+		}
+		hash = src_b->state * PHI32;
+		for (new_i = 0; new_i < new_count; new_i++) {
+			dst_b = &new_buckets[(hash + new_i) & new_mask];
+			if (dst_b->state == BUCKET_NO_STATE) {
+				dst_b->state = src_b->state;
+				dst_b->ids = src_b->ids;
+				copied = 1;
+				new_used++;
+				break;
+			}
+		}
+		assert(copied);
+	}
+	assert(new_used == info->buckets_used);
+
+	f_free(alloc, info->buckets);
+	info->buckets = new_buckets;
+	info->bucket_count = new_count;
+	return 1;
+}
+
+enum fsm_endid_set_res
 fsm_endid_set(struct fsm *fsm,
     fsm_state_t state, fsm_end_id_t id)
 {
+	struct endid_info *ei = NULL;
+	int has_grown = 0;
+	unsigned hash;
 	size_t i;
-	struct endid_info *info = NULL;
-	struct fsm_endid_info *ei = NULL;
+	unsigned mask;
+
 	assert(fsm != NULL);
 	ei = fsm->endid_info;
 	assert(ei != NULL);
-	assert(ei->count < MAX_END_STATES);
-	assert(state < fsm->statecount);
-	assert(fsm_isend(fsm, state));
 
-	for (i = 0; i < ei->count; i++) {
-		info = &ei->states[i];
-		if (info->state == state) {
-			assert(info->count < MAX_END_IDS);
-			info->ids[info->count] = id;
-			info->count++;
-			return 1;
+rehash:
+
+	hash = state * PHI32;
+	mask = ei->bucket_count - 1;
+	assert((mask & ei->bucket_count) == 0); /* power of 2 */
+
+#if LOG_ENDIDS > 2
+	fprintf(stderr, "fsm_endid_set: state %d, id %d -> hash %x\n",
+	    state, id, hash);
+#endif
+
+	for (i = 0; i < ei->bucket_count; i++) {
+		const size_t b_i = (hash + i) & mask;
+		struct endid_info_bucket *b = &ei->buckets[b_i];
+
+#if LOG_ENDIDS > 2
+		fprintf(stderr, "fsm_endid_set[%lu/%u]: %d for state %d\n",
+		    b_i, ei->bucket_count, b->state, state);
+#endif
+
+		if (b->state == BUCKET_NO_STATE) { /* empty */
+			struct end_info_ids *ids = NULL;
+			const size_t id_alloc_size = sizeof(*ids)
+			    + (DEF_BUCKET_ID_COUNT - 1) * sizeof(ids->ids[0]);
+
+#if LOG_ENDIDS > 2
+		fprintf(stderr, "fsm_endid_set: setting empty bucket %lu\n", b_i);
+#endif
+			if (ei->buckets_used == ei->bucket_count / 2) {
+				assert(!has_grown); /* should only happen once */
+
+#if LOG_ENDIDS > 2
+				fprintf(stderr, "  -- growing buckets [%u/%u used], then rehashing\n",
+				    ei->buckets_used, ei->bucket_count);
+#endif
+				if (!grow_endid_buckets(fsm->opt->alloc, ei)) {
+					return FSM_ENDID_SET_ERROR_ALLOC_FAIL;
+				}
+				has_grown = 1;
+				/* At this point, we need to re-hash, since
+				 * the mask has changed and the collisions
+				 * may be different. */
+				goto rehash;
+			}
+
+			ids = f_malloc(fsm->opt->alloc, id_alloc_size);
+			if (ids == NULL) {
+				return FSM_ENDID_SET_ERROR_ALLOC_FAIL;
+			}
+			ids->ids[0] = id;
+			ids->count = 1;
+			ids->ceil = DEF_BUCKET_ID_COUNT;
+
+			b->state = state;
+			b->ids = ids;
+			ei->buckets_used++;
+
+#if LOG_ENDIDS > 3
+			fprintf(stderr, "fsm_endid_set: [%lu] now %d (on %p)\n",
+			    b_i, b->state, (void *)ei->buckets);
+			dump_buckets("set_dump", ei);
+#else
+	(void)dump_buckets;
+#endif
+			return FSM_ENDID_SET_ADDED;
+		} else if (b->state == state) {	   /* add if not present */
+			size_t j;
+#if LOG_ENDIDS > 2
+			fprintf(stderr, "fsm_endid_set: appending to bucket %lu's IDs, [%u/%u used]\n",
+			    b_i, b->ids->count, b->ids->ceil);
+#endif
+
+			if (b->ids->count == b->ids->ceil) { /* grow? */
+				struct end_info_ids *nids;
+				const size_t nceil = 2*b->ids->ceil;
+				const size_t id_realloc_size = sizeof(*nids)
+				    + (nceil - 1) * sizeof(nids->ids[0]);
+				assert(nceil > b->ids->ceil);
+
+#if LOG_ENDIDS > 2
+			fprintf(stderr, "fsm_endid_set: growing id array %u -> %zu\n",
+			    b->ids->ceil, nceil);
+#endif
+				nids = f_realloc(fsm->opt->alloc,
+				    b->ids, id_realloc_size);
+				if (nids == NULL) {
+					return FSM_ENDID_SET_ERROR_ALLOC_FAIL; /* alloc fail */
+				}
+				nids->ceil = nceil;
+				b->ids = nids;
+			}
+
+			/* This does not order the IDs. We could also
+			 * bsearch and shift them down, etc. */
+			for (j = 0; j < b->ids->count; j++) {
+				if (b->ids->ids[j] == id) {
+#if LOG_ENDIDS > 2
+					fprintf(stderr, "fsm_endid_set: already present, skipping\n");
+#endif
+					return FSM_ENDID_SET_ALREADY_PRESENT;
+				}
+			}
+
+			b->ids->ids[b->ids->count] = id;
+			b->ids->count++;
+
+#if LOG_ENDIDS > 3
+			fprintf(stderr, "fsm_endid_set: wrote %d at %d/%d\n",
+			    id, b->ids->count - 1, b->ids->ceil);
+			dump_buckets("set_dump", ei);
+#endif
+			return FSM_ENDID_SET_ADDED;
+		} else {			   /* collision */
+#if LOG_ENDIDS > 4
+			fprintf(stderr, "fsm_endid_set: collision, continuing\n");
+#endif
+			continue;
 		}
 	}
 
-	info = &ei->states[ei->count];
-	info->state = state;
-	info->ids[0] = id;
-	info->count++;
-	ei->count++;
-
-	return 1;
+	assert(!"unreachable: full but not resizing");
+	return FSM_ENDID_SET_ERROR_ALLOC_FAIL;
 }
 
 size_t
 fsm_endid_count(const struct fsm *fsm,
     fsm_state_t state)
 {
-	const struct fsm_endid_info *ei = NULL;
+	const struct endid_info *ei = NULL;
 	size_t i;
+
+	unsigned hash = state * PHI32;
+	unsigned mask;
+
 	assert(fsm != NULL);
 	ei = fsm->endid_info;
 	assert(ei != NULL);
 
-	for (i = 0; i < ei->count; i++) {
-		if (ei->states[i].state == state) {
-			return ei->states[i].count;
+	mask = ei->bucket_count - 1;
+	/* bucket count is a power of 2 */
+	assert((mask & ei->bucket_count) == 0);
+
+	for (i = 0; i < ei->bucket_count; i++) {
+		const size_t b_i = (hash + i) & mask;
+		struct endid_info_bucket *b = &ei->buckets[b_i];
+
+		if (b->state == BUCKET_NO_STATE) {
+			return 0; /* not found */
+		} else if (b->state == state) {
+			return b->ids->count;
+		} else {	/* collision */
+			continue;
 		}
 	}
-
+	assert(!"unreachable");
 	return 0;
 }
 
-int
+enum fsm_getendids_res
 fsm_endid_get(const struct fsm *fsm, fsm_state_t end_state,
     size_t id_buf_count, fsm_end_id_t *id_buf,
     size_t *ids_written)
 {
-	size_t i, j;
-	const struct endid_info *info = NULL;
-	const struct fsm_endid_info *ei = NULL;
+	size_t i;
+	size_t written = 0;
+	const struct endid_info *ei = NULL;
+
+	unsigned hash = end_state * PHI32;
+	unsigned mask;
+
+	(void)written;
+
 	assert(fsm != NULL);
 	ei = fsm->endid_info;
 	assert(ei != NULL);
@@ -126,23 +369,78 @@ fsm_endid_get(const struct fsm *fsm, fsm_state_t end_state,
 	assert(id_buf != NULL);
 	assert(ids_written != NULL);
 
-	assert(ei->count < MAX_END_STATES);
+	mask = ei->bucket_count - 1;
+	/* bucket count is a power of 2 */
+	assert((mask & ei->bucket_count) == 0);
 
-	for (i = 0; i < ei->count; i++) {
-		info = &ei->states[i];
-		if (info->state == end_state) {
-			if (id_buf_count < info->count) {
-				return 0;
+#if LOG_ENDIDS > 3
+	dump_buckets("fsm_endid_get", ei);
+#endif
+
+	for (i = 0; i < ei->bucket_count; i++) {
+		const size_t b_i = (hash + i) & mask;
+		struct endid_info_bucket *b = &ei->buckets[b_i];
+#if LOG_ENDIDS > 2
+		fprintf(stderr, "fsm_endid_get[%lu/%u]: %d for end_state %d\n",
+		    b_i, ei->bucket_count, b->state, end_state);
+#endif
+		if (b->state == BUCKET_NO_STATE) {
+#if LOG_ENDIDS > 2
+			fprintf(stderr, "fsm_endid_get: not found\n");
+#endif
+			*ids_written = 0; /* not found */
+			return FSM_GETENDIDS_NOT_FOUND;
+		} else if (b->state == end_state) {
+			size_t id_i;
+			if (b->ids->count > id_buf_count) {
+#if LOG_ENDIDS > 2
+				fprintf(stderr, "fsm_endid_get: insufficient space\n");
+#endif
+				return FSM_GETENDIDS_ERROR_INSUFFICIENT_SPACE;
 			}
-			for (j = 0; j < info->count; j++) {
-				id_buf[j] = info->ids[j];
+			for (id_i = 0; id_i < b->ids->count; id_i++) {
+#if LOG_ENDIDS > 2
+				fprintf(stderr, "fsm_endid_get: writing id[%zu]: %d\n", k, b->ids->ids[k]);
+#endif
+				id_buf[id_i] = b->ids->ids[id_i];
 			}
-			*ids_written = j;
-			return 1;
+
+			/* todo: could sort them here, if it matters. */
+			*ids_written = b->ids->count;
+			return FSM_GETENDIDS_FOUND;
+		} else {	/* collision */
+#if LOG_ENDIDS > 4
+			fprintf(stderr, "fsm_endid_get: collision\n");
+#endif
+			continue;
 		}
 	}
 
-	*ids_written = 0;
+	assert(!"unreachable");
+	return FSM_GETENDIDS_NOT_FOUND;
+}
+
+struct carry_env {
+	char tag;
+	struct fsm *dst;
+	fsm_state_t dst_state;
+	int ok;
+};
+
+static int
+carry_iter_cb(fsm_state_t state, fsm_end_id_t id, void *opaque)
+{
+	enum fsm_endid_set_res sres;
+	struct carry_env *env = opaque;
+	assert(env->tag == 'C');
+
+	(void)state;
+
+	sres = fsm_endid_set(env->dst, env->dst_state, id);
+	if (sres == FSM_ENDID_SET_ERROR_ALLOC_FAIL) {
+		env->ok = 0;
+		return 0;
+	}
 	return 1;
 }
 
@@ -151,35 +449,35 @@ fsm_endid_carry(const struct fsm *src_fsm, const struct state_set *src_set,
     struct fsm *dst_fsm, fsm_state_t dst_state)
 {
 	const int log_carry = 0;
-	/* FIXME */
-	struct state_set *src_set_notconst = (struct state_set *)src_set;
 
-#define ID_BUF_SIZE 10
-	fsm_end_id_t id_buf[ID_BUF_SIZE];
+#define ID_BUF_SIZE 64
 	struct state_iter it;
 	fsm_state_t s;
-	size_t j;
+
+	/* These must be distinct, otherwise we can end up adding to
+	 * the hash table while iterating over it, and resizing will
+	 * lead to corruption. */
+	assert(src_fsm != dst_fsm);
 
 	if (log_carry) {
 		fprintf(stderr, "==== fsm_endid_carry: before\n");
 		fsm_endid_dump(stderr, src_fsm);
 	}
 
-	for (state_set_reset(src_set_notconst, &it); state_set_next(&it, &s); ) {
-		size_t written;
+	for (state_set_reset(src_set, &it); state_set_next(&it, &s); ) {
+		struct carry_env env;
+		env.tag = 'C';
+		env.dst = dst_fsm;
+		env.dst_state = dst_state;
+		env.ok = 1;
+
 		if (!fsm_isend(src_fsm, s)) {
 			continue;
 		}
-		if (!fsm_endid_get(src_fsm, s,
-			ID_BUF_SIZE, id_buf, &written)) {
-			assert(!"todo dynamic size");
-		}
 
-		for (j = 0; j < written; j++) {
-			if (!fsm_endid_set(dst_fsm,
-				dst_state, id_buf[j])) {
-				return 0;
-			}
+		fsm_endid_iter_state(src_fsm, s, carry_iter_cb, &env);
+		if (!env.ok) {
+			return 0;
 		}
 	}
 
@@ -195,9 +493,9 @@ void
 fsm_endid_iter(const struct fsm *fsm,
     fsm_endid_iter_cb *cb, void *opaque)
 {
-	size_t i;
-	const struct endid_info *info = NULL;
-	const struct fsm_endid_info *ei = NULL;
+	size_t b_i;
+	struct endid_info *ei = NULL;
+	size_t bucket_count;
 
 	assert(fsm != NULL);
 	assert(cb != NULL);
@@ -207,10 +505,98 @@ fsm_endid_iter(const struct fsm *fsm,
 		return;
 	}
 
-	for (i = 0; i < ei->count; i++) {
-		info = &ei->states[i];
-		if (!cb(info->state, info->count, info->ids, opaque)) {
+	bucket_count = ei->bucket_count;
+
+	for (b_i = 0; b_i < bucket_count; b_i++) {
+		struct endid_info_bucket *b = &ei->buckets[b_i];
+		size_t id_i;
+		size_t count;
+		if (b->state == BUCKET_NO_STATE) {
+			continue;
+		}
+		count = b->ids->count;
+
+		/* Note: We need to check b->ids each time here,
+		 * because the callback is allowed to call fsm_endid_set,
+		 * which can cause b->ids->ids[] to relocate. It appends
+		 * to the end, so the position in the array is the same. */
+		for (id_i = 0; id_i < b->ids->count; id_i++) {
+			assert(b->ids->count == count);
+			if (!cb(b->state, b->ids->ids[id_i], opaque)) {
+				break;
+			}
+
+			/* The cb must not grow the hash table. */
+			assert(bucket_count == ei->bucket_count);
+		}
+	}
+}
+
+void
+fsm_endid_iter_state(const struct fsm *fsm, fsm_state_t state,
+    fsm_endid_iter_cb *cb, void *opaque)
+{
+	size_t id_i = 0;
+	size_t b_i;
+	size_t bucket_count;
+	struct endid_info *ei = NULL;
+
+	unsigned hash;
+	unsigned mask;
+
+	assert(fsm != NULL);
+	assert(cb != NULL);
+
+	ei = fsm->endid_info;
+	if (ei == NULL) {
+		return;
+	}
+
+	assert(state != BUCKET_NO_STATE);
+
+	hash = state * PHI32;
+	bucket_count = ei->bucket_count;
+	mask = bucket_count - 1;
+	assert((mask & bucket_count) == 0); /* power of 2 */
+
+#if LOG_ENDIDS > 2
+	fprintf(stderr, "fsm_endid_iter_state: state %d -> hash %x\n",
+	    state, hash);
+#endif
+
+#if LOG_ENDIDS > 3
+	dump_buckets("fsm_endid_iter_state, before", ei);
+#endif
+
+	for (b_i = 0; b_i < bucket_count; b_i++) {
+		struct endid_info_bucket *b = &ei->buckets[(hash + b_i) & mask];
+#if LOG_ENDIDS > 2
+		fprintf(stderr, "fsm_endid_iter_state: bucket [%ld/%ld]: %d\n",
+		    (hash + b_i) & mask, bucket_count, b->state);
+#endif
+
+		if (b->state == BUCKET_NO_STATE) { /* unused bucket */
+			return;	/* empty -> not found */
+		} else if (b->state == state) {
+			const size_t id_count = b->ids->count;
+			while (id_i < id_count) {
+#if LOG_ENDIDS > 2
+				fprintf(stderr, "fsm_endid_iter_state[%d], ids[%ld] -> %d\n",
+				    b->state, id_i, b->ids->ids[id_i]);
+#endif
+				if (!cb(b->state, b->ids->ids[id_i], opaque)) {
+					return;
+				}
+				id_i++;
+
+				/* The cb must not grow the hash table. */
+				assert(bucket_count == ei->bucket_count);
+				assert(b->ids->count == id_count);
+			}
 			break;
+		} else {
+			assert(b->state != state);
+			continue;
 		}
 	}
 }
@@ -220,18 +606,10 @@ struct dump_env {
 };
 
 static int
-dump_cb(fsm_state_t state,
-    size_t count, const fsm_end_id_t *ids,
-    void *opaque)
+dump_cb(fsm_state_t state, const fsm_end_id_t id, void *opaque)
 {
 	struct dump_env *env = opaque;
-	size_t i;
-	fprintf(env->f, "state[%u]:", state);
-
-	for (i = 0; i < count; i++) {
-		fprintf(env->f, " %u", ids[i]);
-	}
-	fprintf(env->f, "\n");
+	fprintf(env->f, "state[%u]: %u\n", state, id);
 	return 1;
 }
 
@@ -239,6 +617,7 @@ void
 fsm_endid_dump(FILE *f, const struct fsm *fsm)
 {
 	struct dump_env env;
+
 	env.f = f;
 
 	fsm_endid_iter(fsm, dump_cb, &env);

--- a/src/libfsm/endids.c
+++ b/src/libfsm/endids.c
@@ -6,47 +6,240 @@
 
 #include "endids_internal.h"
 
-struct fsm_endid_info *
-fsm_endid_alloc(struct fsm_alloc *alloc)
+int
+fsm_setendid(struct fsm *fsm, fsm_end_id_t id)
 {
-	(void)alloc;
-	return NULL;
-}
+	fsm_state_t i;
 
-void
-fsm_endid_free(struct fsm_endid_info *ei)
-{
-	(void)ei;
+	/* for every end state */
+	for (i = 0; i < fsm->statecount; i++) {
+		if (fsm_isend(fsm, i)) {
+			if (!fsm_endid_set(fsm, i, id)) {
+				return 0;
+			}
+		}
+	}
+
+	return 1;
 }
 
 int
-fsm_endid_set(struct fsm_endid_info *ei,
-    fsm_state_t state, fsm_end_id_t id)
-{
-	(void)ei;
-	(void)state;
-	(void)id;
-	return 0;
-}
-
-size_t
-fsm_endid_count(const struct fsm_endid_info *ei,
-    fsm_state_t state)
-{
-	(void)ei;
-	(void)state;
-	return 0;
-}
-
-int
-fsm_endid_get(const struct fsm_endid_info *ei, fsm_state_t end_state,
+fsm_getendids(const struct fsm *fsm, fsm_state_t end_state,
     size_t id_buf_count, fsm_end_id_t *id_buf,
     size_t *ids_written)
 {
-	(void)ei;
-	(void)end_state;
-	(void)id_buf;
-	(void)id_buf_count;
-	(void)ids_written;
+	return fsm_endid_get(fsm, end_state,
+	    id_buf_count, id_buf, ids_written);
+}
+
+size_t
+fsm_getendidcount(const struct fsm *fsm, fsm_state_t end_state)
+{
+	return fsm_endid_count(fsm, end_state);
+}
+
+int
+fsm_endid_init(struct fsm *fsm)
+{
+	struct fsm_endid_info *res = f_calloc(fsm->opt->alloc, 1, sizeof(*res));
+	assert(res != NULL);
+
+	res->alloc = fsm->opt->alloc;
+	fsm->endid_info = res;
+	return 1;
+}
+
+void
+fsm_endid_free(struct fsm *fsm)
+{
+	if (fsm == NULL || fsm->endid_info == NULL) {
+		return;
+	}
+
+	f_free(fsm->opt->alloc, fsm->endid_info);
+}
+
+int
+fsm_endid_set(struct fsm *fsm,
+    fsm_state_t state, fsm_end_id_t id)
+{
+	size_t i;
+	struct endid_info *info = NULL;
+	struct fsm_endid_info *ei = NULL;
+	assert(fsm != NULL);
+	ei = fsm->endid_info;
+	assert(ei != NULL);
+	assert(ei->count < MAX_END_STATES);
+	assert(state < fsm->statecount);
+	assert(fsm_isend(fsm, state));
+
+	for (i = 0; i < ei->count; i++) {
+		info = &ei->states[i];
+		if (info->state == state) {
+			assert(info->count < MAX_END_IDS);
+			info->ids[info->count] = id;
+			info->count++;
+			return 1;
+		}
+	}
+
+	info = &ei->states[ei->count];
+	info->state = state;
+	info->ids[0] = id;
+	info->count++;
+	ei->count++;
+
+	return 1;
+}
+
+size_t
+fsm_endid_count(const struct fsm *fsm,
+    fsm_state_t state)
+{
+	const struct fsm_endid_info *ei = NULL;
+	size_t i;
+	assert(fsm != NULL);
+	ei = fsm->endid_info;
+	assert(ei != NULL);
+
+	for (i = 0; i < ei->count; i++) {
+		if (ei->states[i].state == state) {
+			return ei->states[i].count;
+		}
+	}
+
 	return 0;
+}
+
+int
+fsm_endid_get(const struct fsm *fsm, fsm_state_t end_state,
+    size_t id_buf_count, fsm_end_id_t *id_buf,
+    size_t *ids_written)
+{
+	size_t i, j;
+	const struct endid_info *info = NULL;
+	const struct fsm_endid_info *ei = NULL;
+	assert(fsm != NULL);
+	ei = fsm->endid_info;
+	assert(ei != NULL);
+
+	assert(id_buf != NULL);
+	assert(ids_written != NULL);
+
+	assert(ei->count < MAX_END_STATES);
+
+	for (i = 0; i < ei->count; i++) {
+		info = &ei->states[i];
+		if (info->state == end_state) {
+			if (id_buf_count < info->count) {
+				return 0;
+			}
+			for (j = 0; j < info->count; j++) {
+				id_buf[j] = info->ids[j];
+			}
+			*ids_written = j;
+			return 1;
+		}
+	}
+
+	*ids_written = 0;
+	return 1;
+}
+
+int
+fsm_endid_carry(const struct fsm *src_fsm, const struct state_set *src_set,
+    struct fsm *dst_fsm, fsm_state_t dst_state)
+{
+	const int log_carry = 0;
+	/* FIXME */
+	struct state_set *src_set_notconst = (struct state_set *)src_set;
+
+#define ID_BUF_SIZE 10
+	fsm_end_id_t id_buf[ID_BUF_SIZE];
+	struct state_iter it;
+	fsm_state_t s;
+	size_t j;
+
+	if (log_carry) {
+		fprintf(stderr, "==== fsm_endid_carry: before\n");
+		fsm_endid_dump(stderr, src_fsm);
+	}
+
+	for (state_set_reset(src_set_notconst, &it); state_set_next(&it, &s); ) {
+		size_t written;
+		if (!fsm_isend(src_fsm, s)) {
+			continue;
+		}
+		if (!fsm_endid_get(src_fsm, s,
+			ID_BUF_SIZE, id_buf, &written)) {
+			assert(!"todo dynamic size");
+		}
+
+		for (j = 0; j < written; j++) {
+			if (!fsm_endid_set(dst_fsm,
+				dst_state, id_buf[j])) {
+				return 0;
+			}
+		}
+	}
+
+	if (log_carry) {
+		fprintf(stderr, "==== fsm_endid_carry: after\n");
+		fsm_endid_dump(stderr, dst_fsm);
+	}
+
+	return 1;
+}
+
+void
+fsm_endid_iter(const struct fsm *fsm,
+    fsm_endid_iter_cb *cb, void *opaque)
+{
+	size_t i;
+	const struct endid_info *info = NULL;
+	const struct fsm_endid_info *ei = NULL;
+
+	assert(fsm != NULL);
+	assert(cb != NULL);
+
+	ei = fsm->endid_info;
+	if (ei == NULL) {
+		return;
+	}
+
+	for (i = 0; i < ei->count; i++) {
+		info = &ei->states[i];
+		if (!cb(info->state, info->count, info->ids, opaque)) {
+			break;
+		}
+	}
+}
+
+struct dump_env {
+	FILE *f;
+};
+
+static int
+dump_cb(fsm_state_t state,
+    size_t count, const fsm_end_id_t *ids,
+    void *opaque)
+{
+	struct dump_env *env = opaque;
+	size_t i;
+	fprintf(env->f, "state[%u]:", state);
+
+	for (i = 0; i < count; i++) {
+		fprintf(env->f, " %u", ids[i]);
+	}
+	fprintf(env->f, "\n");
+	return 1;
+}
+
+void
+fsm_endid_dump(FILE *f, const struct fsm *fsm)
+{
+	struct dump_env env;
+	env.f = f;
+
+	fsm_endid_iter(fsm, dump_cb, &env);
 }

--- a/src/libfsm/endids.c
+++ b/src/libfsm/endids.c
@@ -516,18 +516,14 @@ fsm_endid_iter(const struct fsm *fsm,
 		}
 		count = b->ids->count;
 
-		/* Note: We need to check b->ids each time here,
-		 * because the callback is allowed to call fsm_endid_set,
-		 * which can cause b->ids->ids[] to relocate. It appends
-		 * to the end, so the position in the array is the same. */
-		for (id_i = 0; id_i < b->ids->count; id_i++) {
-			assert(b->ids->count == count);
+		for (id_i = 0; id_i < count; id_i++) {
 			if (!cb(b->state, b->ids->ids[id_i], opaque)) {
 				break;
 			}
 
 			/* The cb must not grow the hash table. */
 			assert(bucket_count == ei->bucket_count);
+			assert(b->ids->count == count);
 		}
 	}
 }

--- a/src/libfsm/endids.h
+++ b/src/libfsm/endids.h
@@ -1,0 +1,29 @@
+#ifndef ENDIDS_H
+#define ENDIDS_H
+
+#include <stdlib.h>
+#include <fsm/fsm.h>
+
+/* Opaque. */
+struct fsm_endid_info;
+
+struct fsm_endid_info *
+fsm_endid_alloc(struct fsm_alloc *alloc);
+
+void
+fsm_endid_free(struct fsm_endid_info *ei);
+
+int
+fsm_endid_set(struct fsm_endid_info *ei,
+    fsm_state_t state, fsm_end_id_t id);
+
+size_t
+fsm_endid_count(const struct fsm_endid_info *ei,
+    fsm_state_t state);
+
+int
+fsm_endid_get(const struct fsm_endid_info *ei, fsm_state_t end_state,
+    size_t id_buf_count, fsm_end_id_t *id_buf,
+    size_t *ids_written);
+
+#endif

--- a/src/libfsm/endids.h
+++ b/src/libfsm/endids.h
@@ -4,16 +4,18 @@
 #include <stdlib.h>
 #include <fsm/fsm.h>
 
-/* Opaque. */
-struct fsm_endid_info;
-
 int
 fsm_endid_init(struct fsm *fsm);
 
 void
 fsm_endid_free(struct fsm *fsm);
 
-int
+enum fsm_endid_set_res {
+	FSM_ENDID_SET_ADDED,
+	FSM_ENDID_SET_ALREADY_PRESENT,
+	FSM_ENDID_SET_ERROR_ALLOC_FAIL = -1
+};
+enum fsm_endid_set_res
 fsm_endid_set(struct fsm *fsm,
     fsm_state_t state, fsm_end_id_t id);
 
@@ -21,7 +23,7 @@ size_t
 fsm_endid_count(const struct fsm *fsm,
     fsm_state_t state);
 
-int
+enum fsm_getendids_res
 fsm_endid_get(const struct fsm *fsm, fsm_state_t end_state,
     size_t id_buf_count, fsm_end_id_t *id_buf,
     size_t *ids_written);
@@ -33,12 +35,15 @@ fsm_endid_carry(const struct fsm *src_fsm, const struct state_set *src_set,
 /* Callback when iterating over the endids.
  * Return 0 to halt, or non-zero to continue. */
 typedef int
-fsm_endid_iter_cb(fsm_state_t state,
-    size_t count, const fsm_end_id_t *ids,
-    void *opaque);
+fsm_endid_iter_cb(fsm_state_t state, const fsm_end_id_t id, void *opaque);
 
 void
 fsm_endid_iter(const struct fsm *fsm,
+    fsm_endid_iter_cb *cb, void *opaque);
+
+/* Same as fsm_endid_iter, but only for a single state. */
+void
+fsm_endid_iter_state(const struct fsm *fsm, fsm_state_t state,
     fsm_endid_iter_cb *cb, void *opaque);
 
 void

--- a/src/libfsm/endids.h
+++ b/src/libfsm/endids.h
@@ -7,23 +7,41 @@
 /* Opaque. */
 struct fsm_endid_info;
 
-struct fsm_endid_info *
-fsm_endid_alloc(struct fsm_alloc *alloc);
+int
+fsm_endid_init(struct fsm *fsm);
 
 void
-fsm_endid_free(struct fsm_endid_info *ei);
+fsm_endid_free(struct fsm *fsm);
 
 int
-fsm_endid_set(struct fsm_endid_info *ei,
+fsm_endid_set(struct fsm *fsm,
     fsm_state_t state, fsm_end_id_t id);
 
 size_t
-fsm_endid_count(const struct fsm_endid_info *ei,
+fsm_endid_count(const struct fsm *fsm,
     fsm_state_t state);
 
 int
-fsm_endid_get(const struct fsm_endid_info *ei, fsm_state_t end_state,
+fsm_endid_get(const struct fsm *fsm, fsm_state_t end_state,
     size_t id_buf_count, fsm_end_id_t *id_buf,
     size_t *ids_written);
+
+int
+fsm_endid_carry(const struct fsm *src_fsm, const struct state_set *src_set,
+    struct fsm *dst_fsm, fsm_state_t dst_state);
+
+/* Callback when iterating over the endids.
+ * Return 0 to halt, or non-zero to continue. */
+typedef int
+fsm_endid_iter_cb(fsm_state_t state,
+    size_t count, const fsm_end_id_t *ids,
+    void *opaque);
+
+void
+fsm_endid_iter(const struct fsm *fsm,
+    fsm_endid_iter_cb *cb, void *opaque);
+
+void
+fsm_endid_dump(FILE *f, const struct fsm *fsm);
 
 #endif

--- a/src/libfsm/endids_internal.h
+++ b/src/libfsm/endids_internal.h
@@ -18,18 +18,25 @@
 #include "internal.h"
 #include "endids.h"
 
-/* temporary */
-#define MAX_END_STATES 4
-#define MAX_END_IDS 4
+#define BUCKET_NO_STATE ((fsm_state_t)-1)
+#define DEF_BUCKET_COUNT 4
+#define DEF_BUCKET_ID_COUNT 16
 
-struct fsm_endid_info {
-	const struct fsm_alloc *alloc;
-	size_t count;
-	struct endid_info {
-		size_t count;
+struct endid_info {
+	/* Add-only hash table, with a state ID and an associated
+	 * non-empty ordered array of unique end IDs. The state is the
+	 * key. Grows when the buckets are more than half full. */
+	unsigned bucket_count;
+	unsigned buckets_used;
+
+	struct endid_info_bucket {
 		fsm_state_t state;
-		fsm_end_id_t ids[MAX_END_IDS];
-	} states[MAX_END_STATES];
+		struct end_info_ids {
+			unsigned count;
+			unsigned ceil;
+			fsm_end_id_t ids[1];
+		} *ids;
+	} *buckets;
 };
 
 #endif

--- a/src/libfsm/endids_internal.h
+++ b/src/libfsm/endids_internal.h
@@ -7,8 +7,9 @@
 #include <fsm/alloc.h>
 #include <fsm/capture.h>
 #include <fsm/fsm.h>
+#include <fsm/pred.h>
 
-#include <adt/edgeset.h>
+#include <adt/stateset.h>
 
 #include <string.h>
 #include <assert.h>
@@ -17,8 +18,18 @@
 #include "internal.h"
 #include "endids.h"
 
+/* temporary */
+#define MAX_END_STATES 4
+#define MAX_END_IDS 4
+
 struct fsm_endid_info {
-	int todo;
+	const struct fsm_alloc *alloc;
+	size_t count;
+	struct endid_info {
+		size_t count;
+		fsm_state_t state;
+		fsm_end_id_t ids[MAX_END_IDS];
+	} states[MAX_END_STATES];
 };
 
 #endif

--- a/src/libfsm/endids_internal.h
+++ b/src/libfsm/endids_internal.h
@@ -1,0 +1,24 @@
+#ifndef ENDIDS_INTERNAL_H
+#define ENDIDS_INTERNAL_H
+
+#include <stdlib.h>
+#include <stdint.h>
+
+#include <fsm/alloc.h>
+#include <fsm/capture.h>
+#include <fsm/fsm.h>
+
+#include <adt/edgeset.h>
+
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+
+#include "internal.h"
+#include "endids.h"
+
+struct fsm_endid_info {
+	int todo;
+};
+
+#endif

--- a/src/libfsm/fsm.c
+++ b/src/libfsm/fsm.c
@@ -21,6 +21,7 @@
 
 #include "internal.h"
 #include "capture.h"
+#include "endids.h"
 
 void
 free_contents(struct fsm *fsm)
@@ -35,6 +36,7 @@ free_contents(struct fsm *fsm)
 	}
 
 	fsm_capture_free(fsm);
+	fsm_endid_free(fsm);
 
 	f_free(fsm->opt->alloc, fsm->states);
 }
@@ -60,6 +62,7 @@ fsm_new(const struct fsm_options *opt)
 	new->statecount = 0;
 	new->endcount   = 0;
 	new->capture_info = NULL;
+	new->endid_info = NULL;
 
 	new->states = f_malloc(f.opt->alloc, new->statealloc * sizeof *new->states);
 	if (new->states == NULL) {
@@ -74,6 +77,11 @@ fsm_new(const struct fsm_options *opt)
 	if (!fsm_capture_init(new)) {
 		f_free(f.opt->alloc, new->states);
 		f_free(f.opt->alloc, new);
+		return NULL;
+	}
+
+	if (!fsm_endid_init(new)) {
+		/* FIXME cleanup */
 		return NULL;
 	}
 
@@ -122,6 +130,7 @@ fsm_move(struct fsm *dst, struct fsm *src)
 	dst->endcount   = src->endcount;
 
 	dst->capture_info = src->capture_info;
+	dst->endid_info = src->endid_info;
 
 	f_free(src->opt->alloc, src);
 }

--- a/src/libfsm/fsm.c
+++ b/src/libfsm/fsm.c
@@ -81,7 +81,9 @@ fsm_new(const struct fsm_options *opt)
 	}
 
 	if (!fsm_endid_init(new)) {
-		/* FIXME cleanup */
+		f_free(f.opt->alloc, new->states);
+		f_free(f.opt->alloc, new);
+		fsm_capture_free(new);
 		return NULL;
 	}
 

--- a/src/libfsm/glushkovise.c
+++ b/src/libfsm/glushkovise.c
@@ -18,6 +18,7 @@
 
 #include "internal.h"
 #include "capture.h"
+#include "endids.h"
 
 #define DUMP_EPSILON_CLOSURES 0
 #define DEF_PENDING_CAPTURE_ACTIONS_CEIL 2
@@ -146,6 +147,10 @@ fsm_glushkovise(struct fsm *nfa)
 		 * known to have been an end state.
 		 */
 		fsm_carryopaque(nfa, eclosures[s], nfa, s);
+
+		if (!fsm_endid_carry(nfa, eclosures[s], nfa, s)) {
+			goto error;
+		}
 	}
 
 	if (!remap_capture_actions(nfa, eclosures)) {

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -74,6 +74,7 @@ struct fsm {
 	unsigned int hasstart:1;
 
 	struct fsm_capture_info *capture_info;
+	struct fsm_endid_info *endid_info;
 	const struct fsm_options *opt;
 };
 

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -42,6 +42,9 @@ struct state_array;
 
 #define FSM_CAPTURE_MAX INT_MAX
 
+/* 32-bit approximation of golden ratio, used for hashing */
+#define PHI32 0x9e3779b9
+
 struct fsm_edge {
 	fsm_state_t state; /* destination */
 	unsigned char symbol;
@@ -74,7 +77,7 @@ struct fsm {
 	unsigned int hasstart:1;
 
 	struct fsm_capture_info *capture_info;
-	struct fsm_endid_info *endid_info;
+	struct endid_info *endid_info;
 	const struct fsm_options *opt;
 };
 

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -80,6 +80,10 @@ fsm_setendopaque
 fsm_setopaque
 fsm_getopaque
 
+fsm_getendidcount
+fsm_getendids
+fsm_setendid
+
 fsm_countedges
 fsm_countstates
 

--- a/src/libfsm/merge.c
+++ b/src/libfsm/merge.c
@@ -22,6 +22,8 @@
 #include "internal.h"
 #include "endids.h"
 
+#define LOG_MERGE_ENDIDS 0
+
 struct copy_capture_env {
 	char tag;
 	struct fsm *dst;
@@ -160,21 +162,21 @@ struct copy_end_ids_env {
 };
 
 static int
-copy_end_ids_cb(fsm_state_t state,
-    size_t count, const fsm_end_id_t *ids,
-    void *opaque)
+copy_end_ids_cb(fsm_state_t state, fsm_end_id_t id, void *opaque)
 {
-	size_t i;
+	enum fsm_endid_set_res sres;
 	struct copy_end_ids_env *env = opaque;
 	assert(env->tag == 'M');
 
-	for (i = 0; i < count; i++) {
-		if (!fsm_endid_set(env->dst,
-			state + env->base_src,
-			ids[i])) {
-			env->ok = 0;
-			return 0;
-		}
+#if LOG_MERGE_ENDIDS > 1
+	fprintf(stderr, "merge[%d] <- %d\n",
+	    state + env->base_src, id);
+#endif
+
+	sres = fsm_endid_set(env->dst, state + env->base_src, id);
+	if (sres == FSM_ENDID_SET_ERROR_ALLOC_FAIL) {
+		env->ok = 0;
+		return 0;
 	}
 
 	return 1;

--- a/tests/capture/captest.c
+++ b/tests/capture/captest.c
@@ -161,6 +161,22 @@ captest_run_single(const struct captest_single_fsm_test_info *info)
 		}
 	}
 
+	{
+		fsm_end_id_t id_buf[1] = { ~0 };
+		size_t written;
+		if (1 != fsm_getendidcount(fsm, end)) {
+			FAIL("did not have exactly one end ID");
+		}
+
+		if (!fsm_getendids(fsm, end, 1, id_buf, &written)) {
+			FAIL("failed to get end IDs");
+		}
+
+		if (0 != id_buf[0]) {
+			FAIL("failed to get end ID of 0");
+		}
+	}
+
 	for (i = 0; i < capture_count; i++) {
 #if CAPTEST_RUN_SINGLE_LOG
 		fprintf(stderr, "captest: capture %lu: exp (%ld, %ld), got (%ld, %ld)\n",
@@ -222,6 +238,10 @@ captest_fsm_of_string(const char *string, unsigned end_id)
 	}
 	fsm_setend(fsm, length, 1);
 	fsm_setopaque(fsm, length, eo);
+
+	if (!fsm_setendid(fsm, end_id)) {
+		goto cleanup;
+	}
 
 	return fsm;
 

--- a/tests/capture/captest.c
+++ b/tests/capture/captest.c
@@ -163,12 +163,14 @@ captest_run_single(const struct captest_single_fsm_test_info *info)
 
 	{
 		fsm_end_id_t id_buf[1] = { ~0 };
+		enum fsm_getendids_res gres;
 		size_t written;
 		if (1 != fsm_getendidcount(fsm, end)) {
 			FAIL("did not have exactly one end ID");
 		}
 
-		if (!fsm_getendids(fsm, end, 1, id_buf, &written)) {
+		gres = fsm_getendids(fsm, end, 1, id_buf, &written);
+		if (gres != FSM_GETENDIDS_FOUND) {
 			FAIL("failed to get end IDs");
 		}
 

--- a/tests/capture/capture4.c
+++ b/tests/capture/capture4.c
@@ -195,6 +195,10 @@ build_ab_c(void)
 
 	fsm_setend(fsm, 3, 1);
 	fsm_setopaque(fsm, 3, eo);
+	if (!fsm_setendid(fsm, 1)) {
+		goto fail;
+	}
+
 	return fsm;
 
 fail:
@@ -254,4 +258,23 @@ check(const struct fsm *fsm, const char *string,
 	assert(captures[cb_a].pos[1] == pa_1);
 	assert(captures[cb_b].pos[0] == pb_0);
 	assert(captures[cb_b].pos[1] == pb_1);
+
+	{
+		fsm_end_id_t id_buf[2];
+		size_t written;
+		if (!fsm_getendids(fsm, end, 2, id_buf, &written)) {
+			assert(!"fsm_getendids failed");
+		}
+
+		if (expected_ends == 0x2) {
+			assert(written == 1);
+			assert(id_buf[0] == 1);
+		} else if (expected_ends == 0x3) {
+			assert(written == 2);
+			assert(id_buf[0] == 0);
+			assert(id_buf[1] == 1);
+		} else {
+			assert(!"test not handled");
+		}
+	}
 }

--- a/tests/capture/capture4.c
+++ b/tests/capture/capture4.c
@@ -242,17 +242,7 @@ check(const struct fsm *fsm, const char *string,
 	if (eo->ends != expected_ends) {
 		fprintf(stderr, "Expected ends 0x%x, got 0x%x\n",
 		    expected_ends, eo->ends);
-		/* FIXME: The case where "abc" matches both /ab*c/ AND
-		 * /abc/ is currently not detected propertly, most
-		 * likely due to a bug in either how carryopaque is
-		 * being used in fsm_determinise or in
-		 * captest_carryopaque.
-		 *
-		 * The next pass will be more formally supporting
-		 * end state set management independent of the
-		 * carryopaque mechanism, revisiting this in
-		 * greater detail, so for now this is ignored. */
-		/* exit(EXIT_FAILURE); */
+		exit(EXIT_FAILURE);
 	}
 
 	/* check captures */

--- a/tests/capture/capture4.c
+++ b/tests/capture/capture4.c
@@ -260,9 +260,11 @@ check(const struct fsm *fsm, const char *string,
 	assert(captures[cb_b].pos[1] == pb_1);
 
 	{
+		enum fsm_getendids_res gres;
 		fsm_end_id_t id_buf[2];
 		size_t written;
-		if (!fsm_getendids(fsm, end, 2, id_buf, &written)) {
+		gres = fsm_getendids(fsm, end, 2, id_buf, &written);
+		if (gres != FSM_GETENDIDS_FOUND) {
 			assert(!"fsm_getendids failed");
 		}
 


### PR DESCRIPTION
Add a new set of operations to the API, for "end IDs": before combining multiple DFAs with `fsm_union`, make it possible to associate a numeric ID with each's end states, so that reaching a particular end state in the combined DFA can be associated with a match of one _or more_ of the original DFAs. This is needed to filter out false positives with group captures, because partially overlapping paths in the combined state machine may set captures that should only be valid when halting at specific end states. For example, with `(ab*)(c)` vs`(ab)(c)`, when there is `a`, exactly one `b`, then `c` the input matches both, but any other number of `b`s only matches the former, yet the capture for `(ab)` will still be set for "abbbbc".

There are several changes to preserve and convert this end metadata through transformations. This was previously done in a very ad hoc way through the `opaque` interface, but that would not compose with other uses of that interface, and since the use case for end IDs is better specified, the library itself can manage the dataflow better.

Some of this functionality is still under development -- the next in this series of PRs will add a standalone command line program which reads a list of regexes from a file, combines them into a single DFA, and then reads input and prints which regexes matched and the contents of any captures. Several things still need to be hooked up to support this in libre (such as associating `(` `)` in the AST with match groups), and integrating that will probably find some details that got missed.