### PR TITLE
Address some UBSan warnings/errors related to numeric type conversion/overflow

### DIFF
--- a/include/common/check.h
+++ b/include/common/check.h
@@ -4,8 +4,8 @@
  * See LICENCE for the full copyright terms.
  */
 
-#ifndef LIBFSM_COMMON_H
-#define LIBFSM_COMMON_H
+#ifndef LIBFSM_CHECK_H
+#define LIBFSM_CHECK_H
 
 #if defined(__clang__)
 /* Newer versions of clang's UBSan emit warnings about *all* unsigned

--- a/include/common/libfsm_common.h
+++ b/include/common/libfsm_common.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2021 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#ifndef LIBFSM_COMMON_H
+#define LIBFSM_COMMON_H
+
+#if defined(__clang__)
+/* Newer versions of clang's UBSan emit warnings about *all* unsigned
+ * integer overflows. While they are defined behavior, overflow can
+ * cause bugs. This macro ignores them for a particular function.
+ * Overflow/rollover is expected in when hashing, for example. */
+#define SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()		\
+	__attribute__((no_sanitize("integer")))
+#else
+#define SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
+#endif
+
+#endif

--- a/src/adt/internedstateset.c
+++ b/src/adt/internedstateset.c
@@ -13,7 +13,7 @@
 #include <adt/stateset.h>
 #include <adt/internedstateset.h>
 
-#include "common/libfsm_common.h"
+#include "common/check.h"
 
 #define ISS_BUCKET_DEF_CEIL 4
 #define CACHE_BUCKET_DEF_CEIL 32

--- a/src/adt/siphash.c
+++ b/src/adt/siphash.c
@@ -20,7 +20,7 @@
 #include <string.h>
 
 /* Added to suppress UBSan warning for (expected) unsigned integer overflow. */
-#include "common/libfsm_common.h"
+#include "common/check.h"
 
 /* default: SipHash-2-4 */
 #define cROUNDS 2

--- a/src/adt/siphash.c
+++ b/src/adt/siphash.c
@@ -19,6 +19,9 @@
 #include <stdio.h>
 #include <string.h>
 
+/* Added to suppress UBSan warning for (expected) unsigned integer overflow. */
+#include "common/libfsm_common.h"
+
 /* default: SipHash-2-4 */
 #define cROUNDS 2
 #define dROUNDS 4
@@ -75,6 +78,7 @@
 #define TRACE
 #endif
 
+SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
 int siphash(const uint8_t *in, const size_t inlen, const uint8_t *k,
             uint8_t *out, const size_t outlen) {
 

--- a/src/libfsm/capture.c
+++ b/src/libfsm/capture.c
@@ -281,6 +281,13 @@ fsm_capture_add_action(struct fsm *fsm,
 	    state, &action);
 }
 
+SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
+static unsigned
+hash_state(fsm_state_t state)
+{
+	return PHI32 * (state + 1);
+}
+
 static int
 add_capture_action(struct fsm *fsm, struct fsm_capture_info *ci,
     fsm_state_t state, const struct fsm_capture_action *action)
@@ -307,7 +314,7 @@ add_capture_action(struct fsm *fsm, struct fsm_capture_info *ci,
 		}
 	}
 
-	h = PHI32 * state;
+	h = hash_state(state);
 	mask = ci->bucket_count - 1;
 
 	for (b_i = 0; b_i < ci->bucket_count; b_i++) {
@@ -365,7 +372,7 @@ grow_capture_action_buckets(const struct fsm_alloc *alloc,
 			continue;
 		}
 
-		h = PHI32 * src_b->state;
+		h = hash_state(src_b->state);
 		for (b_i = 0; b_i < ncount; b_i++) {
 			struct fsm_capture_action_bucket *dst_b;
 			dst_b = &nbuckets[(h + b_i) & mask];
@@ -643,7 +650,7 @@ fsm_capture_update_captures(const struct fsm *fsm,
 	ci = fsm->capture_info;
 	assert(ci != NULL);
 
-	h = PHI32 * cur_state;
+	h = hash_state(cur_state);
 	mask = ci->bucket_count - 1;
 
 #if LOG_CAPTURE > 0

--- a/src/libfsm/endids.c
+++ b/src/libfsm/endids.c
@@ -118,6 +118,13 @@ fsm_endid_free(struct fsm *fsm)
 	f_free(fsm->opt->alloc, fsm->endid_info);
 }
 
+SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
+static unsigned long
+hash_state(fsm_state_t state)
+{
+	return PHI32 * (state + 1);
+}
+
 static int
 grow_endid_buckets(const struct fsm_alloc *alloc, struct endid_info *info)
 {
@@ -155,7 +162,7 @@ grow_endid_buckets(const struct fsm_alloc *alloc, struct endid_info *info)
 		if (src_b->state == BUCKET_NO_STATE) {
 			continue;
 		}
-		hash = src_b->state * PHI32;
+		hash = hash_state(src_b->state);
 		for (new_i = 0; new_i < new_count; new_i++) {
 			dst_b = &new_buckets[(hash + new_i) & new_mask];
 			if (dst_b->state == BUCKET_NO_STATE) {
@@ -192,7 +199,7 @@ fsm_endid_set(struct fsm *fsm,
 
 rehash:
 
-	hash = state * PHI32;
+	hash = hash_state(state);
 	mask = ei->bucket_count - 1;
 	assert((mask & ei->bucket_count) == 0); /* power of 2 */
 
@@ -321,7 +328,7 @@ fsm_endid_count(const struct fsm *fsm,
 	const struct endid_info *ei = NULL;
 	size_t i;
 
-	unsigned hash = state * PHI32;
+	unsigned hash = hash_state(state);
 	unsigned mask;
 
 	assert(fsm != NULL);
@@ -357,7 +364,7 @@ fsm_endid_get(const struct fsm *fsm, fsm_state_t end_state,
 	size_t written = 0;
 	const struct endid_info *ei = NULL;
 
-	unsigned hash = end_state * PHI32;
+	unsigned hash = hash_state(end_state);
 	unsigned mask;
 
 	(void)written;
@@ -550,7 +557,7 @@ fsm_endid_iter_state(const struct fsm *fsm, fsm_state_t state,
 
 	assert(state != BUCKET_NO_STATE);
 
-	hash = state * PHI32;
+	hash = hash_state(state);
 	bucket_count = ei->bucket_count;
 	mask = bucket_count - 1;
 	assert((mask & bucket_count) == 0); /* power of 2 */

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -13,6 +13,8 @@
 #include <fsm/fsm.h>
 #include <fsm/options.h>
 
+#include "common/libfsm_common.h"
+
 struct bm;
 struct edge_set;
 struct state_set;

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -13,7 +13,7 @@
 #include <fsm/fsm.h>
 #include <fsm/options.h>
 
-#include "common/libfsm_common.h"
+#include "common/check.h"
 
 struct bm;
 struct edge_set;

--- a/src/libre/ast_analysis.c
+++ b/src/libre/ast_analysis.c
@@ -549,13 +549,17 @@ assign_lasts(struct ast_expr *n)
 
 		set_flags(n, AST_FLAG_LAST);
 
-		/* iterate in reverse, break on rollover */
-		for (i = n->u.concat.count - 1; i < n->u.concat.count; i--) {
-			struct ast_expr *child = n->u.concat.n[i];
-			assign_lasts(child);
-			if (always_consumes_input(child) || is_end_anchor(child)) {
-				break;
-			}
+		/* iterate in reverse */
+		i = n->u.concat.count;
+		if (i > 0) {
+			do {
+				i--;
+				struct ast_expr *child = n->u.concat.n[i];
+				assign_lasts(child);
+				if (always_consumes_input(child) || is_end_anchor(child)) {
+					break;
+				}
+			} while (i > 0);
 		}
 		break;
 	}

--- a/src/libre/ast_compile.c
+++ b/src/libre/ast_compile.c
@@ -865,7 +865,7 @@ comp_iter(struct comp_env *env,
 		re_flags = n->re_flags;
 
 		/* wouldn't want to reverse twice! */
-		re_flags &= ~RE_REVERSE;
+		re_flags &= ~(unsigned)RE_REVERSE;
 
 		a = expr_compile(n->u.subtract.a, re_flags,
 			fsm_getoptions(env->fsm), env->err);


### PR DESCRIPTION
This addresses several UBSan errors related to numeric types.

- Fix warnings about unsigned integer overflow in hash functions. That's defined, safe, and expected.
- Restructure a reverse iteration that counts down to not have potential UB around 0.
- Add a cast for a negated flag.

There are warnings remaining related to implicit conversions between `char` and `unsigned char`, but addressing them will require several interface changes. There is also warnings related to numeric type truncation in `parser.act` around `strtoul`, but those should be handled separately, especially since they will require the other parsers to be re-generated.