### PR TITLE
Determinise with grouped edges

### DIFF
--- a/include/adt/edgeset.h
+++ b/include/adt/edgeset.h
@@ -29,6 +29,39 @@ struct edge_ordered_iter {
 	uint64_t symbols_used[4];
 };
 
+enum edge_group_iter_type {
+	EDGE_GROUP_ITER_ALL,
+	EDGE_GROUP_ITER_UNIQUE
+};
+
+struct edge_group_iter {
+	const struct edge_set *set;
+	unsigned flag;
+	size_t i;
+	uint64_t internal[256/64];
+};
+
+struct edge_group_iter_info {
+	int unique;
+	fsm_state_t to;
+	uint64_t symbols[256/64];
+};
+
+/* Reset an iterator for groups of edges.
+ * If iter_type is set to EDGE_GROUP_ITER_UNIQUE,
+ * edges with labels that only appear once will be
+ * yielded with unique set to 1, all others set to 0.
+ * If iter_type is EDGE_GROUP_ITER_ALL, they will not
+ * be separated, and unique will not be set. */
+void
+edge_set_group_iter_reset(const struct edge_set *s,
+    enum edge_group_iter_type iter_type,
+    struct edge_group_iter *egi);
+
+int
+edge_set_group_iter_next(struct edge_group_iter *egi,
+    struct edge_group_iter_info *eg);
+
 /* Opaque struct type for edge iterator,
  * which does extra processing upfront to iterate over
  * edges in lexicographically ascending order; the

--- a/include/adt/edgeset.h
+++ b/include/adt/edgeset.h
@@ -41,6 +41,8 @@ struct edge_group_iter {
 	uint64_t internal[256/64];
 };
 
+/* TODO: symbols: macros for bit flags, first, count, etc. */
+
 struct edge_group_iter_info {
 	int unique;
 	fsm_state_t to;

--- a/include/adt/edgeset.h
+++ b/include/adt/edgeset.h
@@ -81,6 +81,10 @@ edge_set_add(struct edge_set **set, const struct fsm_alloc *alloc,
 	unsigned char symbol, fsm_state_t state);
 
 int
+edge_set_add_bulk(struct edge_set **pset, const struct fsm_alloc *alloc,
+	uint64_t symbols[256/64], fsm_state_t state);
+
+int
 edge_set_add_state_set(struct edge_set **setp, const struct fsm_alloc *alloc,
 	unsigned char symbol, const struct state_set *state_set);
 

--- a/include/adt/edgeset.h
+++ b/include/adt/edgeset.h
@@ -86,6 +86,13 @@ int
 edge_set_add_bulk(struct edge_set **pset, const struct fsm_alloc *alloc,
 	uint64_t symbols[256/64], fsm_state_t state);
 
+/* Notify the data structure that it wis likely to soon need to grow
+ * to fit N more bulk edge groups. This can avoid resizing multiple times
+ * in smaller increments. */
+int
+edge_set_advise_growth(struct edge_set **pset, const struct fsm_alloc *alloc,
+    size_t count);
+
 int
 edge_set_add_state_set(struct edge_set **setp, const struct fsm_alloc *alloc,
 	unsigned char symbol, const struct state_set *state_set);

--- a/include/adt/ipriq.h
+++ b/include/adt/ipriq.h
@@ -1,0 +1,43 @@
+#ifndef IPRIQ_H
+#define IPRIQ_H
+
+#include <stdlib.h>
+
+#include <adt/alloc.h>
+
+/* Opaque index priority queue handle. */
+struct ipriq;
+
+/* Comparison function for two indices, which may refer
+ * to elements in the opaque structure. */
+enum ipriq_cmp_res {
+	IPRIQ_CMP_LT = -1,
+	IPRIQ_CMP_EQ = 0,
+	IPRIQ_CMP_GT = 1,
+};
+typedef enum ipriq_cmp_res
+ipriq_cmp_fun(size_t a, size_t b, void *opaque);
+
+/* Allocate a new ipriq handle. Returns NULL on error.
+ *
+ * alloc and opaque can be NULL, cmp must be non-NULL. */
+struct ipriq *
+ipriq_new(const struct fsm_alloc *alloc,
+    ipriq_cmp_fun *cmp, void *opaque);
+
+void
+ipriq_free(struct ipriq *pq);
+
+int
+ipriq_empty(const struct ipriq *pq);
+
+int
+ipriq_peek(const struct ipriq *pq, size_t *res);
+
+int
+ipriq_pop(struct ipriq *pq, size_t *res);
+
+int
+ipriq_add(struct ipriq *pq, size_t x);
+
+#endif

--- a/src/adt/Makefile
+++ b/src/adt/Makefile
@@ -4,6 +4,7 @@ SRC += src/adt/alloc.c
 SRC += src/adt/bitmap.c
 SRC += src/adt/dlist.c
 SRC += src/adt/internedstateset.c
+SRC += src/adt/ipriq.c
 SRC += src/adt/priq.c
 SRC += src/adt/path.c
 SRC += src/adt/xalloc.c
@@ -23,7 +24,7 @@ CFLAGS.${src} += -I src # XXX: for internal.h
 DFLAGS.${src} += -I src # XXX: for internal.h
 .endfor
 
-.for src in ${SRC:Msrc/adt/siphash.c} ${SRC:Msrc/adt/edgeset.c}
+.for src in ${SRC:Msrc/adt/siphash.c} ${SRC:Msrc/adt/edgeset.c} ${SRC:Msrc/adt/ipriq.c}
 CFLAGS.${src} += -std=c99 # XXX: for internal.h
 DFLAGS.${src} += -std=c99 # XXX: for internal.h
 .endfor

--- a/src/adt/edgeset.c
+++ b/src/adt/edgeset.c
@@ -268,6 +268,21 @@ edge_set_add(struct edge_set **setp, const struct fsm_alloc *alloc,
 }
 
 int
+edge_set_add_bulk(struct edge_set **pset, const struct fsm_alloc *alloc,
+	uint64_t symbols[256/64], fsm_state_t state)
+{
+	size_t i;
+	for (i = 0; i < 256; i++) {
+		if (SYMBOLS_GET(symbols, i)) {
+			if (!edge_set_add(pset, alloc, i, state)) {
+				return 0;
+			}
+		}
+	}
+	return 1;
+}
+
+int
 edge_set_add_state_set(struct edge_set **setp, const struct fsm_alloc *alloc,
 	unsigned char symbol, const struct state_set *state_set)
 {
@@ -1098,6 +1113,117 @@ edge_set_add(struct edge_set **pset, const struct fsm_alloc *alloc,
 	eg->to = state;
 	memset(eg->symbols, 0x00, sizeof(eg->symbols));
 	SYMBOLS_SET(eg->symbols, symbol);
+	set->count++;
+	dump_edge_set(set);
+
+	return 1;
+}
+
+int
+edge_set_add_bulk(struct edge_set **pset, const struct fsm_alloc *alloc,
+	uint64_t symbols[256/64], fsm_state_t state)
+{
+	struct edge_set *set;
+	struct edge_group *eg;
+	size_t i;
+
+	assert(pset != NULL);
+
+	set = *pset;
+
+	/* FIXME: factor out duplication once grouped determinisation works */
+
+	if (set == NULL) {	/* empty */
+		set = f_calloc(alloc, 1, sizeof(*set));
+		if (set == NULL) {
+			return 0;
+		}
+
+		set->groups = f_malloc(alloc,
+		    DEF_EDGE_GROUP_CEIL * sizeof(set->groups[0]));
+		if (set->groups == NULL) {
+			f_free(alloc, set);
+			return 0;
+		}
+
+		set->ceil = DEF_EDGE_GROUP_CEIL;
+		set->count = 0;
+
+		eg = &set->groups[0];
+		eg->to = state;
+		memcpy(eg->symbols, symbols, sizeof(eg->symbols));
+		set->count++;
+
+		*pset = set;
+
+#if LOG_BITSET
+		fprintf(stderr, " -- edge_set_add: symbols [0x%lx, 0x%lx, 0x%lx, 0x%lx] -> state %d on empty -> %p\n",
+		    symbols[0], symbols[1], symbols[2], symbols[3],
+		    state, (void *)set);
+#endif
+		dump_edge_set(set);
+
+		return 1;
+	}
+
+	assert(set->ceil > 0);
+	assert(set->count <= set->ceil);
+
+#if LOG_BITSET
+		fprintf(stderr, " -- edge_set_add: symbols [0x%lx, 0x%lx, 0x%lx, 0x%lx] -> state %d on %p\n",
+		    symbols[0], symbols[1], symbols[2], symbols[3],
+		    state, (void *)set);
+#endif
+
+	/* Linear search for a group with the same destination
+	 * state, or the position where that group would go. */
+	for (i = 0; i < set->count; i++) {
+		eg = &set->groups[i];
+
+		if (eg->to == state) {
+			/* This API does not indicate whether that
+			 * symbol -> to edge was already present. */
+			size_t i;
+			for (i = 0; i < 256/64; i++) {
+				eg->symbols[i] |= symbols[i];
+			}
+			dump_edge_set(set);
+			return 1;
+		} else if (eg->to > state) {
+			break;	/* will shift down and insert below */
+		} else {
+			continue;
+		}
+	}
+
+	/* insert/append at i */
+	if (set->count == set->ceil) {
+		if (!grow_groups(set, alloc)) {
+			return 0;
+		}
+	}
+
+	eg = &set->groups[i];
+
+	if (i < set->count && eg->to != state) {  /* shift down by one */
+		const size_t to_mv = set->count - i;
+
+#if LOG_BITSET
+		fprintf(stderr, "   --- shifting, count %ld, i %ld, to_mv %ld\n",
+		    set->count, i, to_mv);
+#endif
+
+		if (to_mv > 0) {
+			memmove(&set->groups[i + 1],
+			    &set->groups[i],
+			    to_mv * sizeof(set->groups[i]));
+		}
+		eg = &set->groups[i];
+	}
+
+	eg->to = state;
+	memset(eg->symbols, 0x00, sizeof(eg->symbols));
+	memcpy(eg->symbols, symbols, sizeof(eg->symbols));
 	set->count++;
 	dump_edge_set(set);
 

--- a/src/adt/edgeset.c
+++ b/src/adt/edgeset.c
@@ -917,7 +917,7 @@ edge_set_ordered_iter_next(struct edge_ordered_iter *eoi, struct fsm_edge *e)
 #include <adt/stateset.h>
 #include <adt/edgeset.h>
 
-#define DEF_EDGE_GROUP_CEIL 2
+#define DEF_EDGE_GROUP_CEIL 1
 
 /* Array of <to, symbols> tuples, sorted by to.
  *

--- a/src/adt/edgeset.c
+++ b/src/adt/edgeset.c
@@ -924,9 +924,7 @@ edge_set_ordered_iter_next(struct edge_ordered_iter *eoi, struct fsm_edge *e)
  * Design assumption: It is significantly more likely in practice to
  * have to be more edges with different labels going to the same state
  * than the same symbol going to different states. This does not
- * include epsilon edges, which can be stored in a state_set.
- *
- * A NULL pointer is treated as the empty set, because */
+ * include epsilon edges, which can be stored in a state_set. */
 struct edge_set {
 	size_t ceil;		/* nonzero */
 	size_t count;		/* <= ceil */

--- a/src/adt/edgeset.c
+++ b/src/adt/edgeset.c
@@ -1336,6 +1336,9 @@ edge_set_hasnondeterminism(const struct edge_set *set, struct bm *bm)
 				if (cur & (1ULL << b_i)) {
 					const size_t bit = 64*w_i + b_i;
 					if (bm_get(bm, bit)) {
+#if LOG_BITSET > 1
+						fprintf(stderr, "-- eshnd: hit on bit %lu\n", bit);
+#endif
 						return 1;
 					}
 					bm_set(bm, bit);
@@ -2015,6 +2018,11 @@ edge_set_group_iter_reset(const struct edge_set *set,
 	egi->set = set;
 	egi->flag = iter_type;
 
+#if LOG_BITSET > 1
+	fprintf(stderr, " -- edge_set_group_iter_reset: set %p, type %d\n",
+	    (void *)set, iter_type);
+#endif
+
 	if (iter_type == EDGE_GROUP_ITER_UNIQUE && set != NULL) {
 		struct edge_group *g;
 		size_t g_i, i;
@@ -2047,12 +2055,21 @@ edge_set_group_iter_next(struct edge_group_iter *egi,
 	size_t i;
 advance:
 	if (egi->set == NULL || egi->i == egi->set->count) {
+#if LOG_BITSET > 1
+		fprintf(stderr, " -- edge_set_group_iter_next: set %p, count %lu, done\n",
+		    (void *)egi->set, egi->i);
+#endif
 		return 0;
 	}
 
 	g = &egi->set->groups[egi->i];
 
 	eg->to = g->to;
+
+#if LOG_BITSET > 1
+	fprintf(stderr, " -- edge_set_group_iter_next: flag %d, i %zu, to %d\n",
+	    egi->flag, egi->i, g->to);
+#endif
 
 	if (egi->flag == EDGE_GROUP_ITER_ALL) {
 		egi->i++;

--- a/src/adt/ipriq.c
+++ b/src/adt/ipriq.c
@@ -4,7 +4,7 @@
 #include <limits.h>
 
 #define DEF_CELLS 2
-#define CHECK 1
+#define CHECK 0
 #define LOG 0
 
 #if LOG

--- a/src/adt/ipriq.c
+++ b/src/adt/ipriq.c
@@ -1,0 +1,228 @@
+#include <adt/ipriq.h>
+
+#include <assert.h>
+#include <limits.h>
+
+#define DEF_CELLS 2
+#define CHECK 1
+#define LOG 0
+
+#if LOG
+#include <stdio.h>
+#endif
+
+struct ipriq {
+	const struct fsm_alloc *alloc;
+	ipriq_cmp_fun *cmp;
+	void *opaque;
+
+	size_t ceil;
+	size_t count;
+	size_t *cells;
+};
+
+struct ipriq *
+ipriq_new(const struct fsm_alloc *alloc,
+    ipriq_cmp_fun *cmp, void *opaque)
+{
+	struct ipriq *res;
+	size_t *cells;
+
+	(void)alloc;
+	(void)cmp;
+	(void)opaque;
+
+	if (cmp == NULL) {
+		return NULL;	/* required */
+	}
+
+	res = f_malloc(alloc, sizeof(*res));
+	if (res == NULL) {
+		return NULL;
+	}
+
+	cells = f_malloc(alloc, DEF_CELLS * sizeof(cells[0]));
+	if (cells == NULL) {
+		f_free(alloc, res);
+		return NULL;
+	}
+
+	res->alloc = alloc;
+	res->cmp = cmp;
+	res->opaque = opaque;
+	res->ceil = DEF_CELLS;
+	res->count = 0;
+	res->cells = cells;
+	return res;
+}
+
+void
+ipriq_free(struct ipriq *pq)
+{
+	if (pq == NULL) {
+		return;
+	}
+
+	f_free(pq->alloc, pq->cells);
+	f_free(pq->alloc, pq);
+}
+
+int
+ipriq_empty(const struct ipriq *pq)
+{
+	assert(pq != NULL);
+	return pq->count == 0;
+}
+
+int
+ipriq_peek(const struct ipriq *pq, size_t *res)
+{
+	assert(res != NULL);
+
+	if (ipriq_empty(pq)) {
+		return 0;
+	}
+
+	*res = pq->cells[0];
+	return 1;
+}
+
+static void
+swap(struct ipriq *pq, size_t x, size_t y)
+{
+    const size_t tmp = pq->cells[x];
+    pq->cells[x] = pq->cells[y];
+    pq->cells[y] = tmp;
+}
+
+static void
+check_heapness(const struct ipriq *pq)
+{
+#if CHECK
+	size_t i;
+	for (i = 0; i < pq->count; i++) {
+		if (i > 0) {
+			size_t parent = (i - 1)/2;
+			const size_t pv = pq->cells[parent];
+			const size_t cv = pq->cells[i];
+			assert(pq->cmp(pv, cv, pq->opaque) < IPRIQ_CMP_GT);
+		}
+	}
+#else
+	(void)pq;
+#endif
+}
+
+#define NO_CELL ((size_t)-1)
+
+int
+ipriq_pop(struct ipriq *pq, size_t *res)
+{
+	assert(res != NULL);
+
+	if (ipriq_empty(pq)) {
+		return 0;
+	}
+
+	*res = pq->cells[0];
+
+	if (pq->count > 1) {
+		size_t pos = 0;
+		pq->cells[0] = pq->cells[pq->count - 1];
+		for (;;) {
+			/* left pos, right pos */
+			const size_t lp = 2*(pos + 1) - 1;
+			if (lp >= pq->count) { break; }
+			const size_t rp = 2*(pos + 1);
+
+			/* current, left, right values */
+			const size_t cv = pq->cells[pos];
+			const size_t lv = pq->cells[lp];
+			const size_t rv = (rp >= pq->count ? NO_CELL : pq->cells[rp]);
+#if LOG
+			printf("    -- pos %zu (%zu), lp %zu (%zu), rp %zu (%zu)\n",
+			    pos, cv, lp, lv, rp, rv);
+#endif
+			if (pq->cmp(lv, cv, pq->opaque) == IPRIQ_CMP_LT) {
+				if (rv != NO_CELL
+				    && pq->cmp(rv, lv, pq->opaque) == IPRIQ_CMP_LT) {
+					swap(pq, pos, rp);
+					pos = rp;
+				} else {
+					swap(pq, pos, lp);
+					pos = lp;
+				}
+			} else if (rv != NO_CELL
+			    && pq->cmp(rv, cv, pq->opaque) == IPRIQ_CMP_LT) {
+				swap(pq, pos, rp);
+				pos = rp;
+			} else {
+				break;
+			}
+		}
+	}
+
+	pq->count--;
+#if LOG
+	printf("POP: %zu <-", *res);
+	for (size_t i = 0; i < pq->count; i++) {
+		printf(" %zu", pq->cells[i]);
+	}
+	printf("\n");
+#endif
+
+	check_heapness(pq);
+
+	return 1;
+}
+
+int
+ipriq_add(struct ipriq *pq, size_t x)
+{
+	assert(pq != NULL);
+	(void)x;
+
+	if (pq->count == pq->ceil) {
+		size_t nceil = 2*pq->ceil;
+		assert(nceil > pq->ceil);
+
+		size_t *ncells = realloc(pq->cells,
+		    nceil * sizeof(*ncells));
+		if (ncells == NULL) { return 0; }
+		pq->cells = ncells;
+		pq->ceil = nceil;
+	}
+
+	pq->cells[pq->count] = x;
+
+	size_t pos = pq->count;
+
+	while (pos > 0) {
+		const size_t parent = (pos - 1)/2;
+#if LOG
+		printf("%s: pos %zu, parent %zu\n", __func__, pos, parent);
+#endif
+		const size_t pv = pq->cells[parent];
+		const size_t cv = pq->cells[pos];
+
+		if (pq->cmp(cv, pv, pq->opaque) == IPRIQ_CMP_LT) {
+			swap(pq, parent, pos);
+			pos = parent;
+		} else {
+			break;
+		}
+	}
+
+	pq->count++;
+
+#if LOG
+	printf("ADD:");
+	for (size_t i = 0; i < pq->count; i++) {
+		printf(" %zu", pq->cells[i]);
+	}
+	printf("\n");
+#endif
+
+	check_heapness(pq);
+	return 1;
+}

--- a/src/libfsm/determinise_internal.h
+++ b/src/libfsm/determinise_internal.h
@@ -21,10 +21,15 @@
 #include "capture.h"
 #include "endids.h"
 
+#include <ctype.h>
+
 #define DUMP_MAPPING 0
 #define LOG_DETERMINISE_CLOSURES 0
 #define LOG_DETERMINISE_CAPTURES 0
 #define LOG_SYMBOL_CLOSURE 0
+#define LOG_AC 0
+
+#define PROCESS_AS_GROUP 1
 
 #if LOG_DETERMINISE_CAPTURES
 #include <fsm/print.h>
@@ -54,7 +59,6 @@ struct map {
 	struct mapping {
 		struct interned_state_set *iss;
 		size_t dfastate;
-		fsm_state_t oldstate;
 		struct edge_set *edges;
 	} **buckets;
 };
@@ -85,33 +89,103 @@ struct mappingstack {
 	struct mapping **s;
 };
 
-#define MAX_EGM 100		/* FIXME: make dynamic and not global */
+#define MAX_EGM 10000		/* FIXME: make dynamic and not global */
 
-/* This should be stored in a dynamic set later,
- * keyed on <on, to, first>. Locality on 'on' may be beneficial. */
+/* This should be stored in a dynamic set later, */
 struct edge_group_mapping {
-	fsm_state_t on;
-	fsm_state_t to;
-
+	struct interned_state_set *iss;
 	/* first label, which stands for all the labels */
 	unsigned char first;
 	uint64_t labels[256/64];
 };
 
+#define AC_NO_STATE ((fsm_state_t)-1)
+#define DEF_ITER_CEIL 4
+#define DEF_GROUP_CEIL 4
+#define DEF_OUTPUT_CEIL 4
+
+struct analyze_closures_env {
+	const struct fsm_alloc *alloc;
+	const struct fsm *fsm;
+	struct interned_state_set_pool *issp;
+
+	struct edge_group_mapping *egm;
+	size_t egm_count;
+
+	/* Temporary state for iterators */
+	size_t iter_ceil;
+	size_t iter_count;
+	struct ac_iter {
+		/* if info.to is AC_NO_STATE then it's done */
+		struct edge_group_iter iter;
+		struct edge_group_iter_info info;
+	} *iters;
+
+	/* All sets of labels leading to states,
+	 * stored in ascending order. */
+	size_t group_ceil;
+	size_t group_count;
+	struct ac_group {
+		fsm_state_t to;
+		uint64_t labels[256/64];
+	} *groups;
+
+	/* A collection of (label set -> interned state set) pairs. */
+	size_t output_ceil;
+	size_t output_count;
+	struct ac_output {
+		uint64_t labels[256/64];
+		struct interned_state_set *iss;
+	} *outputs;
+};
+
+static int
+analyze_closures_for_iss(struct analyze_closures_env *env,
+	struct interned_state_set *curr_iss);
+
+static int
+analyze_closures__init_iterators(struct analyze_closures_env *env,
+	const struct state_set *ss, size_t set_count);
+
+enum ac_collect_res {
+	AC_COLLECT_DONE,
+	AC_COLLECT_EMPTY,
+	AC_COLLECT_ERROR = -1,
+};
+
+static enum ac_collect_res
+analyze_closures__collect(struct analyze_closures_env *env);
+
+static int
+analyze_closures__analyze(struct analyze_closures_env *env);
+
+static int
+analyze_closures__save_output(struct analyze_closures_env *env,
+    const uint64_t labels[256/4], struct interned_state_set *iss);
+
+static int
+analyze_closures__grow_iters(struct analyze_closures_env *env,
+    size_t set_count);
+
+static int
+analyze_closures__grow_groups(struct analyze_closures_env *env);
+
+static int
+analyze_closures__grow_outputs(struct analyze_closures_env *env);
+
 static int
 save_egm(struct edge_group_mapping *egm, size_t *egm_count,
-	fsm_state_t on, fsm_state_t to, unsigned char first,
+	struct interned_state_set *iss, unsigned char first,
 	uint64_t *labels);
 
 static int
 load_egm(const struct edge_group_mapping *egm, size_t egm_count,
-	fsm_state_t on, unsigned char first,
+	struct interned_state_set *iss, unsigned char first,
 	uint64_t *labels);
 
 static int
 map_add(struct map *map,
-	fsm_state_t dfastate, struct interned_state_set *iss,
-	fsm_state_t oldstate, struct mapping **new_mapping);
+	fsm_state_t dfastate, struct interned_state_set *iss, struct mapping **new_mapping);
 
 static int
 map_find(const struct map *map, struct interned_state_set *iss,
@@ -138,8 +212,7 @@ det_copy_capture_actions(struct reverse_mapping *reverse_mappings,
 static int
 interned_symbol_closure_without_epsilons(const struct fsm *fsm, fsm_state_t s,
 	struct interned_state_set_pool *issp,
-	struct interned_state_set *sclosures[static FSM_SIGMA_COUNT],
-	struct edge_group_mapping *egm, size_t *egm_count);
+	struct interned_state_set *sclosures[static FSM_SIGMA_COUNT], size_t dfa_state);
 
 static int
 grow_map(struct map *map);

--- a/theft/Makefile
+++ b/theft/Makefile
@@ -6,6 +6,7 @@ SRC += theft/util.c
 SRC += theft/wrap.c
 
 SRC += theft/fuzz_adt_edge_set.c
+SRC += theft/fuzz_adt_ipriq.c
 SRC += theft/fuzz_adt_priq.c
 SRC += theft/fuzz_adt_set.c
 SRC += theft/fuzz_capture_string_set.c
@@ -25,6 +26,7 @@ SRC += theft/type_info_nfa.c
 SRC += theft/type_info_re.c
 SRC += theft/type_info_re_literal.c
 SRC += theft/type_info_re_pcre.c
+SRC += theft/type_info_adt_ipriq.c
 SRC += theft/type_info_adt_priq.c
 SRC += theft/type_info_adt_set.c
 

--- a/theft/fuzz_adt_ipriq.c
+++ b/theft/fuzz_adt_ipriq.c
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2021 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include "type_info_adt_ipriq.h"
+
+#include <adt/ipriq.h>
+#include <adt/xalloc.h>
+
+struct model {
+	size_t used;
+	size_t entries[];
+};
+
+static enum ipriq_cmp_res
+cmp_size_t(size_t a, size_t b, void *opaque)
+{
+	(void)opaque;
+	return a < b ? IPRIQ_CMP_LT :
+	    a > b ? IPRIQ_CMP_GT : IPRIQ_CMP_EQ;
+}
+
+static int exec_add(size_t x, struct model *m, struct ipriq *pq)
+{
+	if (!ipriq_add(pq, x)) {
+		return 0;
+	}
+
+	m->entries[m->used] = x;
+	m->used++;
+	return 1;
+}
+
+static int find_min_pos(const struct model *m, size_t *pos)
+{
+	size_t i;
+	if (m->used == 0) {
+		return 0;
+	}
+
+	size_t res, min;
+	res = 0;
+	min = m->entries[0];
+
+	for (i = 1; i < m->used; i++) {
+		if (m->entries[i] < min) {
+			res = i;
+			min = m->entries[i];
+		}
+	}
+	*pos = res;
+	return 1;
+}
+
+static int exec_peek(struct model *m, struct ipriq *pq)
+{
+	size_t res;
+
+	if (!ipriq_peek(pq, &res)) {
+		return m->used == 0;
+	}
+
+	size_t pos;
+	if (!find_min_pos(m, &pos)) {
+		assert(!"unreachable (peek)");
+	}
+
+	return res == m->entries[pos];
+}
+
+static int exec_pop(struct model *m, struct ipriq *pq)
+{
+	size_t res;
+
+	if (!ipriq_pop(pq, &res)) {
+		return m->used == 0;
+	}
+
+	size_t pos;
+	if (!find_min_pos(m, &pos)) {
+		assert(!"unreachable (pop)");
+	}
+
+	if (res != m->entries[pos]) {
+		return 0;
+	}
+
+	assert(m->used > 0);
+	if (pos < m->used - 1) {
+		m->entries[pos] = m->entries[m->used - 1];
+	}
+	m->used--;
+	return 1;
+}
+
+static enum theft_trial_res
+compare_against_model(const struct ipriq_scenario *scen)
+{
+	enum theft_trial_res res = THEFT_TRIAL_FAIL;
+	size_t i;
+
+	struct model *m = malloc(sizeof(*m)
+	    + scen->count * sizeof(m->entries[0]));
+	if (m == NULL) {
+		return THEFT_TRIAL_ERROR;
+	}
+	m->used = 0;
+
+	struct ipriq *pq = ipriq_new(NULL, cmp_size_t, NULL);
+	if (pq == NULL) {
+		return THEFT_TRIAL_ERROR;
+	}
+
+	for (i = 0; i < scen->count; i++) {
+		const struct ipriq_op *op = &scen->ops[i];
+
+		switch (op->t) {
+		case IPRIQ_OP_ADD:
+			if (!exec_add(op->u.add.x, m, pq)) {
+				goto cleanup;
+			}
+			break;
+
+		case IPRIQ_OP_PEEK:
+			if (!exec_peek(m, pq)) {
+				goto cleanup;
+			}
+			break;
+
+		case IPRIQ_OP_POP:
+			if (!exec_pop(m, pq)) {
+				goto cleanup;
+			}
+			break;
+
+		default:
+			assert(false); break;
+		}
+	}
+
+	res = THEFT_TRIAL_PASS;
+
+cleanup:
+	free(m);
+
+	return res;
+}
+
+static enum theft_trial_res
+prop_ipriq_model(struct theft *t, void *arg1)
+{
+	const struct ipriq_scenario *scen = arg1;
+	(void)t;
+	return compare_against_model(scen);
+}
+
+static bool
+test_ipriq(theft_seed seed, uintptr_t limit)
+{
+	enum theft_run_res res;
+
+	struct ipriq_hook_env env = {
+		.tag = 'I',
+		.limit = limit,
+	};
+
+	struct theft_run_config config = {
+		.name = __func__,
+		.prop1 = prop_ipriq_model,
+		.type_info = { &type_info_adt_ipriq },
+		.trials = 1000,
+		.hooks = {
+			.trial_pre  = theft_hook_first_fail_halt,
+			.env = &env,
+		},
+		.fork = {
+			.enable = true,
+		},
+
+		.seed = seed,
+	};
+
+	(void)limit;
+
+	res = theft_run(&config);
+	printf("%s: %s\n", __func__, theft_run_res_str(res));
+
+	return res == THEFT_RUN_PASS;
+}
+
+void
+register_test_adt_ipriq(void)
+{
+	reg_test1("adt_ipriq", test_ipriq, 10000);
+}

--- a/theft/main.c
+++ b/theft/main.c
@@ -236,6 +236,7 @@ main(int argc, char **argv)
 	}
 
 	register_test_adt_edge_set();
+	register_test_adt_ipriq();
 	register_test_literals();
 	register_test_re();
 	register_test_adt_priq();

--- a/theft/theft_libfsm.h
+++ b/theft/theft_libfsm.h
@@ -68,6 +68,7 @@ void reg_test3(const char *name, test_fun3 *test,
 /* Register tests within a module. */
 void register_test_literals(void);
 void register_test_re(void);
+void register_test_adt_ipriq(void);
 void register_test_adt_priq(void);
 void register_test_adt_set(void);
 void register_test_capture_string_set(void);

--- a/theft/type_info_adt_ipriq.c
+++ b/theft/type_info_adt_ipriq.c
@@ -1,0 +1,89 @@
+#include "type_info_adt_ipriq.h"
+
+#include <adt/xalloc.h>
+
+static enum theft_alloc_res
+alloc(struct theft *t, void *type_env, void **output)
+{
+	struct ipriq_scenario *res;
+	size_t limit;
+	const uint8_t id_bits = 16;
+
+	(void) type_env;
+
+	struct ipriq_hook_env *env = theft_hook_get_env(t);
+	assert(env->tag == 'I');
+
+	limit = theft_random_choice(t, env->limit);
+
+	res = xmalloc(sizeof *res + limit * sizeof *res->ops);
+
+	res->count = 0;
+	for (size_t i = 0; i < limit; i++) {
+		struct ipriq_op *op;
+		op = &res->ops[res->count];
+		op->t = theft_random_choice(t, IPRIQ_OP_TYPE_COUNT);
+		switch (op->t) {
+		case IPRIQ_OP_PEEK:
+		case IPRIQ_OP_POP:
+			break;
+
+		case IPRIQ_OP_ADD:
+			op->u.add.x = theft_random_bits(t, id_bits);
+			break;
+
+		default:
+			assert(false);
+			break;
+		}
+
+		/* foothold to shrink away operations */
+		if (theft_random_bits(t, 3) > 0) { /* keep? */
+			res->count++;
+		}
+	}
+
+	*output = res;
+
+	return THEFT_ALLOC_OK;
+}
+
+static void
+print(FILE *f, const void *instance, void *type_env)
+{
+	const struct ipriq_scenario *scen;
+
+	(void) type_env;
+
+	scen = instance;
+
+	for (size_t i = 0; i < scen->count; i++) {
+		const struct ipriq_op *op = &scen->ops[i];
+
+		switch (op->t) {
+		case IPRIQ_OP_ADD:
+			fprintf(f, "%zd: ADD %zu\n", i, op->u.add.x);
+			break;
+
+		case IPRIQ_OP_PEEK:
+			fprintf(f, "%zd: PEEK\n", i);
+			break;
+
+		case IPRIQ_OP_POP:
+			fprintf(f, "%zd: POP\n", i);
+			break;
+
+		default:
+			assert(false); break;
+		}
+	}
+}
+
+struct theft_type_info type_info_adt_ipriq = {
+	.alloc = alloc,
+	.print = print,
+	.free  = theft_generic_free_cb,
+	.autoshrink_config = {
+		.enable = true,
+	}
+};

--- a/theft/type_info_adt_ipriq.h
+++ b/theft/type_info_adt_ipriq.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2021 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#ifndef TYPE_INFO_ADT_IPRIQ_H
+#define TYPE_INFO_ADT_IPRIQ_H
+
+#include "theft_libfsm.h"
+
+enum ipriq_op_type {
+	IPRIQ_OP_ADD,
+	IPRIQ_OP_PEEK,
+	IPRIQ_OP_POP,
+	IPRIQ_OP_TYPE_COUNT,
+};
+
+struct ipriq_op {
+	enum ipriq_op_type t;
+	union {
+		struct {
+			size_t x;
+		} add;
+	} u;
+};
+
+struct ipriq_scenario {
+	size_t count;
+	struct ipriq_op ops[];
+};
+
+struct ipriq_hook_env {
+	char tag;
+	size_t limit;
+};
+
+extern struct theft_type_info type_info_adt_ipriq;
+
+#endif


### PR DESCRIPTION
This reworks `fsm_determinise` to take advantage of label grouping in the new edgeset ADT. Casual benchmarking suggests this may be about 5x faster for my test data. There is a lot of room for further performance tuning, but this seems like a good waypoint.

Rather than analyzing every label independently, build a table of all of the `(label set)->to state` groups for each state set, then analyze the table to partition into non-overlapping groups, then add each set of edges all at once.

This adds a new ADT, "ipriq" (index priority queue), which is a heap-based priority queue whose cells are all indices into a separate structure. An opaque pointer to it and comparison callback are passed in. A new theft test exercises it.