### PR TITLE
Add pcre test suite for CI

### DIFF
--- a/.github/workflows/san.yml
+++ b/.github/workflows/san.yml
@@ -78,7 +78,32 @@ jobs:
             < ${BUILD}/${PCRE_VER}/testdata/$i \
             > ${BUILD}/test/retest/$i.tst
         done
+        # things which will probably never be relevant for us:
+        rm ${BUILD}/test/retest/testinput2.tst # pcre options
+        rm ${BUILD}/test/retest/testinput3.tst # locale
+        rm ${BUILD}/test/retest/testinput5.tst # pcre options
+        rm ${BUILD}/test/retest/testinput8.tst # pcre bytecode
+        rm ${BUILD}/test/retest/testinput9.tst # character encodings
+        rm ${BUILD}/test/retest/testinput10.tst # character encodings
+        rm ${BUILD}/test/retest/testinput11.tst # character encodings
+        rm ${BUILD}/test/retest/testinput12.tst # character encodings
+        rm ${BUILD}/test/retest/testinput13.tst # character encodings
+        rm ${BUILD}/test/retest/testinput15.tst # backtracking limits
+        rm ${BUILD}/test/retest/testinput16.tst # JIT options
+        rm ${BUILD}/test/retest/testinput17.tst # JIT options
+        rm ${BUILD}/test/retest/testinput20.tst # serialisation
+        rm ${BUILD}/test/retest/testinput21.tst # \C
+        rm ${BUILD}/test/retest/testinput22.tst # \C
+        rm ${BUILD}/test/retest/testinput23.tst # \C
         rm ${BUILD}/test/retest/testinputEBC.tst # EBCDIC
+        # things we should eventually support, but don't yet:
+        rm ${BUILD}/test/retest/testinput4.tst # we don't provide UTF8 yet
+        rm ${BUILD}/test/retest/testinput7.tst # we don't provide UTF8 yet
+        rm ${BUILD}/test/retest/testinput14.tst # we don't provide UTF8 yet
+        rm ${BUILD}/test/retest/testinput18.tst # POSIX dialect
+        rm ${BUILD}/test/retest/testinput19.tst # POSIX dialect
+        rm ${BUILD}/test/retest/testinput24.tst # POSIX dialect
+        rm ${BUILD}/test/retest/testinput25.tst # POSIX dialect
 
     - name: run pcre test suite (vm v1)
       env:

--- a/.github/workflows/san.yml
+++ b/.github/workflows/san.yml
@@ -59,3 +59,43 @@ jobs:
       # I don't want to build SID just for sake of its -l test
       run: bmake -r -j 2 ${{ matrix.san }}=1 ${{ matrix.debug }}=1 PKGCONF=pkg-config SID='true; echo sid' CC=${{ matrix.cc }} LX=./build/bin/lx test
 
+    - name: fetch pcre test suite
+      env:
+        PCRE_VER: pcre2-10.36
+        BUILD: ./build
+      run: |
+        wget -nv -P ${BUILD}/ https://ftp.pcre.org/pub/pcre/${PCRE_VER}.zip
+        unzip -d ${BUILD}/ ${BUILD}/${PCRE_VER}.zip "${PCRE_VER}/testdata/*"
+        mkdir -p ${BUILD}/test/retest
+        ${BUILD}/bin/cvtpcre < ${BUILD}/${PCRE_VER}/testdata/testinput1 > ${BUILD}/test/retest/testinput1.tst
+
+    - name: run pcre test suite (vm v1)
+      env:
+        BUILD: ./build
+      run: |
+        ${BUILD}/bin/retest -O1 -l vm -x v1 ${BUILD}/test/retest/testinput1.tst
+
+    - name: run pcre test suite (vm v2)
+      env:
+        BUILD: ./build
+      run: |
+        ${BUILD}/bin/retest -O1 -l vm -x v2 ${BUILD}/test/retest/testinput1.tst
+
+    - name: run pcre test suite (asm)
+      env:
+        BUILD: ./build
+      run: |
+        ${BUILD}/bin/retest -O1 -l asm ${BUILD}/test/retest/testinput1.tst
+
+    - name: run pcre test suite (c)
+      env:
+        BUILD: ./build
+      run: |
+        ${BUILD}/bin/retest -O1 -l c ${BUILD}/test/retest/testinput1.tst
+
+    - name: run pcre test suite (vmc)
+      env:
+        BUILD: ./build
+      run: |
+        ${BUILD}/bin/retest -O1 -l vmc ${BUILD}/test/retest/testinput1.tst
+

--- a/.github/workflows/san.yml
+++ b/.github/workflows/san.yml
@@ -67,35 +67,40 @@ jobs:
         wget -nv -P ${BUILD}/ https://ftp.pcre.org/pub/pcre/${PCRE_VER}.zip
         unzip -d ${BUILD}/ ${BUILD}/${PCRE_VER}.zip "${PCRE_VER}/testdata/*"
         mkdir -p ${BUILD}/test/retest
-        ${BUILD}/bin/cvtpcre < ${BUILD}/${PCRE_VER}/testdata/testinput1 > ${BUILD}/test/retest/testinput1.tst
+        # the regexps skipped here take too long to compile in CI at the moment
+        for i in $(cd ${BUILD}/${PCRE_VER}/testdata; ls -1 testinput*); do
+            ${BUILD}/bin/cvtpcre \
+                -s 'word (?:[a-zA-Z0-9]+ ){0,300}otherword' \
+                -s 'Z*(|d*){216}' \
+                -s 'X?(R||){3335}' \
+                -s '(|]+){2,2452}' \
+                -s 'z{65536}' \
+            < ${BUILD}/${PCRE_VER}/testdata/$i \
+            > ${BUILD}/test/retest/$i.tst
+        done
 
     - name: run pcre test suite (vm v1)
       env:
         BUILD: ./build
-      run: |
-        ${BUILD}/bin/retest -O1 -l vm -x v1 ${BUILD}/test/retest/testinput1.tst
+      run: ${BUILD}/bin/retest -O1 -l vm -x v1 ${BUILD}/test/retest/*.tst
 
     - name: run pcre test suite (vm v2)
       env:
         BUILD: ./build
-      run: |
-        ${BUILD}/bin/retest -O1 -l vm -x v2 ${BUILD}/test/retest/testinput1.tst
+      run: ${BUILD}/bin/retest -O1 -l vm -x v2 ${BUILD}/test/retest/*.tst
 
     - name: run pcre test suite (asm)
       env:
         BUILD: ./build
-      run: |
-        ${BUILD}/bin/retest -O1 -l asm ${BUILD}/test/retest/testinput1.tst
+      run: ${BUILD}/bin/retest -O1 -l asm ${BUILD}/test/retest/*.tst
 
     - name: run pcre test suite (c)
       env:
         BUILD: ./build
-      run: |
-        ${BUILD}/bin/retest -O1 -l c ${BUILD}/test/retest/testinput1.tst
+      run: ${BUILD}/bin/retest -O1 -l c ${BUILD}/test/retest/*.tst
 
     - name: run pcre test suite (vmc)
       env:
         BUILD: ./build
-      run: |
-        ${BUILD}/bin/retest -O1 -l vmc ${BUILD}/test/retest/testinput1.tst
+      run: ${BUILD}/bin/retest -O1 -l vmc ${BUILD}/test/retest/*.tst
 

--- a/.github/workflows/san.yml
+++ b/.github/workflows/san.yml
@@ -78,6 +78,7 @@ jobs:
             < ${BUILD}/${PCRE_VER}/testdata/$i \
             > ${BUILD}/test/retest/$i.tst
         done
+        rm ${BUILD}/test/retest/testinputEBC.tst # EBCDIC
 
     - name: run pcre test suite (vm v1)
       env:

--- a/src/libfsm/print/vmasm.c
+++ b/src/libfsm/print/vmasm.c
@@ -74,8 +74,6 @@ print_asm_amd64(FILE *f, const char *funcname, const struct ir *ir, const struct
 	assert(opt != NULL);
 	assert(a != NULL);
 
-	assert(ir->n > 0);
-
 	switch (dialect) {
 	case AMD64_ATT:  comment = "#"; break;
 	case AMD64_NASM: comment = ";"; break;

--- a/src/libfsm/vm/ir.c
+++ b/src/libfsm/vm/ir.c
@@ -744,7 +744,7 @@ initial_translate_state(struct dfavm_assembler_ir *a, const struct ir *ir, size_
 
 	switch (st->strategy) {
 	case IR_NONE:
-		*opp = opasm_new_stop(a, VM_CMP_ALWAYS, 0, st->isend ? VM_END_SUCC : VM_END_FAIL, st);
+		*opp = opasm_new_stop(a, VM_CMP_ALWAYS, 0, VM_END_FAIL, st);
 		opp = &(*opp)->next;
 		break;
 

--- a/src/retest/main.c
+++ b/src/retest/main.c
@@ -984,8 +984,7 @@ process_test_file(const char *fname, enum re_dialect default_dialect, enum imple
 				alarm(watchdog_secs);
 			}
 
-			/* XXX - minimize or determinize? */
-			succ = fsm_determinise(fsm);
+			succ = fsm_determinise(fsm) && fsm_minimise(fsm);
 
 			if (do_watchdog) {
 				watchdog_on = 0;


### PR DESCRIPTION
This isn't quite ready yet; I'm making the PR so I can keep track of what I'm doing.

The pcre suite is under a licence that isn't suitable for including in this repo directly. Here I'm having CI download the source, and that way we don't commit those tests. This is a CI action though, so you can't run this from the build system using make. Perhaps I should move the guts to the makefiles instead, to allow for that.