### PR TITLE
Update brew

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -38,6 +38,7 @@ jobs:
       if: matrix.os == 'macos'
       run: |
         uname -a
+        brew update
         brew install bmake pcre
         ${{ matrix.cc }} --version
 

--- a/.github/workflows/san.yml
+++ b/.github/workflows/san.yml
@@ -42,6 +42,7 @@ jobs:
       if: matrix.os == 'macos'
       run: |
         uname -a
+        brew update
         brew install bmake pcre
         ${{ matrix.cc }} --version
 


### PR DESCRIPTION
CI fails currently because of brew on macos:
```
; wget https://homebrew.bintray.com/bottles/bmake-20200902.catalina.bottle.tar.gz
2021-04-12 11:44:03 ERROR 403: Forbidden.
```

brew looks to have moved its packages from bintray to download from github instead. `brew update` seems to update the sources; I suppose we'll need this until github's CI images have the next stable brew release which contains this fix.

Discussion here:
https://github.com/Homebrew/discussions/discussions/691