### PR TITLE
Address several new warnings

### DIFF
--- a/src/adt/internedstateset.c
+++ b/src/adt/internedstateset.c
@@ -116,7 +116,7 @@ interned_state_set_pool_alloc(const struct fsm_alloc *a)
 	{
 		const unsigned long mask = CACHE_BUCKET_DEF_CEIL - 1;
 		struct cache_bucket *b = &res->cache.buckets[empty_i->hash & mask];
-		assert(b->iss = NO_ISS);
+		assert(b->iss == NO_ISS);
 		b->hash = empty_i->hash;
 		b->iss = empty_i;
 	}

--- a/src/adt/stateset.c
+++ b/src/adt/stateset.c
@@ -216,7 +216,6 @@ state_set_add(struct state_set **setp, const struct fsm_alloc *alloc,
 	size_t i;
 
 	assert(setp != NULL);
-	assert(state <= SINGLETON_MAX);
 
 	if (*setp == NULL) {
 		*setp = SINGLETON_ENCODE(state);
@@ -609,7 +608,6 @@ state_set_rebase(struct state_set **setp, fsm_state_t base)
 		state = SINGLETON_DECODE(*setp);
 		state += base;
 
-		assert(state <= SINGLETON_MAX);
 		*setp = SINGLETON_ENCODE(state);
 		return;
 	}
@@ -628,7 +626,6 @@ state_set_replace(struct state_set **setp, fsm_state_t old, fsm_state_t new)
 	size_t i;
 
 	assert(setp != NULL);
-	assert(new <= SINGLETON_MAX);
 
 	if (IS_SINGLETON(*setp)) {
 		if (SINGLETON_DECODE(*setp) != old) {

--- a/src/libfsm/edge.c
+++ b/src/libfsm/edge.c
@@ -43,7 +43,7 @@ fsm_addedge_any(struct fsm *fsm,
 
 	/* TODO: bulk add by symbol, presumably as a bitmap */
 	for (i = 0; i <= UCHAR_MAX; i++) {
-		if (!fsm_addedge_literal(fsm, from, to, (unsigned char) i)) {
+		if (!fsm_addedge_literal(fsm, from, to, (char)i)) {
 			return 0;
 		}
 	}
@@ -60,7 +60,7 @@ fsm_addedge_literal(struct fsm *fsm,
 	assert(from < fsm->statecount);
 	assert(to < fsm->statecount);
 
-	if (!edge_set_add(&fsm->states[from].edges, fsm->opt->alloc, c, to)) {
+	if (!edge_set_add(&fsm->states[from].edges, fsm->opt->alloc, (unsigned char)c, to)) {
 		return 0;
 	}
 

--- a/src/libfsm/minimise.c
+++ b/src/libfsm/minimise.c
@@ -265,7 +265,7 @@ build_minimised_mapping(const struct fsm *fsm,
 				if (next == NO_ID) {
 					continue;    /* 0 elements, skip */
 				}
-				should_gather_EC_labels = next & SMALL_EC_FLAG;
+				should_gather_EC_labels = (next & SMALL_EC_FLAG) != 0;
 				next = MASK_EC_HEAD(next);
 
 				if (env.jump[next] == NO_ID) {

--- a/src/libfsm/print/fsm.c
+++ b/src/libfsm/print/fsm.c
@@ -140,7 +140,7 @@ fsm_print_fsm(FILE *f, const struct fsm *fsm)
 			fprintf(f, "%-2u -> %2u", s, e.state);
 
 			fputs(" \"", f);
-			fsm_escputc(f, fsm->opt, e.symbol);
+			fsm_escputc(f, fsm->opt, (char)e.symbol);
 			putc('\"', f);
 
 			fprintf(f, ";");

--- a/src/libfsm/shortest.c
+++ b/src/libfsm/shortest.c
@@ -116,7 +116,7 @@ fsm_shortest(const struct fsm *fsm,
 
 			assert(v->state == e.state);
 
-			c = cost(u->state, v->state, e.symbol);
+			c = cost(u->state, v->state, (char)e.symbol);
 
 			/* relax */
 			if (v->cost > u->cost + c) {

--- a/src/libfsm/walk2.c
+++ b/src/libfsm/walk2.c
@@ -440,7 +440,7 @@ fsm_walk2_edges(struct fsm_walk2_data *data,
 
 		assert(dst->comb < data->new->statecount);
 
-		if (!fsm_addedge_literal(data->new, qc, dst->comb, i)) {
+		if (!fsm_addedge_literal(data->new, qc, dst->comb, (char)i)) {
 			return 0;
 		}
 

--- a/src/libre/ast.c
+++ b/src/libre/ast.c
@@ -410,6 +410,7 @@ ast_endpoint_cmp(const struct ast_endpoint *a, const struct ast_endpoint *b)
 
 	default:
 		assert(!"unreached");
+		return 0;
 	}
 }
 


### PR DESCRIPTION
Some of these are new in clang-9, some are from UBSan.

There are some type inconsistencies in our interfaces, UBSan is (understandably) complaining about us going back and forth between signed and unsigned char types implicitly with function parameters. I added casts, but should we just plan on using unsigned char throughout?

UBSan is also complaining at length about unsigned integer overflows in hash functions (particularly siphash), but the overflowing is intentional and (since it's unsigned) should still be defined behavior. Just adding casts is not satisfying UBSan, and the non-fixed-width numeric types will make addressing this a pain.