### PR TITLE
Update kmkf to conditionally elide rules for generating targets when not invoking `gen::` explicitly

### DIFF
--- a/src/libre/class/Makefile
+++ b/src/libre/class/Makefile
@@ -121,6 +121,7 @@ SRC += src/libre/class/${class}.c
 
 .endfor
 
+.if make(gen)
 gen:: src/libre/class.h
 src/libre/class.h:
 	printf "/* generated */\n" > ${.TARGET}
@@ -152,10 +153,13 @@ src/libre/class.h:
 	done >> ${.TARGET}
 	printf "\n" >> ${.TARGET}
 	printf "#endif\n" >> ${.TARGET}
+.endif
 
+.if make(gen)
 .for src in ${SRC:Msrc/libre/class/*.c}
 gen:: ${src}
 .endfor
+.endif
 
 .for src in ${SRC:Msrc/libre/class/*.c}
 CFLAGS.${src} += -I src/libre # XXX: for class.h
@@ -179,6 +183,7 @@ CFLAGS.${src} += -Wno-overflow
 .endfor
 .endif
 
+.if make(gen)
 gen:: src/libre/class_name.c
 src/libre/class_name.c:
 	printf "/* generated */\n" > ${.TARGET}
@@ -219,4 +224,5 @@ src/libre/class_name.c:
 	printf "\treturn NULL;\n" >> ${.TARGET}
 	printf "}\n" >> ${.TARGET}
 	printf "\n" >> ${.TARGET}
+.endif
 


### PR DESCRIPTION
Making this draft PR so I don't forget. I'm intending to fix the pcregrep CI error on main first, then rebase this (and write a proper description for it)

depreciating (and later removing) `.MADE`:
https://github.com/openbsd/src/commit/6c0d9dcd87ae1329dfcfced82fe671fc2514315b