### PR TITLE
Fixes error with freeing resources in fsm_glushkovise()

### DIFF
--- a/src/libfsm/glushkovise.c
+++ b/src/libfsm/glushkovise.c
@@ -133,6 +133,7 @@ fsm_glushkovise(struct fsm *nfa)
 
 			/* XXX: we took a copy, but i would prefer to bulk transplant ownership instead */
 			state_set_free(sclosures[i]);
+			sclosures[i] = NULL; /* prevent double free if we encounter an error */
 		}
 
 		/* all elements in sclosures[] have been freed or moved to their


### PR DESCRIPTION
This fixes a potential double free situation cleaning up resources when fsm_glushkovise() fails to allocate memory.
