### PR TITLE
Add a term to lx's generated code to avoid adding zero to a null pointer

### DIFF
--- a/src/libfsm/lexer.c
+++ b/src/libfsm/lexer.c
@@ -82,7 +82,7 @@ lx_dynpush(void *buf_opaque, char c)
 
 	assert(t != NULL);
 
-	if (t->p == t->a + t->len) {
+	if (t->a == NULL || t->p == t->a + t->len) {
 		size_t len;
 		ptrdiff_t off;
 		char *tmp;

--- a/src/libfsm/lexer.c
+++ b/src/libfsm/lexer.c
@@ -38,6 +38,7 @@ lx_getc(struct lx *lx)
 
 	if (c == '\n') {
 		lx->end.line++;
+		lx->end.saved_col = lx->end.col - 1;
 		lx->end.col = 1;
 	}
 
@@ -61,7 +62,7 @@ lx_ungetc(struct lx *lx, int c)
 
 	if (c == '\n') {
 		lx->end.line--;
-		lx->end.col = 0; /* XXX: lost information */
+		lx->end.col = lx->end.saved_col;
 	}
 }
 
@@ -259,7 +260,6 @@ z1(struct lx *lx)
 			case 'r':
 			case 't':
 			case 'v': state = S4; break;
-			case 'x': state = S6; break;
 			case '0':
 			case '1':
 			case '2':
@@ -268,6 +268,7 @@ z1(struct lx *lx)
 			case '5':
 			case '6':
 			case '7': state = S5; break;
+			case 'x': state = S6; break;
 			default:  lx_ungetc(lx, c); return TOK_CHAR;
 			}
 			break;
@@ -405,7 +406,7 @@ z2(struct lx *lx)
 		case S1: /* e.g. "a" */
 			lx_ungetc(lx, c); return lx->z(lx);
 
-		case S2: /* e.g. "\n" */
+		case S2: /* e.g. "" */
 			lx_ungetc(lx, c); return lx->z = z3, lx->z(lx);
 
 		default:
@@ -546,7 +547,7 @@ z3(struct lx *lx)
 			}
 			break;
 
-		case S1: /* e.g. "\t" */
+		case S1: /* e.g. "\\x09" */
 			switch ((unsigned char) c) {
 			case '\t':
 			case '\n':
@@ -570,7 +571,7 @@ z3(struct lx *lx)
 
 		case S6: /* e.g. "-" */
 			switch ((unsigned char) c) {
-			case '>': state = S12; break;
+			case '>': state = S20; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
@@ -714,14 +715,13 @@ z3(struct lx *lx)
 			case 'x':
 			case 'y':
 			case 'z': state = S7; break;
-			case 'n': state = S13; break;
+			case 'n': state = S17; break;
 			default:  lx_ungetc(lx, c); return TOK_IDENT;
 			}
 			break;
 
 		case S11: /* e.g. "s" */
 			switch ((unsigned char) c) {
-			case 't': state = S14; break;
 			case '0':
 			case '1':
 			case '2':
@@ -784,85 +784,13 @@ z3(struct lx *lx)
 			case 'x':
 			case 'y':
 			case 'z': state = S7; break;
+			case 't': state = S12; break;
 			default:  lx_ungetc(lx, c); return TOK_IDENT;
 			}
 			break;
 
-		case S12: /* e.g. "->" */
-			lx_ungetc(lx, c); return TOK_TO;
-
-		case S13: /* e.g. "en" */
+		case S12: /* e.g. "st" */
 			switch ((unsigned char) c) {
-			case 'd': state = S19; break;
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9':
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F':
-			case 'G':
-			case 'H':
-			case 'I':
-			case 'J':
-			case 'K':
-			case 'L':
-			case 'M':
-			case 'N':
-			case 'O':
-			case 'P':
-			case 'Q':
-			case 'R':
-			case 'S':
-			case 'T':
-			case 'U':
-			case 'V':
-			case 'W':
-			case 'X':
-			case 'Y':
-			case 'Z':
-			case '_':
-			case 'a':
-			case 'b':
-			case 'c':
-			case 'e':
-			case 'f':
-			case 'g':
-			case 'h':
-			case 'i':
-			case 'j':
-			case 'k':
-			case 'l':
-			case 'm':
-			case 'n':
-			case 'o':
-			case 'p':
-			case 'q':
-			case 'r':
-			case 's':
-			case 't':
-			case 'u':
-			case 'v':
-			case 'w':
-			case 'x':
-			case 'y':
-			case 'z': state = S7; break;
-			default:  lx_ungetc(lx, c); return TOK_IDENT;
-			}
-			break;
-
-		case S14: /* e.g. "st" */
-			switch ((unsigned char) c) {
-			case 'a': state = S15; break;
 			case '0':
 			case '1':
 			case '2':
@@ -925,13 +853,13 @@ z3(struct lx *lx)
 			case 'x':
 			case 'y':
 			case 'z': state = S7; break;
+			case 'a': state = S13; break;
 			default:  lx_ungetc(lx, c); return TOK_IDENT;
 			}
 			break;
 
-		case S15: /* e.g. "sta" */
+		case S13: /* e.g. "sta" */
 			switch ((unsigned char) c) {
-			case 'r': state = S16; break;
 			case '0':
 			case '1':
 			case '2':
@@ -994,13 +922,13 @@ z3(struct lx *lx)
 			case 'x':
 			case 'y':
 			case 'z': state = S7; break;
+			case 'r': state = S14; break;
 			default:  lx_ungetc(lx, c); return TOK_IDENT;
 			}
 			break;
 
-		case S16: /* e.g. "star" */
+		case S14: /* e.g. "star" */
 			switch ((unsigned char) c) {
-			case 't': state = S17; break;
 			case '0':
 			case '1':
 			case '2':
@@ -1063,13 +991,13 @@ z3(struct lx *lx)
 			case 'x':
 			case 'y':
 			case 'z': state = S7; break;
+			case 't': state = S15; break;
 			default:  lx_ungetc(lx, c); return TOK_IDENT;
 			}
 			break;
 
-		case S17: /* e.g. "start" */
+		case S15: /* e.g. "start" */
 			switch ((unsigned char) c) {
-			case ':': state = S18; break;
 			case '0':
 			case '1':
 			case '2':
@@ -1133,14 +1061,84 @@ z3(struct lx *lx)
 			case 'x':
 			case 'y':
 			case 'z': state = S7; break;
+			case ':': state = S16; break;
 			default:  lx_ungetc(lx, c); return TOK_IDENT;
 			}
 			break;
 
-		case S18: /* e.g. "start:" */
+		case S16: /* e.g. "start:" */
 			lx_ungetc(lx, c); return TOK_START;
 
-		case S19: /* e.g. "end" */
+		case S17: /* e.g. "en" */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9':
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'G':
+			case 'H':
+			case 'I':
+			case 'J':
+			case 'K':
+			case 'L':
+			case 'M':
+			case 'N':
+			case 'O':
+			case 'P':
+			case 'Q':
+			case 'R':
+			case 'S':
+			case 'T':
+			case 'U':
+			case 'V':
+			case 'W':
+			case 'X':
+			case 'Y':
+			case 'Z':
+			case '_':
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'e':
+			case 'f':
+			case 'g':
+			case 'h':
+			case 'i':
+			case 'j':
+			case 'k':
+			case 'l':
+			case 'm':
+			case 'n':
+			case 'o':
+			case 'p':
+			case 'q':
+			case 'r':
+			case 's':
+			case 't':
+			case 'u':
+			case 'v':
+			case 'w':
+			case 'x':
+			case 'y':
+			case 'z': state = S7; break;
+			case 'd': state = S18; break;
+			default:  lx_ungetc(lx, c); return TOK_IDENT;
+			}
+			break;
+
+		case S18: /* e.g. "end" */
 			switch ((unsigned char) c) {
 			case '0':
 			case '1':
@@ -1205,13 +1203,16 @@ z3(struct lx *lx)
 			case 'x':
 			case 'y':
 			case 'z': state = S7; break;
-			case ':': state = S20; break;
+			case ':': state = S19; break;
 			default:  lx_ungetc(lx, c); return TOK_IDENT;
 			}
 			break;
 
-		case S20: /* e.g. "end:" */
+		case S19: /* e.g. "end:" */
 			lx_ungetc(lx, c); return TOK_END;
+
+		case S20: /* e.g. "->" */
+			lx_ungetc(lx, c); return TOK_TO;
 
 		default:
 			; /* unreached */
@@ -1249,15 +1250,15 @@ z3(struct lx *lx)
 	case S9: return TOK_ANY;
 	case S10: return TOK_IDENT;
 	case S11: return TOK_IDENT;
-	case S12: return TOK_TO;
+	case S12: return TOK_IDENT;
 	case S13: return TOK_IDENT;
 	case S14: return TOK_IDENT;
 	case S15: return TOK_IDENT;
-	case S16: return TOK_IDENT;
+	case S16: return TOK_START;
 	case S17: return TOK_IDENT;
-	case S18: return TOK_START;
-	case S19: return TOK_IDENT;
-	case S20: return TOK_END;
+	case S18: return TOK_IDENT;
+	case S19: return TOK_END;
+	case S20: return TOK_TO;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
 }
@@ -1292,35 +1293,69 @@ lx_example(enum lx_token (*z)(struct lx *), enum lx_token t)
 
 	if (z == z0) {
 		switch (t) {
-		case TOK_CHAR: return "a";
-		case TOK_LABEL: return "'";
+		case TOK_COMMA: return "";
+		case TOK_SEP: return "";
+		case TOK_ANY: return "";
+		case TOK_TO: return "";
+		case TOK_IDENT: return "";
+		case TOK_END: return "";
+		case TOK_START: return "";
+		case TOK_CHAR: return "";
+		case TOK_HEX: return "";
+		case TOK_OCT: return "";
+		case TOK_ESC: return "";
+		case TOK_LABEL: return "";
 		default: goto error;
 		}
 	} else
 	if (z == z1) {
 		switch (t) {
-		case TOK_CHAR: return "a";
-		case TOK_HEX: return "\\xa";
-		case TOK_OCT: return "\\0";
-		case TOK_ESC: return "\\f";
-		case TOK_LABEL: return "\"";
+		case TOK_COMMA: return "";
+		case TOK_SEP: return "";
+		case TOK_ANY: return "";
+		case TOK_TO: return "";
+		case TOK_IDENT: return "";
+		case TOK_END: return "";
+		case TOK_START: return "";
+		case TOK_CHAR: return "";
+		case TOK_HEX: return "";
+		case TOK_OCT: return "";
+		case TOK_ESC: return "";
+		case TOK_LABEL: return "";
 		default: goto error;
 		}
 	} else
 	if (z == z2) {
 		switch (t) {
+		case TOK_COMMA: return "";
+		case TOK_SEP: return "";
+		case TOK_ANY: return "";
+		case TOK_TO: return "";
+		case TOK_IDENT: return "";
+		case TOK_END: return "";
+		case TOK_START: return "";
+		case TOK_CHAR: return "";
+		case TOK_HEX: return "";
+		case TOK_OCT: return "";
+		case TOK_ESC: return "";
+		case TOK_LABEL: return "";
 		default: goto error;
 		}
 	} else
 	if (z == z3) {
 		switch (t) {
-		case TOK_COMMA: return ",";
-		case TOK_SEP: return ";";
-		case TOK_ANY: return "?";
-		case TOK_TO: return "->";
-		case TOK_IDENT: return "a";
-		case TOK_END: return "end:";
-		case TOK_START: return "start:";
+		case TOK_COMMA: return "";
+		case TOK_SEP: return "";
+		case TOK_ANY: return "";
+		case TOK_TO: return "";
+		case TOK_IDENT: return "";
+		case TOK_END: return "";
+		case TOK_START: return "";
+		case TOK_CHAR: return "";
+		case TOK_HEX: return "";
+		case TOK_OCT: return "";
+		case TOK_ESC: return "";
+		case TOK_LABEL: return "";
 		default: goto error;
 		}
 	}

--- a/src/libfsm/lexer.h
+++ b/src/libfsm/lexer.h
@@ -23,12 +23,13 @@ enum lx_token {
 
 /*
  * .byte is 0-based.
- * .line and .col are 1-based; 0 means unknown.
+ * .line, .col, and .saved_col are 1-based; 0 means unknown.
  */
 struct lx_pos {
 	unsigned byte;
 	unsigned line;
 	unsigned col;
+	unsigned saved_col;
 };
 
 struct lx {

--- a/src/libfsm/parser.c
+++ b/src/libfsm/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 26 "src/libfsm/parser.act"
+#line 150 "src/libfsm/parser.act"
 
 
 	#include <assert.h>
@@ -174,7 +174,7 @@ p_label(fsm fsm, lex_state lex_state, act_state act_state, char *ZOc)
 				{
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
-#line 235 "src/libfsm/parser.act"
+#line 239 "src/libfsm/parser.act"
 
 		assert(lex_state->buf.a[0] != '\0');
 		assert(lex_state->buf.a[1] == '\0');
@@ -191,7 +191,7 @@ p_label(fsm fsm, lex_state lex_state, act_state act_state, char *ZOc)
 				{
 					/* BEGINNING OF EXTRACT: ESC */
 					{
-#line 163 "src/libfsm/parser.act"
+#line 167 "src/libfsm/parser.act"
 
 		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
 		assert(2 == strlen(lex_state->buf.a));
@@ -219,7 +219,7 @@ p_label(fsm fsm, lex_state lex_state, act_state act_state, char *ZOc)
 				{
 					/* BEGINNING OF EXTRACT: HEX */
 					{
-#line 208 "src/libfsm/parser.act"
+#line 232 "src/libfsm/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -256,7 +256,7 @@ p_label(fsm fsm, lex_state lex_state, act_state act_state, char *ZOc)
 				{
 					/* BEGINNING OF EXTRACT: OCT */
 					{
-#line 181 "src/libfsm/parser.act"
+#line 205 "src/libfsm/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -329,7 +329,7 @@ ZL2_items:;
 							case (TOK_IDENT):
 								/* BEGINNING OF EXTRACT: IDENT */
 								{
-#line 242 "src/libfsm/parser.act"
+#line 243 "src/libfsm/parser.act"
 
 		ZIa = xstrdup(lex_state->buf.a);
 		if (ZIa == NULL) {
@@ -360,7 +360,7 @@ ZL2_items:;
 			goto ZL2_items;
 			/* END OF INLINE: items */
 		}
-		/* UNREACHED */
+		/*UNREACHED*/
 	case (ERROR_TERMINAL):
 		return;
 	default:
@@ -397,7 +397,7 @@ p_xstart(fsm fsm, lex_state lex_state, act_state act_state)
 				{
 					/* BEGINNING OF ACTION: err-expected-start */
 					{
-#line 369 "src/libfsm/parser.act"
+#line 371 "src/libfsm/parser.act"
 
 		err_expected(lex_state, "'start:'");
 	
@@ -415,7 +415,7 @@ p_xstart(fsm fsm, lex_state lex_state, act_state act_state)
 					case (TOK_IDENT):
 						/* BEGINNING OF EXTRACT: IDENT */
 						{
-#line 242 "src/libfsm/parser.act"
+#line 243 "src/libfsm/parser.act"
 
 		ZIn = xstrdup(lex_state->buf.a);
 		if (ZIn == NULL) {
@@ -441,7 +441,7 @@ p_xstart(fsm fsm, lex_state lex_state, act_state act_state)
 			}
 			/* BEGINNING OF ACTION: add-state */
 			{
-#line 252 "src/libfsm/parser.act"
+#line 254 "src/libfsm/parser.act"
 
 		struct act_statelist *p;
 		const unsigned hash = hash_of_id((ZIn));
@@ -502,7 +502,7 @@ p_xstart(fsm fsm, lex_state lex_state, act_state act_state)
 			/* END OF ACTION: add-state */
 			/* BEGINNING OF ACTION: mark-start */
 			{
-#line 308 "src/libfsm/parser.act"
+#line 309 "src/libfsm/parser.act"
 
 		fsm_setstart(fsm, (ZIs));
 	
@@ -511,7 +511,7 @@ p_xstart(fsm fsm, lex_state lex_state, act_state act_state)
 			/* END OF ACTION: mark-start */
 			/* BEGINNING OF ACTION: free */
 			{
-#line 316 "src/libfsm/parser.act"
+#line 317 "src/libfsm/parser.act"
 
 		free((ZIn));
 	
@@ -553,7 +553,7 @@ p_xend(fsm fsm, lex_state lex_state, act_state act_state)
 				{
 					/* BEGINNING OF ACTION: err-expected-end */
 					{
-#line 373 "src/libfsm/parser.act"
+#line 375 "src/libfsm/parser.act"
 
 		err_expected(lex_state, "'end:'");
 	
@@ -603,7 +603,7 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-sep */
 		{
-#line 357 "src/libfsm/parser.act"
+#line 359 "src/libfsm/parser.act"
 
 		err_expected(lex_state, "';'");
 	
@@ -631,7 +631,7 @@ p_63(fsm fsm, lex_state lex_state, act_state act_state, string *ZIa)
 					case (TOK_IDENT):
 						/* BEGINNING OF EXTRACT: IDENT */
 						{
-#line 242 "src/libfsm/parser.act"
+#line 243 "src/libfsm/parser.act"
 
 		ZIb = xstrdup(lex_state->buf.a);
 		if (ZIb == NULL) {
@@ -652,7 +652,7 @@ p_63(fsm fsm, lex_state lex_state, act_state act_state, string *ZIa)
 			/* END OF INLINE: id */
 			/* BEGINNING OF ACTION: add-state */
 			{
-#line 252 "src/libfsm/parser.act"
+#line 254 "src/libfsm/parser.act"
 
 		struct act_statelist *p;
 		const unsigned hash = hash_of_id((*ZIa));
@@ -713,7 +713,7 @@ p_63(fsm fsm, lex_state lex_state, act_state act_state, string *ZIa)
 			/* END OF ACTION: add-state */
 			/* BEGINNING OF ACTION: add-state */
 			{
-#line 252 "src/libfsm/parser.act"
+#line 254 "src/libfsm/parser.act"
 
 		struct act_statelist *p;
 		const unsigned hash = hash_of_id((ZIb));
@@ -774,7 +774,7 @@ p_63(fsm fsm, lex_state lex_state, act_state act_state, string *ZIa)
 			/* END OF ACTION: add-state */
 			/* BEGINNING OF ACTION: free */
 			{
-#line 316 "src/libfsm/parser.act"
+#line 317 "src/libfsm/parser.act"
 
 		free((*ZIa));
 	
@@ -783,7 +783,7 @@ p_63(fsm fsm, lex_state lex_state, act_state act_state, string *ZIa)
 			/* END OF ACTION: free */
 			/* BEGINNING OF ACTION: free */
 			{
-#line 316 "src/libfsm/parser.act"
+#line 317 "src/libfsm/parser.act"
 
 		free((ZIb));
 	
@@ -798,7 +798,7 @@ p_63(fsm fsm, lex_state lex_state, act_state act_state, string *ZIa)
 						ADVANCE_LEXER;
 						/* BEGINNING OF ACTION: add-edge-any */
 						{
-#line 342 "src/libfsm/parser.act"
+#line 343 "src/libfsm/parser.act"
 
 		if (!fsm_addedge_any(fsm, (ZIx), (ZIy))) {
 			perror("fsm_addedge_any");
@@ -821,7 +821,7 @@ p_63(fsm fsm, lex_state lex_state, act_state act_state, string *ZIa)
 						}
 						/* BEGINNING OF ACTION: add-edge-literal */
 						{
-#line 335 "src/libfsm/parser.act"
+#line 336 "src/libfsm/parser.act"
 
 		if (!fsm_addedge_literal(fsm, (ZIx), (ZIy), (ZIc))) {
 			perror("fsm_addedge_literal");
@@ -837,7 +837,7 @@ p_63(fsm fsm, lex_state lex_state, act_state act_state, string *ZIa)
 					{
 						/* BEGINNING OF ACTION: add-edge-epsilon */
 						{
-#line 349 "src/libfsm/parser.act"
+#line 350 "src/libfsm/parser.act"
 
 		if (!fsm_addedge_epsilon(fsm, (ZIx), (ZIy))) {
 			perror("fsm_addedge_epsilon");
@@ -855,7 +855,7 @@ p_63(fsm fsm, lex_state lex_state, act_state act_state, string *ZIa)
 				{
 					/* BEGINNING OF ACTION: err-expected-trans */
 					{
-#line 361 "src/libfsm/parser.act"
+#line 363 "src/libfsm/parser.act"
 
 		err_expected(lex_state, "transition");
 	
@@ -879,7 +879,7 @@ p_63(fsm fsm, lex_state lex_state, act_state act_state, string *ZIa)
 
 			/* BEGINNING OF ACTION: add-state */
 			{
-#line 252 "src/libfsm/parser.act"
+#line 254 "src/libfsm/parser.act"
 
 		struct act_statelist *p;
 		const unsigned hash = hash_of_id((*ZIa));
@@ -940,7 +940,7 @@ p_63(fsm fsm, lex_state lex_state, act_state act_state, string *ZIa)
 			/* END OF ACTION: add-state */
 			/* BEGINNING OF ACTION: free */
 			{
-#line 316 "src/libfsm/parser.act"
+#line 317 "src/libfsm/parser.act"
 
 		free((*ZIa));
 	
@@ -987,7 +987,7 @@ p_fsm(fsm fsm, lex_state lex_state, act_state act_state)
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: free-statelist */
 		{
-#line 320 "src/libfsm/parser.act"
+#line 333 "src/libfsm/parser.act"
 
 		struct act_statelist *p;
 		struct act_statelist *next;
@@ -1011,7 +1011,7 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-syntax */
 		{
-#line 377 "src/libfsm/parser.act"
+#line 380 "src/libfsm/parser.act"
 
 		err(lex_state, "Syntax error");
 		exit(EXIT_FAILURE);
@@ -1052,7 +1052,7 @@ ZL2_xend_C_Cend_Hids:;
 						{
 							/* BEGINNING OF ACTION: err-expected-comma */
 							{
-#line 365 "src/libfsm/parser.act"
+#line 367 "src/libfsm/parser.act"
 
 		err_expected(lex_state, "','");
 	
@@ -1067,7 +1067,7 @@ ZL2_xend_C_Cend_Hids:;
 					goto ZL2_xend_C_Cend_Hids;
 					/* END OF INLINE: xend::end-ids */
 				}
-				/* UNREACHED */
+				/*UNREACHED*/
 			case (ERROR_TERMINAL):
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1100,7 +1100,7 @@ p_xend_C_Cend_Hid(fsm fsm, lex_state lex_state, act_state act_state)
 				case (TOK_IDENT):
 					/* BEGINNING OF EXTRACT: IDENT */
 					{
-#line 242 "src/libfsm/parser.act"
+#line 243 "src/libfsm/parser.act"
 
 		ZIn = xstrdup(lex_state->buf.a);
 		if (ZIn == NULL) {
@@ -1121,7 +1121,7 @@ p_xend_C_Cend_Hid(fsm fsm, lex_state lex_state, act_state act_state)
 		/* END OF INLINE: id */
 		/* BEGINNING OF ACTION: add-state */
 		{
-#line 252 "src/libfsm/parser.act"
+#line 254 "src/libfsm/parser.act"
 
 		struct act_statelist *p;
 		const unsigned hash = hash_of_id((ZIn));
@@ -1182,7 +1182,7 @@ p_xend_C_Cend_Hid(fsm fsm, lex_state lex_state, act_state act_state)
 		/* END OF ACTION: add-state */
 		/* BEGINNING OF ACTION: mark-end */
 		{
-#line 312 "src/libfsm/parser.act"
+#line 313 "src/libfsm/parser.act"
 
 		fsm_setend(fsm, (ZIs), 1);
 	
@@ -1191,7 +1191,7 @@ p_xend_C_Cend_Hid(fsm fsm, lex_state lex_state, act_state act_state)
 		/* END OF ACTION: mark-end */
 		/* BEGINNING OF ACTION: free */
 		{
-#line 316 "src/libfsm/parser.act"
+#line 317 "src/libfsm/parser.act"
 
 		free((ZIn));
 	
@@ -1207,7 +1207,7 @@ ZL1:;
 
 /* BEGINNING OF TRAILER */
 
-#line 382 "src/libfsm/parser.act"
+#line 436 "src/libfsm/parser.act"
 
 
 	struct fsm *fsm_parse(FILE *f, const struct fsm_options *opt) {

--- a/src/libfsm/parser.h
+++ b/src/libfsm/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 150 "src/libfsm/parser.act"
+#line 159 "src/libfsm/parser.act"
 
 
 	typedef struct lex_state * lex_state;
@@ -26,7 +26,7 @@
 extern void p_fsm(fsm, lex_state, act_state);
 /* BEGINNING OF TRAILER */
 
-#line 436 "src/libfsm/parser.act"
+#line 437 "src/libfsm/parser.act"
 
 #line 32 "src/libfsm/parser.h"
 

--- a/src/libre/dialect/glob/lexer.c
+++ b/src/libre/dialect/glob/lexer.c
@@ -35,6 +35,7 @@ lx_getc(struct lx_glob_lx *lx)
 
 	if (c == '\n') {
 		lx->end.line++;
+		lx->end.saved_col = lx->end.col - 1;
 		lx->end.col = 1;
 	}
 
@@ -58,7 +59,7 @@ lx_glob_ungetc(struct lx_glob_lx *lx, int c)
 
 	if (c == '\n') {
 		lx->end.line--;
-		lx->end.col = 0; /* XXX: lost information */
+		lx->end.col = lx->end.saved_col;
 	}
 }
 
@@ -225,9 +226,9 @@ lx_glob_example(enum lx_glob_token (*z)(struct lx_glob_lx *), enum lx_glob_token
 
 	if (z == z0) {
 		switch (t) {
-		case TOK_CHAR: return "a";
-		case TOK_MANY: return "*";
-		case TOK_ANY: return "?";
+		case TOK_CHAR: return "";
+		case TOK_MANY: return "";
+		case TOK_ANY: return "";
 		default: goto error;
 		}
 	}

--- a/src/libre/dialect/glob/lexer.c
+++ b/src/libre/dialect/glob/lexer.c
@@ -70,7 +70,7 @@ lx_glob_dynpush(void *buf_opaque, char c)
 
 	assert(t != NULL);
 
-	if (t->p == t->a + t->len) {
+	if (t->a == NULL || t->p == t->a + t->len) {
 		size_t len;
 		ptrdiff_t off;
 		char *tmp;

--- a/src/libre/dialect/glob/lexer.h
+++ b/src/libre/dialect/glob/lexer.h
@@ -14,12 +14,13 @@ enum lx_glob_token {
 
 /*
  * .byte is 0-based.
- * .line and .col are 1-based; 0 means unknown.
+ * .line, .col, and .saved_col are 1-based; 0 means unknown.
  */
 struct lx_pos {
 	unsigned byte;
 	unsigned line;
 	unsigned col;
+	unsigned saved_col;
 };
 
 struct lx_glob_lx {

--- a/src/libre/dialect/like/lexer.c
+++ b/src/libre/dialect/like/lexer.c
@@ -35,6 +35,7 @@ lx_getc(struct lx_like_lx *lx)
 
 	if (c == '\n') {
 		lx->end.line++;
+		lx->end.saved_col = lx->end.col - 1;
 		lx->end.col = 1;
 	}
 
@@ -58,7 +59,7 @@ lx_like_ungetc(struct lx_like_lx *lx, int c)
 
 	if (c == '\n') {
 		lx->end.line--;
-		lx->end.col = 0; /* XXX: lost information */
+		lx->end.col = lx->end.saved_col;
 	}
 }
 
@@ -225,9 +226,9 @@ lx_like_example(enum lx_like_token (*z)(struct lx_like_lx *), enum lx_like_token
 
 	if (z == z0) {
 		switch (t) {
-		case TOK_CHAR: return "a";
-		case TOK_MANY: return "%";
-		case TOK_ANY: return "_";
+		case TOK_CHAR: return "";
+		case TOK_MANY: return "";
+		case TOK_ANY: return "";
 		default: goto error;
 		}
 	}

--- a/src/libre/dialect/like/lexer.c
+++ b/src/libre/dialect/like/lexer.c
@@ -70,7 +70,7 @@ lx_like_dynpush(void *buf_opaque, char c)
 
 	assert(t != NULL);
 
-	if (t->p == t->a + t->len) {
+	if (t->a == NULL || t->p == t->a + t->len) {
 		size_t len;
 		ptrdiff_t off;
 		char *tmp;

--- a/src/libre/dialect/like/lexer.h
+++ b/src/libre/dialect/like/lexer.h
@@ -14,12 +14,13 @@ enum lx_like_token {
 
 /*
  * .byte is 0-based.
- * .line and .col are 1-based; 0 means unknown.
+ * .line, .col, and .saved_col are 1-based; 0 means unknown.
  */
 struct lx_pos {
 	unsigned byte;
 	unsigned line;
 	unsigned col;
+	unsigned saved_col;
 };
 
 struct lx_like_lx {

--- a/src/libre/dialect/literal/lexer.c
+++ b/src/libre/dialect/literal/lexer.c
@@ -35,6 +35,7 @@ lx_getc(struct lx_literal_lx *lx)
 
 	if (c == '\n') {
 		lx->end.line++;
+		lx->end.saved_col = lx->end.col - 1;
 		lx->end.col = 1;
 	}
 
@@ -58,7 +59,7 @@ lx_literal_ungetc(struct lx_literal_lx *lx, int c)
 
 	if (c == '\n') {
 		lx->end.line--;
-		lx->end.col = 0; /* XXX: lost information */
+		lx->end.col = lx->end.saved_col;
 	}
 }
 
@@ -210,7 +211,7 @@ lx_literal_example(enum lx_literal_token (*z)(struct lx_literal_lx *), enum lx_l
 
 	if (z == z0) {
 		switch (t) {
-		case TOK_CHAR: return "a";
+		case TOK_CHAR: return "";
 		default: goto error;
 		}
 	}

--- a/src/libre/dialect/literal/lexer.c
+++ b/src/libre/dialect/literal/lexer.c
@@ -70,7 +70,7 @@ lx_literal_dynpush(void *buf_opaque, char c)
 
 	assert(t != NULL);
 
-	if (t->p == t->a + t->len) {
+	if (t->a == NULL || t->p == t->a + t->len) {
 		size_t len;
 		ptrdiff_t off;
 		char *tmp;

--- a/src/libre/dialect/literal/lexer.h
+++ b/src/libre/dialect/literal/lexer.h
@@ -12,12 +12,13 @@ enum lx_literal_token {
 
 /*
  * .byte is 0-based.
- * .line and .col are 1-based; 0 means unknown.
+ * .line, .col, and .saved_col are 1-based; 0 means unknown.
  */
 struct lx_pos {
 	unsigned byte;
 	unsigned line;
 	unsigned col;
+	unsigned saved_col;
 };
 
 struct lx_literal_lx {

--- a/src/libre/dialect/native/lexer.c
+++ b/src/libre/dialect/native/lexer.c
@@ -72,7 +72,7 @@ lx_native_dynpush(void *buf_opaque, char c)
 
 	assert(t != NULL);
 
-	if (t->p == t->a + t->len) {
+	if (t->a == NULL || t->p == t->a + t->len) {
 		size_t len;
 		ptrdiff_t off;
 		char *tmp;

--- a/src/libre/dialect/pcre/lexer.c
+++ b/src/libre/dialect/pcre/lexer.c
@@ -77,7 +77,7 @@ lx_pcre_dynpush(void *buf_opaque, char c)
 
 	assert(t != NULL);
 
-	if (t->p == t->a + t->len) {
+	if (t->a == NULL || t->p == t->a + t->len) {
 		size_t len;
 		ptrdiff_t off;
 		char *tmp;

--- a/src/libre/dialect/sql/lexer.c
+++ b/src/libre/dialect/sql/lexer.c
@@ -72,7 +72,7 @@ lx_sql_dynpush(void *buf_opaque, char c)
 
 	assert(t != NULL);
 
-	if (t->p == t->a + t->len) {
+	if (t->a == NULL || t->p == t->a + t->len) {
 		size_t len;
 		ptrdiff_t off;
 		char *tmp;

--- a/src/libre/dialect/sql/lexer.c
+++ b/src/libre/dialect/sql/lexer.c
@@ -37,6 +37,7 @@ lx_getc(struct lx_sql_lx *lx)
 
 	if (c == '\n') {
 		lx->end.line++;
+		lx->end.saved_col = lx->end.col - 1;
 		lx->end.col = 1;
 	}
 
@@ -60,7 +61,7 @@ lx_sql_ungetc(struct lx_sql_lx *lx, int c)
 
 	if (c == '\n') {
 		lx->end.line--;
-		lx->end.col = 0; /* XXX: lost information */
+		lx->end.col = lx->end.saved_col;
 	}
 }
 
@@ -169,7 +170,7 @@ z0(struct lx_sql_lx *lx)
 		switch (state) {
 		case S0: /* start */
 			switch ((unsigned char) c) {
-			case '}': state = S3; break;
+			case ',': state = S1; break;
 			case '0':
 			case '1':
 			case '2':
@@ -180,7 +181,7 @@ z0(struct lx_sql_lx *lx)
 			case '7':
 			case '8':
 			case '9': state = S2; break;
-			case ',': state = S1; break;
+			case '}': state = S3; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
@@ -300,193 +301,193 @@ z1(struct lx_sql_lx *lx)
 
 		case S7: /* e.g. "[:A" */
 			switch ((unsigned char) c) {
-			case 'L': state = S16; break;
+			case 'L': state = S30; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
 		case S8: /* e.g. "[:D" */
 			switch ((unsigned char) c) {
-			case 'I': state = S21; break;
+			case 'I': state = S27; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
 		case S9: /* e.g. "[:L" */
 			switch ((unsigned char) c) {
-			case 'O': state = S15; break;
+			case 'O': state = S26; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
 		case S10: /* e.g. "[:S" */
 			switch ((unsigned char) c) {
-			case 'P': state = S31; break;
+			case 'P': state = S23; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
 		case S11: /* e.g. "[:U" */
 			switch ((unsigned char) c) {
-			case 'P': state = S13; break;
+			case 'P': state = S17; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
 		case S12: /* e.g. "[:W" */
 			switch ((unsigned char) c) {
-			case 'H': state = S27; break;
+			case 'H': state = S13; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S13: /* e.g. "[:UP" */
+		case S13: /* e.g. "[:WH" */
 			switch ((unsigned char) c) {
-			case 'P': state = S14; break;
+			case 'I': state = S14; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S14: /* e.g. "[:LOW" */
+		case S14: /* e.g. "[:WHI" */
 			switch ((unsigned char) c) {
-			case 'E': state = S34; break;
+			case 'T': state = S15; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S15: /* e.g. "[:LO" */
+		case S15: /* e.g. "[:WHIT" */
 			switch ((unsigned char) c) {
-			case 'W': state = S14; break;
+			case 'E': state = S16; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S16: /* e.g. "[:AL" */
-			switch ((unsigned char) c) {
-			case 'N': state = S17; break;
-			case 'P': state = S18; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S17: /* e.g. "[:ALN" */
-			switch ((unsigned char) c) {
-			case 'U': state = S19; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S18: /* e.g. "[:ALP" */
-			switch ((unsigned char) c) {
-			case 'H': state = S23; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S19: /* e.g. "[:ALNU" */
-			switch ((unsigned char) c) {
-			case 'M': state = S20; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S20: /* e.g. "[:ALNUM" */
-			switch ((unsigned char) c) {
-			case ':': state = S25; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S21: /* e.g. "[:DI" */
-			switch ((unsigned char) c) {
-			case 'G': state = S22; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S22: /* e.g. "[:DIG" */
-			switch ((unsigned char) c) {
-			case 'I': state = S24; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S23: /* e.g. "[:ALPH" */
-			switch ((unsigned char) c) {
-			case 'A': state = S20; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S24: /* e.g. "[:DIGI" */
-			switch ((unsigned char) c) {
-			case 'T': state = S20; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S25: /* e.g. "[:ALNUM:" */
-			switch ((unsigned char) c) {
-			case ']': state = S26; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S26: /* e.g. "[:ALNUM:]" */
-			lx_sql_ungetc(lx, c); return TOK_NAMED__CLASS;
-
-		case S27: /* e.g. "[:WH" */
-			switch ((unsigned char) c) {
-			case 'I': state = S28; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S28: /* e.g. "[:WHI" */
-			switch ((unsigned char) c) {
-			case 'T': state = S29; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S29: /* e.g. "[:WHIT" */
-			switch ((unsigned char) c) {
-			case 'E': state = S30; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S30: /* e.g. "[:WHITE" */
+		case S16: /* e.g. "[:WHITE" */
 			switch ((unsigned char) c) {
 			case 'S': state = S10; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S31: /* e.g. "[:SP" */
+		case S17: /* e.g. "[:UP" */
 			switch ((unsigned char) c) {
-			case 'A': state = S32; break;
+			case 'P': state = S18; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S32: /* e.g. "[:SPA" */
+		case S18: /* e.g. "[:LOW" */
 			switch ((unsigned char) c) {
-			case 'C': state = S33; break;
+			case 'E': state = S19; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S33: /* e.g. "[:SPAC" */
+		case S19: /* e.g. "[:LOWE" */
+			switch ((unsigned char) c) {
+			case 'R': state = S20; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S20: /* e.g. "[:ALPHA" */
+			switch ((unsigned char) c) {
+			case ':': state = S21; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S21: /* e.g. "[:ALPHA:" */
+			switch ((unsigned char) c) {
+			case ']': state = S22; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S22: /* e.g. "[:ALPHA:]" */
+			lx_sql_ungetc(lx, c); return TOK_NAMED__CLASS;
+
+		case S23: /* e.g. "[:SP" */
+			switch ((unsigned char) c) {
+			case 'A': state = S24; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S24: /* e.g. "[:SPA" */
+			switch ((unsigned char) c) {
+			case 'C': state = S25; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S25: /* e.g. "[:SPAC" */
 			switch ((unsigned char) c) {
 			case 'E': state = S20; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S34: /* e.g. "[:LOWE" */
+		case S26: /* e.g. "[:LO" */
 			switch ((unsigned char) c) {
-			case 'R': state = S20; break;
+			case 'W': state = S18; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S27: /* e.g. "[:DI" */
+			switch ((unsigned char) c) {
+			case 'G': state = S28; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S28: /* e.g. "[:DIG" */
+			switch ((unsigned char) c) {
+			case 'I': state = S29; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S29: /* e.g. "[:DIGI" */
+			switch ((unsigned char) c) {
+			case 'T': state = S20; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S30: /* e.g. "[:AL" */
+			switch ((unsigned char) c) {
+			case 'N': state = S31; break;
+			case 'P': state = S32; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S31: /* e.g. "[:ALN" */
+			switch ((unsigned char) c) {
+			case 'U': state = S34; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S32: /* e.g. "[:ALP" */
+			switch ((unsigned char) c) {
+			case 'H': state = S33; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S33: /* e.g. "[:ALPH" */
+			switch ((unsigned char) c) {
+			case 'A': state = S20; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S34: /* e.g. "[:ALNU" */
+			switch ((unsigned char) c) {
+			case 'M': state = S20; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
@@ -511,7 +512,7 @@ z1(struct lx_sql_lx *lx)
 	case S3: return TOK_CHAR;
 	case S4: return TOK_CLOSEGROUP;
 	case S5: return TOK_INVERT;
-	case S26: return TOK_NAMED__CLASS;
+	case S22: return TOK_NAMED__CLASS;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
 }
@@ -657,35 +658,70 @@ lx_sql_example(enum lx_sql_token (*z)(struct lx_sql_lx *), enum lx_sql_token t)
 
 	if (z == z0) {
 		switch (t) {
-		case TOK_SEP: return ",";
-		case TOK_COUNT: return "0";
-		case TOK_CLOSECOUNT: return "}";
+		case TOK_SEP: return "";
+		case TOK_COUNT: return "";
+		case TOK_CLOSECOUNT: return "";
+		case TOK_OPENCOUNT: return "";
+		case TOK_CHAR: return "";
+		case TOK_NAMED__CLASS: return "";
+		case TOK_RANGE: return "";
+		case TOK_INVERT: return "";
+		case TOK_CLOSEGROUP: return "";
+		case TOK_OPENGROUP: return "";
+		case TOK_ALT: return "";
+		case TOK_PLUS: return "";
+		case TOK_STAR: return "";
+		case TOK_OPT: return "";
+		case TOK_CLOSESUB: return "";
+		case TOK_OPENSUB: return "";
+		case TOK_MANY: return "";
+		case TOK_ANY: return "";
 		default: goto error;
 		}
 	} else
 	if (z == z1) {
 		switch (t) {
-		case TOK_CHAR: return "a";
-		case TOK_NAMED__CLASS: return "[:ALNUM:]";
-		case TOK_RANGE: return "-";
-		case TOK_INVERT: return "^";
-		case TOK_CLOSEGROUP: return "]";
+		case TOK_SEP: return "";
+		case TOK_COUNT: return "";
+		case TOK_CLOSECOUNT: return "";
+		case TOK_OPENCOUNT: return "";
+		case TOK_CHAR: return "";
+		case TOK_NAMED__CLASS: return "";
+		case TOK_RANGE: return "";
+		case TOK_INVERT: return "";
+		case TOK_CLOSEGROUP: return "";
+		case TOK_OPENGROUP: return "";
+		case TOK_ALT: return "";
+		case TOK_PLUS: return "";
+		case TOK_STAR: return "";
+		case TOK_OPT: return "";
+		case TOK_CLOSESUB: return "";
+		case TOK_OPENSUB: return "";
+		case TOK_MANY: return "";
+		case TOK_ANY: return "";
 		default: goto error;
 		}
 	} else
 	if (z == z2) {
 		switch (t) {
-		case TOK_OPENCOUNT: return "{";
-		case TOK_CHAR: return "a";
-		case TOK_OPENGROUP: return "[";
-		case TOK_ALT: return "|";
-		case TOK_PLUS: return "+";
-		case TOK_STAR: return "*";
-		case TOK_OPT: return "?";
-		case TOK_CLOSESUB: return ")";
-		case TOK_OPENSUB: return "(";
-		case TOK_MANY: return "%";
-		case TOK_ANY: return "_";
+		case TOK_SEP: return "";
+		case TOK_COUNT: return "";
+		case TOK_CLOSECOUNT: return "";
+		case TOK_OPENCOUNT: return "";
+		case TOK_CHAR: return "";
+		case TOK_NAMED__CLASS: return "";
+		case TOK_RANGE: return "";
+		case TOK_INVERT: return "";
+		case TOK_CLOSEGROUP: return "";
+		case TOK_OPENGROUP: return "";
+		case TOK_ALT: return "";
+		case TOK_PLUS: return "";
+		case TOK_STAR: return "";
+		case TOK_OPT: return "";
+		case TOK_CLOSESUB: return "";
+		case TOK_OPENSUB: return "";
+		case TOK_MANY: return "";
+		case TOK_ANY: return "";
 		default: goto error;
 		}
 	}

--- a/src/libre/dialect/sql/lexer.h
+++ b/src/libre/dialect/sql/lexer.h
@@ -29,12 +29,13 @@ enum lx_sql_token {
 
 /*
  * .byte is 0-based.
- * .line and .col are 1-based; 0 means unknown.
+ * .line, .col, and .saved_col are 1-based; 0 means unknown.
  */
 struct lx_pos {
 	unsigned byte;
 	unsigned line;
 	unsigned col;
+	unsigned saved_col;
 };
 
 struct lx_sql_lx {

--- a/src/lx/lexer.c
+++ b/src/lx/lexer.c
@@ -83,7 +83,7 @@ lx_dynpush(void *buf_opaque, char c)
 
 	assert(t != NULL);
 
-	if (t->p == t->a + t->len) {
+	if (t->a == NULL || t->p == t->a + t->len) {
 		size_t len;
 		ptrdiff_t off;
 		char *tmp;

--- a/src/lx/lexer.c
+++ b/src/lx/lexer.c
@@ -521,7 +521,7 @@ z3(struct lx *lx)
 		case S1: /* e.g. "a" */
 			lx_ungetc(lx, c); return lx->z(lx);
 
-		case S2: /* e.g. "\n" */
+		case S2: /* e.g. "" */
 			lx_ungetc(lx, c); return lx->z = z4, lx->z(lx);
 
 		default:
@@ -668,7 +668,7 @@ z4(struct lx *lx)
 			}
 			break;
 
-		case S1: /* e.g. "\t" */
+		case S1: /* e.g. "\\x09" */
 			switch ((unsigned char) c) {
 			case '\t':
 			case '\n':

--- a/src/lx/print/c.c
+++ b/src/lx/print/c.c
@@ -455,7 +455,7 @@ print_buf(FILE *f)
 		fprintf(f, "\n");
 		fprintf(f, "\tassert(t != NULL);\n");
 		fprintf(f, "\n");
-		fprintf(f, "\tif (t->p == t->a + t->len) {\n");
+		fprintf(f, "\tif (t->a == NULL || t->p == t->a + t->len) {\n"); /* (t->a == NULL || ...) is to appease ubsan */
 		fprintf(f, "\t\tsize_t len;\n");
 		fprintf(f, "\t\tptrdiff_t off;\n");
 		fprintf(f, "\t\tchar *tmp;\n");


### PR DESCRIPTION
This PR introduces an extra condition to appease ubsan.

This is redundant; it's here to avoid depending on `t->a + 0` where `.a` is NULL. ubsan complains about this, which is probably reasonable. I don't really care if it's reasonable or not; it's no trouble to avoid it in the first place even if I think the extra term here is redundant.

This was found by clang in CI, I think by github updating their build machines.