### PR TITLE
Determinise using interned state set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ SUBDIR += tests/trim
 SUBDIR += tests/union
 SUBDIR += tests/set
 SUBDIR += tests/stateset
+SUBDIR += tests/internedstateset
 SUBDIR += tests/sql
 SUBDIR += tests/hashset
 SUBDIR += tests/queue

--- a/include/adt/internedstateset.h
+++ b/include/adt/internedstateset.h
@@ -30,8 +30,7 @@ interned_state_set_pool_alloc(const struct fsm_alloc *a);
 void
 interned_state_set_pool_free(struct interned_state_set_pool *pool);
 
-/* Get a handle to the empty state set.
- * Returns NULL on alloc failure. */
+/* Get a handle to the empty state set. Can not fail. */
 struct interned_state_set *
 interned_state_set_empty(struct interned_state_set_pool *pool);
 

--- a/include/adt/internedstateset.h
+++ b/include/adt/internedstateset.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#ifndef INTERNEDSTATESET_H
+#define INTERNEDSTATESET_H
+
+struct fsm_alloc;
+struct state_set;
+
+/* This is a wrapper for state_set instances, which creates and caches
+ * sets created by adding a single state to existing sets. As long as
+ * the pool is active, the state sets themselves should not be
+ * modified. */
+
+/* Opaque types */
+struct interned_state_set;
+struct interned_state_set_pool;
+
+/* Allocate an interned state set pool. */
+struct interned_state_set_pool *
+interned_state_set_pool_alloc(const struct fsm_alloc *a);
+
+/* Free the pool.
+ * Any state_sets that have not been had a referenced outside
+ * the pool marked live via `interned_state_set_retain` will
+ * be freed with it. */
+void
+interned_state_set_pool_free(struct interned_state_set_pool *pool);
+
+/* Get a handle to the empty state set.
+ * Returns NULL on alloc failure. */
+struct interned_state_set *
+interned_state_set_empty(struct interned_state_set_pool *pool);
+
+/* Get a handle to the state set representing set with id added.
+ * Returns an opaque set instance, or NULL on alloc failure.
+ *
+ * If an existing state set is recreated, the existing one will
+ * be reused. */
+struct interned_state_set *
+interned_state_set_add(struct interned_state_set_pool *pool,
+    struct interned_state_set *set, fsm_state_t state);
+
+/* Get a reference to the state_set managed by the pool.
+ * Note that it should not be modified while the pool is active.
+ *
+ * Calling this also informs the pool that there is a live reference
+ * to the state_set outside the pool, so freeing the pool will no
+ * longer free the state_set. */
+struct state_set *
+interned_state_set_retain(struct interned_state_set *set);
+
+/* Inform the pool that the reference to the state_set outside
+ * the pool is no longer being used. If there are no longer any
+ * live references, the state_set will be freed with the pool.
+ *
+ * This is mostly useful if debugging code grabs a reference to
+ * the state_set to print it or something, then lets go of it. */
+void
+interned_state_set_release(struct interned_state_set *set);
+
+#endif

--- a/src/adt/Makefile
+++ b/src/adt/Makefile
@@ -3,6 +3,7 @@
 SRC += src/adt/alloc.c
 SRC += src/adt/bitmap.c
 SRC += src/adt/dlist.c
+SRC += src/adt/internedstateset.c
 SRC += src/adt/priq.c
 SRC += src/adt/path.c
 SRC += src/adt/xalloc.c

--- a/src/adt/internedstateset.c
+++ b/src/adt/internedstateset.c
@@ -1,0 +1,393 @@
+/*
+ * Copyright 2020 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stddef.h>
+
+#include <fsm/fsm.h>
+
+#include <adt/alloc.h>
+#include <adt/stateset.h>
+#include <adt/internedstateset.h>
+
+#define ISS_BUCKET_DEF_CEIL 4
+#define CACHE_BUCKET_DEF_CEIL 32
+#define LOG_INTERNEDSTATESET 0
+
+#if LOG_INTERNEDSTATESET
+#include <stdio.h>
+#endif
+
+/* 32-bit approximation of golden ratio, used for hashing */
+#define PHI32 0x9e3779b9
+
+#define NO_ISS ((struct interned_state_set *)-1)
+#define BUCKET_STATE_NONE ((fsm_state_t)-1)
+
+struct interned_state_set {
+	unsigned refcount;
+	unsigned long hash;
+	struct state_set *set;
+
+	/* Cache of other interned state sets derived directly from the
+	 * current set by adding one state. These are weak references
+	 * and aren't reflected in the refcount. */
+	struct iss_kids {
+		unsigned bucket_count;
+		unsigned buckets_used;
+		struct kid_bucket {
+			fsm_state_t state; /* or BUCKET_STATE_NONE */
+			struct interned_state_set *kid;
+		} *buckets;
+	} kids;
+};
+
+struct interned_state_set_pool {
+	const struct fsm_alloc *a;
+
+	struct interned_state_set *empty;
+
+	/* Cache of state sets. */
+	struct issp_cache {
+		unsigned bucket_count;
+		unsigned buckets_used;
+		struct cache_bucket {
+			unsigned long hash;
+			struct interned_state_set *iss; /* NO_ISS if empty */
+		} *buckets;
+	} cache;
+};
+
+static int
+grow_cache_buckets(struct interned_state_set_pool *pool);
+
+static void
+add_kid_to_iss_cache(struct interned_state_set_pool *pool,
+    struct interned_state_set *set, fsm_state_t state,
+    struct interned_state_set *kid);
+
+struct interned_state_set_pool *
+interned_state_set_pool_alloc(const struct fsm_alloc *a)
+{
+	struct interned_state_set_pool *res;
+	struct cache_bucket *buckets = NULL;
+	struct interned_state_set *empty_i = NULL;
+	struct state_set *empty_ss;
+
+	size_t i;
+
+	res = f_calloc(a, 1, sizeof(*res));
+	if (res == NULL) {
+		goto cleanup;
+	}
+
+	buckets = f_malloc(a,
+	    CACHE_BUCKET_DEF_CEIL * sizeof(buckets[0]));
+	if (buckets == NULL) {
+		goto cleanup;
+	}
+	for (i = 0; i < CACHE_BUCKET_DEF_CEIL; i++) {
+		buckets[i].iss = NO_ISS;
+	}
+
+	empty_i = f_calloc(a, 1, sizeof(*empty_i));
+	if (empty_i == NULL) {
+		goto cleanup;
+	}
+
+	/* Currently, a NULL pointer is treated as a boxed
+	 * empty state set. There isn't a constructor. */
+	empty_ss = NULL;	/* can't fail */
+
+	empty_i->refcount = 1;
+	empty_i->hash = state_set_hash(empty_ss);
+	empty_i->set = empty_ss;
+	assert(empty_i->kids.bucket_count == 0); /* starts unallocated */
+
+	res->a = a;
+	res->cache.bucket_count = CACHE_BUCKET_DEF_CEIL;
+	res->cache.buckets = buckets;
+	{
+		const unsigned long mask = CACHE_BUCKET_DEF_CEIL - 1;
+		struct cache_bucket *b = &res->cache.buckets[empty_i->hash & mask];
+		assert(b->iss = NO_ISS);
+		b->hash = empty_i->hash;
+		b->iss = empty_i;
+	}
+	res->empty = empty_i;
+
+	return res;
+
+cleanup:
+	if (res != NULL) {
+		f_free(a, res);
+	}
+	if (buckets != NULL) {
+		f_free(a, buckets);
+	}
+	if (empty_i != NULL) {
+		f_free(a, empty_i);
+	}
+	return NULL;
+}
+
+void
+interned_state_set_pool_free(struct interned_state_set_pool *pool)
+{
+	size_t i;
+	if (pool == NULL) {
+		return;
+	}
+
+	for (i = 0; i < pool->cache.bucket_count; i++) {
+		struct cache_bucket *b = &pool->cache.buckets[i];
+		if (b->iss != NO_ISS) {
+			struct interned_state_set *iss = b->iss;
+			iss->refcount--;
+			if (iss->refcount == 0) {
+				state_set_free(iss->set);
+				f_free(pool->a, iss->kids.buckets);
+				f_free(pool->a, iss);
+			}
+		}
+	}
+
+	f_free(pool->a, pool->cache.buckets);
+	f_free(pool->a, pool);
+}
+
+struct interned_state_set *
+interned_state_set_empty(struct interned_state_set_pool *pool)
+{
+	return pool->empty;
+}
+
+struct interned_state_set *
+interned_state_set_add(struct interned_state_set_pool *pool,
+    struct interned_state_set *set, fsm_state_t state)
+{
+	struct interned_state_set *res;
+	size_t i;
+	unsigned long h, mask;
+	struct state_set *ss = NULL;
+
+#if LOG_INTERNEDSTATESET
+	fprintf(stderr, "interned_state_set_add: adding state %d to %p\n", state, (void *)set);
+#endif
+
+	assert(pool != NULL);
+	assert(set != NULL);
+	assert(state != BUCKET_STATE_NONE);
+
+	/* First, check if the interned state set has a known
+	 * child derived by adding that id. */
+	if (set->kids.bucket_count > 0) {
+		struct iss_kids *kcache = &set->kids;
+		mask = kcache->bucket_count - 1;
+		h = PHI32 * (state + 1);
+		for (i = 0; i < kcache->bucket_count; i++) {
+			struct kid_bucket *kb = &kcache->buckets[(h + i) & mask];
+			if (kb->state == BUCKET_STATE_NONE) {
+				break; /* not found */
+			} else if (kb->state == state) {
+#if LOG_INTERNEDSTATESET
+				fprintf(stderr, "interned_state_set_add: KID_CACHE_HIT: %p on %d\n",
+				    (void *)kb->kid, state);
+#endif
+				return kb->kid;
+			} else {
+				/* collision, continue */
+			}
+		}
+	}
+
+	/* If not, check the global cache, and add the child
+	 * if present.
+	 *
+	 * Because currently hashing isn't incremental and depends on
+	 * constructing the set, we need to make a copy just to check if
+	 * it already exists. This is expensive. */
+	if (!state_set_copy(&ss, pool->a, set->set)) {
+		return NULL;
+	}
+	if (!state_set_add(&ss, pool->a, state)) {
+		return NULL;
+	}
+
+	h = state_set_hash(ss);
+	mask = pool->cache.bucket_count - 1;
+	for (i = 0; i < pool->cache.bucket_count; i++) {
+		struct cache_bucket *cb = &pool->cache.buckets[(h + i) & mask];
+		if (cb->iss == NO_ISS) {
+			break;	/* not found */
+		} else if (cb->hash == h && 0 == state_set_cmp(ss, cb->iss->set)) {
+			state_set_free(ss);
+#if LOG_INTERNEDSTATESET
+			fprintf(stderr, "interned_state_set_add: GLOBAL_CACHE HIT: %p\n",
+			    (void *)cb->iss);
+#endif
+
+			add_kid_to_iss_cache(pool, set, state, cb->iss);
+			return cb->iss;
+		} else {
+			/* collision, continue */
+		}
+	}
+
+	/* If not, create one and add it to both caches. */
+	res = f_calloc(pool->a, 1, sizeof(*res));
+	if (res == NULL) {
+		return NULL;
+	}
+	res->refcount = 1;
+	res->hash = h;
+	res->set = ss;
+
+#if LOG_INTERNEDSTATESET > 1
+	fprintf(stderr, "interned_state_set_add: cache is using %d / %d\n",
+	    pool->cache.buckets_used, pool->cache.bucket_count);
+#endif
+	if (pool->cache.buckets_used == pool->cache.bucket_count/2) {
+		if (!grow_cache_buckets(pool)) {
+			return NULL;
+		}
+	}
+
+	for (i = 0; i < pool->cache.bucket_count; i++) {
+		struct cache_bucket *cb = &pool->cache.buckets[(h + i) & mask];
+		if (cb->iss == NO_ISS) {
+			pool->cache.buckets_used++;
+			cb->hash = h;
+			cb->iss = res;
+
+			add_kid_to_iss_cache(pool, set, state, res);
+			return res;
+		} else {
+			/* collision, continue */
+		}
+	}
+	assert(i < pool->cache.bucket_count); /* found a spot */
+
+	add_kid_to_iss_cache(pool, set, state, res);
+	return res;
+}
+
+static int
+grow_cache_buckets(struct interned_state_set_pool *pool)
+{
+	size_t o_i, n_i;
+	const size_t nceil = 2 * pool->cache.bucket_count;
+	const size_t nmask = nceil - 1;
+	struct cache_bucket *nbuckets;
+	assert(nceil > 0);
+#if LOG_INTERNEDSTATESET
+	fprintf(stderr, "grow_cache_buckets: %u -> %lu\n",
+	    pool->cache.bucket_count, nceil);
+#endif
+
+	nbuckets = f_malloc(pool->a, nceil * sizeof(nbuckets[0]));
+	if (nbuckets == NULL) {
+		return 0;
+	}
+
+	for (n_i = 0; n_i < nceil; n_i++) {
+		nbuckets[n_i].iss = NO_ISS;
+	}
+
+	for (o_i = 0; o_i < pool->cache.bucket_count; o_i++) {
+		struct cache_bucket *cb = &pool->cache.buckets[o_i];
+		if (cb->iss == NO_ISS) {
+			continue;
+		}
+
+		for (n_i = 0; n_i < nceil; n_i++) {
+			struct cache_bucket *ncb = &nbuckets[(cb->hash + n_i) & nmask];
+			if (ncb->iss == NO_ISS) {
+				ncb->iss = cb->iss;
+				ncb->hash = cb->hash;
+				break;
+			} else {
+				/* collision, skip */
+			}
+		}
+		assert(n_i < nceil); /* found a new position */
+	}
+
+	f_free(pool->a, pool->cache.buckets);
+	pool->cache.buckets = nbuckets;
+	pool->cache.bucket_count = nceil;
+	return 1;
+}
+
+/* This failing will degrade performance but not correctness,
+ * and will try to add it again next time. */
+static void
+add_kid_to_iss_cache(struct interned_state_set_pool *pool,
+    struct interned_state_set *set, fsm_state_t state,
+    struct interned_state_set *kid)
+{
+	size_t i;
+	const unsigned long h = PHI32 * (state + 1);
+	unsigned long mask;
+
+#if LOG_INTERNEDSTATESET
+	fprintf(stderr, "add_kid_to_iss_cache: set %p, state %d, kid %p\n",
+	    (void *)set, state, (void *)kid);
+#endif
+
+	if (set->kids.bucket_count == 0) {
+		assert(set->kids.buckets == NULL);
+		assert(set->kids.buckets_used == 0);
+		set->kids.buckets = f_malloc(pool->a,
+		    ISS_BUCKET_DEF_CEIL * sizeof(set->kids.buckets[0]));
+		if (set->kids.buckets == NULL) {
+			return;
+		}
+		set->kids.bucket_count = ISS_BUCKET_DEF_CEIL;
+		for (i = 0; i < ISS_BUCKET_DEF_CEIL; i++) {
+			set->kids.buckets[i].state = BUCKET_STATE_NONE;
+		}
+	}
+
+	assert(set->kids.bucket_count > 0);
+	if (set->kids.buckets_used == set->kids.bucket_count/2) {
+		assert(!"todo: grow"); /* FIXME: exercise this. */
+	}
+
+	mask = set->kids.bucket_count - 1;
+	for (i = 0; i < set->kids.bucket_count; i++) {
+		struct kid_bucket *kb = &set->kids.buckets[(h + i) & mask];
+		if (kb->state == BUCKET_STATE_NONE) {
+			kb->state = state;
+			kb->kid = kid;
+			set->kids.buckets_used++;
+			break;
+		} else if (kb->state == state) {
+			assert(!"already present");
+		} else {
+			/* collision, skip */
+		}
+	}
+}
+
+struct state_set *
+interned_state_set_retain(struct interned_state_set *set)
+{
+	struct state_set *res;
+	assert(set != NULL);
+	assert(set->refcount >= 1); /* pool has a reference */
+	set->refcount++;
+	res = set->set;
+	return res;
+}
+
+void
+interned_state_set_release(struct interned_state_set *set)
+{
+	assert(set != NULL);
+	assert(set->refcount > 1); /* pool still has a reference */
+	set->refcount--;
+}

--- a/src/adt/stateset.c
+++ b/src/adt/stateset.c
@@ -655,7 +655,9 @@ state_set_replace(struct state_set **setp, fsm_state_t old, fsm_state_t new)
 unsigned long
 state_set_hash(const struct state_set *set)
 {
-	assert(set != NULL);
+	if (set == NULL) {
+		return 0;	/* empty */
+	}
 
 	if (IS_SINGLETON(set)) {
 		fsm_state_t state;

--- a/src/libfsm/Makefile
+++ b/src/libfsm/Makefile
@@ -66,7 +66,7 @@ CFLAGS.src/libfsm/parser.c += -Wno-unused-parameter
 ${src}: src/libfsm/lexer.h
 .endfor
 
-.for src in ${SRC:Msrc/libfsm/closure.c} ${SRC:Msrc/libfsm/minimise.c} ${SRC:Msrc/libfsm/vm.c} ${SRC:Msrc/libfsm/example.c}
+.for src in ${SRC:Msrc/libfsm/closure.c} ${SRC:Msrc/libfsm/determinise.c} ${SRC:Msrc/libfsm/minimise.c} ${SRC:Msrc/libfsm/vm.c} ${SRC:Msrc/libfsm/example.c}
 CFLAGS.${src} += -std=c99
 DFLAGS.${src} += -std=c99
 .endfor

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -4,225 +4,22 @@
  * See LICENCE for the full copyright terms.
  */
 
-#include <assert.h>
-#include <stddef.h>
-#include <errno.h>
-
-#include <fsm/fsm.h>
-#include <fsm/capture.h>
-#include <fsm/pred.h>
-#include <fsm/walk.h>
-
-#include <adt/alloc.h>
-#include <adt/set.h>
-#include <adt/edgeset.h>
-#include <adt/stateset.h>
-#include <adt/hashset.h>
-#include <adt/mappinghashset.h>
-
-#include "internal.h"
-#include "capture.h"
-#include "endids.h"
-
-#define DUMP_MAPPING 0
-#define LOG_DETERMINISE_CLOSURES 0
-#define LOG_DETERMINISE_CAPTURES 0
-
-/*
- * This maps a DFA state onto its associated NFA symbol closure, such that an
- * existing DFA state may be found given any particular set of NFA states
- * forming a symbol closure.
- */
-struct mapping {
-	/* The set of NFA states forming the symbol closure for this DFA state */
-	struct state_set *closure;
-
-	/* The DFA state associated with this epsilon closure of NFA states */
-	fsm_state_t dfastate;
-
-	/* Newly-created DFA edges */
-	struct edge_set *edges;
-};
-
-struct reverse_mapping {
-	unsigned count;
-	unsigned ceil;
-	fsm_state_t *list;
-};
-
-struct det_copy_capture_actions_env {
-	char tag;
-	struct fsm *dst;
-	struct reverse_mapping *reverse_mappings;
-	int ok;
-};
-
-static int
-remap_capture_actions(struct mapping_hashset *mappings,
-    struct fsm *dst_dfa, struct fsm *src_nfa);
-
-static int
-add_reverse_mapping(const struct fsm_alloc *alloc,
-    struct reverse_mapping *reverse_mappings,
-    fsm_state_t dfa_state, fsm_state_t nfa_state);
-
-static int
-det_copy_capture_actions(struct reverse_mapping *reverse_mappings,
-    struct fsm *dst, struct fsm *src);
-
-static int
-cmp_mapping(const void *a, const void *b)
-{
-	const struct mapping * const *ma = a, * const *mb = b;
-
-	assert(ma != NULL && *ma != NULL);
-	assert(mb != NULL && *mb != NULL);
-
-	return state_set_cmp((*ma)->closure, (*mb)->closure);
-}
-
-static unsigned long
-hash_mapping(const void *a)
-{
-	const struct mapping *m = a;
-
-	/* TODO: could cache the hashed value in the mapping struct,
-	 * or populate it when making the mapping */
-	return state_set_hash(m->closure);
-}
-
-static struct mapping *
-mapping_find(const struct mapping_hashset *mappings, const struct state_set *closure)
-{
-	struct mapping *m, search;
-
-	assert(mappings != NULL);
-	assert(closure != NULL);
-
-	search.closure = (void *) closure;
-	m = mapping_hashset_find(mappings, &search);
-	if (m != NULL) {
-		return m;
-	}
-
-	return NULL;
-}
-
-/*
- * By contract an existing mapping is assumed to not exist.
- */
-static struct mapping *
-mapping_add(struct mapping_hashset *mappings, const struct fsm_alloc *alloc,
-	fsm_state_t dfastate, struct state_set *closure)
-{
-	struct mapping *m;
-
-	assert(mappings != NULL);
-	assert(!mapping_find(mappings, closure));
-	assert(closure != NULL);
-
-	m = f_malloc(alloc, sizeof *m);
-	if (m == NULL) {
-		return NULL;
-	}
-
-	m->closure  = closure;
-	m->dfastate = dfastate;
-	m->edges    = NULL;
-
-	if (!mapping_hashset_add(mappings, m)) {
-		f_free(alloc, m);
-		return NULL;
-	}
-
-	return m;
-}
-
-struct mappingstack {
-	const struct fsm_alloc *alloc;
-	size_t ceil;
-	size_t depth;
-	struct mapping **s;
-};
-
-#define MAPPINGSTACK_DEF_CEIL 16
-
-static struct mappingstack *
-stack_init(const struct fsm_alloc *alloc)
-{
-	struct mapping **s;
-	struct mappingstack *res = f_malloc(alloc, sizeof(*res));
-	if (res == NULL) {
-		return NULL;
-	}
-
-	s = f_malloc(alloc, MAPPINGSTACK_DEF_CEIL * sizeof(s[0]));
-	if (s == NULL) {
-		f_free(alloc, res);
-		return NULL;
-	}
-
-	res->alloc = alloc;
-	res->ceil = MAPPINGSTACK_DEF_CEIL;
-	res->depth = 0;
-	res->s = s;
-
-	return res;
-}
-
-static void
-stack_free(struct mappingstack *stack)
-{
-	if (stack == NULL) {
-		return;
-	}
-	f_free(stack->alloc, stack->s);
-	f_free(stack->alloc, stack);
-}
-
-static int
-stack_push(struct mappingstack *stack, struct mapping *item)
-{
-	if (stack->depth + 1 == stack->ceil) {
-		size_t nceil = 2 * stack->ceil;
-		struct mapping **ns = f_realloc(stack->alloc,
-		    stack->s, nceil * sizeof(stack->s[0]));
-		if (ns == NULL) {
-			return 0;
-		}
-		stack->ceil = nceil;
-		stack->s = ns;
-	}
-
-	stack->s[stack->depth] = item;
-	stack->depth++;
-	return 1;
-}
-
-static struct mapping *
-stack_pop(struct mappingstack *stack)
-{
-	struct mapping *m;
-
-	assert(stack != NULL);
-	if (stack->depth == 0) {
-		return NULL;
-	}
-
-	stack->depth--;
-	m = stack->s[stack->depth];
-	return m;
-}
+#include "determinise_internal.h"
 
 int
 fsm_determinise(struct fsm *nfa)
 {
+	int res = 0;
 	struct mappingstack *stack = NULL;
-	struct mapping_hashset *mappings;
-	struct mapping *curr;
-	size_t dfacount;
+
+	struct interned_state_set_pool *issp = NULL;
+	struct interned_state_set *empty = NULL;
+	struct map map = { NULL, 0, 0, NULL };
+	struct mapping *curr = NULL;
+	size_t dfacount = 0;
 
 	assert(nfa != NULL);
+	map.alloc = nfa->opt->alloc;
 
 	/*
 	 * This NFA->DFA implementation is for Glushkov NFA only; it keeps things
@@ -241,16 +38,17 @@ fsm_determinise(struct fsm *nfa)
 	fsm_capture_dump(stderr, "#### post_glushkovise", nfa);
 #endif
 
-	dfacount = 0;
-
-	mappings = mapping_hashset_create(nfa->opt->alloc, hash_mapping, cmp_mapping);
-	if (mappings == NULL) {
+	issp = interned_state_set_pool_alloc(nfa->opt->alloc);
+	if (issp == NULL) {
 		return 0;
 	}
 
+	empty = interned_state_set_empty(issp);
+	assert(empty != NULL);	/* cannot fail */
+
 	{
 		fsm_state_t start;
-		struct state_set *set;
+		struct interned_state_set *start_set;
 
 		/*
 		 * The starting condition is the epsilon closure of a set of states
@@ -267,25 +65,22 @@ fsm_determinise(struct fsm *nfa)
 		 */
 
 		if (!fsm_getstart(nfa, &start)) {
-			mapping_hashset_free(mappings);
+			interned_state_set_pool_free(issp);
 			return 1;
-		}
-
-		set = NULL;
-
-		if (!state_set_add(&set, nfa->opt->alloc, start)) {
-			goto error;
 		}
 
 #if LOG_DETERMINISE_CAPTURES
 		fprintf(stderr, "#### Adding mapping for start state %u -> 0\n", start);
 #endif
-
-		curr = mapping_add(mappings, nfa->opt->alloc, dfacount++, set);
-		if (curr == NULL) {
-			/* TODO: free mappings, set */
-			goto error;
+		start_set = interned_state_set_add(issp, empty, start);
+		if (start_set == NULL) {
+			goto cleanup;
 		}
+
+		if (!map_add(&map, dfacount, start_set, &curr)) {
+			goto cleanup;
+		}
+		dfacount++;
 	}
 
 	/*
@@ -294,13 +89,12 @@ fsm_determinise(struct fsm *nfa)
 	 */
 	stack = stack_init(nfa->opt->alloc);
 	if (stack == NULL) {
-		goto error;
+		goto cleanup;
 	}
 
 	do {
-		struct state_set *sclosures[FSM_SIGMA_COUNT] = { NULL };
+		struct interned_state_set *sclosures[FSM_SIGMA_COUNT] = { NULL };
 		int i;
-
 		assert(curr != NULL);
 
 		/*
@@ -311,14 +105,14 @@ fsm_determinise(struct fsm *nfa)
 		{
 			struct state_iter it;
 			fsm_state_t s;
+			struct state_set *ss = interned_state_set_retain(curr->iss);
 
-			for (state_set_reset(curr->closure, &it); state_set_next(&it, &s); ) {
-				/* TODO: could inline this, and destructively hijack state sets from the source NFA */
-				if (!symbol_closure_without_epsilons(nfa, s, sclosures)) {
-					/* TODO: free mappings, sclosures, stack */
-					goto error;
+			for (state_set_reset(ss, &it); state_set_next(&it, &s); ) {
+ 				if (!interned_symbol_closure_without_epsilons(nfa, s, issp, sclosures)) {
+					goto cleanup;
 				}
 			}
+			interned_state_set_release(curr->iss);
 		}
 
 		for (i = 0; i <= FSM_SIGMA_MAX; i++) {
@@ -329,65 +123,58 @@ fsm_determinise(struct fsm *nfa)
 			}
 
 #if LOG_DETERMINISE_CLOSURES
-			fprintf(stderr, "fsm_determinise: cur (dfa %u) label '%c': %p:",
+			fprintf(stderr, "fsm_determinise: cur (dfa %zu) label '%c': %p:",
 			    curr->dfastate, (char)i, (void *)sclosures[i]);
 			{
 				struct state_iter it;
 				fsm_state_t s;
+				struct state_set *ss = interned_state_set_retain(sclosures[i]);
 
-				for (state_set_reset(sclosures[i], &it); state_set_next(&it, &s); ) {
+				for (state_set_reset(ss, &it); state_set_next(&it, &s); ) {
 					fprintf(stderr, " %u", s);
 				}
 				fprintf(stderr, "\n");
+				interned_state_set_release(sclosures[i]);
 			}
 #endif
 
 			/*
 			 * The set of NFA states sclosures[i] represents a single DFA state.
-			 * We use the mappings as a de-duplication mechanism, keyed by this
+			 * We use the mappings as a de-duplication mechanism, keyed by the
 			 * set of NFA states.
 			 */
 
-			/* Use an existing mapping if present, otherwise add a new one */
-			m = mapping_find(mappings, sclosures[i]);
-			if (m != NULL) {
-				/* we already have this closure, free this instance */
-				state_set_free(sclosures[i]);
-
+			/* If this interned_state_set isn't present, then save it as a new mapping. */
+			if (map_find(&map, sclosures[i], &m)) {
+				/* we already have this closure interned */
 				assert(m->dfastate < dfacount);
 			} else {
-				m = mapping_add(mappings, nfa->opt->alloc, dfacount++, sclosures[i]);
-				if (m == NULL) {
-					/* TODO: free mappings, sclosures, stack */
-					goto error;
+				/* not found -- add a new one */
+				if (!map_add(&map, dfacount, sclosures[i], &m)) {
+					goto cleanup;
 				}
-
-				/* ownership belongs to the mapping now, so don't free sclosures[i] */
-
+				dfacount++;
 				if (!stack_push(stack, m)) {
-					/* TODO: free mappings, sclosures, stack */
-					goto error;
+					goto cleanup;
 				}
 			}
 
 			if (!edge_set_add(&curr->edges, nfa->opt->alloc, i, m->dfastate)) {
-				/* TODO: free mappings, sclosures, stack */
-				goto error;
+				goto cleanup;
 			}
 		}
 
-		/* all elements in sclosures[] have been freed or moved to their
-		 * respective mapping, so there's nothing to free here */
-	} while (curr = stack_pop(stack), curr != NULL);
+		/* All elements in sclosures[] are interned, so they will be freed later. */
+	} while ((curr = stack_pop(stack)));
 
 	{
-		struct mapping_hashset_iter it;
+		struct map_iter it;
 		struct mapping *m;
 		struct fsm *dfa;
 
 		dfa = fsm_new(nfa->opt);
 		if (dfa == NULL) {
-			goto error;
+			goto cleanup;
 		}
 
 #if DUMP_MAPPING
@@ -396,22 +183,23 @@ fsm_determinise(struct fsm *nfa)
 
 			/* build reverse mappings table: for every NFA state X, if X is part
 			 * of the new DFA state Y, then add Y to a list for X */
-			for (m = mapping_hashset_first(mappings, &it); m != NULL; m = mapping_hashset_next(&it)) {
+			for (m = map_first(&map, &it); m != NULL; m = map_next(&it)) {
 				struct state_iter si;
 				fsm_state_t state;
-				fprintf(stderr, "%u:", m->dfastate);
+				struct state_set *ss = interned_state_set_retain(m->iss);
+				fprintf(stderr, "%zu:", m->dfastate);
 
-				for (state_set_reset(m->closure, &si); state_set_next(&si, &state); ) {
+				for (state_set_reset(ss, &si); state_set_next(&si, &state); ) {
 					fprintf(stderr, " %u", state);
 				}
 				fprintf(stderr, "\n");
+				interned_state_set_release(m->iss);
 			}
 			fprintf(stderr, "#### fsm_determinise: end of mapping\n");
 		}
 #endif
 		if (!fsm_addstate_bulk(dfa, dfacount)) {
-			/* TODO: free stuff */
-			goto error;
+			goto cleanup;
 		}
 
 		assert(dfa->statecount == dfacount);
@@ -422,7 +210,8 @@ fsm_determinise(struct fsm *nfa)
 		 */
 		fsm_setstart(dfa, 0);
 
-		for (m = mapping_hashset_first(mappings, &it); m != NULL; m = mapping_hashset_next(&it)) {
+		for (m = map_first(&map, &it); m != NULL; m = map_next(&it)) {
+			struct state_set *ss;
 			assert(m->dfastate < dfa->statecount);
 			assert(dfa->states[m->dfastate].edges == NULL);
 
@@ -433,7 +222,9 @@ fsm_determinise(struct fsm *nfa)
 			 * states are end states.
 			 */
 
-			if (!state_set_has(nfa, m->closure, fsm_isend)) {
+			ss = interned_state_set_retain(m->iss);
+			if (!state_set_has(nfa, ss, fsm_isend)) {
+				interned_state_set_release(m->iss);
 				continue;
 			}
 
@@ -446,115 +237,27 @@ fsm_determinise(struct fsm *nfa)
 			 * The closure may contain non-end states, but at least one state is
 			 * known to have been an end state.
 			 */
-			fsm_carryopaque(nfa, m->closure, dfa, m->dfastate);
+			fsm_carryopaque(nfa, ss, dfa, m->dfastate);
 
-			if (!fsm_endid_carry(nfa, m->closure, dfa, m->dfastate)) {
-				goto error;
+			if (!fsm_endid_carry(nfa, ss, dfa, m->dfastate)) {
+				goto cleanup;
 			}
+			interned_state_set_release(m->iss);
 		}
 
-		if (!remap_capture_actions(mappings, dfa, nfa)) {
-			goto error;
+		if (!remap_capture_actions(&map, dfa, nfa)) {
+			goto cleanup;
 		}
 
 		fsm_move(nfa, dfa);
 	}
 
-	{
-		struct mapping_hashset_iter it;
-		struct mapping *m;
-
-		for (m = mapping_hashset_first(mappings, &it); m != NULL; m = mapping_hashset_next(&it)) {
-			state_set_free(m->closure);
-			f_free(nfa->opt->alloc, m);
-		}
-	}
-
-	mapping_hashset_free(mappings);
-	stack_free(stack);
-
-	return 1;
-
-error:
-
-	/* TODO: free stuff */
-	mapping_hashset_free(mappings);
-	stack_free(stack);
-
-	return 0;
-}
-
-static int
-remap_capture_actions(struct mapping_hashset *mappings,
-    struct fsm *dst_dfa, struct fsm *src_nfa)
-{
-	struct mapping_hashset_iter it;
-	struct state_iter si;
-	struct mapping *m;
-	struct reverse_mapping *reverse_mappings;
-	fsm_state_t state;
-	const size_t capture_count = fsm_countcaptures(src_nfa);
-	size_t i, j;
-	int res = 0;
-
-	if (capture_count == 0) {
-		return 1;
-	}
-
-	/* This is not 1 to 1 -- if state X is now represented by multiple
-	 * states Y in the DFA, and state X has action(s) when transitioning
-	 * to state Z, this needs to be added on every Y, for every state
-	 * representing Z in the DFA.
-	 *
-	 * We could probably filter this somehow, at the very least by
-	 * checking reachability from every X, but the actual path
-	 * handling later will also check reachability. */
-	reverse_mappings = f_calloc(dst_dfa->opt->alloc, src_nfa->statecount, sizeof(reverse_mappings[0]));
-	if (reverse_mappings == NULL) {
-		return 0;
-	}
-
-	/* build reverse mappings table: for every NFA state X, if X is part
-	 * of the new DFA state Y, then add Y to a list for X */
-	for (m = mapping_hashset_first(mappings, &it); m != NULL; m = mapping_hashset_next(&it)) {
-		assert(m->dfastate < dst_dfa->statecount);
-
-		for (state_set_reset(m->closure, &si); state_set_next(&si, &state); ) {
-			if (!add_reverse_mapping(dst_dfa->opt->alloc,
-				reverse_mappings,
-				m->dfastate, state)) {
-				goto cleanup;
-			}
-		}
-	}
-
-#if LOG_DETERMINISE_CAPTURES
-	fprintf(stderr, "#### reverse mapping for %zu states\n", src_nfa->statecount);
-	for (i = 0; i < src_nfa->statecount; i++) {
-		struct reverse_mapping *rm = &reverse_mappings[i];
-		fprintf(stderr, "%lu:", i);
-		for (j = 0; j < rm->count; j++) {
-			fprintf(stderr, " %u", rm->list[j]);
-		}
-		fprintf(stderr, "\n");
-	}
-#else
-	(void)j;
-#endif
-
-	if (!det_copy_capture_actions(reverse_mappings, dst_dfa, src_nfa)) {
-		goto cleanup;
-	}
-
 	res = 1;
-cleanup:
-	for (i = 0; i < src_nfa->statecount; i++) {
-		if (reverse_mappings[i].list != NULL) {
-			f_free(dst_dfa->opt->alloc, reverse_mappings[i].list);
-		}
-	}
-	f_free(dst_dfa->opt->alloc, reverse_mappings);
 
+cleanup:
+	map_free(&map);
+	stack_free(stack);
+	interned_state_set_pool_free(issp);
 	return res;
 }
 
@@ -562,7 +265,7 @@ cleanup:
 static int
 add_reverse_mapping(const struct fsm_alloc *alloc,
     struct reverse_mapping *reverse_mappings,
-    fsm_state_t dfa_state, fsm_state_t nfa_state)
+    fsm_state_t dfastate, fsm_state_t nfa_state)
 {
 	struct reverse_mapping *rm = &reverse_mappings[nfa_state];
 	if (rm->count == rm->ceil) {
@@ -576,7 +279,7 @@ add_reverse_mapping(const struct fsm_alloc *alloc,
 		rm->ceil = nceil;
 	}
 
-	rm->list[rm->count] = dfa_state;
+	rm->list[rm->count] = dfastate;
 	rm->count++;
 	return 1;
 }
@@ -635,4 +338,359 @@ det_copy_capture_actions(struct reverse_mapping *reverse_mappings,
 
 	fsm_capture_action_iter(src, det_copy_capture_actions_cb, &env);
 	return env.ok;
+}
+
+static int
+interned_symbol_closure_without_epsilons(const struct fsm *fsm, fsm_state_t s,
+	struct interned_state_set_pool *issp,
+	struct interned_state_set *sclosures[static FSM_SIGMA_COUNT])
+{
+	struct edge_iter jt;
+	struct fsm_edge e;
+
+	assert(fsm != NULL);
+	assert(sclosures != NULL);
+
+	if (fsm->states[s].edges == NULL) {
+		return 1;
+	}
+
+	/*
+	 * TODO: it's common for many symbols to have transitions to the same state
+	 * (the worst case being an "any" transition). It'd be nice to find a way
+	 * to avoid repeating that work by de-duplicating on the destination.
+	 */
+
+	for (edge_set_reset(fsm->states[s].edges, &jt); edge_set_next(&jt, &e); ) {
+		struct interned_state_set *iss = sclosures[e.symbol];
+		struct interned_state_set *updated;
+		if (iss == NULL) {
+			iss = interned_state_set_empty(issp);
+		}
+
+		updated = interned_state_set_add(issp, iss, e.state);
+		if (updated == NULL) {
+			return 0;
+		}
+		sclosures[e.symbol] = updated;
+	}
+
+	return 1;
+}
+
+static unsigned long
+hash_iss(const struct interned_state_set *iss)
+{
+	/* Just hashing the address directly is fine here -- since they're
+	 * interned, they're identified by pointer equality. */
+	return PHI32 * (uintptr_t)iss;
+}
+
+static struct mapping *
+map_first(struct map *map, struct map_iter *iter)
+{
+	iter->m = map;
+	iter->i = 0;
+	return map_next(iter);
+}
+
+static struct mapping *
+map_next(struct map_iter *iter)
+{
+	const size_t limit = iter->m->count;
+	while (iter->i < limit) {
+		struct mapping **m = &iter->m->buckets[iter->i];
+		iter->i++;
+		if (*m == NULL) {
+			continue;
+		}
+		return *m;
+	}
+
+	return NULL;
+}
+
+static int
+map_add(struct map *map,
+	fsm_state_t dfastate, struct interned_state_set *iss,
+	struct mapping **new_mapping)
+{
+	size_t i;
+	unsigned long h, mask;
+
+	if (map->buckets == NULL) {
+		assert(map->count == 0);
+		assert(map->used == 0);
+
+		map->buckets = f_calloc(map->alloc,
+		    DEF_MAP_BUCKET_CEIL, sizeof(map->buckets[0]));
+		if (map->buckets == NULL) {
+			return 0;
+		}
+		map->count = DEF_MAP_BUCKET_CEIL;
+	}
+
+	if (map->used == map->count/2) {
+		if (!grow_map(map)) {
+			return 0;
+		}
+	}
+
+	h = hash_iss(iss);
+	mask = map->count - 1;
+
+	for (i = 0; i < map->count; i++) {
+		struct mapping **b = &map->buckets[(h + i) & mask];
+		if (*b == NULL) {
+			struct mapping *m = f_malloc(map->alloc, sizeof(*m));
+			if (m == NULL) {
+				return 0;
+			}
+			m->iss = iss;
+			m->dfastate = dfastate;
+			m->edges = NULL;
+			*b = m;
+
+			if (new_mapping != NULL) {
+				*new_mapping = m;
+			}
+			map->used++;
+			return 1;
+		} else {
+			continue; /* hash collision */
+		}
+	}
+
+	assert(!"unreachable");
+	return 0;
+}
+
+static int
+grow_map(struct map *map)
+{
+	size_t nceil = 2 * map->count;
+	struct mapping **nbuckets;
+	size_t o_i, n_i;
+	const size_t nmask = nceil - 1;
+
+	assert(nceil > 0);
+
+	nbuckets = f_calloc(map->alloc,
+	    nceil, sizeof(nbuckets[0]));
+	if (nbuckets == NULL) {
+		return 0;
+	}
+
+	for (o_i = 0; o_i < map->count; o_i++) {
+		unsigned long h;
+		struct mapping *ob = map->buckets[o_i];
+		if (ob == NULL) {
+			continue; /* empty */
+		}
+		h = hash_iss(ob->iss);
+		for (n_i = 0; n_i < nmask; n_i++) {
+			struct mapping **nb = &nbuckets[(h + n_i) & nmask];
+			if (*nb == NULL) {
+				*nb = ob;
+				break;
+			}
+		}
+		assert(n_i < nmask); /* found a spot */
+	}
+
+	f_free(map->alloc, map->buckets);
+	map->count = nceil;
+	map->buckets = nbuckets;
+	return 1;
+}
+
+static int
+map_find(const struct map *map, struct interned_state_set *iss,
+	struct mapping **mapping)
+{
+	size_t i;
+	unsigned long h, mask;
+
+	if (map->buckets == NULL) {
+		return 0;
+	}
+
+	h = hash_iss(iss);
+	mask = map->count - 1;
+
+	for (i = 0; i < map->count; i++) {
+		struct mapping *b = map->buckets[(h + i) & mask];
+		if (b == NULL) {
+			return 0; /* not found */
+		} else if (b->iss == iss) {
+			*mapping = b;
+			return 1;
+		} else {
+			continue; /* hash collision */
+		}
+	}
+
+	assert(!"unreachable");
+	return 0;
+}
+
+static void
+map_free(struct map *map)
+{
+	size_t i;
+	if (map->buckets == NULL) {
+		return;
+	}
+
+	for (i = 0; i < map->count; i++) {
+		struct mapping *b = map->buckets[i];
+		if (b == NULL) {
+			continue;
+		}
+		f_free(map->alloc, b);
+	}
+
+	f_free(map->alloc, map->buckets);
+}
+
+static struct mappingstack *
+stack_init(const struct fsm_alloc *alloc)
+{
+	struct mapping **s;
+	struct mappingstack *res = f_malloc(alloc, sizeof(*res));
+	if (res == NULL) {
+		return NULL;
+	}
+
+	s = f_malloc(alloc, MAPPINGSTACK_DEF_CEIL * sizeof(s[0]));
+	if (s == NULL) {
+		f_free(alloc, res);
+		return NULL;
+	}
+
+	res->alloc = alloc;
+	res->ceil = MAPPINGSTACK_DEF_CEIL;
+	res->depth = 0;
+	res->s = s;
+
+	return res;
+}
+
+static void
+stack_free(struct mappingstack *stack)
+{
+	if (stack == NULL) {
+		return;
+	}
+	f_free(stack->alloc, stack->s);
+	f_free(stack->alloc, stack);
+}
+
+static int
+stack_push(struct mappingstack *stack, struct mapping *item)
+{
+	if (stack->depth + 1 == stack->ceil) {
+		size_t nceil = 2 * stack->ceil;
+		struct mapping **ns = f_realloc(stack->alloc,
+		    stack->s, nceil * sizeof(ns[0]));
+		if (ns == NULL) {
+			return 0;
+		}
+		stack->ceil = nceil;
+		stack->s = ns;
+	}
+
+	stack->s[stack->depth] = item;
+	stack->depth++;
+	return 1;
+}
+
+static struct mapping *
+stack_pop(struct mappingstack *stack)
+{
+	assert(stack != NULL);
+	if (stack->depth == 0) {
+		return 0;
+	}
+
+	stack->depth--;
+	struct mapping *item = stack->s[stack->depth];
+	return item;
+}
+
+static int
+remap_capture_actions(struct map *map,
+    struct fsm *dst_dfa, struct fsm *src_nfa)
+{
+	struct map_iter it;
+	struct state_iter si;
+	struct mapping *m;
+	struct reverse_mapping *reverse_mappings;
+	fsm_state_t state;
+	const size_t capture_count = fsm_countcaptures(src_nfa);
+	size_t i, j;
+	int res = 0;
+
+	if (capture_count == 0) {
+		return 1;
+	}
+
+	/* This is not 1 to 1 -- if state X is now represented by multiple
+	 * states Y in the DFA, and state X has action(s) when transitioning
+	 * to state Z, this needs to be added on every Y, for every state
+	 * representing Z in the DFA.
+	 *
+	 * We could probably filter this somehow, at the very least by
+	 * checking reachability from every X, but the actual path
+	 * handling later will also check reachability. */
+	reverse_mappings = f_calloc(dst_dfa->opt->alloc, src_nfa->statecount, sizeof(reverse_mappings[0]));
+	if (reverse_mappings == NULL) {
+		return 0;
+	}
+
+	/* build reverse mappings table: for every NFA state X, if X is part
+	 * of the new DFA state Y, then add Y to a list for X */
+	for (m = map_first(map, &it); m != NULL; m = map_next(&it)) {
+		struct state_set *ss;
+		assert(m->dfastate < dst_dfa->statecount);
+		ss = interned_state_set_retain(m->iss);
+
+		for (state_set_reset(ss, &si); state_set_next(&si, &state); ) {
+			if (!add_reverse_mapping(dst_dfa->opt->alloc,
+				reverse_mappings,
+				m->dfastate, state)) {
+				goto cleanup;
+			}
+		}
+		interned_state_set_release(m->iss);
+	}
+
+#if LOG_DETERMINISE_CAPTURES
+	fprintf(stderr, "#### reverse mapping for %zu states\n", src_nfa->statecount);
+	for (i = 0; i < src_nfa->statecount; i++) {
+		struct reverse_mapping *rm = &reverse_mappings[i];
+		fprintf(stderr, "%lu:", i);
+		for (j = 0; j < rm->count; j++) {
+			fprintf(stderr, " %u", rm->list[j]);
+		}
+		fprintf(stderr, "\n");
+	}
+#else
+	(void)j;
+#endif
+
+	if (!det_copy_capture_actions(reverse_mappings, dst_dfa, src_nfa)) {
+		goto cleanup;
+	}
+
+	res = 1;
+cleanup:
+	for (i = 0; i < src_nfa->statecount; i++) {
+		if (reverse_mappings[i].list != NULL) {
+			f_free(dst_dfa->opt->alloc, reverse_mappings[i].list);
+		}
+	}
+	f_free(dst_dfa->opt->alloc, reverse_mappings);
+
+	return res;
 }

--- a/src/libfsm/determinise_internal.h
+++ b/src/libfsm/determinise_internal.h
@@ -1,0 +1,137 @@
+#ifndef DETERMINISE_INTERNAL_H
+#define DETERMINISE_INTERNAL_H
+
+#include <assert.h>
+#include <stddef.h>
+#include <string.h>
+#include <errno.h>
+
+#include <fsm/fsm.h>
+#include <fsm/capture.h>
+#include <fsm/pred.h>
+#include <fsm/walk.h>
+
+#include <adt/alloc.h>
+#include <adt/set.h>
+#include <adt/edgeset.h>
+#include <adt/stateset.h>
+#include <adt/internedstateset.h>
+
+#include "internal.h"
+#include "capture.h"
+#include "endids.h"
+
+#define DUMP_MAPPING 0
+#define LOG_DETERMINISE_CLOSURES 0
+#define LOG_DETERMINISE_CAPTURES 0
+
+#if LOG_DETERMINISE_CAPTURES
+#include <fsm/print.h>
+#endif
+
+/* Starting number of buckets for the map's
+ * hash table. Must be a power of 2. */
+#define DEF_MAP_BUCKET_CEIL 4
+
+/*
+ * This maps a DFA state onto its associated NFA symbol closure, such that an
+ * existing DFA state may be found given any particular set of NFA states
+ * forming a symbol closure.
+ *
+ * Since the same state sets tend to be constructed over and over during
+ * determinization, they are interned -- constructing a set with the same
+ * contents will instead get a reference to an existing instance.
+ */
+struct map {
+	const struct fsm_alloc *alloc;
+
+	size_t used;
+	size_t count;
+
+	/* These are allocated on demand, because they're pushed onto the
+	 * stack by address, and *edges is used by address. */
+	struct mapping {
+		struct interned_state_set *iss;
+		size_t dfastate;
+		struct edge_set *edges;
+	} **buckets;
+};
+
+struct map_iter {
+	struct map *m;
+	size_t i;
+};
+
+struct reverse_mapping {
+	unsigned count;
+	unsigned ceil;
+	fsm_state_t *list;
+};
+
+struct det_copy_capture_actions_env {
+	char tag;
+	struct fsm *dst;
+	struct reverse_mapping *reverse_mappings;
+	int ok;
+};
+
+#define MAPPINGSTACK_DEF_CEIL 16
+struct mappingstack {
+	const struct fsm_alloc *alloc;
+	size_t ceil;
+	size_t depth;
+	struct mapping **s;
+};
+
+static int
+map_add(struct map *map,
+	fsm_state_t dfastate, struct interned_state_set *iss,
+	struct mapping **new_mapping);
+
+static int
+map_find(const struct map *map, struct interned_state_set *iss,
+	struct mapping **mapping);
+
+static void
+map_free(struct map *map);
+
+static struct mapping *
+map_first(struct map *map, struct map_iter *iter);
+
+static struct mapping *
+map_next(struct map_iter *iter);
+
+static int
+add_reverse_mapping(const struct fsm_alloc *alloc,
+	struct reverse_mapping *reverse_mappings,
+	fsm_state_t dfastate, fsm_state_t nfa_state);
+
+static int
+det_copy_capture_actions(struct reverse_mapping *reverse_mappings,
+	struct fsm *dst, struct fsm *src);
+
+static int
+interned_symbol_closure_without_epsilons(const struct fsm *fsm, fsm_state_t s,
+	struct interned_state_set_pool *issp,
+	struct interned_state_set *sclosures[static FSM_SIGMA_COUNT]);
+
+static int
+grow_map(struct map *map);
+
+static int
+remap_capture_actions(struct map *map,
+	struct fsm *dst_dfa, struct fsm *src_nfa);
+
+static struct mappingstack *
+stack_init(const struct fsm_alloc *alloc);
+
+static void
+stack_free(struct mappingstack *stack);
+
+static int
+stack_push(struct mappingstack *stack, struct mapping *item);
+
+static struct mapping *
+stack_pop(struct mappingstack *stack);
+
+#endif

--- a/tests/internedstateset/Makefile
+++ b/tests/internedstateset/Makefile
@@ -1,0 +1,19 @@
+.include "../../share/mk/top.mk"
+
+TEST.tests/internedstateset != ls -1 tests/internedstateset/internedstateset*.c
+TEST_SRCDIR.tests/internedstateset = tests/internedstateset
+TEST_OUTDIR.tests/internedstateset = ${BUILD}/tests/internedstateset
+
+.for n in ${TEST.tests/internedstateset:T:R:C/^internedstateset//}
+INCDIR.${TEST_SRCDIR.tests/internedstateset}/internedstateset${n}.c += src/adt
+.endfor
+
+.for n in ${TEST.tests/internedstateset:T:R:C/^internedstateset//}
+test:: ${TEST_OUTDIR.tests/internedstateset}/res${n}
+SRC += ${TEST_SRCDIR.tests/internedstateset}/internedstateset${n}.c
+CFLAGS.${TEST_SRCDIR.tests/internedstateset}/internedstateset${n}.c += -UNDEBUG
+${TEST_OUTDIR.tests/internedstateset}/run${n}: ${TEST_OUTDIR.tests/internedstateset}/internedstateset${n}.o ${BUILD}/lib/adt.o
+	${CC} ${CFLAGS} ${CFLAGS.${TEST_SRCDIR.tests/internedstateset}/internedstateset${n}.c} -o ${TEST_OUTDIR.tests/internedstateset}/run${n} ${TEST_OUTDIR.tests/internedstateset}/internedstateset${n}.o ${BUILD}/lib/adt.o
+${TEST_OUTDIR.tests/internedstateset}/res${n}: ${TEST_OUTDIR.tests/internedstateset}/run${n}
+	( ${TEST_OUTDIR.tests/internedstateset}/run${n} 1>&2 && echo PASS || echo FAIL ) > ${TEST_OUTDIR.tests/internedstateset}/res${n}
+.endfor

--- a/tests/internedstateset/internedstateset_basic.c
+++ b/tests/internedstateset/internedstateset_basic.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+
+#include <fsm/fsm.h>
+
+#include <adt/internedstateset.h>
+
+int main(void) {
+	struct interned_state_set *empty;
+	struct interned_state_set *cur, *set_up, *set_up2, *set_down, *set_down2;
+	fsm_state_t i;
+	const size_t limit = 1000;
+
+	struct interned_state_set_pool *issp = interned_state_set_pool_alloc(NULL);
+	assert(issp);
+
+	empty = interned_state_set_empty(issp);
+	assert(empty != NULL);
+
+	/* Create state sets with [], [0], [0, 1], ... [0, ... limit-1] */
+	cur = empty;
+	for (i = 0; i < limit; i++) {
+		cur = interned_state_set_add(issp, cur, i);
+		assert(cur != NULL);
+	}
+	set_up = cur;
+
+	/* Create the same ones again */
+	cur = empty;
+	for (i = 0; i < limit; i++) {
+		cur = interned_state_set_add(issp, cur, i);
+		assert(cur != NULL);
+	}
+	set_up2 = cur;
+
+	/* Check that they match. */
+	assert(set_up == set_up2);
+
+	/* Create state sets [], [limit-1], [limit-2, limit-1], ... */
+	cur = empty;
+	i = limit;
+	while (i > 0) {
+		i--;
+		cur = interned_state_set_add(issp, cur, i);
+		assert(cur != NULL);
+	}
+	set_down = cur;
+
+	/* Both should end up with the same state set once all are added. */
+	assert(set_up == set_down);
+
+	/* Create the state set in descending order again. These should all
+	 * be cached. */
+	cur = empty;
+	i = limit;
+	while (i > 0) {
+		i--;
+		cur = interned_state_set_add(issp, cur, i);
+		assert(cur != NULL);
+	}
+	set_down2 = cur;
+
+	/* These should also be pointer-equal. */
+	assert(set_down2 == set_down);
+
+	/* Free the pool. Check that no memory leaked. */
+	interned_state_set_pool_free(issp);
+	return 0;
+}


### PR DESCRIPTION
Add a wrapper around `state_set` construction that interns them, and use it in `fsm_determinise`.

While investigating ways to improve determinisation performance, I realized that it was spending the majority of its time constructing `state_set`s, checking if they existed, realizing they were redundant, and then freeing them. Moving the cache check into construction itself speeds this up considerably; each `state_set` is cached, and the wrapper keeps track of other derived `state_set`s that are created by adding a single state to an existing set. There is also a global cache, so if an equivalent set is incrementally built up in a different order, it will still converge on the same set, and get cached on the other interned state set. Then, we can use pointer equality to compare the `state_set`s in the transitive-closure-to-DFA-state mapping, rather than checking that every individual state in each set matches, which eliminates a lot of overhead in the mapping's bookkeeping.

This needs further testing and benchmarking, but casual benchmarking suggests that it's roughly twice as fast.

This looks like a gnarlier diff than it is; the overarching logic hasn't changed that much, but the specific data structure types have, so there are a lot of small changes all over the place. It uses a couple bespoke data structures, rather than the `adt` ones, because it needs two fairly simple add-only hash tables which are hashing an interned pointer (a unique ID) or a single state ID and don't need most of the adt hash table interfaces. (`siphash` is also pretty heavyweight for this use case, and dominates profiling.) The interned state set is added to adt/.

I've done some testing for memory leaks, but haven't thoroughly exercised the error handling yet; I was more interested in checking the tests and performance for a couple test data sets I've been using. All the existing tests pass.

The next step would be switching state_set from an ordered array to something with cheaper insertion. I have a prototype of this on another branch, but found that then instead of `state_set_add` dominating the profile, then it became state set comparison, and realized why `fsm_determinise` was spending nearly all of its time in `mapping_find`. Rather than using statehashset, I tried using a new implementation that hashed as a sum of `PHI32 * (state + 1)` for each state, because (unless I'm horribly mistaken) those will converged on the same hash in any order, and we can incrementally construct the hash -- in other words, it becomes cheap to check whether adding a state to an existing state_set would produce an existing, cached state_set without needing to actually construct it, which should speed up determinisation further (as will using a state set that is cheaper to insert into). Instead it would probably be better to integrate this idea into `statehashset.c` and use that instead.