### PR TITLE
Grouped edge_set ADT

### DIFF
--- a/include/adt/edgeset.h
+++ b/include/adt/edgeset.h
@@ -80,8 +80,8 @@ edge_set_remove(struct edge_set **set, unsigned char symbol);
 void
 edge_set_remove_state(struct edge_set **set, fsm_state_t state);
 
-void
-edge_set_compact(struct edge_set **set,
+int
+edge_set_compact(struct edge_set **set, const struct fsm_alloc *alloc,
     fsm_state_remap_fun *remap, const void *opaque);
 
 void
@@ -93,8 +93,9 @@ edge_set_next(struct edge_iter *it, struct fsm_edge *e);
 void
 edge_set_rebase(struct edge_set **setp, fsm_state_t base);
 
-void
-edge_set_replace_state(struct edge_set **setp, fsm_state_t old, fsm_state_t new);
+int
+edge_set_replace_state(struct edge_set **setp,
+    const struct fsm_alloc *alloc, fsm_state_t old, fsm_state_t new);
 
 int
 edge_set_empty(const struct edge_set *s);

--- a/include/adt/edgeset.h
+++ b/include/adt/edgeset.h
@@ -17,7 +17,7 @@ struct edge_set;
 struct state_set;
 
 struct edge_iter {
-	size_t i;
+	size_t i, j;
 	const struct edge_set *set;
 };
 
@@ -68,6 +68,8 @@ edge_set_transition(const struct edge_set *set, unsigned char symbol,
 size_t
 edge_set_count(const struct edge_set *set);
 
+/* Note: this should actually union src into *dst, if *dst already
+ * exists, not replace it. */
 int
 edge_set_copy(struct edge_set **dst, const struct fsm_alloc *alloc,
 	const struct edge_set *src);

--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -114,7 +114,7 @@ fsm_addstate_bulk(struct fsm *fsm, size_t n);
  /*
  * Remove a state. Any edges transitioning to this state are also removed.
  */
-void
+int
 fsm_removestate(struct fsm *fsm, fsm_state_t state);
 
 /* Use the state passed in via opaque to determine whether the state[id]

--- a/src/adt/Makefile
+++ b/src/adt/Makefile
@@ -22,7 +22,7 @@ CFLAGS.${src} += -I src # XXX: for internal.h
 DFLAGS.${src} += -I src # XXX: for internal.h
 .endfor
 
-.for src in ${SRC:Msrc/adt/siphash.c}
+.for src in ${SRC:Msrc/adt/siphash.c} ${SRC:Msrc/adt/edgeset.c}
 CFLAGS.${src} += -std=c99 # XXX: for internal.h
 DFLAGS.${src} += -std=c99 # XXX: for internal.h
 .endfor

--- a/src/adt/edgeset.c
+++ b/src/adt/edgeset.c
@@ -9,6 +9,16 @@
 #include <string.h>
 #include <stdio.h>
 
+/* If non-zero, use an experimental edge_set implementation
+ * that collects edges leading to the same set in a group
+ * and uses bitflags for individual labels. While there should
+ * be some space savings vs. storing every <label, state> pair
+ * individually, the bigger motivation is to do processing for
+ * some operations (especially fsm_determinise) by group rather
+ * than for every individual pair. */
+#define USE_EDGE_BITSET 1
+
+#if !USE_EDGE_BITSET
 #include "libfsm/internal.h" /* XXX: for allocating struct fsm_edge, and the edges array */
 
 #include <print/esc.h>
@@ -18,6 +28,7 @@
 #include <adt/set.h>
 #include <adt/stateset.h>
 #include <adt/edgeset.h>
+
 
 /* This is a simple linear-probing hash table, keyed by the edge symbol.
  * Since many edge sets only contain a single item, there is a special
@@ -871,3 +882,989 @@ edge_set_ordered_iter_next(struct edge_ordered_iter *eoi, struct fsm_edge *e)
 		}
 	}
 }
+
+#else /* USE_EDGE_BITSET */
+
+#define LOG_BITSET 0
+
+#include "libfsm/internal.h" /* XXX: for allocating struct fsm_edge, and the edges array */
+
+#include <print/esc.h>
+
+#include <adt/alloc.h>
+#include <adt/bitmap.h>
+#include <adt/set.h>
+#include <adt/stateset.h>
+#include <adt/edgeset.h>
+
+#define DEF_EDGE_GROUP_CEIL 2
+
+/* Array of <to, symbols> tuples, sorted by to.
+ *
+ * Design assumption: It is significantly more likely in practice to
+ * have to be more edges with different labels going to the same state
+ * than the same symbol going to different states. This does not
+ * include epsilon edges, which can be stored in a state_set.
+ *
+ * A NULL pointer is treated as the empty set, because */
+struct edge_set {
+	size_t ceil;		/* nonzero */
+	size_t count;		/* <= ceil */
+	struct edge_group {
+		fsm_state_t to;	/* distinct */
+		uint64_t symbols[256/64];
+	} *groups;		/* sorted by .to */
+};
+
+#define SYMBOLS_SET(S, ID) (S[ID/64] |= (1ULL << (ID & 63)))
+#define SYMBOLS_GET(S, ID) (S[ID/64] & (1ULL << (ID & 63)))
+#define SYMBOLS_CLEAR(S, ID) (S[ID/64] &=~ (1ULL << (ID & 63)))
+
+struct edge_set *
+edge_set_new(void)
+{
+#if LOG_BITSET
+	fprintf(stderr, " -- edge_set_new\n");
+#endif
+	return NULL;		/* -> empty set */
+}
+
+void
+edge_set_free(const struct fsm_alloc *a, struct edge_set *set)
+{
+#if LOG_BITSET
+	fprintf(stderr, " -- edge_set_free %p\n", (void *)set);
+#endif
+	if (set == NULL) {
+		return;
+	}
+
+	f_free(a, set->groups);
+	f_free(a, set);
+}
+
+static int
+grow_groups(struct edge_set *set, const struct fsm_alloc *alloc)
+{
+	/* TODO: This could also squash out any groups where
+	 * none of the symbols are set anymore. */
+	const size_t nceil = 2 *set->ceil;
+	struct edge_group *ng;
+	assert(nceil > 0);
+
+#if LOG_BITSET
+	fprintf(stderr, " -- edge_set grow_groups: %lu -> %lu\n",
+	    set->ceil, nceil);
+#endif
+
+	ng = f_realloc(alloc, set->groups,
+	    nceil * sizeof(set->groups[0]));
+	if (ng == NULL) {
+		return 0;
+	}
+
+	set->ceil = nceil;
+	set->groups = ng;
+
+	return 1;
+}
+
+static void
+dump_edge_set(const struct edge_set *set)
+{
+	const struct edge_group *eg;
+	size_t i;
+#if LOG_BITSET < 2
+	return;
+#endif
+
+	if (edge_set_empty(set)) {
+		fprintf(stderr, "dump_edge_set: <empty>\n");
+		return;
+	}
+
+	fprintf(stderr, "dump_edge_set: %p\n", (void *)set);
+
+	for (i = 0; i < set->count; i++) {
+		eg = &set->groups[i];
+		fprintf(stderr, " -- %ld: [0x%lx, 0x%lx, 0x%lx, 0x%lx] -> %u\n",
+		    i,
+		    eg->symbols[0], eg->symbols[1],
+		    eg->symbols[2], eg->symbols[3], eg->to);
+	}
+}
+
+int
+edge_set_add(struct edge_set **pset, const struct fsm_alloc *alloc,
+	unsigned char symbol, fsm_state_t state)
+{
+	struct edge_set *set;
+	struct edge_group *eg;
+	size_t i;
+
+	assert(pset != NULL);
+
+	set = *pset;
+
+	if (set == NULL) {	/* empty */
+		set = f_calloc(alloc, 1, sizeof(*set));
+		if (set == NULL) {
+			return 0;
+		}
+
+		set->groups = f_malloc(alloc,
+		    DEF_EDGE_GROUP_CEIL * sizeof(set->groups[0]));
+		if (set->groups == NULL) {
+			f_free(alloc, set);
+			return 0;
+		}
+
+		set->ceil = DEF_EDGE_GROUP_CEIL;
+		set->count = 0;
+
+		eg = &set->groups[0];
+		eg->to = state;
+		memset(eg->symbols, 0x00, sizeof(eg->symbols));
+		SYMBOLS_SET(eg->symbols, symbol);
+		set->count++;
+
+		*pset = set;
+
+#if LOG_BITSET
+		fprintf(stderr, " -- edge_set_add: symbol 0x%x -> state %d on empty -> %p\n",
+		    symbol, state, (void *)set);
+#endif
+		dump_edge_set(set);
+
+		return 1;
+	}
+
+	assert(set->ceil > 0);
+	assert(set->count <= set->ceil);
+
+#if LOG_BITSET
+	fprintf(stderr, " -- edge_set_add: symbol 0x%x -> state %d on %p\n",
+	    symbol, state, (void *)set);
+#endif
+
+	/* Linear search for a group with the same destination
+	 * state, or the position where that group would go. */
+	for (i = 0; i < set->count; i++) {
+		eg = &set->groups[i];
+
+		if (eg->to == state) {
+			/* This API does not indicate whether that
+			 * symbol -> to edge was already present. */
+			SYMBOLS_SET(eg->symbols, symbol);
+			dump_edge_set(set);
+			return 1;
+		} else if (eg->to > state) {
+			break;	/* will shift down and insert below */
+		} else {
+			continue;
+		}
+	}
+
+	/* insert/append at i */
+	if (set->count == set->ceil) {
+		if (!grow_groups(set, alloc)) {
+			return 0;
+		}
+	}
+
+	eg = &set->groups[i];
+
+	if (i < set->count && eg->to != state) {  /* shift down by one */
+		const size_t to_mv = set->count - i;
+
+#if LOG_BITSET
+		fprintf(stderr, "   --- shifting, count %ld, i %ld, to_mv %ld\n",
+		    set->count, i, to_mv);
+#endif
+
+		if (to_mv > 0) {
+			memmove(&set->groups[i + 1],
+			    &set->groups[i],
+			    to_mv * sizeof(set->groups[i]));
+		}
+		eg = &set->groups[i];
+	}
+
+	eg->to = state;
+	memset(eg->symbols, 0x00, sizeof(eg->symbols));
+	SYMBOLS_SET(eg->symbols, symbol);
+	set->count++;
+	dump_edge_set(set);
+
+	return 1;
+}
+
+int
+edge_set_add_state_set(struct edge_set **setp, const struct fsm_alloc *alloc,
+	unsigned char symbol, const struct state_set *state_set)
+{
+	struct state_iter si;
+	fsm_state_t state;
+
+	state_set_reset(state_set, &si);
+
+	while (state_set_next(&si, &state)) {
+		if (!edge_set_add(setp, alloc, symbol, state)) {
+			return 0;
+		}
+	}
+
+	return 1;
+}
+
+int
+edge_set_find(const struct edge_set *set, unsigned char symbol,
+	struct fsm_edge *e)
+{
+	const struct edge_group *eg;
+	size_t i;
+	if (set == NULL) {
+		return 0;
+	}
+
+#if LOG_BITSET
+	fprintf(stderr, " -- edge_set_find: symbol 0x%x on %p\n",
+	    symbol, (void *)set);
+#endif
+
+	for (i = 0; i < set->count; i++) {
+		eg = &set->groups[i];
+		if (SYMBOLS_GET(eg->symbols, symbol)) {
+			e->state = eg->to;
+			e->symbol = symbol;
+			return 1;
+		}
+	}
+
+	return 0;		/* not found */
+}
+
+int
+edge_set_contains(const struct edge_set *set, unsigned char symbol)
+{
+	const struct edge_group *eg;
+	size_t i;
+	if (edge_set_empty(set)) {
+		return 0;
+	}
+
+#if LOG_BITSET
+	fprintf(stderr, " -- edge_set_contains: symbol 0x%x on %p\n",
+	    symbol, (void *)set);
+#endif
+
+	for (i = 0; i < set->count; i++) {
+		eg = &set->groups[i];
+		if (SYMBOLS_GET(eg->symbols, symbol)) {
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+int
+edge_set_hasnondeterminism(const struct edge_set *set, struct bm *bm)
+{
+	size_t i, w_i;
+	assert(bm != NULL);
+
+#if LOG_BITSET
+	fprintf(stderr, " -- edge_set_hasnondeterminism: on %p\n",
+	    (void *)set);
+#endif
+
+	dump_edge_set(set);
+
+	if (edge_set_empty(set)) {
+		return 0;
+	}
+
+	for (i = 0; i < set->count; i++) {
+		const struct edge_group *eg = &set->groups[i];
+		for (w_i = 0; w_i < 4; w_i++) {
+			const uint64_t cur = eg->symbols[w_i];
+			size_t b_i;
+			if (cur == 0) {
+				continue;
+			}
+
+#if LOG_BITSET > 1
+			fprintf(stderr, " -- eshnd: [0x%lx, 0x%lx, 0x%lx, 0x%lx] + group %ld cur %ld: 0x%lx\n",
+			    eg->symbols[0], eg->symbols[1],
+			    eg->symbols[2], eg->symbols[3],
+			    i, w_i, cur);
+#endif
+
+			for (b_i = 0; b_i < 64; b_i++) {
+				if (cur & (1ULL << b_i)) {
+					const size_t bit = 64*w_i + b_i;
+					if (bm_get(bm, bit)) {
+						return 1;
+					}
+					bm_set(bm, bit);
+				}
+			}
+		}
+	}
+
+	return 0;
+}
+
+int
+edge_set_transition(const struct edge_set *set, unsigned char symbol,
+	fsm_state_t *state)
+{
+	/*
+	 * This function is meaningful for DFA only; we require a DFA
+	 * by contract in order to identify a single destination state
+	 * for a given symbol.
+	 */
+	struct fsm_edge e;
+	if (!edge_set_find(set, symbol, &e)) {
+		return 0;
+	}
+	*state = e.state;
+	return 1;
+}
+
+size_t
+edge_set_count(const struct edge_set *set)
+{
+	size_t res = 0;
+	size_t i;
+
+#if LOG_BITSET
+	fprintf(stderr, " -- edge_set_count: on %p\n",
+	    (void *)set);
+#endif
+
+	/* This does not call edge_set_empty directly
+	 * here, because that does the same scan as below,
+	 * it just exits at the first label found. */
+	if (set == NULL) {
+		return 0;
+	}
+
+	for (i = 0; i < set->count; i++) {
+		size_t w_i;
+		const struct edge_group *eg = &set->groups[i];
+		for (w_i = 0; w_i < 4; w_i++) {
+			/* TODO: res += popcount64(w) */
+			const uint64_t w = eg->symbols[w_i];
+			uint64_t bit;
+			if (w == 0) {
+				continue;
+			}
+			for (bit = (uint64_t)1; bit; bit <<= 1) {
+				if (w & bit) {
+					res++;
+				}
+			}
+		}
+	}
+
+#if LOG_BITSET
+	fprintf(stderr, " -- edge_set_count: %zu\n", res);
+#endif
+	return res;
+}
+
+static int
+find_first_group_label(const struct edge_group *g, unsigned char *label)
+{
+	size_t i, bit;
+	for (i = 0; i < 4; i++) {
+		if (g->symbols[i] == 0) {
+			continue;
+		}
+		for (bit = 0; bit < 64; bit++) {
+			if (g->symbols[i] & ((uint64_t)1 << bit)) {
+				*label = i*64 + bit;
+				return 1;
+			}
+		}
+	}
+	return 0;
+}
+
+static int
+edge_set_copy_into(struct edge_set **pdst, const struct fsm_alloc *alloc,
+	const struct edge_set *src)
+{
+	/* Because the source and destination edge_set groups are
+	 * sorted by .to, we can pairwise bulk merge them. If the
+	 * to label appears in src, we can just bitwise-or the
+	 * labels over in parallel; if not, we need to add it
+	 * first, but it will be added at the current offset. */
+	size_t sg_i, dg_i, w_i;	/* src/dst group index, word index */
+	struct edge_set *dst = *pdst;
+
+	dg_i = 0;
+	sg_i = 0;
+	while (sg_i < src->count) {
+		const struct edge_group *src_g = &src->groups[sg_i];
+		struct edge_group *dst_g = (dg_i < dst->count
+		    ? &dst->groups[dg_i]
+		    : NULL);
+		if (dst_g == NULL || dst_g->to > src_g->to) {
+			unsigned char label;
+
+			/* If the src group is empty, skip it (that can
+			 * happen as labels are added and removed,
+			 * we don't currently prune empty ones),
+			 * otherwise get the first label present for
+			 * the edge_set_add below. */
+			if (!find_first_group_label(src_g, &label)) {
+				sg_i++;
+				continue;
+			}
+
+			/* Insert the first label, so a group with
+			 * that .to will exist at the current offset. */
+			if (!edge_set_add(&dst, alloc,
+				label, src_g->to)) {
+				return 0;
+			}
+
+			dst_g = &dst->groups[dg_i];
+		}
+
+		assert(dst_g != NULL); /* exists now */
+		if (dst_g->to < src_g->to) {
+			dg_i++;
+			continue;
+		}
+
+		assert(dst_g->to == src_g->to);
+		for (w_i = 0; w_i < 4; w_i++) { /* bit-parallel union */
+			dst_g->symbols[w_i] |= src_g->symbols[w_i];
+		}
+		sg_i++;
+		dg_i++;
+	}
+	return 1;
+}
+
+int
+edge_set_copy(struct edge_set **dst, const struct fsm_alloc *alloc,
+	const struct edge_set *src)
+{
+	struct edge_set *set;
+	assert(dst != NULL);
+
+#if LOG_BITSET
+	fprintf(stderr, " -- edge_set_copy: on %p -> %p\n",
+	    (void *)src, (void *)*dst);
+#endif
+
+	if (*dst != NULL) {
+		/* The other `edge_set_copy` copies in the
+		 * edges from src if *dst already exists. */
+		return edge_set_copy_into(dst, alloc, src);
+	}
+
+	if (edge_set_empty(src)) {
+		*dst = NULL;
+		return 1;
+	}
+
+	set = f_calloc(alloc, 1, sizeof(*set));
+	if (set == NULL) {
+		return 0;
+	}
+
+	set->groups = f_malloc(alloc,
+	    src->ceil * sizeof(set->groups[0]));
+	if (set->groups == NULL) {
+		f_free(alloc, set);
+		return 0;
+	}
+
+	set->ceil = src->ceil;
+	memcpy(set->groups, src->groups,
+	    src->count * sizeof(src->groups[0]));
+	set->count = src->count;
+
+#if LOG_BITSET
+	{
+		size_t i;
+		for (i = 0; i < set->count; i++) {
+			fprintf(stderr, "edge_set[%zd]: to %d, [0x%lx, 0x%lx, 0x%lx, 0x%lx]\n",
+			    i, set->groups[i].to,
+			    set->groups[i].symbols[0],
+			    set->groups[i].symbols[1],
+			    set->groups[i].symbols[2],
+			    set->groups[i].symbols[3]);
+		}
+	}
+#endif
+
+	*dst = set;
+	return 1;
+}
+
+void
+edge_set_remove(struct edge_set **pset, unsigned char symbol)
+{
+	size_t i;
+	struct edge_set *set;
+
+	assert(pset != NULL);
+	set = *pset;
+
+#if LOG_BITSET
+	fprintf(stderr, " -- edge_set_remove: symbol 0x%x on %p\n",
+	    symbol, (void *)set);
+#endif
+
+	if (edge_set_empty(set)) {
+		return;
+	}
+
+	/* This does not track whether edge(s) were actually removed.
+	 * It also does not remove edge groups where none of the
+	 * symbols are set anymore. */
+	for (i = 0; i < set->count; i++) {
+		struct edge_group *eg = &set->groups[i];
+		SYMBOLS_CLEAR(eg->symbols, symbol);
+	}
+}
+
+void
+edge_set_remove_state(struct edge_set **pset, fsm_state_t state)
+{
+	size_t i;
+	struct edge_set *set;
+
+	assert(pset != NULL);
+	set = *pset;
+
+#if LOG_BITSET
+	fprintf(stderr, " -- edge_set_remove_state: state %d on %p\n",
+	    state, (void *)set);
+#endif
+
+	if (edge_set_empty(set)) {
+		return;
+	}
+
+	i = 0;
+	while (i < set->count) {
+		const struct edge_group *eg = &set->groups[i];
+		if (eg->to == state) {
+			const size_t to_mv = set->count - i;
+			memmove(&set->groups[i],
+			    &set->groups[i + 1],
+			    to_mv * sizeof(*eg));
+			set->count--;
+		} else {
+			i++;
+		}
+	}
+}
+
+struct to_info {
+	fsm_state_t old_to;
+	fsm_state_t new_to;
+	fsm_state_t assignment;
+};
+
+static int
+collate_info_by_new_to(const void *pa, const void *pb)
+{
+	const struct to_info *a = (const struct to_info *)pa;
+	const struct to_info *b = (const struct to_info *)pb;
+	if (a->new_to < b->new_to) {
+		return -1;
+	} else if (a->new_to > b->new_to) {
+		return 1;
+	} else {
+		return 0;
+	}
+}
+
+static int
+collate_info_by_old_to(const void *pa, const void *pb)
+{
+	const struct to_info *a = (const struct to_info *)pa;
+	const struct to_info *b = (const struct to_info *)pb;
+	if (a->old_to < b->old_to) {
+		return -1;
+	} else if (a->old_to > b->old_to) {
+		return 1;
+	} else {
+		assert(!"violated uniqueness invariant");
+		return 0;
+	}
+}
+
+void
+edge_set_compact(struct edge_set **pset,
+    fsm_state_remap_fun *remap, const void *opaque)
+{
+	struct edge_set *set;
+	size_t i;
+	struct to_info *info;
+	struct edge_group *ngroups;
+	size_t ncount = 0;
+
+	assert(pset != NULL);
+	set = *pset;
+
+#if LOG_BITSET
+	fprintf(stderr, " -- edge_set_compact: set %p\n",
+	    (void *)set);
+#endif
+
+	if (edge_set_empty(set)) {
+		return;
+	}
+
+	assert(set->count > 0);
+
+	/* FIXME: needs alloc if we do this */
+	info = malloc(set->count * sizeof(info[0]));
+	assert(info != NULL);	/* FIXME: can now fail */
+
+	ngroups = calloc(set->ceil, sizeof(ngroups[0]));
+	assert(ngroups != NULL); /* FIXME: can now fail */
+
+	/* first pass, construct mapping */
+	for (i = 0; i < set->count; i++) {
+		struct edge_group *eg = &set->groups[i];
+		const fsm_state_t new_to = remap(eg->to, opaque);
+#if LOG_BITSET > 1
+		fprintf(stderr, "compact: %ld, to %d -> %d\n",
+		    i, eg->to, new_to);
+#endif
+		info[i].old_to = eg->to;
+		info[i].new_to = new_to;
+		info[i].assignment = (fsm_state_t)-1; /* not yet assigned */
+	}
+
+	/* sort info by new_state */
+	qsort(info, set->count, sizeof(info[0]),
+	    collate_info_by_new_to);
+
+#if LOG_BITSET > 1
+	fprintf(stderr, "== after sort by new_state\n");
+	for (i = 0; i < set->count; i++) {
+		fprintf(stderr, " -- %lu: %d, %d, %d\n",
+		    i,
+		    info[i].old_to,
+		    info[i].new_to,
+		    info[i].assignment);
+	}
+#endif
+
+	info[0].assignment = 0;
+	ncount++;
+
+	for (i = 1; i < set->count; i++) {
+		const fsm_state_t prev_new_to = info[i - 1].new_to;
+		const fsm_state_t prev_assignment = info[i - 1].assignment;
+
+		assert(info[i].new_to >= prev_new_to);
+
+		if (info[i].new_to == FSM_STATE_REMAP_NO_STATE) {
+			break;
+		}
+
+		if (info[i].new_to == prev_new_to) {
+			info[i].assignment = prev_assignment;
+		} else {
+			info[i].assignment = prev_assignment + 1;
+			ncount++;
+		}
+	}
+
+	/* sort again, by old_state */
+	qsort(info, set->count, sizeof(info[0]),
+	    collate_info_by_old_to);
+
+#if LOG_BITSET > 1
+	fprintf(stderr, "== after sort by old_state\n");
+	for (i = 0; i < set->count; i++) {
+		fprintf(stderr, " -- %lu: %d, %d, %d\n",
+		    i,
+		    info[i].old_to,
+		    info[i].new_to,
+		    info[i].assignment);
+	}
+#endif
+
+	/* second pass, copy/condense */
+	for (i = 0; i < set->count; i++) {
+		struct edge_group *g;
+		size_t w_i;
+		if (info[i].new_to == FSM_STATE_REMAP_NO_STATE) {
+			continue;
+		}
+		g = &ngroups[info[i].assignment];
+		g->to = info[i].new_to;
+
+		for (w_i = 0; w_i < 256/64; w_i++) {
+			g->symbols[w_i] |= set->groups[i].symbols[w_i];
+		}
+	}
+
+	free(info);
+	free(set->groups);
+	set->groups = ngroups;
+	set->count = ncount;
+
+#if LOG_BITSET > 1
+	for (i = 0; i < set->count; i++) {
+		fprintf(stderr, "ngroups[%zu]: to %d\n",
+		    i, set->groups[i].to);
+	}
+#endif
+
+	(void)cmp_groups;
+	return;
+}
+
+void
+edge_set_reset(const struct edge_set *set, struct edge_iter *it)
+{
+	assert(it != NULL);
+
+#if LOG_BITSET
+	fprintf(stderr, " -- edge_set_reset: set %p\n",
+	    (void *)set);
+#endif
+
+	it->i = 0;
+	it->j = 0;
+	it->set = set;
+}
+
+int
+edge_set_next(struct edge_iter *it, struct fsm_edge *e)
+{
+	const struct edge_set *set;
+	assert(it != NULL);
+	set = it->set;
+
+	set = it->set;
+
+#if LOG_BITSET > 1
+	fprintf(stderr, " -- edge_set_next: set %p, i %ld, j 0x%x\n",
+	    (void *)set, it->i, (unsigned)it->j);
+#endif
+
+	if (set == NULL) {
+		return 0;
+	}
+
+	while (it->i < set->count) {
+		const struct edge_group *eg = &set->groups[it->i];
+		while (it->j < 256) {
+			if ((it->j & 63) == 0 && 0 == eg->symbols[it->j/64]) {
+				it->j += 64;
+			} else {
+				if (SYMBOLS_GET(eg->symbols, it->j)) {
+					e->symbol = it->j;
+					e->state = eg->to;
+					it->j++;
+					return 1;
+				}
+				it->j++;
+			}
+		}
+
+		it->i++;
+		it->j = 0;
+	}
+
+	return 0;
+}
+
+void
+edge_set_rebase(struct edge_set **pset, fsm_state_t base)
+{
+	size_t i;
+	struct edge_set *set;
+
+	assert(pset != NULL);
+	set = *pset;
+
+#if LOG_BITSET
+	fprintf(stderr, " -- edge_set_rebase: set %p, base %d\n",
+	    (void *)set, base);
+#endif
+
+	if (edge_set_empty(set)) {
+		return;
+	}
+
+	for (i = 0; i < set->count; i++) {
+		struct edge_group *eg = &set->groups[i];
+		eg->to += base;
+	}
+}
+
+void
+edge_set_replace_state(struct edge_set **pset, fsm_state_t old, fsm_state_t new)
+{
+	size_t i;
+	struct edge_set *set;
+	struct edge_group cp;
+	const struct fsm_alloc *alloc = NULL; /* FIXME */
+
+	assert(pset != NULL);
+	set = *pset;
+
+#if LOG_BITSET
+	fprintf(stderr, " -- edge_set_replace_state: set %p, state %d -> %d\n",
+	    (void *)set, old, new);
+#endif
+
+	if (edge_set_empty(set)) {
+		return;
+	}
+
+	/* Invariants: if a group with .to == old appears in the group,
+	 * it should only appear once. Replacing .to may lead to
+	 * duplicates, so duplicates may need to be merged after. */
+
+	for (i = 0; i < set->count; i++) {
+		struct edge_group *eg = &set->groups[i];
+		if (eg->to == old) {
+			const size_t to_mv = set->count - i;
+			unsigned char label;
+			if (!find_first_group_label(eg, &label)) {
+				return; /* ignore empty group */
+			}
+
+#if LOG_BITSET
+			fprintf(stderr, " -- edge_set_replace_state: removing group at %ld with .to=%d\n", i, old);
+#endif
+			/* Remove group */
+			memcpy(&cp, eg, sizeof(cp));
+			memmove(&set->groups[i],
+			    &set->groups[i + 1],
+			    to_mv * sizeof(set->groups[i]));
+			set->count--;
+
+#if LOG_BITSET
+			dump_edge_set(set);
+			fprintf(stderr, " -- edge_set_replace_state: reinserting group with .to=%d and label 0x%x\n", new, (unsigned)label);
+#endif
+
+			/* Reinsert group in appropriate place */
+			if (!edge_set_add(&set, alloc,
+				label, new)) {
+				return; /* FIXME: can fail now */
+			}
+			dump_edge_set(set);
+
+			for (i = 0; i < set->count; i++) {
+				eg = &set->groups[i];
+				if (eg->to == new) {
+					size_t w_i;
+#if LOG_BITSET
+					fprintf(stderr, " -- edge_set_replace_state: found new group at %ld, setting other labels from copy\n", i);
+#endif
+					for (w_i = 0; w_i < 4; w_i++) {
+						eg->symbols[w_i] |= cp.symbols[w_i];
+					}
+					dump_edge_set(set);
+					return;
+				}
+			}
+			assert(!"internal error: just added, but not found");
+		}
+	}
+}
+
+int
+edge_set_empty(const struct edge_set *s)
+{
+	size_t i;
+	if (s == NULL || s->count == 0) {
+		return 1;
+	}
+
+	for (i = 0; i < s->count; i++) {
+		unsigned char label;
+		if (find_first_group_label(&s->groups[i], &label)) {
+			return 0;
+		}
+	}
+
+	return 1;
+}
+
+void
+edge_set_ordered_iter_reset_to(const struct edge_set *set,
+    struct edge_ordered_iter *eoi, unsigned char symbol)
+{
+	eoi->symbol = symbol;		/* stride by character */
+	eoi->pos = 0;
+	eoi->set = set;
+
+#if LOG_BITSET
+	fprintf(stderr, " -- edge_set_ordered_iter_reset_to: set %p, symbol 0x%x\n",
+	    (void *)set, symbol);
+#endif
+
+}
+
+/* Reset an ordered iterator, equivalent to
+ * edge_set_ordered_iter_reset_to(set, eoi, '\0'). */
+void
+edge_set_ordered_iter_reset(const struct edge_set *set,
+    struct edge_ordered_iter *eoi)
+{
+	edge_set_ordered_iter_reset_to(set, eoi, 0x00);
+}
+
+/* Get the next edge from an ordered iterator and return 1,
+ * or return 0 when no more are available. */
+int
+edge_set_ordered_iter_next(struct edge_ordered_iter *eoi, struct fsm_edge *e)
+{
+	const struct edge_set *set;
+	assert(eoi != NULL);
+
+	set = eoi->set;
+
+#if LOG_BITSET
+	fprintf(stderr, " -- edge_set_ordered_iter_next: set %p, pos %ld, symbol 0x%x\n",
+	    (void *)set, eoi->pos, eoi->symbol);
+#endif
+
+	if (set == NULL) {
+		return 0;
+	}
+
+	for (;;) {
+		while (eoi->pos < set->count) {
+			struct edge_group *eg = &set->groups[eoi->pos++];
+			if (SYMBOLS_GET(eg->symbols, eoi->symbol)) {
+				e->symbol = eoi->symbol;
+				e->state = eg->to;
+				return 1;
+			}
+		}
+
+		if (eoi->symbol == 255) { /* done */
+			eoi->set = NULL;
+			return 0;
+		} else {
+			eoi->symbol++;
+			eoi->pos = 0;
+		}
+	}
+
+	return 0;
+}
+
+#endif

--- a/src/libfsm/consolidate.c
+++ b/src/libfsm/consolidate.c
@@ -130,7 +130,7 @@ fsm_consolidate(struct fsm *src,
 				goto cleanup;
 			}
 			edge_set_compact(&dst->states[dst_i].edges,
-			    mapping_cb, &closure);
+			    dst->opt->alloc, mapping_cb, &closure);
 
 			if (fsm_isend(src, src_i)) {
 				fsm_setend(dst, dst_i, 1);

--- a/src/libfsm/consolidate.c
+++ b/src/libfsm/consolidate.c
@@ -273,8 +273,8 @@ consolidate_end_ids_cb(fsm_state_t state, const fsm_end_id_t id,
 	assert(env->tag == 'C');
 
 #if LOG_CONSOLIDATE_ENDIDS > 1
-	fprintf(stderr, "consolidate_end_ids_cb: state %u, count %lu, IDs:",
-	    state, count);
+	fprintf(stderr, "consolidate_end_ids_cb: state %u, count %lu, ID %d:",
+	    state, id);
 	for (i = 0; i < count; i++) {
 		fprintf(stderr, " %u", ids[i]);
 	}

--- a/src/libfsm/mergestates.c
+++ b/src/libfsm/mergestates.c
@@ -58,7 +58,9 @@ fsm_mergestates(struct fsm *fsm, fsm_state_t a, fsm_state_t b,
 		edge_set_remove_state(&fsm->states[i].edges, b);
 	}
 
-	fsm_removestate(fsm, b);
+	if (!fsm_removestate(fsm, b)) {
+		return 0;
+	}
 
 	if (q != NULL) {
 		*q = a;

--- a/src/libfsm/state.c
+++ b/src/libfsm/state.c
@@ -111,7 +111,7 @@ otherwise realloc to += twice as much more
 	return 1;
 }
 
-void
+int
 fsm_removestate(struct fsm *fsm, fsm_state_t state)
 {
 	fsm_state_t start, i;
@@ -150,11 +150,14 @@ fsm_removestate(struct fsm *fsm, fsm_state_t state)
 
 		for (i = 0; i < fsm->statecount - 1; i++) {
 			state_set_replace(&fsm->states[i].epsilons, fsm->statecount - 1, state);
-			edge_set_replace_state(&fsm->states[i].edges, fsm->statecount - 1, state);
+			if (!edge_set_replace_state(&fsm->states[i].edges, fsm->opt->alloc, fsm->statecount - 1, state)) {
+				return 0;
+			}
 		}
 	}
 
 	fsm->statecount--;
+	return 1;
 }
 
 static fsm_state_t
@@ -208,7 +211,7 @@ fsm_compact_states(struct fsm *fsm,
 		}
 		state_set_compact(&s->epsilons, mapping_cb, mapping);
 		if (fsm->states[i].edges != NULL) {
-			edge_set_compact(&s->edges, mapping_cb, mapping);
+			edge_set_compact(&s->edges, fsm->opt->alloc, mapping_cb, mapping);
 		}
 	}
 

--- a/theft/fuzz_adt_edge_set.c
+++ b/theft/fuzz_adt_edge_set.c
@@ -284,9 +284,11 @@ prop_model_check_eval(const struct edge_set_op *op,
 			}
 		}
 
-		edge_set_replace_state(es,
-		    op->u.replace_state.old,
-		    op->u.replace_state.new);
+		if (!edge_set_replace_state(es, NULL,
+			op->u.replace_state.old,
+			op->u.replace_state.new)) {
+			assert(!"alloc fail");
+		}
 		break;
 	}
 
@@ -318,7 +320,7 @@ prop_model_check_eval(const struct edge_set_op *op,
 		 * shift IDs down, but not combine multiple edges that
 		 * were previously distinct. The function currently does
 		 * not detect and reject that. */
-		edge_set_compact(es,
+		edge_set_compact(es, NULL,
 		    kept_remap, kept);
 
 		break;

--- a/theft/fuzz_adt_edge_set.c
+++ b/theft/fuzz_adt_edge_set.c
@@ -724,6 +724,45 @@ regression5(theft_seed unused)
 	return res == THEFT_TRIAL_PASS;
 }
 
+static bool
+regression6(theft_seed unused)
+{
+	(void)unused;
+
+	/* edge_set_replace_state was dropping a label->state pair when
+	 * replacing the destination state led to groups merging. */
+	struct edge_set_op op_list[] = {
+		{
+			.t = ESO_ADD,
+			.u.add = {
+				.symbol = 0x00,
+				.state = 3,
+			},
+		},
+		{
+			.t = ESO_ADD,
+			.u.add = {
+				.symbol = 0x01,
+				.state = 0,
+			},
+		},
+		{
+			.t = ESO_REPLACE_STATE,
+			.u.replace_state = {
+				.old = 0,
+				.new = 3,
+			},
+		},
+	};
+	struct edge_set_ops ops = {
+		.count = sizeof(op_list)/sizeof(op_list[0]),
+		.ops = op_list,
+	};
+
+	enum theft_trial_res res = ops_model_check(&ops);
+	return res == THEFT_TRIAL_PASS;
+}
+
 void
 register_test_adt_edge_set(void)
 {
@@ -736,4 +775,5 @@ register_test_adt_edge_set(void)
 	reg_test("adt_edge_set_regression3", regression3);
 	reg_test("adt_edge_set_regression4", regression4);
 	reg_test("adt_edge_set_regression5", regression5);
+	reg_test("adt_edge_set_regression6", regression6);
 }


### PR DESCRIPTION
Add grouped implementation of edge_set ADT.

This uses a bitset for the labels, since it's very common to have several labels that lead to the same state (in particular, "everything else goes here" edges) that could be beneficially combined, but it's comparatively rare to have the same label lead to lots of distinct states.

This currently leaves the existing implementation behind an `#if`, so that we can switch back and forth for benchmarking. Memory usage is likely better for large DFAs, but the callers will need to be adapted to truly benefit from these changes -- The iterator yields individual <label, state> pairs from each group to maintain compatibility with the existing implementation, but ideally some operations (especially `fsm_determinise`) should switch to processing groups of labels with the same destination together, because it will massively improve performance with large FSMs.

All tests are passing, including the edge_set properly tests, which were invaluable for testing.

Note: This adds various interface changes driven by edge_set operations that now alloc, and can therefore now fail.

These operations need an allocator handle for the edge_set label bit-set implementation. These changes should have little impact, because they're bubbling up an error for allocation failure, which is already largely non-recoverable, and fsm_removestate appears to only be called in fsm_mergestates, which is unused (and, per discussion, likely to be removed outside this PR).
