### PR TITLE
tests/pcre/Makefile: call pcregrep with `--no-jit`. pcregrep bug?

### DIFF
--- a/tests/pcre/Makefile
+++ b/tests/pcre/Makefile
@@ -26,7 +26,7 @@ ${TEST_OUTDIR.tests/pcre-pcregrep}/in${n}.txt: ${TEST_SRCDIR.tests/pcre}/in${n}.
 	> $@
 
 ${TEST_OUTDIR.tests/pcre-pcregrep}/res${n}: ${TEST_OUTDIR.tests/pcre-pcregrep}/in${n}.txt
-	${PCREGREP} -M -qxf ${TEST_SRCDIR.tests/pcre}/in${n}.re < ${.ALLSRC:M*.txt}; \
+	${PCREGREP} -M --no-jit -qxf ${TEST_SRCDIR.tests/pcre}/in${n}.re < ${.ALLSRC:M*.txt}; \
 	if [ $$? -eq 0 ]; then echo PASS; else echo FAIL; fi \
 	> $@
 


### PR DESCRIPTION
The following tests started failing for me, on `main`:

 - build/tests/pcre-pcregrep/res11:FAIL
 - build/tests/pcre-pcregrep/res12:FAIL
 - build/tests/pcre-pcregrep/res44:FAIL

Sometimes they fail in CI, sometimes they don't. It seems to be related to `pcregrep`'s `-M` flag: removing the flag causes those
tests to pass, and the failure appears to have to do with multi-line mode.

@sfstewman found that pcregrep's `-M` option behaves differently with and without `--no-jit`. Confirmed locally, but I have not
investigated further. If it's a bug in heuristics related to JIT-ing, that would explain why it comes and goes.