### PR TITLE
Overrides for a few more linguist things

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,9 @@ lexer.? linguist-generated=true
 parser.? linguist-generated=true
 src/libre/class/*.c linguist-generated=true
 src/libre/class_name.c
+man/* linguist-documentation
+doc/* linguist-documentation
+*.inc linguist-language=C
+share/hcd/*.txt linguist-vendored
+*.h linguist-language=C
+*.re linguist-language=Regular-Expression


### PR DESCRIPTION
There seems to be no way to test this; I think the github UI only shows classifications from `main`. So I guess I have to merge it and see if it does what I want.