### PR TITLE
Disallow ambiguous syntax for parsing backreferences vs. decimal literals

### DIFF
--- a/src/libre/ast.c
+++ b/src/libre/ast.c
@@ -739,7 +739,7 @@ ast_make_expr_repeat(struct ast_expr_pool **poolp, enum re_flags re_flags, struc
 }
 
 struct ast_expr *
-ast_make_expr_group(struct ast_expr_pool **poolp, enum re_flags re_flags, struct ast_expr *e)
+ast_make_expr_group(struct ast_expr_pool **poolp, enum re_flags re_flags, struct ast_expr *e, unsigned id)
 {
 	struct ast_expr *res;
 
@@ -751,7 +751,7 @@ ast_make_expr_group(struct ast_expr_pool **poolp, enum re_flags re_flags, struct
 	res->type = AST_EXPR_GROUP;
 	res->re_flags = re_flags;
 	res->u.group.e = e;
-	res->u.group.id = NO_GROUP_ID; /* not yet assigned */
+	res->u.group.id = id;
 
 	return res;
 }

--- a/src/libre/ast.h
+++ b/src/libre/ast.h
@@ -79,8 +79,6 @@ enum ast_flags {
 	AST_FLAG_NONE = 0x00
 };
 
-#define NO_GROUP_ID ((unsigned)-1)
-
 enum ast_endpoint_type {
 	AST_ENDPOINT_LITERAL,
 	AST_ENDPOINT_CODEPOINT,
@@ -271,7 +269,7 @@ struct ast_expr *
 ast_make_expr_repeat(struct ast_expr_pool **poolp, enum re_flags re_flags, struct ast_expr *e, struct ast_count count);
 
 struct ast_expr *
-ast_make_expr_group(struct ast_expr_pool **poolp, enum re_flags re_flags, struct ast_expr *e);
+ast_make_expr_group(struct ast_expr_pool **poolp, enum re_flags re_flags, struct ast_expr *e, unsigned id);
 
 struct ast_expr *
 ast_make_expr_anchor(struct ast_expr_pool **poolp, enum re_flags re_flags, enum ast_anchor_type type);

--- a/src/libre/dialect/glob/parser.c
+++ b/src/libre/dialect/glob/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 142 "src/libre/parser.act"
+#line 149 "src/libre/parser.act"
 
 
 	#include <assert.h>
@@ -90,6 +90,7 @@
 	typedef const struct class * t_ast__class__id;
 	typedef struct ast_count t_ast__count;
 	typedef struct ast_endpoint t_endpoint;
+	typedef unsigned t_group__id;
 
 	struct act_state {
 		struct ast_expr_pool **poolp;
@@ -112,6 +113,12 @@
 		struct re_pos groupstart; struct re_pos groupend;
 		struct re_pos rangestart; struct re_pos rangeend;
 		struct re_pos countstart; struct re_pos countend;
+
+		/*
+		 * Numbering for capturing groups. By convention these start from 1,
+		 * and 0 represents the entire matching text.
+		 */
+		unsigned group_id;
 	};
 
 	struct lex_state {
@@ -148,7 +155,6 @@
 	{
 		enum re_flags fl = (lex_state->flags_ptr != NULL) ? lex_state->flags_ptr[0] : 0;
 		enum LX_TOKEN tok;
-
 
 		if ((fl & RE_EXTENDED) == 0) {
 			tok = act_state->lex_tok;
@@ -281,7 +287,7 @@
 		return s;
 	}
 
-#line 285 "src/libre/dialect/glob/parser.c"
+#line 291 "src/libre/dialect/glob/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -316,16 +322,16 @@ ZL2_list_Hof_Hatoms:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 987 "src/libre/parser.act"
+#line 997 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
 		}
 	
-#line 326 "src/libre/dialect/glob/parser.c"
+#line 332 "src/libre/dialect/glob/parser.c"
 		}
 		/* END OF ACTION: ast-add-concat */
-		/* BEGINNING OF INLINE: 113 */
+		/* BEGINNING OF INLINE: 115 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_MANY): case (TOK_CHAR):
@@ -339,7 +345,7 @@ ZL2_list_Hof_Hatoms:;
 				break;
 			}
 		}
-		/* END OF INLINE: 113 */
+		/* END OF INLINE: 115 */
 	}
 	return;
 ZL1:;
@@ -360,24 +366,24 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: class-any */
 			{
-#line 735 "src/libre/parser.act"
+#line 741 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
 		(ZIa) = (*flags & RE_SINGLE) ? &class_any : &class_notnl;
 	
-#line 369 "src/libre/dialect/glob/parser.c"
+#line 375 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 980 "src/libre/parser.act"
+#line 990 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_named(act_state->poolp, *flags, (ZIa));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 381 "src/libre/dialect/glob/parser.c"
+#line 387 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 		}
@@ -385,35 +391,35 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 	case (TOK_CHAR):
 		{
 			t_char ZIc;
-			t_pos ZI109;
-			t_pos ZI110;
+			t_pos ZI111;
+			t_pos ZI112;
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
-#line 530 "src/libre/parser.act"
+#line 536 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI109 = lex_state->lx.start;
-		ZI110   = lex_state->lx.end;
+		ZI111 = lex_state->lx.start;
+		ZI112   = lex_state->lx.end;
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 404 "src/libre/dialect/glob/parser.c"
+#line 410 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 831 "src/libre/parser.act"
+#line 837 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 417 "src/libre/dialect/glob/parser.c"
+#line 423 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -427,38 +433,38 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: class-any */
 			{
-#line 735 "src/libre/parser.act"
+#line 741 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
 		(ZIa) = (*flags & RE_SINGLE) ? &class_any : &class_notnl;
 	
-#line 436 "src/libre/dialect/glob/parser.c"
+#line 442 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 980 "src/libre/parser.act"
+#line 990 "src/libre/parser.act"
 
 		(ZIg) = ast_make_expr_named(act_state->poolp, *flags, (ZIa));
 		if ((ZIg) == NULL) {
 			goto ZL1;
 		}
 	
-#line 448 "src/libre/dialect/glob/parser.c"
+#line 454 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 			/* BEGINNING OF ACTION: count-zero-or-more */
 			{
-#line 760 "src/libre/parser.act"
+#line 766 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 457 "src/libre/dialect/glob/parser.c"
+#line 463 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 			/* BEGINNING OF ACTION: ast-make-piece */
 			{
-#line 850 "src/libre/parser.act"
+#line 860 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
@@ -472,7 +478,7 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			goto ZL1;
 		}
 	
-#line 476 "src/libre/dialect/glob/parser.c"
+#line 482 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: ast-make-piece */
 		}
@@ -487,26 +493,26 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-atom */
 		{
-#line 644 "src/libre/parser.act"
+#line 650 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXATOM;
 		}
 		goto ZL2;
 	
-#line 498 "src/libre/dialect/glob/parser.c"
+#line 504 "src/libre/dialect/glob/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 810 "src/libre/parser.act"
+#line 816 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZIe) == NULL) {
 			goto ZL2;
 		}
 	
-#line 510 "src/libre/dialect/glob/parser.c"
+#line 516 "src/libre/dialect/glob/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -527,21 +533,21 @@ p_re__glob(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 116 */
+		/* BEGINNING OF INLINE: 118 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_MANY): case (TOK_CHAR):
 				{
 					/* BEGINNING OF ACTION: ast-make-concat */
 					{
-#line 817 "src/libre/parser.act"
+#line 823 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_concat(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 545 "src/libre/dialect/glob/parser.c"
+#line 551 "src/libre/dialect/glob/parser.c"
 					}
 					/* END OF ACTION: ast-make-concat */
 					p_list_Hof_Hatoms (flags, lex_state, act_state, err, ZInode);
@@ -555,22 +561,22 @@ p_re__glob(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 				{
 					/* BEGINNING OF ACTION: ast-make-empty */
 					{
-#line 810 "src/libre/parser.act"
+#line 816 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 566 "src/libre/dialect/glob/parser.c"
+#line 572 "src/libre/dialect/glob/parser.c"
 					}
 					/* END OF ACTION: ast-make-empty */
 				}
 				break;
 			}
 		}
-		/* END OF INLINE: 116 */
-		/* BEGINNING OF INLINE: 117 */
+		/* END OF INLINE: 118 */
+		/* BEGINNING OF INLINE: 119 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -586,20 +592,20 @@ p_re__glob(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 693 "src/libre/parser.act"
+#line 699 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
 		}
 		goto ZL1;
 	
-#line 597 "src/libre/dialect/glob/parser.c"
+#line 603 "src/libre/dialect/glob/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 117 */
+		/* END OF INLINE: 119 */
 	}
 	goto ZL0;
 ZL1:;
@@ -611,7 +617,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 1143 "src/libre/parser.act"
+#line 1155 "src/libre/parser.act"
 
 
 	static int
@@ -687,6 +693,8 @@ ZL0:;
 		act_state->overlap = overlap;
 		act_state->poolp   = &ast->pool;
 
+		act_state->group_id = 1;
+
 		err->e = RE_ESUCCESS;
 
 		ADVANCE_LEXER;
@@ -757,6 +765,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 761 "src/libre/dialect/glob/parser.c"
+#line 769 "src/libre/dialect/glob/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/glob/parser.h
+++ b/src/libre/dialect/glob/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 304 "src/libre/parser.act"
+#line 310 "src/libre/parser.act"
 
 
 	#include <re/re.h>
@@ -28,7 +28,7 @@
 extern void p_re__glob(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 1145 "src/libre/parser.act"
+#line 1157 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/glob/parser.h"

--- a/src/libre/dialect/glob/parser.sid
+++ b/src/libre/dialect/glob/parser.sid
@@ -15,6 +15,7 @@
 	ast_count;
 	ast_class_id;
 	!endpoint;
+	!group_id;
 
 %terminals%
 
@@ -83,6 +84,7 @@
 	!<count-one>:         () -> (:ast_count);
 	!<count-range>: (:unsigned, :pos, :unsigned, :pos) -> (:ast_count);
 
+	!<make-group-id>:      () -> (:group_id);
 	!<make-literal-cbrak>: () -> (:char);
 	!<make-literal-cr>:    () -> (:char);
 	!<make-literal-nl>:    () -> (:char);
@@ -95,7 +97,7 @@
 	<ast-make-concat>:        ()                       -> (:ast_expr);
 	!<ast-make-alt>:          ()                       -> (:ast_expr);
 	<ast-make-piece>:         (:ast_expr, :ast_count)  -> (:ast_expr);
-	!<ast-make-group>:        (:ast_expr)              -> (:ast_expr);
+	!<ast-make-group>:        (:ast_expr, :group_id)   -> (:ast_expr);
 	!<ast-get-re-flags>:      ()                       -> (:re_flags);
 	!<ast-set-re-flags>:      (:re_flags)              -> ();
 	!<ast-mask-re-flags>:     (:re_flags, :re_flags)   -> ();

--- a/src/libre/dialect/like/parser.c
+++ b/src/libre/dialect/like/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 142 "src/libre/parser.act"
+#line 149 "src/libre/parser.act"
 
 
 	#include <assert.h>
@@ -90,6 +90,7 @@
 	typedef const struct class * t_ast__class__id;
 	typedef struct ast_count t_ast__count;
 	typedef struct ast_endpoint t_endpoint;
+	typedef unsigned t_group__id;
 
 	struct act_state {
 		struct ast_expr_pool **poolp;
@@ -112,6 +113,12 @@
 		struct re_pos groupstart; struct re_pos groupend;
 		struct re_pos rangestart; struct re_pos rangeend;
 		struct re_pos countstart; struct re_pos countend;
+
+		/*
+		 * Numbering for capturing groups. By convention these start from 1,
+		 * and 0 represents the entire matching text.
+		 */
+		unsigned group_id;
 	};
 
 	struct lex_state {
@@ -148,7 +155,6 @@
 	{
 		enum re_flags fl = (lex_state->flags_ptr != NULL) ? lex_state->flags_ptr[0] : 0;
 		enum LX_TOKEN tok;
-
 
 		if ((fl & RE_EXTENDED) == 0) {
 			tok = act_state->lex_tok;
@@ -281,7 +287,7 @@
 		return s;
 	}
 
-#line 285 "src/libre/dialect/like/parser.c"
+#line 291 "src/libre/dialect/like/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -316,16 +322,16 @@ ZL2_list_Hof_Hatoms:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 987 "src/libre/parser.act"
+#line 997 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
 		}
 	
-#line 326 "src/libre/dialect/like/parser.c"
+#line 332 "src/libre/dialect/like/parser.c"
 		}
 		/* END OF ACTION: ast-add-concat */
-		/* BEGINNING OF INLINE: 113 */
+		/* BEGINNING OF INLINE: 115 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_MANY): case (TOK_CHAR):
@@ -339,7 +345,7 @@ ZL2_list_Hof_Hatoms:;
 				break;
 			}
 		}
-		/* END OF INLINE: 113 */
+		/* END OF INLINE: 115 */
 	}
 	return;
 ZL1:;
@@ -360,24 +366,24 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: class-any */
 			{
-#line 735 "src/libre/parser.act"
+#line 741 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
 		(ZIa) = (*flags & RE_SINGLE) ? &class_any : &class_notnl;
 	
-#line 369 "src/libre/dialect/like/parser.c"
+#line 375 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 980 "src/libre/parser.act"
+#line 990 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_named(act_state->poolp, *flags, (ZIa));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 381 "src/libre/dialect/like/parser.c"
+#line 387 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 		}
@@ -385,35 +391,35 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 	case (TOK_CHAR):
 		{
 			t_char ZIc;
-			t_pos ZI111;
-			t_pos ZI112;
+			t_pos ZI113;
+			t_pos ZI114;
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
-#line 530 "src/libre/parser.act"
+#line 536 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI111 = lex_state->lx.start;
-		ZI112   = lex_state->lx.end;
+		ZI113 = lex_state->lx.start;
+		ZI114   = lex_state->lx.end;
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 404 "src/libre/dialect/like/parser.c"
+#line 410 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 831 "src/libre/parser.act"
+#line 837 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 417 "src/libre/dialect/like/parser.c"
+#line 423 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -427,38 +433,38 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: class-any */
 			{
-#line 735 "src/libre/parser.act"
+#line 741 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
 		(ZIa) = (*flags & RE_SINGLE) ? &class_any : &class_notnl;
 	
-#line 436 "src/libre/dialect/like/parser.c"
+#line 442 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 980 "src/libre/parser.act"
+#line 990 "src/libre/parser.act"
 
 		(ZIg) = ast_make_expr_named(act_state->poolp, *flags, (ZIa));
 		if ((ZIg) == NULL) {
 			goto ZL1;
 		}
 	
-#line 448 "src/libre/dialect/like/parser.c"
+#line 454 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 			/* BEGINNING OF ACTION: count-zero-or-more */
 			{
-#line 760 "src/libre/parser.act"
+#line 766 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 457 "src/libre/dialect/like/parser.c"
+#line 463 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 			/* BEGINNING OF ACTION: ast-make-piece */
 			{
-#line 850 "src/libre/parser.act"
+#line 860 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
@@ -472,7 +478,7 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			goto ZL1;
 		}
 	
-#line 476 "src/libre/dialect/like/parser.c"
+#line 482 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: ast-make-piece */
 		}
@@ -487,26 +493,26 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-atom */
 		{
-#line 644 "src/libre/parser.act"
+#line 650 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXATOM;
 		}
 		goto ZL2;
 	
-#line 498 "src/libre/dialect/like/parser.c"
+#line 504 "src/libre/dialect/like/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 810 "src/libre/parser.act"
+#line 816 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZIe) == NULL) {
 			goto ZL2;
 		}
 	
-#line 510 "src/libre/dialect/like/parser.c"
+#line 516 "src/libre/dialect/like/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -527,21 +533,21 @@ p_re__like(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 116 */
+		/* BEGINNING OF INLINE: 118 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_MANY): case (TOK_CHAR):
 				{
 					/* BEGINNING OF ACTION: ast-make-concat */
 					{
-#line 817 "src/libre/parser.act"
+#line 823 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_concat(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 545 "src/libre/dialect/like/parser.c"
+#line 551 "src/libre/dialect/like/parser.c"
 					}
 					/* END OF ACTION: ast-make-concat */
 					p_list_Hof_Hatoms (flags, lex_state, act_state, err, ZInode);
@@ -555,22 +561,22 @@ p_re__like(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 				{
 					/* BEGINNING OF ACTION: ast-make-empty */
 					{
-#line 810 "src/libre/parser.act"
+#line 816 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 566 "src/libre/dialect/like/parser.c"
+#line 572 "src/libre/dialect/like/parser.c"
 					}
 					/* END OF ACTION: ast-make-empty */
 				}
 				break;
 			}
 		}
-		/* END OF INLINE: 116 */
-		/* BEGINNING OF INLINE: 117 */
+		/* END OF INLINE: 118 */
+		/* BEGINNING OF INLINE: 119 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -586,20 +592,20 @@ p_re__like(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 693 "src/libre/parser.act"
+#line 699 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
 		}
 		goto ZL1;
 	
-#line 597 "src/libre/dialect/like/parser.c"
+#line 603 "src/libre/dialect/like/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 117 */
+		/* END OF INLINE: 119 */
 	}
 	goto ZL0;
 ZL1:;
@@ -611,7 +617,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 1143 "src/libre/parser.act"
+#line 1155 "src/libre/parser.act"
 
 
 	static int
@@ -687,6 +693,8 @@ ZL0:;
 		act_state->overlap = overlap;
 		act_state->poolp   = &ast->pool;
 
+		act_state->group_id = 1;
+
 		err->e = RE_ESUCCESS;
 
 		ADVANCE_LEXER;
@@ -757,6 +765,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 761 "src/libre/dialect/like/parser.c"
+#line 769 "src/libre/dialect/like/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/like/parser.h
+++ b/src/libre/dialect/like/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 304 "src/libre/parser.act"
+#line 310 "src/libre/parser.act"
 
 
 	#include <re/re.h>
@@ -28,7 +28,7 @@
 extern void p_re__like(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 1145 "src/libre/parser.act"
+#line 1157 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/like/parser.h"

--- a/src/libre/dialect/like/parser.sid
+++ b/src/libre/dialect/like/parser.sid
@@ -15,6 +15,7 @@
 	ast_count;
 	ast_class_id;
 	!endpoint;
+	!group_id;
 
 %terminals%
 
@@ -83,6 +84,7 @@
 	!<count-one>:         () -> (:ast_count);
 	!<count-range>: (:unsigned, :pos, :unsigned, :pos) -> (:ast_count);
 
+	!<make-group-id>:      () -> (:group_id);
 	!<make-literal-cbrak>: () -> (:char);
 	!<make-literal-cr>:    () -> (:char);
 	!<make-literal-nl>:    () -> (:char);
@@ -95,7 +97,7 @@
 	<ast-make-concat>:        ()                       -> (:ast_expr);
 	!<ast-make-alt>:          ()                       -> (:ast_expr);
 	<ast-make-piece>:         (:ast_expr, :ast_count)  -> (:ast_expr);
-	!<ast-make-group>:        (:ast_expr)              -> (:ast_expr);
+	!<ast-make-group>:        (:ast_expr, :group_id)   -> (:ast_expr);
 	!<ast-get-re-flags>:      ()                       -> (:re_flags);
 	!<ast-set-re-flags>:      (:re_flags)              -> ();
 	!<ast-mask-re-flags>:     (:re_flags, :re_flags)   -> ();

--- a/src/libre/dialect/literal/parser.c
+++ b/src/libre/dialect/literal/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 142 "src/libre/parser.act"
+#line 149 "src/libre/parser.act"
 
 
 	#include <assert.h>
@@ -90,6 +90,7 @@
 	typedef const struct class * t_ast__class__id;
 	typedef struct ast_count t_ast__count;
 	typedef struct ast_endpoint t_endpoint;
+	typedef unsigned t_group__id;
 
 	struct act_state {
 		struct ast_expr_pool **poolp;
@@ -112,6 +113,12 @@
 		struct re_pos groupstart; struct re_pos groupend;
 		struct re_pos rangestart; struct re_pos rangeend;
 		struct re_pos countstart; struct re_pos countend;
+
+		/*
+		 * Numbering for capturing groups. By convention these start from 1,
+		 * and 0 represents the entire matching text.
+		 */
+		unsigned group_id;
 	};
 
 	struct lex_state {
@@ -148,7 +155,6 @@
 	{
 		enum re_flags fl = (lex_state->flags_ptr != NULL) ? lex_state->flags_ptr[0] : 0;
 		enum LX_TOKEN tok;
-
 
 		if ((fl & RE_EXTENDED) == 0) {
 			tok = act_state->lex_tok;
@@ -281,7 +287,7 @@
 		return s;
 	}
 
-#line 285 "src/libre/dialect/literal/parser.c"
+#line 291 "src/libre/dialect/literal/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -316,16 +322,16 @@ ZL2_list_Hof_Hatoms:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 987 "src/libre/parser.act"
+#line 997 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
 		}
 	
-#line 326 "src/libre/dialect/literal/parser.c"
+#line 332 "src/libre/dialect/literal/parser.c"
 		}
 		/* END OF ACTION: ast-add-concat */
-		/* BEGINNING OF INLINE: 112 */
+		/* BEGINNING OF INLINE: 114 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CHAR):
@@ -339,7 +345,7 @@ ZL2_list_Hof_Hatoms:;
 				break;
 			}
 		}
-		/* END OF INLINE: 112 */
+		/* END OF INLINE: 114 */
 	}
 	return;
 ZL1:;
@@ -356,21 +362,21 @@ p_re__literal(flags flags, lex_state lex_state, act_state act_state, err err, t_
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 114 */
+		/* BEGINNING OF INLINE: 116 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CHAR):
 				{
 					/* BEGINNING OF ACTION: ast-make-concat */
 					{
-#line 817 "src/libre/parser.act"
+#line 823 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_concat(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 374 "src/libre/dialect/literal/parser.c"
+#line 380 "src/libre/dialect/literal/parser.c"
 					}
 					/* END OF ACTION: ast-make-concat */
 					p_list_Hof_Hatoms (flags, lex_state, act_state, err, ZInode);
@@ -384,22 +390,22 @@ p_re__literal(flags flags, lex_state lex_state, act_state act_state, err err, t_
 				{
 					/* BEGINNING OF ACTION: ast-make-empty */
 					{
-#line 810 "src/libre/parser.act"
+#line 816 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 395 "src/libre/dialect/literal/parser.c"
+#line 401 "src/libre/dialect/literal/parser.c"
 					}
 					/* END OF ACTION: ast-make-empty */
 				}
 				break;
 			}
 		}
-		/* END OF INLINE: 114 */
-		/* BEGINNING OF INLINE: 115 */
+		/* END OF INLINE: 116 */
+		/* BEGINNING OF INLINE: 117 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -415,20 +421,20 @@ p_re__literal(flags flags, lex_state lex_state, act_state act_state, err err, t_
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 693 "src/libre/parser.act"
+#line 699 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
 		}
 		goto ZL1;
 	
-#line 426 "src/libre/dialect/literal/parser.c"
+#line 432 "src/libre/dialect/literal/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 115 */
+		/* END OF INLINE: 117 */
 	}
 	goto ZL0;
 ZL1:;
@@ -448,24 +454,24 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 	}
 	{
 		t_char ZIc;
-		t_pos ZI109;
-		t_pos ZI110;
+		t_pos ZI111;
+		t_pos ZI112;
 
 		switch (CURRENT_TERMINAL) {
 		case (TOK_CHAR):
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
-#line 530 "src/libre/parser.act"
+#line 536 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI109 = lex_state->lx.start;
-		ZI110   = lex_state->lx.end;
+		ZI111 = lex_state->lx.start;
+		ZI112   = lex_state->lx.end;
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 469 "src/libre/dialect/literal/parser.c"
+#line 475 "src/libre/dialect/literal/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			break;
@@ -475,14 +481,14 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-make-literal */
 		{
-#line 831 "src/libre/parser.act"
+#line 837 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 486 "src/libre/dialect/literal/parser.c"
+#line 492 "src/libre/dialect/literal/parser.c"
 		}
 		/* END OF ACTION: ast-make-literal */
 	}
@@ -491,26 +497,26 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-atom */
 		{
-#line 644 "src/libre/parser.act"
+#line 650 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXATOM;
 		}
 		goto ZL2;
 	
-#line 502 "src/libre/dialect/literal/parser.c"
+#line 508 "src/libre/dialect/literal/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 810 "src/libre/parser.act"
+#line 816 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL2;
 		}
 	
-#line 514 "src/libre/dialect/literal/parser.c"
+#line 520 "src/libre/dialect/literal/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -524,7 +530,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 1143 "src/libre/parser.act"
+#line 1155 "src/libre/parser.act"
 
 
 	static int
@@ -600,6 +606,8 @@ ZL0:;
 		act_state->overlap = overlap;
 		act_state->poolp   = &ast->pool;
 
+		act_state->group_id = 1;
+
 		err->e = RE_ESUCCESS;
 
 		ADVANCE_LEXER;
@@ -670,6 +678,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 674 "src/libre/dialect/literal/parser.c"
+#line 682 "src/libre/dialect/literal/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/literal/parser.h
+++ b/src/libre/dialect/literal/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 304 "src/libre/parser.act"
+#line 310 "src/libre/parser.act"
 
 
 	#include <re/re.h>
@@ -28,7 +28,7 @@
 extern void p_re__literal(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 1145 "src/libre/parser.act"
+#line 1157 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/literal/parser.h"

--- a/src/libre/dialect/literal/parser.sid
+++ b/src/libre/dialect/literal/parser.sid
@@ -15,6 +15,7 @@
 	!ast_count;
 	!ast_class_id;
 	!endpoint;
+	!group_id;
 
 %terminals%
 
@@ -83,6 +84,7 @@
 	!<count-one>:          () -> (:ast_count);
 	!<count-range>: (:unsigned, :pos, :unsigned, :pos) -> (:ast_count);
 
+	!<make-group-id>:      () -> (:group_id);
 	!<make-literal-cbrak>: () -> (:char);
 	!<make-literal-cr>:    () -> (:char);
 	!<make-literal-nl>:    () -> (:char);
@@ -95,7 +97,7 @@
 	<ast-make-concat>:        ()                       -> (:ast_expr);
 	!<ast-make-alt>:          ()                       -> (:ast_expr);
 	!<ast-make-piece>:        (:ast_expr, :ast_count)  -> (:ast_expr);
-	!<ast-make-group>:        (:ast_expr)              -> (:ast_expr);
+	!<ast-make-group>:        (:ast_expr, :group_id)   -> (:ast_expr);
 	!<ast-get-re-flags>:      ()                       -> (:re_flags);
 	!<ast-set-re-flags>:      (:re_flags)              -> ();
 	!<ast-mask-re-flags>:     (:re_flags, :re_flags)   -> ();

--- a/src/libre/dialect/native/parser.c
+++ b/src/libre/dialect/native/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 142 "src/libre/parser.act"
+#line 149 "src/libre/parser.act"
 
 
 	#include <assert.h>
@@ -90,6 +90,7 @@
 	typedef const struct class * t_ast__class__id;
 	typedef struct ast_count t_ast__count;
 	typedef struct ast_endpoint t_endpoint;
+	typedef unsigned t_group__id;
 
 	struct act_state {
 		struct ast_expr_pool **poolp;
@@ -112,6 +113,12 @@
 		struct re_pos groupstart; struct re_pos groupend;
 		struct re_pos rangestart; struct re_pos rangeend;
 		struct re_pos countstart; struct re_pos countend;
+
+		/*
+		 * Numbering for capturing groups. By convention these start from 1,
+		 * and 0 represents the entire matching text.
+		 */
+		unsigned group_id;
 	};
 
 	struct lex_state {
@@ -148,7 +155,6 @@
 	{
 		enum re_flags fl = (lex_state->flags_ptr != NULL) ? lex_state->flags_ptr[0] : 0;
 		enum LX_TOKEN tok;
-
 
 		if ((fl & RE_EXTENDED) == 0) {
 			tok = act_state->lex_tok;
@@ -281,7 +287,7 @@
 		return s;
 	}
 
-#line 285 "src/libre/dialect/native/parser.c"
+#line 291 "src/libre/dialect/native/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -291,27 +297,27 @@
 /* BEGINNING OF FUNCTION DECLARATIONS */
 
 static void p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags, lex_state, act_state, err, t_endpoint *, t_pos *, t_pos *);
-static void p_265(flags, lex_state, act_state, err, t_pos *, t_unsigned *, t_ast__count *);
+static void p_267(flags, lex_state, act_state, err, t_pos *, t_unsigned *, t_ast__count *);
 static void p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms(flags, lex_state, act_state, err, t_ast__expr);
-static void p_152(flags, lex_state, act_state, err);
+static void p_154(flags, lex_state, act_state, err);
 static void p_expr_C_Clist_Hof_Hpieces(flags, lex_state, act_state, err, t_ast__expr);
 static void p_expr_C_Cliteral(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hclass(flags, lex_state, act_state, err, t_endpoint *, t_pos *, t_pos *);
-static void p_178(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Ccharacter_Hclass(flags, lex_state, act_state, err, t_ast__expr *);
+static void p_180(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_Hend(flags, lex_state, act_state, err, t_endpoint *, t_pos *);
 static void p_expr_C_Cpiece(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_193(flags, lex_state, act_state, err, t_pos *, t_char *, t_ast__expr *);
 static void p_expr(flags, lex_state, act_state, err, t_ast__expr *);
+static void p_195(flags, lex_state, act_state, err, t_pos *, t_char *, t_ast__expr *);
 extern void p_re__native(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint(flags, lex_state, act_state, err, t_endpoint *, t_pos *, t_pos *);
 static void p_expr_C_Clist_Hof_Halts(flags, lex_state, act_state, err, t_ast__expr);
 static void p_expr_C_Cpiece_C_Ccount(flags, lex_state, act_state, err, t_ast__count *);
 static void p_expr_C_Cpiece_C_Catom(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_246(flags, lex_state, act_state, err, t_ast__class__id *, t_pos *, t_ast__expr *);
+static void p_248(flags, lex_state, act_state, err, t_ast__class__id *, t_pos *, t_ast__expr *);
 static void p_expr_C_Calt(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_250(flags, lex_state, act_state, err, t_char *, t_pos *, t_ast__expr *);
+static void p_252(flags, lex_state, act_state, err, t_char *, t_pos *, t_ast__expr *);
 
 /* BEGINNING OF STATIC VARIABLES */
 
@@ -331,14 +337,14 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 	{
 		t_char ZIc;
 
-		/* BEGINNING OF INLINE: 139 */
+		/* BEGINNING OF INLINE: 141 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CHAR):
 				{
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
-#line 530 "src/libre/parser.act"
+#line 536 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -348,7 +354,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 352 "src/libre/dialect/native/parser.c"
+#line 358 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: CHAR */
 					ADVANCE_LEXER;
@@ -358,7 +364,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 				{
 					/* BEGINNING OF EXTRACT: ESC */
 					{
-#line 365 "src/libre/parser.act"
+#line 371 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -381,7 +387,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 385 "src/libre/dialect/native/parser.c"
+#line 391 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: ESC */
 					ADVANCE_LEXER;
@@ -391,7 +397,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 				{
 					/* BEGINNING OF EXTRACT: HEX */
 					{
-#line 489 "src/libre/parser.act"
+#line 495 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -436,7 +442,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 440 "src/libre/dialect/native/parser.c"
+#line 446 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: HEX */
 					ADVANCE_LEXER;
@@ -446,7 +452,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 				{
 					/* BEGINNING OF EXTRACT: OCT */
 					{
-#line 449 "src/libre/parser.act"
+#line 455 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -486,7 +492,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 490 "src/libre/dialect/native/parser.c"
+#line 496 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: OCT */
 					ADVANCE_LEXER;
@@ -496,15 +502,15 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 139 */
+		/* END OF INLINE: 141 */
 		/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 		{
-#line 796 "src/libre/parser.act"
+#line 802 "src/libre/parser.act"
 
 		(ZIr).type = AST_ENDPOINT_LITERAL;
 		(ZIr).u.literal.c = (ZIc);
 	
-#line 508 "src/libre/dialect/native/parser.c"
+#line 514 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-range-endpoint-literal */
 	}
@@ -519,40 +525,40 @@ ZL0:;
 }
 
 static void
-p_265(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI263, t_unsigned *ZIm, t_ast__count *ZOc)
+p_267(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI265, t_unsigned *ZIm, t_ast__count *ZOc)
 {
 	t_ast__count ZIc;
 
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CLOSECOUNT):
 		{
-			t_pos ZI215;
+			t_pos ZI217;
 			t_pos ZIend;
 
 			/* BEGINNING OF EXTRACT: CLOSECOUNT */
 			{
-#line 356 "src/libre/parser.act"
+#line 362 "src/libre/parser.act"
 
-		ZI215 = lex_state->lx.start;
+		ZI217 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 540 "src/libre/dialect/native/parser.c"
+#line 546 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: CLOSECOUNT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 714 "src/libre/parser.act"
+#line 720 "src/libre/parser.act"
 
-		mark(&act_state->countstart, &(*ZI263));
+		mark(&act_state->countstart, &(*ZI265));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 551 "src/libre/dialect/native/parser.c"
+#line 557 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 778 "src/libre/parser.act"
+#line 784 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -561,18 +567,18 @@ p_265(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			err->m = (*ZIm);
 			err->n = (*ZIm);
 
-			mark(&act_state->countstart, &(*ZI263));
+			mark(&act_state->countstart, &(*ZI265));
 			mark(&act_state->countend,   &(ZIend));
 
 			goto ZL1;
 		}
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI263));
+		AST_POS_OF_LX_POS(ast_start, (*ZI265));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (*ZIm), &ast_end);
 	
-#line 576 "src/libre/dialect/native/parser.c"
+#line 582 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: count-range */
 		}
@@ -580,7 +586,7 @@ p_265(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 	case (TOK_SEP):
 		{
 			t_unsigned ZIn;
-			t_pos ZI218;
+			t_pos ZI220;
 			t_pos ZIend;
 
 			ADVANCE_LEXER;
@@ -588,7 +594,7 @@ p_265(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			case (TOK_COUNT):
 				/* BEGINNING OF EXTRACT: COUNT */
 				{
-#line 575 "src/libre/parser.act"
+#line 581 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -608,7 +614,7 @@ p_265(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 
 		ZIn = (unsigned int) u;
 	
-#line 612 "src/libre/dialect/native/parser.c"
+#line 618 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -620,12 +626,12 @@ p_265(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			case (TOK_CLOSECOUNT):
 				/* BEGINNING OF EXTRACT: CLOSECOUNT */
 				{
-#line 356 "src/libre/parser.act"
+#line 362 "src/libre/parser.act"
 
-		ZI218 = lex_state->lx.start;
+		ZI220 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 629 "src/libre/dialect/native/parser.c"
+#line 635 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF EXTRACT: CLOSECOUNT */
 				break;
@@ -635,17 +641,17 @@ p_265(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 714 "src/libre/parser.act"
+#line 720 "src/libre/parser.act"
 
-		mark(&act_state->countstart, &(*ZI263));
+		mark(&act_state->countstart, &(*ZI265));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 644 "src/libre/dialect/native/parser.c"
+#line 650 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 778 "src/libre/parser.act"
+#line 784 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -654,18 +660,18 @@ p_265(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			err->m = (*ZIm);
 			err->n = (ZIn);
 
-			mark(&act_state->countstart, &(*ZI263));
+			mark(&act_state->countstart, &(*ZI265));
 			mark(&act_state->countend,   &(ZIend));
 
 			goto ZL1;
 		}
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI263));
+		AST_POS_OF_LX_POS(ast_start, (*ZI265));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (ZIn), &ast_end);
 	
-#line 669 "src/libre/dialect/native/parser.c"
+#line 675 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: count-range */
 		}
@@ -700,13 +706,13 @@ ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 			}
 			/* BEGINNING OF ACTION: ast-add-alt */
 			{
-#line 993 "src/libre/parser.act"
+#line 1003 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIclass), (ZInode))) {
 			goto ZL1;
 		}
 	
-#line 710 "src/libre/dialect/native/parser.c"
+#line 716 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 			/* BEGINNING OF INLINE: expr::character-class::list-of-class-terms */
@@ -726,27 +732,27 @@ ZL1:;
 }
 
 static void
-p_152(flags flags, lex_state lex_state, act_state act_state, err err)
+p_154(flags flags, lex_state lex_state, act_state act_state, err err)
 {
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 		return;
 	}
 	{
-		t_char ZI153;
-		t_pos ZI154;
-		t_pos ZI155;
+		t_char ZI155;
+		t_pos ZI156;
+		t_pos ZI157;
 
 		switch (CURRENT_TERMINAL) {
 		case (TOK_RANGE):
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 313 "src/libre/parser.act"
+#line 319 "src/libre/parser.act"
 
-		ZI153 = '-';
-		ZI154 = lex_state->lx.start;
-		ZI155   = lex_state->lx.end;
+		ZI155 = '-';
+		ZI156 = lex_state->lx.start;
+		ZI157   = lex_state->lx.end;
 	
-#line 750 "src/libre/dialect/native/parser.c"
+#line 756 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			break;
@@ -760,14 +766,14 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-range */
 		{
-#line 658 "src/libre/parser.act"
+#line 664 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXRANGE;
 		}
 		goto ZL2;
 	
-#line 771 "src/libre/dialect/native/parser.c"
+#line 777 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: err-expected-range */
 	}
@@ -795,16 +801,16 @@ ZL2_expr_C_Clist_Hof_Hpieces:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 987 "src/libre/parser.act"
+#line 997 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
 		}
 	
-#line 805 "src/libre/dialect/native/parser.c"
+#line 811 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-add-concat */
-		/* BEGINNING OF INLINE: 222 */
+		/* BEGINNING OF INLINE: 224 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_START): case (TOK_END): case (TOK_OPENSUB):
@@ -820,7 +826,7 @@ ZL2_expr_C_Clist_Hof_Hpieces:;
 				break;
 			}
 		}
-		/* END OF INLINE: 222 */
+		/* END OF INLINE: 224 */
 	}
 	return;
 ZL1:;
@@ -839,27 +845,27 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 	{
 		t_char ZIc;
 
-		/* BEGINNING OF INLINE: 107 */
+		/* BEGINNING OF INLINE: 109 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CHAR):
 				{
-					t_pos ZI115;
-					t_pos ZI116;
+					t_pos ZI117;
+					t_pos ZI118;
 
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
-#line 530 "src/libre/parser.act"
+#line 536 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI115 = lex_state->lx.start;
-		ZI116   = lex_state->lx.end;
+		ZI117 = lex_state->lx.start;
+		ZI118   = lex_state->lx.end;
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 863 "src/libre/dialect/native/parser.c"
+#line 869 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: CHAR */
 					ADVANCE_LEXER;
@@ -867,12 +873,12 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				break;
 			case (TOK_ESC):
 				{
-					t_pos ZI109;
-					t_pos ZI110;
+					t_pos ZI111;
+					t_pos ZI112;
 
 					/* BEGINNING OF EXTRACT: ESC */
 					{
-#line 365 "src/libre/parser.act"
+#line 371 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -892,10 +898,10 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		default:             break;
 		}
 
-		ZI109 = lex_state->lx.start;
-		ZI110   = lex_state->lx.end;
+		ZI111 = lex_state->lx.start;
+		ZI112   = lex_state->lx.end;
 	
-#line 899 "src/libre/dialect/native/parser.c"
+#line 905 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: ESC */
 					ADVANCE_LEXER;
@@ -903,12 +909,12 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				break;
 			case (TOK_HEX):
 				{
-					t_pos ZI113;
-					t_pos ZI114;
+					t_pos ZI115;
+					t_pos ZI116;
 
 					/* BEGINNING OF EXTRACT: HEX */
 					{
-#line 489 "src/libre/parser.act"
+#line 495 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -917,8 +923,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		assert(0 == strncmp(lex_state->buf.a, "\\x", 2));
 		assert(strlen(lex_state->buf.a) >= 2);  /* pcre allows \x without a suffix */
 
-		ZI113 = lex_state->lx.start;
-		ZI114   = lex_state->lx.end;
+		ZI115 = lex_state->lx.start;
+		ZI116   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -953,7 +959,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 957 "src/libre/dialect/native/parser.c"
+#line 963 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: HEX */
 					ADVANCE_LEXER;
@@ -961,12 +967,12 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				break;
 			case (TOK_OCT):
 				{
-					t_pos ZI111;
-					t_pos ZI112;
+					t_pos ZI113;
+					t_pos ZI114;
 
 					/* BEGINNING OF EXTRACT: OCT */
 					{
-#line 449 "src/libre/parser.act"
+#line 455 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -975,8 +981,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
 		assert(strlen(lex_state->buf.a) >= 2);
 
-		ZI111 = lex_state->lx.start;
-		ZI112   = lex_state->lx.end;
+		ZI113 = lex_state->lx.start;
+		ZI114   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -1006,7 +1012,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 1010 "src/libre/dialect/native/parser.c"
+#line 1016 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: OCT */
 					ADVANCE_LEXER;
@@ -1016,17 +1022,17 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 107 */
+		/* END OF INLINE: 109 */
 		/* BEGINNING OF ACTION: ast-make-literal */
 		{
-#line 831 "src/libre/parser.act"
+#line 837 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1030 "src/libre/dialect/native/parser.c"
+#line 1036 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-make-literal */
 	}
@@ -1046,27 +1052,27 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CHAR):
 		{
-			t_char ZI259;
-			t_pos ZI260;
-			t_pos ZI261;
+			t_char ZI261;
+			t_pos ZI262;
+			t_pos ZI263;
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
-#line 530 "src/libre/parser.act"
+#line 536 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI260 = lex_state->lx.start;
-		ZI261   = lex_state->lx.end;
+		ZI262 = lex_state->lx.start;
+		ZI263   = lex_state->lx.end;
 
-		ZI259 = lex_state->buf.a[0];
+		ZI261 = lex_state->buf.a[0];
 	
-#line 1066 "src/libre/dialect/native/parser.c"
+#line 1072 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
-			p_250 (flags, lex_state, act_state, err, &ZI259, &ZI260, &ZInode);
+			p_252 (flags, lex_state, act_state, err, &ZI261, &ZI262, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1075,40 +1081,40 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		break;
 	case (TOK_ESC):
 		{
-			t_char ZI247;
-			t_pos ZI248;
-			t_pos ZI249;
+			t_char ZI249;
+			t_pos ZI250;
+			t_pos ZI251;
 
 			/* BEGINNING OF EXTRACT: ESC */
 			{
-#line 365 "src/libre/parser.act"
+#line 371 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
 		assert(lex_state->buf.a[2] == '\0');
 
-		ZI247 = lex_state->buf.a[1];
+		ZI249 = lex_state->buf.a[1];
 
-		switch (ZI247) {
-		case 'a': ZI247 = '\a'; break;
-		case 'b': ZI247 = '\b'; break;
-		case 'e': ZI247 = '\033'; break;
-		case 'f': ZI247 = '\f'; break;
-		case 'n': ZI247 = '\n'; break;
-		case 'r': ZI247 = '\r'; break;
-		case 't': ZI247 = '\t'; break;
-		case 'v': ZI247 = '\v'; break;
+		switch (ZI249) {
+		case 'a': ZI249 = '\a'; break;
+		case 'b': ZI249 = '\b'; break;
+		case 'e': ZI249 = '\033'; break;
+		case 'f': ZI249 = '\f'; break;
+		case 'n': ZI249 = '\n'; break;
+		case 'r': ZI249 = '\r'; break;
+		case 't': ZI249 = '\t'; break;
+		case 'v': ZI249 = '\v'; break;
 		default:             break;
 		}
 
-		ZI248 = lex_state->lx.start;
-		ZI249   = lex_state->lx.end;
+		ZI250 = lex_state->lx.start;
+		ZI251   = lex_state->lx.end;
 	
-#line 1108 "src/libre/dialect/native/parser.c"
+#line 1114 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: ESC */
 			ADVANCE_LEXER;
-			p_250 (flags, lex_state, act_state, err, &ZI247, &ZI248, &ZInode);
+			p_252 (flags, lex_state, act_state, err, &ZI249, &ZI250, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1117,13 +1123,13 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		break;
 	case (TOK_HEX):
 		{
-			t_char ZI255;
-			t_pos ZI256;
-			t_pos ZI257;
+			t_char ZI257;
+			t_pos ZI258;
+			t_pos ZI259;
 
 			/* BEGINNING OF EXTRACT: HEX */
 			{
-#line 489 "src/libre/parser.act"
+#line 495 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -1132,8 +1138,8 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		assert(0 == strncmp(lex_state->buf.a, "\\x", 2));
 		assert(strlen(lex_state->buf.a) >= 2);  /* pcre allows \x without a suffix */
 
-		ZI256 = lex_state->lx.start;
-		ZI257   = lex_state->lx.end;
+		ZI258 = lex_state->lx.start;
+		ZI259   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -1166,13 +1172,13 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 			goto ZL1;
 		}
 
-		ZI255 = (char) (unsigned char) u;
+		ZI257 = (char) (unsigned char) u;
 	
-#line 1172 "src/libre/dialect/native/parser.c"
+#line 1178 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: HEX */
 			ADVANCE_LEXER;
-			p_250 (flags, lex_state, act_state, err, &ZI255, &ZI256, &ZInode);
+			p_252 (flags, lex_state, act_state, err, &ZI257, &ZI258, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1181,28 +1187,28 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		break;
 	case (TOK_NAMED__CLASS):
 		{
-			t_ast__class__id ZI243;
-			t_pos ZI244;
-			t_pos ZI245;
+			t_ast__class__id ZI245;
+			t_pos ZI246;
+			t_pos ZI247;
 
 			/* BEGINNING OF EXTRACT: NAMED_CLASS */
 			{
-#line 587 "src/libre/parser.act"
+#line 593 "src/libre/parser.act"
 
-		ZI243 = DIALECT_CLASS(lex_state->buf.a);
-		if (ZI243 == NULL) {
+		ZI245 = DIALECT_CLASS(lex_state->buf.a);
+		if (ZI245 == NULL) {
 			/* syntax error -- unrecognized class */
 			goto ZL1;
 		}
 
-		ZI244 = lex_state->lx.start;
-		ZI245   = lex_state->lx.end;
+		ZI246 = lex_state->lx.start;
+		ZI247   = lex_state->lx.end;
 	
-#line 1202 "src/libre/dialect/native/parser.c"
+#line 1208 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			ADVANCE_LEXER;
-			p_246 (flags, lex_state, act_state, err, &ZI243, &ZI244, &ZInode);
+			p_248 (flags, lex_state, act_state, err, &ZI245, &ZI246, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1211,13 +1217,13 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		break;
 	case (TOK_OCT):
 		{
-			t_char ZI251;
-			t_pos ZI252;
-			t_pos ZI253;
+			t_char ZI253;
+			t_pos ZI254;
+			t_pos ZI255;
 
 			/* BEGINNING OF EXTRACT: OCT */
 			{
-#line 449 "src/libre/parser.act"
+#line 455 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -1226,8 +1232,8 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
 		assert(strlen(lex_state->buf.a) >= 2);
 
-		ZI252 = lex_state->lx.start;
-		ZI253   = lex_state->lx.end;
+		ZI254 = lex_state->lx.start;
+		ZI255   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -1255,13 +1261,13 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 			goto ZL1;
 		}
 
-		ZI251 = (char) (unsigned char) u;
+		ZI253 = (char) (unsigned char) u;
 	
-#line 1261 "src/libre/dialect/native/parser.c"
+#line 1267 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: OCT */
 			ADVANCE_LEXER;
-			p_250 (flags, lex_state, act_state, err, &ZI251, &ZI252, &ZInode);
+			p_252 (flags, lex_state, act_state, err, &ZI253, &ZI254, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1298,7 +1304,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hclass(flags fl
 		case (TOK_NAMED__CLASS):
 			/* BEGINNING OF EXTRACT: NAMED_CLASS */
 			{
-#line 587 "src/libre/parser.act"
+#line 593 "src/libre/parser.act"
 
 		ZIid = DIALECT_CLASS(lex_state->buf.a);
 		if (ZIid == NULL) {
@@ -1309,7 +1315,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hclass(flags fl
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1313 "src/libre/dialect/native/parser.c"
+#line 1319 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			break;
@@ -1319,12 +1325,12 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hclass(flags fl
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-range-endpoint-class */
 		{
-#line 801 "src/libre/parser.act"
+#line 807 "src/libre/parser.act"
 
 		(ZIr).type = AST_ENDPOINT_NAMED;
 		(ZIr).u.named.class = (ZIid);
 	
-#line 1328 "src/libre/dialect/native/parser.c"
+#line 1334 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-range-endpoint-class */
 	}
@@ -1339,43 +1345,483 @@ ZL0:;
 }
 
 static void
-p_178(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZItmp)
+p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
+{
+	t_ast__expr ZInode;
+
+	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+		return;
+	}
+	{
+		t_pos ZIstart;
+		t_ast__expr ZItmp;
+		t_pos ZIend;
+
+		/* BEGINNING OF INLINE: 166 */
+		{
+			switch (CURRENT_TERMINAL) {
+			case (TOK_OPENGROUP):
+				{
+					t_pos ZI167;
+
+					/* BEGINNING OF EXTRACT: OPENGROUP */
+					{
+#line 325 "src/libre/parser.act"
+
+		ZIstart = lex_state->lx.start;
+		ZI167   = lex_state->lx.end;
+	
+#line 1375 "src/libre/dialect/native/parser.c"
+					}
+					/* END OF EXTRACT: OPENGROUP */
+					ADVANCE_LEXER;
+					/* BEGINNING OF ACTION: ast-make-alt */
+					{
+#line 830 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 1388 "src/libre/dialect/native/parser.c"
+					}
+					/* END OF ACTION: ast-make-alt */
+					ZItmp = ZInode;
+					p_180 (flags, lex_state, act_state, err, &ZItmp);
+					p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, ZItmp);
+					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+						RESTORE_LEXER;
+						goto ZL1;
+					}
+				}
+				break;
+			case (TOK_OPENGROUPCB):
+				{
+					t_pos ZI186;
+					t_char ZIcbrak;
+					t_ast__expr ZInode1;
+
+					/* BEGINNING OF EXTRACT: OPENGROUPCB */
+					{
+#line 335 "src/libre/parser.act"
+
+		ZIstart = lex_state->lx.start;
+		ZI186   = lex_state->lx.end;
+	
+#line 1413 "src/libre/dialect/native/parser.c"
+					}
+					/* END OF EXTRACT: OPENGROUPCB */
+					ADVANCE_LEXER;
+					/* BEGINNING OF ACTION: ast-make-alt */
+					{
+#line 830 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 1426 "src/libre/dialect/native/parser.c"
+					}
+					/* END OF ACTION: ast-make-alt */
+					ZItmp = ZInode;
+					/* BEGINNING OF ACTION: make-literal-cbrak */
+					{
+#line 848 "src/libre/parser.act"
+
+		(ZIcbrak) = ']';
+	
+#line 1436 "src/libre/dialect/native/parser.c"
+					}
+					/* END OF ACTION: make-literal-cbrak */
+					p_195 (flags, lex_state, act_state, err, &ZIstart, &ZIcbrak, &ZInode1);
+					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+						RESTORE_LEXER;
+						goto ZL1;
+					}
+					/* BEGINNING OF ACTION: ast-add-alt */
+					{
+#line 1003 "src/libre/parser.act"
+
+		if (!ast_add_expr_alt((ZItmp), (ZInode1))) {
+			goto ZL1;
+		}
+	
+#line 1452 "src/libre/dialect/native/parser.c"
+					}
+					/* END OF ACTION: ast-add-alt */
+					p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, ZItmp);
+					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+						RESTORE_LEXER;
+						goto ZL1;
+					}
+				}
+				break;
+			case (TOK_OPENGROUPINV):
+				{
+					t_pos ZI178;
+
+					/* BEGINNING OF EXTRACT: OPENGROUPINV */
+					{
+#line 330 "src/libre/parser.act"
+
+		ZIstart = lex_state->lx.start;
+		ZI178   = lex_state->lx.end;
+	
+#line 1473 "src/libre/dialect/native/parser.c"
+					}
+					/* END OF EXTRACT: OPENGROUPINV */
+					ADVANCE_LEXER;
+					/* BEGINNING OF ACTION: ast-make-alt */
+					{
+#line 830 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 1486 "src/libre/dialect/native/parser.c"
+					}
+					/* END OF ACTION: ast-make-alt */
+					ZItmp = ZInode;
+					/* BEGINNING OF ACTION: ast-make-invert */
+					{
+#line 947 "src/libre/parser.act"
+
+		struct ast_expr *any;
+
+		/*
+		 * Here we're using an AST_EXPR_SUBTRACT node to implement inversion.
+		 *
+		 * Inversion is not quite equivalent to fsm_complement, because the
+		 * complement of a class FSM (which is structured always left-to-right
+		 * with no repetition) will effectively create .* anchors at the start
+		 * and end (because the class didn't contain those).
+		 *
+		 * If those were added to a class beforehand, then fsm_complement()
+		 * would suffice here (which would be attractive because it's much
+		 * cheaper than constructing two FSM and subtracting them). However
+		 * that would entail the assumption of having no transitions back to
+		 * the start and end nodes, or introducing guard epsilons.
+		 *
+		 * I'd like to avoid those guards. And, unfortunately we'd still need
+		 * to construct an intermediate FSM for fsm_complement() in any case.
+		 * (And less typical, but we do still need AST_EXPR_SUBTRACT for sake
+		 * of the SQL 2003 dialect anyway).
+		 *
+		 * So that idea doesn't satisfy my goal of avoiding intermediate FSM,
+		 * and so I'm going with the simpler thing here until we come across
+		 * a better idea.
+		 */
+
+		any = ast_make_expr_named(act_state->poolp, *flags, &class_any);
+		if (any == NULL) {
+			goto ZL1;
+		}
+
+		(ZInode) = ast_make_expr_subtract(act_state->poolp, *flags, any, (ZInode));
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 1530 "src/libre/dialect/native/parser.c"
+					}
+					/* END OF ACTION: ast-make-invert */
+					p_180 (flags, lex_state, act_state, err, &ZItmp);
+					p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, ZItmp);
+					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+						RESTORE_LEXER;
+						goto ZL1;
+					}
+				}
+				break;
+			case (TOK_OPENGROUPINVCB):
+				{
+					t_pos ZI193;
+					t_char ZIcbrak;
+					t_ast__expr ZInode1;
+
+					/* BEGINNING OF EXTRACT: OPENGROUPINVCB */
+					{
+#line 340 "src/libre/parser.act"
+
+		ZIstart = lex_state->lx.start;
+		ZI193   = lex_state->lx.end;
+	
+#line 1554 "src/libre/dialect/native/parser.c"
+					}
+					/* END OF EXTRACT: OPENGROUPINVCB */
+					ADVANCE_LEXER;
+					/* BEGINNING OF ACTION: ast-make-alt */
+					{
+#line 830 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 1567 "src/libre/dialect/native/parser.c"
+					}
+					/* END OF ACTION: ast-make-alt */
+					ZItmp = ZInode;
+					/* BEGINNING OF ACTION: ast-make-invert */
+					{
+#line 947 "src/libre/parser.act"
+
+		struct ast_expr *any;
+
+		/*
+		 * Here we're using an AST_EXPR_SUBTRACT node to implement inversion.
+		 *
+		 * Inversion is not quite equivalent to fsm_complement, because the
+		 * complement of a class FSM (which is structured always left-to-right
+		 * with no repetition) will effectively create .* anchors at the start
+		 * and end (because the class didn't contain those).
+		 *
+		 * If those were added to a class beforehand, then fsm_complement()
+		 * would suffice here (which would be attractive because it's much
+		 * cheaper than constructing two FSM and subtracting them). However
+		 * that would entail the assumption of having no transitions back to
+		 * the start and end nodes, or introducing guard epsilons.
+		 *
+		 * I'd like to avoid those guards. And, unfortunately we'd still need
+		 * to construct an intermediate FSM for fsm_complement() in any case.
+		 * (And less typical, but we do still need AST_EXPR_SUBTRACT for sake
+		 * of the SQL 2003 dialect anyway).
+		 *
+		 * So that idea doesn't satisfy my goal of avoiding intermediate FSM,
+		 * and so I'm going with the simpler thing here until we come across
+		 * a better idea.
+		 */
+
+		any = ast_make_expr_named(act_state->poolp, *flags, &class_any);
+		if (any == NULL) {
+			goto ZL1;
+		}
+
+		(ZInode) = ast_make_expr_subtract(act_state->poolp, *flags, any, (ZInode));
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 1611 "src/libre/dialect/native/parser.c"
+					}
+					/* END OF ACTION: ast-make-invert */
+					/* BEGINNING OF ACTION: make-literal-cbrak */
+					{
+#line 848 "src/libre/parser.act"
+
+		(ZIcbrak) = ']';
+	
+#line 1620 "src/libre/dialect/native/parser.c"
+					}
+					/* END OF ACTION: make-literal-cbrak */
+					p_195 (flags, lex_state, act_state, err, &ZIstart, &ZIcbrak, &ZInode1);
+					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+						RESTORE_LEXER;
+						goto ZL1;
+					}
+					/* BEGINNING OF ACTION: ast-add-alt */
+					{
+#line 1003 "src/libre/parser.act"
+
+		if (!ast_add_expr_alt((ZItmp), (ZInode1))) {
+			goto ZL1;
+		}
+	
+#line 1636 "src/libre/dialect/native/parser.c"
+					}
+					/* END OF ACTION: ast-add-alt */
+					p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, ZItmp);
+					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+						RESTORE_LEXER;
+						goto ZL1;
+					}
+				}
+				break;
+			default:
+				goto ZL1;
+			}
+		}
+		/* END OF INLINE: 166 */
+		/* BEGINNING OF INLINE: 199 */
+		{
+			switch (CURRENT_TERMINAL) {
+			case (TOK_CLOSEGROUP):
+				{
+					t_char ZI200;
+					t_pos ZI201;
+
+					/* BEGINNING OF EXTRACT: CLOSEGROUP */
+					{
+#line 345 "src/libre/parser.act"
+
+		ZI200 = ']';
+		ZI201 = lex_state->lx.start;
+		ZIend   = lex_state->lx.end;
+	
+#line 1667 "src/libre/dialect/native/parser.c"
+					}
+					/* END OF EXTRACT: CLOSEGROUP */
+					ADVANCE_LEXER;
+					/* BEGINNING OF ACTION: mark-group */
+					{
+#line 710 "src/libre/parser.act"
+
+		mark(&act_state->groupstart, &(ZIstart));
+		mark(&act_state->groupend,   &(ZIend));
+	
+#line 1678 "src/libre/dialect/native/parser.c"
+					}
+					/* END OF ACTION: mark-group */
+				}
+				break;
+			case (TOK_CLOSEGROUPRANGE):
+				{
+					t_char ZIcrange;
+					t_pos ZI203;
+					t_ast__expr ZIrange;
+
+					/* BEGINNING OF EXTRACT: CLOSEGROUPRANGE */
+					{
+#line 351 "src/libre/parser.act"
+
+		ZIcrange = '-';
+		ZI203 = lex_state->lx.start;
+		ZIend   = lex_state->lx.end;
+	
+#line 1697 "src/libre/dialect/native/parser.c"
+					}
+					/* END OF EXTRACT: CLOSEGROUPRANGE */
+					ADVANCE_LEXER;
+					/* BEGINNING OF ACTION: ast-make-literal */
+					{
+#line 837 "src/libre/parser.act"
+
+		(ZIrange) = ast_make_expr_literal(act_state->poolp, *flags, (ZIcrange));
+		if ((ZIrange) == NULL) {
+			goto ZL4;
+		}
+	
+#line 1710 "src/libre/dialect/native/parser.c"
+					}
+					/* END OF ACTION: ast-make-literal */
+					/* BEGINNING OF ACTION: ast-add-alt */
+					{
+#line 1003 "src/libre/parser.act"
+
+		if (!ast_add_expr_alt((ZItmp), (ZIrange))) {
+			goto ZL4;
+		}
+	
+#line 1721 "src/libre/dialect/native/parser.c"
+					}
+					/* END OF ACTION: ast-add-alt */
+					/* BEGINNING OF ACTION: mark-group */
+					{
+#line 710 "src/libre/parser.act"
+
+		mark(&act_state->groupstart, &(ZIstart));
+		mark(&act_state->groupend,   &(ZIend));
+	
+#line 1731 "src/libre/dialect/native/parser.c"
+					}
+					/* END OF ACTION: mark-group */
+				}
+				break;
+			default:
+				goto ZL4;
+			}
+			goto ZL3;
+		ZL4:;
+			{
+				/* BEGINNING OF ACTION: err-expected-closegroup */
+				{
+#line 671 "src/libre/parser.act"
+
+		if (err->e == RE_ESUCCESS) {
+			err->e = RE_EXCLOSEGROUP;
+		}
+		goto ZL1;
+	
+#line 1751 "src/libre/dialect/native/parser.c"
+				}
+				/* END OF ACTION: err-expected-closegroup */
+				ZIend = ZIstart;
+			}
+		ZL3:;
+		}
+		/* END OF INLINE: 199 */
+		/* BEGINNING OF ACTION: mark-expr */
+		{
+#line 727 "src/libre/parser.act"
+
+		struct ast_pos ast_start, ast_end;
+
+		AST_POS_OF_LX_POS(ast_start, (ZIstart));
+		AST_POS_OF_LX_POS(ast_end, (ZIend));
+
+		mark(&act_state->groupstart, &(ZIstart));
+		mark(&act_state->groupend,   &(ZIend));
+
+/* TODO: reinstate this, applies to an expr node in general
+		(ZItmp)->u.class.start = ast_start;
+		(ZItmp)->u.class.end   = ast_end;
+*/
+	
+#line 1776 "src/libre/dialect/native/parser.c"
+		}
+		/* END OF ACTION: mark-expr */
+	}
+	goto ZL0;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+ZL0:;
+	*ZOnode = ZInode;
+}
+
+static void
+p_180(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZItmp)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_RANGE):
 		{
 			t_char ZIc;
 			t_pos ZIrstart;
-			t_pos ZI179;
+			t_pos ZI181;
 			t_ast__expr ZInode1;
 
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 313 "src/libre/parser.act"
+#line 319 "src/libre/parser.act"
 
 		ZIc = '-';
 		ZIrstart = lex_state->lx.start;
-		ZI179   = lex_state->lx.end;
+		ZI181   = lex_state->lx.end;
 	
-#line 1361 "src/libre/dialect/native/parser.c"
+#line 1807 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
-			/* BEGINNING OF INLINE: 180 */
+			/* BEGINNING OF INLINE: 182 */
 			{
 				switch (CURRENT_TERMINAL) {
 				default:
 					{
 						/* BEGINNING OF ACTION: ast-make-literal */
 						{
-#line 831 "src/libre/parser.act"
+#line 837 "src/libre/parser.act"
 
 		(ZInode1) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZInode1) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1379 "src/libre/dialect/native/parser.c"
+#line 1825 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF ACTION: ast-make-literal */
 					}
@@ -1383,31 +1829,31 @@ p_178(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 				case (TOK_RANGE):
 					{
 						t_endpoint ZIlower;
-						t_char ZI181;
-						t_pos ZI182;
-						t_pos ZI183;
+						t_char ZI183;
+						t_pos ZI184;
+						t_pos ZI185;
 						t_endpoint ZIupper;
 						t_pos ZIend;
 
 						/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 						{
-#line 796 "src/libre/parser.act"
+#line 802 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_LITERAL;
 		(ZIlower).u.literal.c = (ZIc);
 	
-#line 1400 "src/libre/dialect/native/parser.c"
+#line 1846 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF ACTION: ast-range-endpoint-literal */
 						/* BEGINNING OF EXTRACT: RANGE */
 						{
-#line 313 "src/libre/parser.act"
+#line 319 "src/libre/parser.act"
 
-		ZI181 = '-';
-		ZI182 = lex_state->lx.start;
-		ZI183   = lex_state->lx.end;
+		ZI183 = '-';
+		ZI184 = lex_state->lx.start;
+		ZI185   = lex_state->lx.end;
 	
-#line 1411 "src/libre/dialect/native/parser.c"
+#line 1857 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF EXTRACT: RANGE */
 						ADVANCE_LEXER;
@@ -1418,7 +1864,7 @@ p_178(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 						}
 						/* BEGINNING OF ACTION: ast-make-range */
 						{
-#line 950 "src/libre/parser.act"
+#line 960 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -1451,23 +1897,23 @@ p_178(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			goto ZL1;
 		}
 	
-#line 1455 "src/libre/dialect/native/parser.c"
+#line 1901 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF ACTION: ast-make-range */
 					}
 					break;
 				}
 			}
-			/* END OF INLINE: 180 */
+			/* END OF INLINE: 182 */
 			/* BEGINNING OF ACTION: ast-add-alt */
 			{
-#line 993 "src/libre/parser.act"
+#line 1003 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((*ZItmp), (ZInode1))) {
 			goto ZL1;
 		}
 	
-#line 1471 "src/libre/dialect/native/parser.c"
+#line 1917 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 		}
@@ -1484,446 +1930,6 @@ ZL1:;
 }
 
 static void
-p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
-{
-	t_ast__expr ZInode;
-
-	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-		return;
-	}
-	{
-		t_pos ZIstart;
-		t_ast__expr ZItmp;
-		t_pos ZIend;
-
-		/* BEGINNING OF INLINE: 164 */
-		{
-			switch (CURRENT_TERMINAL) {
-			case (TOK_OPENGROUP):
-				{
-					t_pos ZI165;
-
-					/* BEGINNING OF EXTRACT: OPENGROUP */
-					{
-#line 319 "src/libre/parser.act"
-
-		ZIstart = lex_state->lx.start;
-		ZI165   = lex_state->lx.end;
-	
-#line 1514 "src/libre/dialect/native/parser.c"
-					}
-					/* END OF EXTRACT: OPENGROUP */
-					ADVANCE_LEXER;
-					/* BEGINNING OF ACTION: ast-make-alt */
-					{
-#line 824 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 1527 "src/libre/dialect/native/parser.c"
-					}
-					/* END OF ACTION: ast-make-alt */
-					ZItmp = ZInode;
-					p_178 (flags, lex_state, act_state, err, &ZItmp);
-					p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, ZItmp);
-					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-						RESTORE_LEXER;
-						goto ZL1;
-					}
-				}
-				break;
-			case (TOK_OPENGROUPCB):
-				{
-					t_pos ZI184;
-					t_char ZIcbrak;
-					t_ast__expr ZInode1;
-
-					/* BEGINNING OF EXTRACT: OPENGROUPCB */
-					{
-#line 329 "src/libre/parser.act"
-
-		ZIstart = lex_state->lx.start;
-		ZI184   = lex_state->lx.end;
-	
-#line 1552 "src/libre/dialect/native/parser.c"
-					}
-					/* END OF EXTRACT: OPENGROUPCB */
-					ADVANCE_LEXER;
-					/* BEGINNING OF ACTION: ast-make-alt */
-					{
-#line 824 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 1565 "src/libre/dialect/native/parser.c"
-					}
-					/* END OF ACTION: ast-make-alt */
-					ZItmp = ZInode;
-					/* BEGINNING OF ACTION: make-literal-cbrak */
-					{
-#line 838 "src/libre/parser.act"
-
-		(ZIcbrak) = ']';
-	
-#line 1575 "src/libre/dialect/native/parser.c"
-					}
-					/* END OF ACTION: make-literal-cbrak */
-					p_193 (flags, lex_state, act_state, err, &ZIstart, &ZIcbrak, &ZInode1);
-					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-						RESTORE_LEXER;
-						goto ZL1;
-					}
-					/* BEGINNING OF ACTION: ast-add-alt */
-					{
-#line 993 "src/libre/parser.act"
-
-		if (!ast_add_expr_alt((ZItmp), (ZInode1))) {
-			goto ZL1;
-		}
-	
-#line 1591 "src/libre/dialect/native/parser.c"
-					}
-					/* END OF ACTION: ast-add-alt */
-					p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, ZItmp);
-					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-						RESTORE_LEXER;
-						goto ZL1;
-					}
-				}
-				break;
-			case (TOK_OPENGROUPINV):
-				{
-					t_pos ZI176;
-
-					/* BEGINNING OF EXTRACT: OPENGROUPINV */
-					{
-#line 324 "src/libre/parser.act"
-
-		ZIstart = lex_state->lx.start;
-		ZI176   = lex_state->lx.end;
-	
-#line 1612 "src/libre/dialect/native/parser.c"
-					}
-					/* END OF EXTRACT: OPENGROUPINV */
-					ADVANCE_LEXER;
-					/* BEGINNING OF ACTION: ast-make-alt */
-					{
-#line 824 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 1625 "src/libre/dialect/native/parser.c"
-					}
-					/* END OF ACTION: ast-make-alt */
-					ZItmp = ZInode;
-					/* BEGINNING OF ACTION: ast-make-invert */
-					{
-#line 937 "src/libre/parser.act"
-
-		struct ast_expr *any;
-
-		/*
-		 * Here we're using an AST_EXPR_SUBTRACT node to implement inversion.
-		 *
-		 * Inversion is not quite equivalent to fsm_complement, because the
-		 * complement of a class FSM (which is structured always left-to-right
-		 * with no repetition) will effectively create .* anchors at the start
-		 * and end (because the class didn't contain those).
-		 *
-		 * If those were added to a class beforehand, then fsm_complement()
-		 * would suffice here (which would be attractive because it's much
-		 * cheaper than constructing two FSM and subtracting them). However
-		 * that would entail the assumption of having no transitions back to
-		 * the start and end nodes, or introducing guard epsilons.
-		 *
-		 * I'd like to avoid those guards. And, unfortunately we'd still need
-		 * to construct an intermediate FSM for fsm_complement() in any case.
-		 * (And less typical, but we do still need AST_EXPR_SUBTRACT for sake
-		 * of the SQL 2003 dialect anyway).
-		 *
-		 * So that idea doesn't satisfy my goal of avoiding intermediate FSM,
-		 * and so I'm going with the simpler thing here until we come across
-		 * a better idea.
-		 */
-
-		any = ast_make_expr_named(act_state->poolp, *flags, &class_any);
-		if (any == NULL) {
-			goto ZL1;
-		}
-
-		(ZInode) = ast_make_expr_subtract(act_state->poolp, *flags, any, (ZInode));
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 1669 "src/libre/dialect/native/parser.c"
-					}
-					/* END OF ACTION: ast-make-invert */
-					p_178 (flags, lex_state, act_state, err, &ZItmp);
-					p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, ZItmp);
-					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-						RESTORE_LEXER;
-						goto ZL1;
-					}
-				}
-				break;
-			case (TOK_OPENGROUPINVCB):
-				{
-					t_pos ZI191;
-					t_char ZIcbrak;
-					t_ast__expr ZInode1;
-
-					/* BEGINNING OF EXTRACT: OPENGROUPINVCB */
-					{
-#line 334 "src/libre/parser.act"
-
-		ZIstart = lex_state->lx.start;
-		ZI191   = lex_state->lx.end;
-	
-#line 1693 "src/libre/dialect/native/parser.c"
-					}
-					/* END OF EXTRACT: OPENGROUPINVCB */
-					ADVANCE_LEXER;
-					/* BEGINNING OF ACTION: ast-make-alt */
-					{
-#line 824 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 1706 "src/libre/dialect/native/parser.c"
-					}
-					/* END OF ACTION: ast-make-alt */
-					ZItmp = ZInode;
-					/* BEGINNING OF ACTION: ast-make-invert */
-					{
-#line 937 "src/libre/parser.act"
-
-		struct ast_expr *any;
-
-		/*
-		 * Here we're using an AST_EXPR_SUBTRACT node to implement inversion.
-		 *
-		 * Inversion is not quite equivalent to fsm_complement, because the
-		 * complement of a class FSM (which is structured always left-to-right
-		 * with no repetition) will effectively create .* anchors at the start
-		 * and end (because the class didn't contain those).
-		 *
-		 * If those were added to a class beforehand, then fsm_complement()
-		 * would suffice here (which would be attractive because it's much
-		 * cheaper than constructing two FSM and subtracting them). However
-		 * that would entail the assumption of having no transitions back to
-		 * the start and end nodes, or introducing guard epsilons.
-		 *
-		 * I'd like to avoid those guards. And, unfortunately we'd still need
-		 * to construct an intermediate FSM for fsm_complement() in any case.
-		 * (And less typical, but we do still need AST_EXPR_SUBTRACT for sake
-		 * of the SQL 2003 dialect anyway).
-		 *
-		 * So that idea doesn't satisfy my goal of avoiding intermediate FSM,
-		 * and so I'm going with the simpler thing here until we come across
-		 * a better idea.
-		 */
-
-		any = ast_make_expr_named(act_state->poolp, *flags, &class_any);
-		if (any == NULL) {
-			goto ZL1;
-		}
-
-		(ZInode) = ast_make_expr_subtract(act_state->poolp, *flags, any, (ZInode));
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 1750 "src/libre/dialect/native/parser.c"
-					}
-					/* END OF ACTION: ast-make-invert */
-					/* BEGINNING OF ACTION: make-literal-cbrak */
-					{
-#line 838 "src/libre/parser.act"
-
-		(ZIcbrak) = ']';
-	
-#line 1759 "src/libre/dialect/native/parser.c"
-					}
-					/* END OF ACTION: make-literal-cbrak */
-					p_193 (flags, lex_state, act_state, err, &ZIstart, &ZIcbrak, &ZInode1);
-					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-						RESTORE_LEXER;
-						goto ZL1;
-					}
-					/* BEGINNING OF ACTION: ast-add-alt */
-					{
-#line 993 "src/libre/parser.act"
-
-		if (!ast_add_expr_alt((ZItmp), (ZInode1))) {
-			goto ZL1;
-		}
-	
-#line 1775 "src/libre/dialect/native/parser.c"
-					}
-					/* END OF ACTION: ast-add-alt */
-					p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, ZItmp);
-					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-						RESTORE_LEXER;
-						goto ZL1;
-					}
-				}
-				break;
-			default:
-				goto ZL1;
-			}
-		}
-		/* END OF INLINE: 164 */
-		/* BEGINNING OF INLINE: 197 */
-		{
-			switch (CURRENT_TERMINAL) {
-			case (TOK_CLOSEGROUP):
-				{
-					t_char ZI198;
-					t_pos ZI199;
-
-					/* BEGINNING OF EXTRACT: CLOSEGROUP */
-					{
-#line 339 "src/libre/parser.act"
-
-		ZI198 = ']';
-		ZI199 = lex_state->lx.start;
-		ZIend   = lex_state->lx.end;
-	
-#line 1806 "src/libre/dialect/native/parser.c"
-					}
-					/* END OF EXTRACT: CLOSEGROUP */
-					ADVANCE_LEXER;
-					/* BEGINNING OF ACTION: mark-group */
-					{
-#line 704 "src/libre/parser.act"
-
-		mark(&act_state->groupstart, &(ZIstart));
-		mark(&act_state->groupend,   &(ZIend));
-	
-#line 1817 "src/libre/dialect/native/parser.c"
-					}
-					/* END OF ACTION: mark-group */
-				}
-				break;
-			case (TOK_CLOSEGROUPRANGE):
-				{
-					t_char ZIcrange;
-					t_pos ZI201;
-					t_ast__expr ZIrange;
-
-					/* BEGINNING OF EXTRACT: CLOSEGROUPRANGE */
-					{
-#line 345 "src/libre/parser.act"
-
-		ZIcrange = '-';
-		ZI201 = lex_state->lx.start;
-		ZIend   = lex_state->lx.end;
-	
-#line 1836 "src/libre/dialect/native/parser.c"
-					}
-					/* END OF EXTRACT: CLOSEGROUPRANGE */
-					ADVANCE_LEXER;
-					/* BEGINNING OF ACTION: ast-make-literal */
-					{
-#line 831 "src/libre/parser.act"
-
-		(ZIrange) = ast_make_expr_literal(act_state->poolp, *flags, (ZIcrange));
-		if ((ZIrange) == NULL) {
-			goto ZL4;
-		}
-	
-#line 1849 "src/libre/dialect/native/parser.c"
-					}
-					/* END OF ACTION: ast-make-literal */
-					/* BEGINNING OF ACTION: ast-add-alt */
-					{
-#line 993 "src/libre/parser.act"
-
-		if (!ast_add_expr_alt((ZItmp), (ZIrange))) {
-			goto ZL4;
-		}
-	
-#line 1860 "src/libre/dialect/native/parser.c"
-					}
-					/* END OF ACTION: ast-add-alt */
-					/* BEGINNING OF ACTION: mark-group */
-					{
-#line 704 "src/libre/parser.act"
-
-		mark(&act_state->groupstart, &(ZIstart));
-		mark(&act_state->groupend,   &(ZIend));
-	
-#line 1870 "src/libre/dialect/native/parser.c"
-					}
-					/* END OF ACTION: mark-group */
-				}
-				break;
-			default:
-				goto ZL4;
-			}
-			goto ZL3;
-		ZL4:;
-			{
-				/* BEGINNING OF ACTION: err-expected-closegroup */
-				{
-#line 665 "src/libre/parser.act"
-
-		if (err->e == RE_ESUCCESS) {
-			err->e = RE_EXCLOSEGROUP;
-		}
-		goto ZL1;
-	
-#line 1890 "src/libre/dialect/native/parser.c"
-				}
-				/* END OF ACTION: err-expected-closegroup */
-				ZIend = ZIstart;
-			}
-		ZL3:;
-		}
-		/* END OF INLINE: 197 */
-		/* BEGINNING OF ACTION: mark-expr */
-		{
-#line 721 "src/libre/parser.act"
-
-		struct ast_pos ast_start, ast_end;
-
-		AST_POS_OF_LX_POS(ast_start, (ZIstart));
-		AST_POS_OF_LX_POS(ast_end, (ZIend));
-
-		mark(&act_state->groupstart, &(ZIstart));
-		mark(&act_state->groupend,   &(ZIend));
-
-/* TODO: reinstate this, applies to an expr node in general
-		(ZItmp)->u.class.start = ast_start;
-		(ZItmp)->u.class.end   = ast_end;
-*/
-	
-#line 1915 "src/libre/dialect/native/parser.c"
-		}
-		/* END OF ACTION: mark-expr */
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOnode = ZInode;
-}
-
-static void
 p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_Hend(flags flags, lex_state lex_state, act_state act_state, err err, t_endpoint *ZOr, t_pos *ZOend)
 {
 	t_endpoint ZIr;
@@ -1933,34 +1939,34 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_Hend(flags flags, lex_state lex_st
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 145 */
+		/* BEGINNING OF INLINE: 147 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_RANGE):
 				{
 					t_char ZIc;
-					t_pos ZI147;
+					t_pos ZI149;
 
 					/* BEGINNING OF EXTRACT: RANGE */
 					{
-#line 313 "src/libre/parser.act"
+#line 319 "src/libre/parser.act"
 
 		ZIc = '-';
-		ZI147 = lex_state->lx.start;
+		ZI149 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1953 "src/libre/dialect/native/parser.c"
+#line 1959 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: RANGE */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 					{
-#line 796 "src/libre/parser.act"
+#line 802 "src/libre/parser.act"
 
 		(ZIr).type = AST_ENDPOINT_LITERAL;
 		(ZIr).u.literal.c = (ZIc);
 	
-#line 1964 "src/libre/dialect/native/parser.c"
+#line 1970 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: ast-range-endpoint-literal */
 				}
@@ -1968,9 +1974,9 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_Hend(flags flags, lex_state lex_st
 			case (TOK_NAMED__CLASS): case (TOK_ESC): case (TOK_OCT): case (TOK_HEX):
 			case (TOK_CHAR):
 				{
-					t_pos ZI146;
+					t_pos ZI148;
 
-					p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint (flags, lex_state, act_state, err, &ZIr, &ZI146, &ZIend);
+					p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint (flags, lex_state, act_state, err, &ZIr, &ZI148, &ZIend);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL1;
@@ -1981,7 +1987,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_Hend(flags flags, lex_state lex_st
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 145 */
+		/* END OF INLINE: 147 */
 	}
 	goto ZL0;
 ZL1:;
@@ -2012,7 +2018,7 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 		}
 		/* BEGINNING OF ACTION: ast-make-piece */
 		{
-#line 850 "src/libre/parser.act"
+#line 860 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
@@ -2026,7 +2032,7 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 			goto ZL1;
 		}
 	
-#line 2030 "src/libre/dialect/native/parser.c"
+#line 2036 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-make-piece */
 	}
@@ -2039,7 +2045,91 @@ ZL0:;
 }
 
 static void
-p_193(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIstart, t_char *ZIcbrak, t_ast__expr *ZOnode1)
+p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
+{
+	t_ast__expr ZInode;
+
+	switch (CURRENT_TERMINAL) {
+	case (TOK_ANY): case (TOK_START): case (TOK_END): case (TOK_OPENSUB):
+	case (TOK_OPENGROUP): case (TOK_OPENGROUPINV): case (TOK_OPENGROUPCB): case (TOK_OPENGROUPINVCB):
+	case (TOK_ESC): case (TOK_OCT): case (TOK_HEX): case (TOK_CHAR):
+		{
+			/* BEGINNING OF ACTION: ast-make-alt */
+			{
+#line 830 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 2067 "src/libre/dialect/native/parser.c"
+			}
+			/* END OF ACTION: ast-make-alt */
+			p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, ZInode);
+			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+				RESTORE_LEXER;
+				goto ZL1;
+			}
+		}
+		break;
+	default:
+		{
+			/* BEGINNING OF ACTION: ast-make-empty */
+			{
+#line 816 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 2088 "src/libre/dialect/native/parser.c"
+			}
+			/* END OF ACTION: ast-make-empty */
+		}
+		break;
+	case (ERROR_TERMINAL):
+		return;
+	}
+	goto ZL0;
+ZL1:;
+	{
+		/* BEGINNING OF ACTION: err-expected-alts */
+		{
+#line 657 "src/libre/parser.act"
+
+		if (err->e == RE_ESUCCESS) {
+			err->e = RE_EXALTS;
+		}
+		goto ZL2;
+	
+#line 2108 "src/libre/dialect/native/parser.c"
+		}
+		/* END OF ACTION: err-expected-alts */
+		/* BEGINNING OF ACTION: ast-make-empty */
+		{
+#line 816 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
+		if ((ZInode) == NULL) {
+			goto ZL2;
+		}
+	
+#line 2120 "src/libre/dialect/native/parser.c"
+		}
+		/* END OF ACTION: ast-make-empty */
+	}
+	goto ZL0;
+ZL2:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+ZL0:;
+	*ZOnode = ZInode;
+}
+
+static void
+p_195(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIstart, t_char *ZIcbrak, t_ast__expr *ZOnode1)
 {
 	t_ast__expr ZInode1;
 
@@ -2048,14 +2138,14 @@ p_193(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 		{
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 831 "src/libre/parser.act"
+#line 837 "src/libre/parser.act"
 
 		(ZInode1) = ast_make_expr_literal(act_state->poolp, *flags, (*ZIcbrak));
 		if ((ZInode1) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2059 "src/libre/dialect/native/parser.c"
+#line 2149 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -2063,32 +2153,32 @@ p_193(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 	case (TOK_RANGE):
 		{
 			t_endpoint ZIr;
-			t_char ZI194;
-			t_pos ZI195;
-			t_pos ZI196;
+			t_char ZI196;
+			t_pos ZI197;
+			t_pos ZI198;
 			t_endpoint ZIupper;
 			t_pos ZIend;
 			t_endpoint ZIlower;
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 796 "src/libre/parser.act"
+#line 802 "src/libre/parser.act"
 
 		(ZIr).type = AST_ENDPOINT_LITERAL;
 		(ZIr).u.literal.c = (*ZIcbrak);
 	
-#line 2081 "src/libre/dialect/native/parser.c"
+#line 2171 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 313 "src/libre/parser.act"
+#line 319 "src/libre/parser.act"
 
-		ZI194 = '-';
-		ZI195 = lex_state->lx.start;
-		ZI196   = lex_state->lx.end;
+		ZI196 = '-';
+		ZI197 = lex_state->lx.start;
+		ZI198   = lex_state->lx.end;
 	
-#line 2092 "src/libre/dialect/native/parser.c"
+#line 2182 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
@@ -2099,17 +2189,17 @@ p_193(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 			}
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 796 "src/libre/parser.act"
+#line 802 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_LITERAL;
 		(ZIlower).u.literal.c = (*ZIcbrak);
 	
-#line 2108 "src/libre/dialect/native/parser.c"
+#line 2198 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 950 "src/libre/parser.act"
+#line 960 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -2142,7 +2232,7 @@ p_193(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 			goto ZL1;
 		}
 	
-#line 2146 "src/libre/dialect/native/parser.c"
+#line 2236 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -2158,90 +2248,6 @@ ZL0:;
 	*ZOnode1 = ZInode1;
 }
 
-static void
-p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
-{
-	t_ast__expr ZInode;
-
-	switch (CURRENT_TERMINAL) {
-	case (TOK_ANY): case (TOK_START): case (TOK_END): case (TOK_OPENSUB):
-	case (TOK_OPENGROUP): case (TOK_OPENGROUPINV): case (TOK_OPENGROUPCB): case (TOK_OPENGROUPINVCB):
-	case (TOK_ESC): case (TOK_OCT): case (TOK_HEX): case (TOK_CHAR):
-		{
-			/* BEGINNING OF ACTION: ast-make-alt */
-			{
-#line 824 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 2181 "src/libre/dialect/native/parser.c"
-			}
-			/* END OF ACTION: ast-make-alt */
-			p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, ZInode);
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-		}
-		break;
-	default:
-		{
-			/* BEGINNING OF ACTION: ast-make-empty */
-			{
-#line 810 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 2202 "src/libre/dialect/native/parser.c"
-			}
-			/* END OF ACTION: ast-make-empty */
-		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
-	}
-	goto ZL0;
-ZL1:;
-	{
-		/* BEGINNING OF ACTION: err-expected-alts */
-		{
-#line 651 "src/libre/parser.act"
-
-		if (err->e == RE_ESUCCESS) {
-			err->e = RE_EXALTS;
-		}
-		goto ZL2;
-	
-#line 2222 "src/libre/dialect/native/parser.c"
-		}
-		/* END OF ACTION: err-expected-alts */
-		/* BEGINNING OF ACTION: ast-make-empty */
-		{
-#line 810 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
-		if ((ZInode) == NULL) {
-			goto ZL2;
-		}
-	
-#line 2234 "src/libre/dialect/native/parser.c"
-		}
-		/* END OF ACTION: ast-make-empty */
-	}
-	goto ZL0;
-ZL2:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOnode = ZInode;
-}
-
 void
 p_re__native(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
 {
@@ -2251,7 +2257,7 @@ p_re__native(flags flags, lex_state lex_state, act_state act_state, err err, t_a
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 230 */
+		/* BEGINNING OF INLINE: 232 */
 		{
 			{
 				p_expr (flags, lex_state, act_state, err, &ZInode);
@@ -2261,8 +2267,8 @@ p_re__native(flags flags, lex_state lex_state, act_state act_state, err err, t_a
 				}
 			}
 		}
-		/* END OF INLINE: 230 */
-		/* BEGINNING OF INLINE: 231 */
+		/* END OF INLINE: 232 */
+		/* BEGINNING OF INLINE: 233 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -2278,20 +2284,20 @@ p_re__native(flags flags, lex_state lex_state, act_state act_state, err err, t_a
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 693 "src/libre/parser.act"
+#line 699 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
 		}
 		goto ZL1;
 	
-#line 2289 "src/libre/dialect/native/parser.c"
+#line 2295 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 231 */
+		/* END OF INLINE: 233 */
 	}
 	goto ZL0;
 ZL1:;
@@ -2312,7 +2318,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint(flags flags, lex_state lex_state, 
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 142 */
+		/* BEGINNING OF INLINE: 144 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_NAMED__CLASS):
@@ -2337,7 +2343,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint(flags flags, lex_state lex_state, 
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 142 */
+		/* END OF INLINE: 144 */
 	}
 	goto ZL0;
 ZL1:;
@@ -2366,16 +2372,16 @@ ZL2_expr_C_Clist_Hof_Halts:;
 		}
 		/* BEGINNING OF ACTION: ast-add-alt */
 		{
-#line 993 "src/libre/parser.act"
+#line 1003 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIalts), (ZIa))) {
 			goto ZL1;
 		}
 	
-#line 2376 "src/libre/dialect/native/parser.c"
+#line 2382 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-add-alt */
-		/* BEGINNING OF INLINE: 228 */
+		/* BEGINNING OF INLINE: 230 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ALT):
@@ -2390,21 +2396,21 @@ ZL2_expr_C_Clist_Hof_Halts:;
 				break;
 			}
 		}
-		/* END OF INLINE: 228 */
+		/* END OF INLINE: 230 */
 	}
 	return;
 ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-alts */
 		{
-#line 651 "src/libre/parser.act"
+#line 657 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXALTS;
 		}
 		goto ZL4;
 	
-#line 2408 "src/libre/dialect/native/parser.c"
+#line 2414 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
 	}
@@ -2423,18 +2429,18 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 	switch (CURRENT_TERMINAL) {
 	case (TOK_OPENCOUNT):
 		{
-			t_pos ZI263;
-			t_pos ZI264;
+			t_pos ZI265;
+			t_pos ZI266;
 			t_unsigned ZIm;
 
 			/* BEGINNING OF EXTRACT: OPENCOUNT */
 			{
-#line 351 "src/libre/parser.act"
+#line 357 "src/libre/parser.act"
 
-		ZI263 = lex_state->lx.start;
-		ZI264   = lex_state->lx.end;
+		ZI265 = lex_state->lx.start;
+		ZI266   = lex_state->lx.end;
 	
-#line 2438 "src/libre/dialect/native/parser.c"
+#line 2444 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: OPENCOUNT */
 			ADVANCE_LEXER;
@@ -2442,7 +2448,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			case (TOK_COUNT):
 				/* BEGINNING OF EXTRACT: COUNT */
 				{
-#line 575 "src/libre/parser.act"
+#line 581 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -2462,7 +2468,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		ZIm = (unsigned int) u;
 	
-#line 2466 "src/libre/dialect/native/parser.c"
+#line 2472 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -2470,7 +2476,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 				goto ZL1;
 			}
 			ADVANCE_LEXER;
-			p_265 (flags, lex_state, act_state, err, &ZI263, &ZIm, &ZIc);
+			p_267 (flags, lex_state, act_state, err, &ZI265, &ZIm, &ZIc);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -2482,11 +2488,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-zero-or-one */
 			{
-#line 768 "src/libre/parser.act"
+#line 774 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, 1, NULL);
 	
-#line 2490 "src/libre/dialect/native/parser.c"
+#line 2496 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-one */
 		}
@@ -2496,11 +2502,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-one-or-more */
 			{
-#line 764 "src/libre/parser.act"
+#line 770 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 2504 "src/libre/dialect/native/parser.c"
+#line 2510 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: count-one-or-more */
 		}
@@ -2510,11 +2516,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-zero-or-more */
 			{
-#line 760 "src/libre/parser.act"
+#line 766 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 2518 "src/libre/dialect/native/parser.c"
+#line 2524 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 		}
@@ -2523,11 +2529,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 		{
 			/* BEGINNING OF ACTION: count-one */
 			{
-#line 772 "src/libre/parser.act"
+#line 778 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 2531 "src/libre/dialect/native/parser.c"
+#line 2537 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: count-one */
 		}
@@ -2540,23 +2546,23 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-count */
 		{
-#line 637 "src/libre/parser.act"
+#line 643 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCOUNT;
 		}
 		goto ZL2;
 	
-#line 2551 "src/libre/dialect/native/parser.c"
+#line 2557 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: err-expected-count */
 		/* BEGINNING OF ACTION: count-one */
 		{
-#line 772 "src/libre/parser.act"
+#line 778 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 2560 "src/libre/dialect/native/parser.c"
+#line 2566 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: count-one */
 	}
@@ -2581,24 +2587,24 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: class-any */
 			{
-#line 735 "src/libre/parser.act"
+#line 741 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
 		(ZIa) = (*flags & RE_SINGLE) ? &class_any : &class_notnl;
 	
-#line 2590 "src/libre/dialect/native/parser.c"
+#line 2596 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 980 "src/libre/parser.act"
+#line 990 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_named(act_state->poolp, *flags, (ZIa));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2602 "src/libre/dialect/native/parser.c"
+#line 2608 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 		}
@@ -2608,23 +2614,33 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-anchor-end */
 			{
-#line 895 "src/libre/parser.act"
+#line 905 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_anchor(act_state->poolp, *flags, AST_ANCHOR_END);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2619 "src/libre/dialect/native/parser.c"
+#line 2625 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-end */
 		}
 		break;
 	case (TOK_OPENSUB):
 		{
+			t_group__id ZIid;
 			t_ast__expr ZIg;
 
 			ADVANCE_LEXER;
+			/* BEGINNING OF ACTION: make-group-id */
+			{
+#line 844 "src/libre/parser.act"
+
+		(ZIid) = act_state->group_id++;
+	
+#line 2642 "src/libre/dialect/native/parser.c"
+			}
+			/* END OF ACTION: make-group-id */
 			p_expr (flags, lex_state, act_state, err, &ZIg);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
@@ -2632,14 +2648,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			}
 			/* BEGINNING OF ACTION: ast-make-group */
 			{
-#line 864 "src/libre/parser.act"
+#line 874 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_group(act_state->poolp, *flags, (ZIg));
+		(ZIe) = ast_make_expr_group(act_state->poolp, *flags, (ZIg), (ZIid));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2643 "src/libre/dialect/native/parser.c"
+#line 2659 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-group */
 			switch (CURRENT_TERMINAL) {
@@ -2656,14 +2672,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-anchor-start */
 			{
-#line 888 "src/libre/parser.act"
+#line 898 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_anchor(act_state->poolp, *flags, AST_ANCHOR_START);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2667 "src/libre/dialect/native/parser.c"
+#line 2683 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-start */
 		}
@@ -2696,26 +2712,26 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-atom */
 		{
-#line 644 "src/libre/parser.act"
+#line 650 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXATOM;
 		}
 		goto ZL2;
 	
-#line 2707 "src/libre/dialect/native/parser.c"
+#line 2723 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 810 "src/libre/parser.act"
+#line 816 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZIe) == NULL) {
 			goto ZL2;
 		}
 	
-#line 2719 "src/libre/dialect/native/parser.c"
+#line 2735 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -2728,7 +2744,7 @@ ZL0:;
 }
 
 static void
-p_246(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class__id *ZI243, t_pos *ZI244, t_ast__expr *ZOnode)
+p_248(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class__id *ZI245, t_pos *ZI246, t_ast__expr *ZOnode)
 {
 	t_ast__expr ZInode;
 
@@ -2737,14 +2753,14 @@ p_246(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 		{
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 980 "src/libre/parser.act"
+#line 990 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_named(act_state->poolp, *flags, (*ZI243));
+		(ZInode) = ast_make_expr_named(act_state->poolp, *flags, (*ZI245));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2748 "src/libre/dialect/native/parser.c"
+#line 2764 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 		}
@@ -2757,15 +2773,15 @@ p_246(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-class */
 			{
-#line 801 "src/libre/parser.act"
+#line 807 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_NAMED;
-		(ZIlower).u.named.class = (*ZI243);
+		(ZIlower).u.named.class = (*ZI245);
 	
-#line 2766 "src/libre/dialect/native/parser.c"
+#line 2782 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-class */
-			p_152 (flags, lex_state, act_state, err);
+			p_154 (flags, lex_state, act_state, err);
 			p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_Hend (flags, lex_state, act_state, err, &ZIupper, &ZIend);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
@@ -2773,22 +2789,22 @@ p_246(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 			}
 			/* BEGINNING OF ACTION: mark-range */
 			{
-#line 709 "src/libre/parser.act"
+#line 715 "src/libre/parser.act"
 
-		mark(&act_state->rangestart, &(*ZI244));
+		mark(&act_state->rangestart, &(*ZI246));
 		mark(&act_state->rangeend,   &(ZIend));
 	
-#line 2782 "src/libre/dialect/native/parser.c"
+#line 2798 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 950 "src/libre/parser.act"
+#line 960 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI244));
+		AST_POS_OF_LX_POS(ast_start, (*ZI246));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		if ((ZIlower).type != AST_ENDPOINT_LITERAL ||
@@ -2816,7 +2832,7 @@ p_246(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 			goto ZL1;
 		}
 	
-#line 2820 "src/libre/dialect/native/parser.c"
+#line 2836 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -2843,14 +2859,14 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 	{
 		/* BEGINNING OF ACTION: ast-make-concat */
 		{
-#line 817 "src/libre/parser.act"
+#line 823 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_concat(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2854 "src/libre/dialect/native/parser.c"
+#line 2870 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-make-concat */
 		p_expr_C_Clist_Hof_Hpieces (flags, lex_state, act_state, err, ZInode);
@@ -2868,7 +2884,7 @@ ZL0:;
 }
 
 static void
-p_250(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI247, t_pos *ZI248, t_ast__expr *ZOnode)
+p_252(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI249, t_pos *ZI250, t_ast__expr *ZOnode)
 {
 	t_ast__expr ZInode;
 
@@ -2877,14 +2893,14 @@ p_250(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		{
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 831 "src/libre/parser.act"
+#line 837 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (*ZI247));
+		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (*ZI249));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2888 "src/libre/dialect/native/parser.c"
+#line 2904 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -2897,15 +2913,15 @@ p_250(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 796 "src/libre/parser.act"
+#line 802 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_LITERAL;
-		(ZIlower).u.literal.c = (*ZI247);
+		(ZIlower).u.literal.c = (*ZI249);
 	
-#line 2906 "src/libre/dialect/native/parser.c"
+#line 2922 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
-			p_152 (flags, lex_state, act_state, err);
+			p_154 (flags, lex_state, act_state, err);
 			p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_Hend (flags, lex_state, act_state, err, &ZIupper, &ZIend);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
@@ -2913,22 +2929,22 @@ p_250(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			}
 			/* BEGINNING OF ACTION: mark-range */
 			{
-#line 709 "src/libre/parser.act"
+#line 715 "src/libre/parser.act"
 
-		mark(&act_state->rangestart, &(*ZI248));
+		mark(&act_state->rangestart, &(*ZI250));
 		mark(&act_state->rangeend,   &(ZIend));
 	
-#line 2922 "src/libre/dialect/native/parser.c"
+#line 2938 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 950 "src/libre/parser.act"
+#line 960 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI248));
+		AST_POS_OF_LX_POS(ast_start, (*ZI250));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		if ((ZIlower).type != AST_ENDPOINT_LITERAL ||
@@ -2956,7 +2972,7 @@ p_250(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			goto ZL1;
 		}
 	
-#line 2960 "src/libre/dialect/native/parser.c"
+#line 2976 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -2974,7 +2990,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 1143 "src/libre/parser.act"
+#line 1155 "src/libre/parser.act"
 
 
 	static int
@@ -3050,6 +3066,8 @@ ZL0:;
 		act_state->overlap = overlap;
 		act_state->poolp   = &ast->pool;
 
+		act_state->group_id = 1;
+
 		err->e = RE_ESUCCESS;
 
 		ADVANCE_LEXER;
@@ -3120,6 +3138,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 3124 "src/libre/dialect/native/parser.c"
+#line 3142 "src/libre/dialect/native/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/native/parser.h
+++ b/src/libre/dialect/native/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 304 "src/libre/parser.act"
+#line 310 "src/libre/parser.act"
 
 
 	#include <re/re.h>
@@ -28,7 +28,7 @@
 extern void p_re__native(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 1145 "src/libre/parser.act"
+#line 1157 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/native/parser.h"

--- a/src/libre/dialect/native/parser.sid
+++ b/src/libre/dialect/native/parser.sid
@@ -20,6 +20,7 @@
 	ast_class_id;
 	ast_count;
 	endpoint;
+	group_id;
 
 %terminals%
 
@@ -87,6 +88,7 @@
 	<count-one>:          () -> (:ast_count);
 	<count-range>: (:unsigned, :pos, :unsigned, :pos) -> (:ast_count);
 
+	<make-group-id>:       () -> (:group_id);
 	<make-literal-cbrak>:  () -> (:char);
 	!<make-literal-cr>:    () -> (:char);
 	!<make-literal-nl>:    () -> (:char);
@@ -99,7 +101,7 @@
 	<ast-make-concat>:       ()                       -> (:ast_expr);
 	<ast-make-alt>:          ()                       -> (:ast_expr);
 	<ast-make-piece>:        (:ast_expr, :ast_count)  -> (:ast_expr);
-	<ast-make-group>:        (:ast_expr)              -> (:ast_expr);
+	<ast-make-group>:        (:ast_expr, :group_id)   -> (:ast_expr);
 	!<ast-get-re-flags>:     ()                       -> (:re_flags);
 	!<ast-set-re-flags>:     (:re_flags)              -> ();
 	!<ast-mask-re-flags>:    (:re_flags, :re_flags)   -> ();
@@ -371,8 +373,9 @@
 				e = character-class;
 			||
 				OPENSUB;
+				id = <make-group-id>;
 				g = expr;
-				e = <ast-make-group>(g);
+				e = <ast-make-group>(g, id);
 				CLOSESUB;
 			##
 				<err-expected-atom>;

--- a/src/libre/dialect/pcre/lexer.c
+++ b/src/libre/dialect/pcre/lexer.c
@@ -175,21 +175,21 @@ z0(struct lx_pcre_lx *lx)
 		switch (state) {
 		case S0: /* start */
 			switch ((unsigned char) c) {
-			case '\\': state = S2; break;
+			case '\\': state = S1; break;
 			case '\x00': lx->lgetc = NULL; return TOK_UNKNOWN;
-			default: state = S1; break;
+			default: state = S2; break;
 			}
 			break;
 
-		case S1: /* e.g. "a" */
-			lx_pcre_ungetc(lx, c); return TOK_CHAR;
-
-		case S2: /* e.g. "\\" */
+		case S1: /* e.g. "\\" */
 			switch ((unsigned char) c) {
 			case 'E': state = S3; break;
 			default:  lx_pcre_ungetc(lx, c); return TOK_CHAR;
 			}
 			break;
+
+		case S2: /* e.g. "a" */
+			lx_pcre_ungetc(lx, c); return TOK_CHAR;
 
 		case S3: /* e.g. "\\E" */
 			lx_pcre_ungetc(lx, c); return lx->z = z7, lx->z(lx);
@@ -251,7 +251,6 @@ z1(struct lx_pcre_lx *lx)
 		switch (state) {
 		case S0: /* start */
 			switch ((unsigned char) c) {
-			case ',': state = S1; break;
 			case '0':
 			case '1':
 			case '2':
@@ -261,16 +260,14 @@ z1(struct lx_pcre_lx *lx)
 			case '6':
 			case '7':
 			case '8':
-			case '9': state = S2; break;
+			case '9': state = S1; break;
+			case ',': state = S2; break;
 			case '}': state = S3; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S1: /* e.g. "," */
-			lx_pcre_ungetc(lx, c); return TOK_SEP;
-
-		case S2: /* e.g. "0" */
+		case S1: /* e.g. "0" */
 			switch ((unsigned char) c) {
 			case '0':
 			case '1':
@@ -285,6 +282,9 @@ z1(struct lx_pcre_lx *lx)
 			default:  lx_pcre_ungetc(lx, c); return TOK_COUNT;
 			}
 			break;
+
+		case S2: /* e.g. "," */
+			lx_pcre_ungetc(lx, c); return TOK_SEP;
 
 		case S3: /* e.g. "}" */
 			lx_pcre_ungetc(lx, c); return lx->z = z7, TOK_CLOSECOUNT;
@@ -304,8 +304,8 @@ z1(struct lx_pcre_lx *lx)
 
 	switch (state) {
 	case NONE: return TOK_EOF;
-	case S1: return TOK_SEP;
-	case S2: return TOK_COUNT;
+	case S1: return TOK_COUNT;
+	case S2: return TOK_SEP;
 	case S3: return TOK_CLOSECOUNT;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
@@ -338,21 +338,21 @@ z2(struct lx_pcre_lx *lx)
 		switch (state) {
 		case S0: /* start */
 			switch ((unsigned char) c) {
-			case '\\': state = S2; break;
+			case '\\': state = S1; break;
 			case '\x00': lx->lgetc = NULL; return TOK_UNKNOWN;
-			default: state = S1; break;
+			default: state = S2; break;
 			}
 			break;
 
-		case S1: /* e.g. "a" */
-			lx_pcre_ungetc(lx, c); return TOK_CHAR;
-
-		case S2: /* e.g. "\\" */
+		case S1: /* e.g. "\\" */
 			switch ((unsigned char) c) {
 			case 'E': state = S3; break;
 			default:  lx_pcre_ungetc(lx, c); return TOK_CHAR;
 			}
 			break;
+
+		case S2: /* e.g. "a" */
+			lx_pcre_ungetc(lx, c); return TOK_CHAR;
 
 		case S3: /* e.g. "\\E" */
 			lx_pcre_ungetc(lx, c); return lx->z = z3, lx->z(lx);
@@ -421,34 +421,40 @@ z3(struct lx_pcre_lx *lx)
 		switch (state) {
 		case S0: /* start */
 			switch ((unsigned char) c) {
-			case '-': state = S2; break;
-			case '[': state = S3; break;
-			case '\\': state = S4; break;
+			case '\\': state = S1; break;
+			case '[': state = S2; break;
+			case '-': state = S4; break;
 			case ']': state = S5; break;
 			case '\x00': lx->lgetc = NULL; return TOK_UNKNOWN;
-			default: state = S1; break;
+			default: state = S3; break;
 			}
 			break;
 
-		case S1: /* e.g. "a" */
-			lx_pcre_ungetc(lx, c); return TOK_CHAR;
-
-		case S2: /* e.g. "-" */
+		case S1: /* e.g. "\\" */
 			switch ((unsigned char) c) {
-			case ']': state = S71; break;
-			default:  lx_pcre_ungetc(lx, c); return TOK_RANGE;
-			}
-			break;
-
-		case S3: /* e.g. "[" */
-			switch ((unsigned char) c) {
-			case ':': state = S24; break;
-			default:  lx_pcre_ungetc(lx, c); return TOK_CHAR;
-			}
-			break;
-
-		case S4: /* e.g. "\\" */
-			switch ((unsigned char) c) {
+			case 'D':
+			case 'H':
+			case 'S':
+			case 'V':
+			case 'W':
+			case 'd':
+			case 'h':
+			case 's':
+			case 'v':
+			case 'w': state = S24; break;
+			case 'Q': state = S55; break;
+			case 'E': state = S56; break;
+			case 'x': state = S57; break;
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7': state = S58; break;
+			case 'o': state = S59; break;
+			case 'c': state = S60; break;
 			case '$':
 			case '(':
 			case '*':
@@ -467,163 +473,555 @@ z3(struct lx_pcre_lx *lx)
 			case 'r':
 			case 't':
 			case '{':
-			case '|': state = S7; break;
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7': state = S8; break;
-			case 'D':
-			case 'H':
-			case 'S':
-			case 'V':
-			case 'W':
-			case 'd':
-			case 'h':
-			case 's':
-			case 'v':
-			case 'w': state = S9; break;
-			case 'E': state = S10; break;
-			case 'Q': state = S11; break;
-			case 'c': state = S12; break;
-			case 'o': state = S13; break;
-			case 'x': state = S14; break;
-			default: state = S6; break;
+			case '|': state = S62; break;
+			default: state = S61; break;
+			}
+			break;
+
+		case S2: /* e.g. "[" */
+			switch ((unsigned char) c) {
+			case ':': state = S7; break;
+			default:  lx_pcre_ungetc(lx, c); return TOK_CHAR;
+			}
+			break;
+
+		case S3: /* e.g. "a" */
+			lx_pcre_ungetc(lx, c); return TOK_CHAR;
+
+		case S4: /* e.g. "-" */
+			switch ((unsigned char) c) {
+			case ']': state = S6; break;
+			default:  lx_pcre_ungetc(lx, c); return TOK_RANGE;
 			}
 			break;
 
 		case S5: /* e.g. "]" */
 			lx_pcre_ungetc(lx, c); return lx->z = z7, TOK_CLOSEGROUP;
 
-		case S6: /* e.g. "\\g" */
-			lx_pcre_ungetc(lx, c); return TOK_NOESC;
+		case S6: /* e.g. "-]" */
+			lx_pcre_ungetc(lx, c); return lx->z = z7, TOK_CLOSEGROUPRANGE;
 
-		case S7: /* e.g. "\\a" */
-			lx_pcre_ungetc(lx, c); return TOK_ESC;
-
-		case S8: /* e.g. "\\0" */
+		case S7: /* e.g. "[:" */
 			switch ((unsigned char) c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7': state = S23; break;
-			default:  lx_pcre_ungetc(lx, c); return TOK_OCT;
-			}
-			break;
-
-		case S9: /* e.g. "\\d" */
-			lx_pcre_ungetc(lx, c); return TOK_NAMED__CLASS;
-
-		case S10: /* e.g. "\\E" */
-			lx_pcre_ungetc(lx, c); return lx->z(lx);
-
-		case S11: /* e.g. "\\Q" */
-			lx_pcre_ungetc(lx, c); return lx->z = z2, lx->z(lx);
-
-		case S12: /* e.g. "\\c" */
-			state = S22; break;
-
-		case S13: /* e.g. "\\o" */
-			switch ((unsigned char) c) {
-			case '{': state = S19; break;
-			default:  lx_pcre_ungetc(lx, c); return TOK_NOESC;
-			}
-			break;
-
-		case S14: /* e.g. "\\x" */
-			switch ((unsigned char) c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9':
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F':
-			case 'a':
-			case 'b':
-			case 'c':
-			case 'd':
-			case 'e':
-			case 'f': state = S15; break;
-			case '{': state = S16; break;
-			default:  lx_pcre_ungetc(lx, c); return TOK_NOESC;
-			}
-			break;
-
-		case S15: /* e.g. "\\xa" */
-			switch ((unsigned char) c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9':
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F':
-			case 'a':
-			case 'b':
-			case 'c':
-			case 'd':
-			case 'e':
-			case 'f': state = S18; break;
-			default:  lx_pcre_ungetc(lx, c); return TOK_HEX;
-			}
-			break;
-
-		case S16: /* e.g. "\\x{" */
-			switch ((unsigned char) c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9':
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F':
-			case 'a':
-			case 'b':
-			case 'c':
-			case 'd':
-			case 'e':
-			case 'f': state = S17; break;
+			case 'd': state = S8; break;
+			case 'u': state = S9; break;
+			case 'w': state = S10; break;
+			case 'x': state = S11; break;
+			case 'b': state = S12; break;
+			case 'c': state = S13; break;
+			case 'l': state = S14; break;
+			case 'a': state = S15; break;
+			case 's': state = S16; break;
+			case 'p': state = S17; break;
+			case 'g': state = S18; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S17: /* e.g. "\\x{a" */
+		case S8: /* e.g. "[:d" */
 			switch ((unsigned char) c) {
+			case 'i': state = S53; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S9: /* e.g. "[:u" */
+			switch ((unsigned char) c) {
+			case 'p': state = S52; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S10: /* e.g. "[:w" */
+			switch ((unsigned char) c) {
+			case 'o': state = S50; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S11: /* e.g. "[:x" */
+			switch ((unsigned char) c) {
+			case 'd': state = S8; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S12: /* e.g. "[:b" */
+			switch ((unsigned char) c) {
+			case 'l': state = S47; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S13: /* e.g. "[:c" */
+			switch ((unsigned char) c) {
+			case 'n': state = S44; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S14: /* e.g. "[:l" */
+			switch ((unsigned char) c) {
+			case 'o': state = S41; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S15: /* e.g. "[:a" */
+			switch ((unsigned char) c) {
+			case 's': state = S33; break;
+			case 'l': state = S34; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S16: /* e.g. "[:s" */
+			switch ((unsigned char) c) {
+			case 'p': state = S30; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S17: /* e.g. "[:p" */
+			switch ((unsigned char) c) {
+			case 'r': state = S25; break;
+			case 'u': state = S26; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S18: /* e.g. "[:g" */
+			switch ((unsigned char) c) {
+			case 'r': state = S19; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S19: /* e.g. "[:gr" */
+			switch ((unsigned char) c) {
+			case 'a': state = S20; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S20: /* e.g. "[:gra" */
+			switch ((unsigned char) c) {
+			case 'p': state = S21; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S21: /* e.g. "[:grap" */
+			switch ((unsigned char) c) {
+			case 'h': state = S22; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S22: /* e.g. "[:word" */
+			switch ((unsigned char) c) {
+			case ':': state = S23; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S23: /* e.g. "[:word:" */
+			switch ((unsigned char) c) {
+			case ']': state = S24; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S24: /* e.g. "\\d" */
+			lx_pcre_ungetc(lx, c); return TOK_NAMED__CLASS;
+
+		case S25: /* e.g. "[:pr" */
+			switch ((unsigned char) c) {
+			case 'i': state = S29; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S26: /* e.g. "[:pu" */
+			switch ((unsigned char) c) {
+			case 'n': state = S27; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S27: /* e.g. "[:pun" */
+			switch ((unsigned char) c) {
+			case 'c': state = S28; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S28: /* e.g. "[:digi" */
+			switch ((unsigned char) c) {
+			case 't': state = S22; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S29: /* e.g. "[:pri" */
+			switch ((unsigned char) c) {
+			case 'n': state = S28; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S30: /* e.g. "[:sp" */
+			switch ((unsigned char) c) {
+			case 'a': state = S31; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S31: /* e.g. "[:spa" */
+			switch ((unsigned char) c) {
+			case 'c': state = S32; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S32: /* e.g. "[:spac" */
+			switch ((unsigned char) c) {
+			case 'e': state = S22; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S33: /* e.g. "[:as" */
+			switch ((unsigned char) c) {
+			case 'c': state = S39; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S34: /* e.g. "[:al" */
+			switch ((unsigned char) c) {
+			case 'n': state = S35; break;
+			case 'p': state = S36; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S35: /* e.g. "[:aln" */
+			switch ((unsigned char) c) {
+			case 'u': state = S38; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S36: /* e.g. "[:alp" */
+			switch ((unsigned char) c) {
+			case 'h': state = S37; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S37: /* e.g. "[:alph" */
+			switch ((unsigned char) c) {
+			case 'a': state = S22; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S38: /* e.g. "[:alnu" */
+			switch ((unsigned char) c) {
+			case 'm': state = S22; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S39: /* e.g. "[:asc" */
+			switch ((unsigned char) c) {
+			case 'i': state = S40; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S40: /* e.g. "[:asci" */
+			switch ((unsigned char) c) {
+			case 'i': state = S22; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S41: /* e.g. "[:lo" */
+			switch ((unsigned char) c) {
+			case 'w': state = S42; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S42: /* e.g. "[:low" */
+			switch ((unsigned char) c) {
+			case 'e': state = S43; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S43: /* e.g. "[:lowe" */
+			switch ((unsigned char) c) {
+			case 'r': state = S22; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S44: /* e.g. "[:cn" */
+			switch ((unsigned char) c) {
+			case 't': state = S45; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S45: /* e.g. "[:cnt" */
+			switch ((unsigned char) c) {
+			case 'r': state = S46; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S46: /* e.g. "[:cntr" */
+			switch ((unsigned char) c) {
+			case 'l': state = S22; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S47: /* e.g. "[:bl" */
+			switch ((unsigned char) c) {
+			case 'a': state = S48; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S48: /* e.g. "[:bla" */
+			switch ((unsigned char) c) {
+			case 'n': state = S49; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S49: /* e.g. "[:blan" */
+			switch ((unsigned char) c) {
+			case 'k': state = S22; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S50: /* e.g. "[:wo" */
+			switch ((unsigned char) c) {
+			case 'r': state = S51; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S51: /* e.g. "[:wor" */
+			switch ((unsigned char) c) {
+			case 'd': state = S22; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S52: /* e.g. "[:up" */
+			switch ((unsigned char) c) {
+			case 'p': state = S42; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S53: /* e.g. "[:di" */
+			switch ((unsigned char) c) {
+			case 'g': state = S54; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S54: /* e.g. "[:dig" */
+			switch ((unsigned char) c) {
+			case 'i': state = S28; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S55: /* e.g. "\\Q" */
+			lx_pcre_ungetc(lx, c); return lx->z = z2, lx->z(lx);
+
+		case S56: /* e.g. "\\E" */
+			lx_pcre_ungetc(lx, c); return lx->z(lx);
+
+		case S57: /* e.g. "\\x" */
+			switch ((unsigned char) c) {
+			case '{': state = S68; break;
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9':
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f': state = S69; break;
+			default:  lx_pcre_ungetc(lx, c); return TOK_NOESC;
+			}
+			break;
+
+		case S58: /* e.g. "\\0" */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7': state = S67; break;
+			default:  lx_pcre_ungetc(lx, c); return TOK_OCT;
+			}
+			break;
+
+		case S59: /* e.g. "\\o" */
+			switch ((unsigned char) c) {
+			case '{': state = S64; break;
+			default:  lx_pcre_ungetc(lx, c); return TOK_NOESC;
+			}
+			break;
+
+		case S60: /* e.g. "\\c" */
+			state = S63; break;
+
+		case S61: /* e.g. "\\g" */
+			lx_pcre_ungetc(lx, c); return TOK_NOESC;
+
+		case S62: /* e.g. "\\a" */
+			lx_pcre_ungetc(lx, c); return TOK_ESC;
+
+		case S63: /* e.g. "\\ca" */
+			lx_pcre_ungetc(lx, c); return TOK_CONTROL;
+
+		case S64: /* e.g. "\\o{" */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7': state = S65; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S65: /* e.g. "\\o{0" */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7': break;
+			case '}': state = S66; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S66: /* e.g. "\\000" */
+			lx_pcre_ungetc(lx, c); return TOK_OCT;
+
+		case S67: /* e.g. "\\00" */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7': state = S66; break;
+			default:  lx_pcre_ungetc(lx, c); return TOK_OCT;
+			}
+			break;
+
+		case S68: /* e.g. "\\x{" */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9':
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f': state = S71; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S69: /* e.g. "\\xa" */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9':
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f': state = S70; break;
+			default:  lx_pcre_ungetc(lx, c); return TOK_HEX;
+			}
+			break;
+
+		case S70: /* e.g. "\\xaa" */
+			lx_pcre_ungetc(lx, c); return TOK_HEX;
+
+		case S71: /* e.g. "\\x{a" */
+			switch ((unsigned char) c) {
+			case '}': state = S70; break;
 			case '0':
 			case '1':
 			case '2':
@@ -646,415 +1044,17 @@ z3(struct lx_pcre_lx *lx)
 			case 'd':
 			case 'e':
 			case 'f': break;
-			case '}': state = S18; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
-
-		case S18: /* e.g. "\\xaa" */
-			lx_pcre_ungetc(lx, c); return TOK_HEX;
-
-		case S19: /* e.g. "\\o{" */
-			switch ((unsigned char) c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7': state = S20; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S20: /* e.g. "\\o{0" */
-			switch ((unsigned char) c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7': break;
-			case '}': state = S21; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S21: /* e.g. "\\000" */
-			lx_pcre_ungetc(lx, c); return TOK_OCT;
-
-		case S22: /* e.g. "\\ca" */
-			lx_pcre_ungetc(lx, c); return TOK_CONTROL;
-
-		case S23: /* e.g. "\\00" */
-			switch ((unsigned char) c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7': state = S21; break;
-			default:  lx_pcre_ungetc(lx, c); return TOK_OCT;
-			}
-			break;
-
-		case S24: /* e.g. "[:" */
-			switch ((unsigned char) c) {
-			case 'a': state = S25; break;
-			case 'b': state = S26; break;
-			case 'c': state = S27; break;
-			case 'd': state = S28; break;
-			case 'g': state = S29; break;
-			case 'l': state = S30; break;
-			case 'p': state = S31; break;
-			case 's': state = S32; break;
-			case 'u': state = S33; break;
-			case 'w': state = S34; break;
-			case 'x': state = S35; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S25: /* e.g. "[:a" */
-			switch ((unsigned char) c) {
-			case 'l': state = S63; break;
-			case 's': state = S64; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S26: /* e.g. "[:b" */
-			switch ((unsigned char) c) {
-			case 'l': state = S60; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S27: /* e.g. "[:c" */
-			switch ((unsigned char) c) {
-			case 'n': state = S57; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S28: /* e.g. "[:d" */
-			switch ((unsigned char) c) {
-			case 'i': state = S55; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S29: /* e.g. "[:g" */
-			switch ((unsigned char) c) {
-			case 'r': state = S52; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S30: /* e.g. "[:l" */
-			switch ((unsigned char) c) {
-			case 'o': state = S51; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S31: /* e.g. "[:p" */
-			switch ((unsigned char) c) {
-			case 'r': state = S46; break;
-			case 'u': state = S47; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S32: /* e.g. "[:s" */
-			switch ((unsigned char) c) {
-			case 'p': state = S43; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S33: /* e.g. "[:u" */
-			switch ((unsigned char) c) {
-			case 'p': state = S40; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S34: /* e.g. "[:w" */
-			switch ((unsigned char) c) {
-			case 'o': state = S36; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S35: /* e.g. "[:x" */
-			switch ((unsigned char) c) {
-			case 'd': state = S28; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S36: /* e.g. "[:wo" */
-			switch ((unsigned char) c) {
-			case 'r': state = S37; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S37: /* e.g. "[:wor" */
-			switch ((unsigned char) c) {
-			case 'd': state = S38; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S38: /* e.g. "[:word" */
-			switch ((unsigned char) c) {
-			case ':': state = S39; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S39: /* e.g. "[:word:" */
-			switch ((unsigned char) c) {
-			case ']': state = S9; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S40: /* e.g. "[:up" */
-			switch ((unsigned char) c) {
-			case 'p': state = S41; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S41: /* e.g. "[:low" */
-			switch ((unsigned char) c) {
-			case 'e': state = S42; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S42: /* e.g. "[:lowe" */
-			switch ((unsigned char) c) {
-			case 'r': state = S38; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S43: /* e.g. "[:sp" */
-			switch ((unsigned char) c) {
-			case 'a': state = S44; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S44: /* e.g. "[:spa" */
-			switch ((unsigned char) c) {
-			case 'c': state = S45; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S45: /* e.g. "[:spac" */
-			switch ((unsigned char) c) {
-			case 'e': state = S38; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S46: /* e.g. "[:pr" */
-			switch ((unsigned char) c) {
-			case 'i': state = S50; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S47: /* e.g. "[:pu" */
-			switch ((unsigned char) c) {
-			case 'n': state = S48; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S48: /* e.g. "[:pun" */
-			switch ((unsigned char) c) {
-			case 'c': state = S49; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S49: /* e.g. "[:digi" */
-			switch ((unsigned char) c) {
-			case 't': state = S38; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S50: /* e.g. "[:pri" */
-			switch ((unsigned char) c) {
-			case 'n': state = S49; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S51: /* e.g. "[:lo" */
-			switch ((unsigned char) c) {
-			case 'w': state = S41; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S52: /* e.g. "[:gr" */
-			switch ((unsigned char) c) {
-			case 'a': state = S53; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S53: /* e.g. "[:gra" */
-			switch ((unsigned char) c) {
-			case 'p': state = S54; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S54: /* e.g. "[:grap" */
-			switch ((unsigned char) c) {
-			case 'h': state = S38; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S55: /* e.g. "[:di" */
-			switch ((unsigned char) c) {
-			case 'g': state = S56; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S56: /* e.g. "[:dig" */
-			switch ((unsigned char) c) {
-			case 'i': state = S49; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S57: /* e.g. "[:cn" */
-			switch ((unsigned char) c) {
-			case 't': state = S58; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S58: /* e.g. "[:cnt" */
-			switch ((unsigned char) c) {
-			case 'r': state = S59; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S59: /* e.g. "[:cntr" */
-			switch ((unsigned char) c) {
-			case 'l': state = S38; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S60: /* e.g. "[:bl" */
-			switch ((unsigned char) c) {
-			case 'a': state = S61; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S61: /* e.g. "[:bla" */
-			switch ((unsigned char) c) {
-			case 'n': state = S62; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S62: /* e.g. "[:blan" */
-			switch ((unsigned char) c) {
-			case 'k': state = S38; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S63: /* e.g. "[:al" */
-			switch ((unsigned char) c) {
-			case 'n': state = S67; break;
-			case 'p': state = S68; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S64: /* e.g. "[:as" */
-			switch ((unsigned char) c) {
-			case 'c': state = S65; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S65: /* e.g. "[:asc" */
-			switch ((unsigned char) c) {
-			case 'i': state = S66; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S66: /* e.g. "[:asci" */
-			switch ((unsigned char) c) {
-			case 'i': state = S38; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S67: /* e.g. "[:aln" */
-			switch ((unsigned char) c) {
-			case 'u': state = S70; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S68: /* e.g. "[:alp" */
-			switch ((unsigned char) c) {
-			case 'h': state = S69; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S69: /* e.g. "[:alph" */
-			switch ((unsigned char) c) {
-			case 'a': state = S38; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S70: /* e.g. "[:alnu" */
-			switch ((unsigned char) c) {
-			case 'm': state = S38; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S71: /* e.g. "-]" */
-			lx_pcre_ungetc(lx, c); return lx->z = z7, TOK_CLOSEGROUPRANGE;
 
 		default:
 			; /* unreached */
 		}
 
 		switch (state) {
-		case S10:
-		case S11:
+		case S55:
+		case S56:
 			break;
 
 		default:
@@ -1072,26 +1072,26 @@ z3(struct lx_pcre_lx *lx)
 
 	switch (state) {
 	case NONE: return TOK_EOF;
-	case S1: return TOK_CHAR;
-	case S2: return TOK_RANGE;
+	case S1: return TOK_INVALID;
+	case S2: return TOK_CHAR;
 	case S3: return TOK_CHAR;
-	case S4: return TOK_INVALID;
+	case S4: return TOK_RANGE;
 	case S5: return TOK_CLOSEGROUP;
-	case S6: return TOK_NOESC;
-	case S7: return TOK_ESC;
-	case S8: return TOK_OCT;
-	case S9: return TOK_NAMED__CLASS;
-	case S10: return TOK_EOF;
-	case S11: return TOK_EOF;
-	case S12: return TOK_NOESC;
-	case S13: return TOK_NOESC;
-	case S14: return TOK_NOESC;
-	case S15: return TOK_HEX;
-	case S18: return TOK_HEX;
-	case S21: return TOK_OCT;
-	case S22: return TOK_CONTROL;
-	case S23: return TOK_OCT;
-	case S71: return TOK_CLOSEGROUPRANGE;
+	case S6: return TOK_CLOSEGROUPRANGE;
+	case S24: return TOK_NAMED__CLASS;
+	case S55: return TOK_EOF;
+	case S56: return TOK_EOF;
+	case S57: return TOK_NOESC;
+	case S58: return TOK_OCT;
+	case S59: return TOK_NOESC;
+	case S60: return TOK_NOESC;
+	case S61: return TOK_NOESC;
+	case S62: return TOK_ESC;
+	case S63: return TOK_CONTROL;
+	case S66: return TOK_OCT;
+	case S67: return TOK_OCT;
+	case S69: return TOK_HEX;
+	case S70: return TOK_HEX;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
 }
@@ -1124,10 +1124,8 @@ z4(struct lx_pcre_lx *lx)
 		switch (state) {
 		case S0: /* start */
 			switch ((unsigned char) c) {
-			case ')': state = S1; break;
 			case '+':
-			case 'R': state = S2; break;
-			case '-': state = S3; break;
+			case 'R': state = S1; break;
 			case '0':
 			case '1':
 			case '2':
@@ -1137,8 +1135,11 @@ z4(struct lx_pcre_lx *lx)
 			case '6':
 			case '7':
 			case '8':
-			case '9': state = S4; break;
-			case ':': state = S5; break;
+			case '9': state = S2; break;
+			case 'n': state = S3; break;
+			case 'x': state = S4; break;
+			case 's': state = S5; break;
+			case 'i': state = S6; break;
 			case 'a':
 			case 'b':
 			case 'c':
@@ -1160,25 +1161,18 @@ z4(struct lx_pcre_lx *lx)
 			case 'v':
 			case 'w':
 			case 'y':
-			case 'z': state = S6; break;
-			case 'i': state = S7; break;
-			case 'n': state = S8; break;
-			case 's': state = S9; break;
-			case 'x': state = S10; break;
+			case 'z': state = S7; break;
+			case '-': state = S8; break;
+			case ')': state = S9; break;
+			case ':': state = S10; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S1: /* e.g. ")" */
-			lx_pcre_ungetc(lx, c); return lx->z = z7, TOK_CLOSE;
-
-		case S2: /* e.g. "R" */
+		case S1: /* e.g. "R" */
 			lx_pcre_ungetc(lx, c); return TOK_UNSUPPORTED;
 
-		case S3: /* e.g. "-" */
-			lx_pcre_ungetc(lx, c); return TOK_NEGATE;
-
-		case S4: /* e.g. "0" */
+		case S2: /* e.g. "0" */
 			switch ((unsigned char) c) {
 			case '0':
 			case '1':
@@ -1194,27 +1188,33 @@ z4(struct lx_pcre_lx *lx)
 			}
 			break;
 
-		case S5: /* e.g. ":" */
-			lx_pcre_ungetc(lx, c); return lx->z = z7, TOK_SUB;
+		case S3: /* e.g. "n" */
+			lx_pcre_ungetc(lx, c); return TOK_INVALID;
 
-		case S6: /* e.g. "a" */
-			lx_pcre_ungetc(lx, c); return TOK_FLAG__UNKNOWN;
-
-		case S7: /* e.g. "i" */
-			lx_pcre_ungetc(lx, c); return TOK_FLAG__INSENSITIVE;
-
-		case S8: /* e.g. "n" */
-			lx_pcre_ungetc(lx, c); return TOK_FLAG__IGNORE;
-
-		case S9: /* e.g. "s" */
-			lx_pcre_ungetc(lx, c); return TOK_FLAG__SINGLE;
-
-		case S10: /* e.g. "x" */
+		case S4: /* e.g. "x" */
 			switch ((unsigned char) c) {
-			case 'x': state = S6; break;
+			case 'x': state = S7; break;
 			default:  lx_pcre_ungetc(lx, c); return TOK_FLAG__EXTENDED;
 			}
 			break;
+
+		case S5: /* e.g. "s" */
+			lx_pcre_ungetc(lx, c); return TOK_FLAG__SINGLE;
+
+		case S6: /* e.g. "i" */
+			lx_pcre_ungetc(lx, c); return TOK_FLAG__INSENSITIVE;
+
+		case S7: /* e.g. "a" */
+			lx_pcre_ungetc(lx, c); return TOK_FLAG__UNKNOWN;
+
+		case S8: /* e.g. "-" */
+			lx_pcre_ungetc(lx, c); return TOK_NEGATE;
+
+		case S9: /* e.g. ")" */
+			lx_pcre_ungetc(lx, c); return lx->z = z7, TOK_CLOSE;
+
+		case S10: /* e.g. ":" */
+			lx_pcre_ungetc(lx, c); return lx->z = z7, TOK_SUB;
 
 		default:
 			; /* unreached */
@@ -1231,16 +1231,16 @@ z4(struct lx_pcre_lx *lx)
 
 	switch (state) {
 	case NONE: return TOK_EOF;
-	case S1: return TOK_CLOSE;
+	case S1: return TOK_UNSUPPORTED;
 	case S2: return TOK_UNSUPPORTED;
-	case S3: return TOK_NEGATE;
-	case S4: return TOK_UNSUPPORTED;
-	case S5: return TOK_SUB;
-	case S6: return TOK_FLAG__UNKNOWN;
-	case S7: return TOK_FLAG__INSENSITIVE;
-	case S8: return TOK_FLAG__IGNORE;
-	case S9: return TOK_FLAG__SINGLE;
-	case S10: return TOK_FLAG__EXTENDED;
+	case S3: return TOK_INVALID;
+	case S4: return TOK_FLAG__EXTENDED;
+	case S5: return TOK_FLAG__SINGLE;
+	case S6: return TOK_FLAG__INSENSITIVE;
+	case S7: return TOK_FLAG__UNKNOWN;
+	case S8: return TOK_NEGATE;
+	case S9: return TOK_CLOSE;
+	case S10: return TOK_SUB;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
 }
@@ -1357,558 +1357,558 @@ z6(struct lx_pcre_lx *lx)
 		switch (state) {
 		case S0: /* start */
 			switch ((unsigned char) c) {
-			case ')': state = S1; break;
-			case ':': state = S2; break;
-			case 'A': state = S3; break;
-			case 'C': state = S4; break;
-			case 'F': state = S5; break;
-			case 'L': state = S6; break;
-			case 'M': state = S7; break;
-			case 'N': state = S8; break;
-			case 'P': state = S9; break;
-			case 'S': state = S10; break;
-			case 'T': state = S11; break;
-			case 'a': state = S12; break;
-			case 'n': state = S13; break;
-			case 'p': state = S14; break;
+			case ':': state = S1; break;
+			case 'L': state = S2; break;
+			case 'p': state = S3; break;
+			case 'M': state = S4; break;
+			case 'T': state = S5; break;
+			case 'S': state = S6; break;
+			case 'P': state = S7; break;
+			case 'A': state = S8; break;
+			case 'a': state = S9; break;
+			case 'N': state = S10; break;
+			case 'C': state = S11; break;
+			case 'n': state = S12; break;
+			case 'F': state = S13; break;
+			case ')': state = S14; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S1: /* e.g. ")" */
-			lx_pcre_ungetc(lx, c); return lx->z = z7, lx->z(lx);
-
-		case S2: /* e.g. ":" */
+		case S1: /* e.g. ":" */
 			switch ((unsigned char) c) {
 			case ')': lx->lgetc = NULL; return TOK_UNKNOWN;
 			default: state = S78; break;
 			}
 			break;
 
-		case S3: /* e.g. "A" */
+		case S2: /* e.g. "L" */
 			switch ((unsigned char) c) {
-			case 'C': state = S71; break;
-			case 'N': state = S72; break;
+			case 'F': state = S37; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S4: /* e.g. "C" */
+		case S3: /* e.g. "p" */
 			switch ((unsigned char) c) {
-			case 'O': state = S66; break;
+			case 'l': state = S18; break;
+			case 'o': state = S76; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S4: /* e.g. "M" */
+			switch ((unsigned char) c) {
+			case 'A': state = S74; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S5: /* e.g. "T" */
+			switch ((unsigned char) c) {
+			case 'H': state = S72; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S6: /* e.g. "S" */
+			switch ((unsigned char) c) {
+			case 'K': state = S70; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S7: /* e.g. "P" */
+			switch ((unsigned char) c) {
 			case 'R': state = S67; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S5: /* e.g. "F" */
+		case S8: /* e.g. "A" */
 			switch ((unsigned char) c) {
-			case ':': state = S2; break;
-			case 'A': state = S64; break;
+			case 'C': state = S60; break;
+			case 'N': state = S61; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S9: /* e.g. "a" */
+			switch ((unsigned char) c) {
+			case 't': state = S56; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S10: /* e.g. "N" */
+			switch ((unsigned char) c) {
+			case 'O': state = S46; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S11: /* e.g. "C" */
+			switch ((unsigned char) c) {
+			case 'R': state = S41; break;
+			case 'O': state = S42; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S12: /* e.g. "n" */
+			switch ((unsigned char) c) {
+			case 'l': state = S18; break;
+			case 'e': state = S19; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S13: /* e.g. "F" */
+			switch ((unsigned char) c) {
+			case ':': state = S1; break;
+			case 'A': state = S15; break;
 			default:  lx_pcre_ungetc(lx, c); return TOK_UNSUPPORTED;
 			}
 			break;
 
-		case S6: /* e.g. "L" */
+		case S14: /* e.g. ")" */
+			lx_pcre_ungetc(lx, c); return lx->z = z7, lx->z(lx);
+
+		case S15: /* e.g. "FA" */
 			switch ((unsigned char) c) {
-			case 'F': state = S35; break;
+			case 'I': state = S16; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S7: /* e.g. "M" */
+		case S16: /* e.g. "FAI" */
 			switch ((unsigned char) c) {
-			case 'A': state = S62; break;
+			case 'L': state = S17; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S8: /* e.g. "N" */
+		case S17: /* e.g. "FAIL" */
 			switch ((unsigned char) c) {
-			case 'O': state = S52; break;
+			case ':': state = S1; break;
+			default:  lx_pcre_ungetc(lx, c); return TOK_UNSUPPORTED;
+			}
+			break;
+
+		case S18: /* e.g. "nl" */
+			switch ((unsigned char) c) {
+			case 'a':
+			case 'b': state = S36; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S9: /* e.g. "P" */
+		case S19: /* e.g. "ne" */
 			switch ((unsigned char) c) {
-			case 'R': state = S49; break;
+			case 'g': state = S20; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S10: /* e.g. "S" */
+		case S20: /* e.g. "neg" */
 			switch ((unsigned char) c) {
-			case 'K': state = S47; break;
+			case 'a': state = S21; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S11: /* e.g. "T" */
+		case S21: /* e.g. "nega" */
 			switch ((unsigned char) c) {
-			case 'H': state = S44; break;
+			case 't': state = S22; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S12: /* e.g. "a" */
+		case S22: /* e.g. "negat" */
 			switch ((unsigned char) c) {
-			case 't': state = S40; break;
+			case 'i': state = S23; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S13: /* e.g. "n" */
+		case S23: /* e.g. "negati" */
 			switch ((unsigned char) c) {
-			case 'l': state = S15; break;
+			case 'v': state = S24; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S24: /* e.g. "negativ" */
+			switch ((unsigned char) c) {
+			case 'e': state = S25; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S25: /* e.g. "negative" */
+			switch ((unsigned char) c) {
+			case '_': state = S26; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S26: /* e.g. "negative_" */
+			switch ((unsigned char) c) {
+			case 'l': state = S27; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S27: /* e.g. "negative_l" */
+			switch ((unsigned char) c) {
+			case 'o': state = S28; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S28: /* e.g. "negative_lo" */
+			switch ((unsigned char) c) {
+			case 'o': state = S29; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S29: /* e.g. "negative_loo" */
+			switch ((unsigned char) c) {
+			case 'k': state = S30; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S30: /* e.g. "negative_look" */
+			switch ((unsigned char) c) {
+			case 'b': state = S31; break;
+			case 'a': state = S32; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S31: /* e.g. "negative_lookb" */
+			switch ((unsigned char) c) {
 			case 'e': state = S38; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S14: /* e.g. "p" */
+		case S32: /* e.g. "negative_looka" */
 			switch ((unsigned char) c) {
-			case 'l': state = S15; break;
-			case 'o': state = S16; break;
+			case 'h': state = S33; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S15: /* e.g. "nl" */
+		case S33: /* e.g. "negative_lookah" */
 			switch ((unsigned char) c) {
-			case 'a':
-			case 'b': state = S34; break;
+			case 'e': state = S34; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S16: /* e.g. "po" */
+		case S34: /* e.g. "negative_lookahe" */
 			switch ((unsigned char) c) {
-			case 's': state = S17; break;
+			case 'a': state = S35; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S17: /* e.g. "pos" */
+		case S35: /* e.g. "negative_lookahea" */
 			switch ((unsigned char) c) {
-			case 'i': state = S18; break;
+			case 'd': state = S36; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S18: /* e.g. "nega" */
+		case S36: /* e.g. "nla" */
 			switch ((unsigned char) c) {
-			case 't': state = S19; break;
+			case ':': state = S37; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S19: /* e.g. "negat" */
-			switch ((unsigned char) c) {
-			case 'i': state = S20; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S20: /* e.g. "negati" */
-			switch ((unsigned char) c) {
-			case 'v': state = S21; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S21: /* e.g. "negativ" */
-			switch ((unsigned char) c) {
-			case 'e': state = S22; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S22: /* e.g. "negative" */
-			switch ((unsigned char) c) {
-			case '_': state = S23; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S23: /* e.g. "negative_" */
-			switch ((unsigned char) c) {
-			case 'l': state = S24; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S24: /* e.g. "negative_l" */
-			switch ((unsigned char) c) {
-			case 'o': state = S25; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S25: /* e.g. "negative_lo" */
-			switch ((unsigned char) c) {
-			case 'o': state = S26; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S26: /* e.g. "negative_loo" */
-			switch ((unsigned char) c) {
-			case 'k': state = S27; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S27: /* e.g. "negative_look" */
-			switch ((unsigned char) c) {
-			case 'a': state = S28; break;
-			case 'b': state = S29; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S28: /* e.g. "negative_looka" */
-			switch ((unsigned char) c) {
-			case 'h': state = S36; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S29: /* e.g. "negative_lookb" */
-			switch ((unsigned char) c) {
-			case 'e': state = S30; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S30: /* e.g. "negative_lookbe" */
-			switch ((unsigned char) c) {
-			case 'h': state = S31; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S31: /* e.g. "negative_lookbeh" */
-			switch ((unsigned char) c) {
-			case 'i': state = S32; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S32: /* e.g. "negative_lookbehi" */
-			switch ((unsigned char) c) {
-			case 'n': state = S33; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S33: /* e.g. "negative_lookahea" */
-			switch ((unsigned char) c) {
-			case 'd': state = S34; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S34: /* e.g. "nla" */
-			switch ((unsigned char) c) {
-			case ':': state = S35; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S35: /* e.g. "LF" */
+		case S37: /* e.g. "LF" */
 			lx_pcre_ungetc(lx, c); return TOK_UNSUPPORTED;
 
-		case S36: /* e.g. "negative_lookah" */
+		case S38: /* e.g. "negative_lookbe" */
 			switch ((unsigned char) c) {
-			case 'e': state = S37; break;
+			case 'h': state = S39; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S37: /* e.g. "negative_lookahe" */
+		case S39: /* e.g. "negative_lookbeh" */
 			switch ((unsigned char) c) {
-			case 'a': state = S33; break;
+			case 'i': state = S40; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S38: /* e.g. "ne" */
+		case S40: /* e.g. "negative_lookbehi" */
 			switch ((unsigned char) c) {
-			case 'g': state = S39; break;
+			case 'n': state = S35; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S39: /* e.g. "neg" */
+		case S41: /* e.g. "CR" */
 			switch ((unsigned char) c) {
-			case 'a': state = S18; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S40: /* e.g. "at" */
-			switch ((unsigned char) c) {
-			case 'o': state = S41; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S41: /* e.g. "ato" */
-			switch ((unsigned char) c) {
-			case 'm': state = S42; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S42: /* e.g. "atom" */
-			switch ((unsigned char) c) {
-			case 'i': state = S43; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S43: /* e.g. "atomi" */
-			switch ((unsigned char) c) {
-			case 'c': state = S34; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S44: /* e.g. "TH" */
-			switch ((unsigned char) c) {
-			case 'E': state = S45; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S45: /* e.g. "THE" */
-			switch ((unsigned char) c) {
-			case 'N': state = S46; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S46: /* e.g. "FAIL" */
-			switch ((unsigned char) c) {
-			case ':': state = S2; break;
+			case 'L': state = S2; break;
 			default:  lx_pcre_ungetc(lx, c); return TOK_UNSUPPORTED;
 			}
 			break;
 
-		case S47: /* e.g. "SK" */
+		case S42: /* e.g. "CO" */
 			switch ((unsigned char) c) {
-			case 'I': state = S48; break;
+			case 'M': state = S43; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S48: /* e.g. "SKI" */
+		case S43: /* e.g. "COM" */
 			switch ((unsigned char) c) {
-			case 'P': state = S46; break;
+			case 'M': state = S44; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S49: /* e.g. "PR" */
+		case S44: /* e.g. "COMM" */
 			switch ((unsigned char) c) {
-			case 'U': state = S50; break;
+			case 'I': state = S45; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S50: /* e.g. "PRU" */
+		case S45: /* e.g. "ACCEP" */
 			switch ((unsigned char) c) {
-			case 'N': state = S51; break;
+			case 'T': state = S17; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S51: /* e.g. "PRUN" */
+		case S46: /* e.g. "NO" */
 			switch ((unsigned char) c) {
-			case 'E': state = S46; break;
+			case '_': state = S47; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S52: /* e.g. "NO" */
+		case S47: /* e.g. "NO_" */
+			switch ((unsigned char) c) {
+			case 'S': state = S48; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S48: /* e.g. "NO_S" */
+			switch ((unsigned char) c) {
+			case 'T': state = S49; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S49: /* e.g. "NO_ST" */
+			switch ((unsigned char) c) {
+			case 'A': state = S50; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S50: /* e.g. "NO_STA" */
+			switch ((unsigned char) c) {
+			case 'R': state = S51; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S51: /* e.g. "NO_STAR" */
+			switch ((unsigned char) c) {
+			case 'T': state = S52; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S52: /* e.g. "NO_START" */
 			switch ((unsigned char) c) {
 			case '_': state = S53; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S53: /* e.g. "NO_" */
+		case S53: /* e.g. "NO_START_" */
 			switch ((unsigned char) c) {
-			case 'S': state = S54; break;
+			case 'O': state = S54; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S54: /* e.g. "NO_S" */
+		case S54: /* e.g. "NO_START_O" */
 			switch ((unsigned char) c) {
-			case 'T': state = S55; break;
+			case 'P': state = S55; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S55: /* e.g. "NO_ST" */
+		case S55: /* e.g. "NO_START_OP" */
 			switch ((unsigned char) c) {
-			case 'A': state = S56; break;
+			case 'T': state = S37; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S56: /* e.g. "NO_STA" */
+		case S56: /* e.g. "at" */
 			switch ((unsigned char) c) {
-			case 'R': state = S57; break;
+			case 'o': state = S57; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S57: /* e.g. "NO_STAR" */
+		case S57: /* e.g. "ato" */
 			switch ((unsigned char) c) {
-			case 'T': state = S58; break;
+			case 'm': state = S58; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S58: /* e.g. "NO_START" */
+		case S58: /* e.g. "atom" */
 			switch ((unsigned char) c) {
-			case '_': state = S59; break;
+			case 'i': state = S59; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S59: /* e.g. "NO_START_" */
+		case S59: /* e.g. "atomi" */
 			switch ((unsigned char) c) {
-			case 'O': state = S60; break;
+			case 'c': state = S36; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S60: /* e.g. "NO_START_O" */
+		case S60: /* e.g. "AC" */
 			switch ((unsigned char) c) {
-			case 'P': state = S61; break;
+			case 'C': state = S65; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S61: /* e.g. "NO_START_OP" */
+		case S61: /* e.g. "AN" */
 			switch ((unsigned char) c) {
-			case 'T': state = S35; break;
+			case 'Y': state = S62; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S62: /* e.g. "MA" */
+		case S62: /* e.g. "ANY" */
 			switch ((unsigned char) c) {
-			case 'R': state = S63; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S63: /* e.g. "MAR" */
-			switch ((unsigned char) c) {
-			case 'K': state = S46; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S64: /* e.g. "FA" */
-			switch ((unsigned char) c) {
-			case 'I': state = S65; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S65: /* e.g. "FAI" */
-			switch ((unsigned char) c) {
-			case 'L': state = S46; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S66: /* e.g. "CO" */
-			switch ((unsigned char) c) {
-			case 'M': state = S68; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S67: /* e.g. "CR" */
-			switch ((unsigned char) c) {
-			case 'L': state = S6; break;
+			case 'C': state = S63; break;
 			default:  lx_pcre_ungetc(lx, c); return TOK_UNSUPPORTED;
 			}
 			break;
 
-		case S68: /* e.g. "COM" */
+		case S63: /* e.g. "ANYC" */
 			switch ((unsigned char) c) {
-			case 'M': state = S69; break;
+			case 'R': state = S64; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S69: /* e.g. "COMM" */
+		case S64: /* e.g. "ANYCR" */
 			switch ((unsigned char) c) {
-			case 'I': state = S70; break;
+			case 'L': state = S2; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S70: /* e.g. "ACCEP" */
+		case S65: /* e.g. "ACC" */
 			switch ((unsigned char) c) {
-			case 'T': state = S46; break;
+			case 'E': state = S66; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S71: /* e.g. "AC" */
+		case S66: /* e.g. "ACCE" */
 			switch ((unsigned char) c) {
-			case 'C': state = S76; break;
+			case 'P': state = S45; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S72: /* e.g. "AN" */
+		case S67: /* e.g. "PR" */
 			switch ((unsigned char) c) {
-			case 'Y': state = S73; break;
+			case 'U': state = S68; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S73: /* e.g. "ANY" */
+		case S68: /* e.g. "PRU" */
 			switch ((unsigned char) c) {
-			case 'C': state = S74; break;
-			default:  lx_pcre_ungetc(lx, c); return TOK_UNSUPPORTED;
+			case 'N': state = S69; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S74: /* e.g. "ANYC" */
+		case S69: /* e.g. "PRUN" */
+			switch ((unsigned char) c) {
+			case 'E': state = S17; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S70: /* e.g. "SK" */
+			switch ((unsigned char) c) {
+			case 'I': state = S71; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S71: /* e.g. "SKI" */
+			switch ((unsigned char) c) {
+			case 'P': state = S17; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S72: /* e.g. "TH" */
+			switch ((unsigned char) c) {
+			case 'E': state = S73; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S73: /* e.g. "THE" */
+			switch ((unsigned char) c) {
+			case 'N': state = S17; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S74: /* e.g. "MA" */
 			switch ((unsigned char) c) {
 			case 'R': state = S75; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S75: /* e.g. "ANYCR" */
+		case S75: /* e.g. "MAR" */
 			switch ((unsigned char) c) {
-			case 'L': state = S6; break;
+			case 'K': state = S17; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S76: /* e.g. "ACC" */
+		case S76: /* e.g. "po" */
 			switch ((unsigned char) c) {
-			case 'E': state = S77; break;
+			case 's': state = S77; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S77: /* e.g. "ACCE" */
+		case S77: /* e.g. "pos" */
 			switch ((unsigned char) c) {
-			case 'P': state = S70; break;
+			case 'i': state = S21; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
@@ -1925,7 +1925,7 @@ z6(struct lx_pcre_lx *lx)
 		}
 
 		switch (state) {
-		case S1:
+		case S14:
 			break;
 
 		default:
@@ -1943,12 +1943,12 @@ z6(struct lx_pcre_lx *lx)
 
 	switch (state) {
 	case NONE: return TOK_EOF;
-	case S1: return TOK_EOF;
-	case S5: return TOK_UNSUPPORTED;
-	case S35: return TOK_UNSUPPORTED;
-	case S46: return TOK_UNSUPPORTED;
-	case S67: return TOK_UNSUPPORTED;
-	case S73: return TOK_UNSUPPORTED;
+	case S13: return TOK_UNSUPPORTED;
+	case S14: return TOK_EOF;
+	case S17: return TOK_UNSUPPORTED;
+	case S37: return TOK_UNSUPPORTED;
+	case S41: return TOK_UNSUPPORTED;
+	case S62: return TOK_UNSUPPORTED;
 	case S78: return TOK_UNSUPPORTED;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
@@ -1985,25 +1985,25 @@ z7(struct lx_pcre_lx *lx)
 		switch (state) {
 		case S0: /* start */
 			switch ((unsigned char) c) {
+			case '\\': state = S2; break;
+			case '\n':
+			case '\r': state = S3; break;
 			case '\t':
 			case '\v':
 			case '\f':
-			case ' ': state = S2; break;
-			case '\n':
-			case '\r': state = S3; break;
-			case '#': state = S4; break;
-			case '$': state = S5; break;
-			case '(': state = S6; break;
-			case ')': state = S7; break;
-			case '*': state = S8; break;
-			case '+': state = S9; break;
+			case ' ': state = S4; break;
+			case '#': state = S5; break;
+			case '{': state = S6; break;
+			case '[': state = S7; break;
+			case '(': state = S8; break;
+			case '|': state = S9; break;
 			case '.': state = S10; break;
-			case '?': state = S11; break;
-			case '[': state = S12; break;
-			case '\\': state = S13; break;
-			case '^': state = S14; break;
-			case '{': state = S15; break;
-			case '|': state = S16; break;
+			case '+': state = S11; break;
+			case '*': state = S12; break;
+			case '?': state = S13; break;
+			case '$': state = S14; break;
+			case '^': state = S15; break;
+			case ')': state = S16; break;
 			case '\x00': lx->lgetc = NULL; return TOK_UNKNOWN;
 			default: state = S1; break;
 			}
@@ -2012,53 +2012,34 @@ z7(struct lx_pcre_lx *lx)
 		case S1: /* e.g. "a" */
 			lx_pcre_ungetc(lx, c); return TOK_CHAR;
 
-		case S2: /* e.g. "\\x09" */
-			lx_pcre_ungetc(lx, c); return TOK_WHITESPACE;
-
-		case S3: /* e.g. "\\x0a" */
-			lx_pcre_ungetc(lx, c); return TOK_NEWLINE;
-
-		case S4: /* e.g. "#" */
-			lx_pcre_ungetc(lx, c); return TOK_MAYBE_COMMENT;
-
-		case S5: /* e.g. "$" */
-			lx_pcre_ungetc(lx, c); return TOK_END__NL;
-
-		case S6: /* e.g. "(" */
+		case S2: /* e.g. "\\" */
 			switch ((unsigned char) c) {
-			case '*': state = S42; break;
-			case '?': state = S43; break;
-			default:  lx_pcre_ungetc(lx, c); return TOK_OPEN;
-			}
-			break;
-
-		case S7: /* e.g. ")" */
-			lx_pcre_ungetc(lx, c); return TOK_CLOSE;
-
-		case S8: /* e.g. "*" */
-			lx_pcre_ungetc(lx, c); return TOK_STAR;
-
-		case S9: /* e.g. "+" */
-			lx_pcre_ungetc(lx, c); return TOK_PLUS;
-
-		case S10: /* e.g. "." */
-			lx_pcre_ungetc(lx, c); return TOK_ANY;
-
-		case S11: /* e.g. "?" */
-			lx_pcre_ungetc(lx, c); return TOK_OPT;
-
-		case S12: /* e.g. "[" */
-			switch ((unsigned char) c) {
-			case ']': state = S39; break;
-			case '^': state = S40; break;
-			default:  lx_pcre_ungetc(lx, c); return lx->z = z3, TOK_OPENGROUP;
-			}
-			break;
-
-		case S13: /* e.g. "\\" */
-			switch ((unsigned char) c) {
-			case 'Z': state = S5; break;
-			case 'A': state = S14; break;
+			case 'Z': state = S14; break;
+			case 'A': state = S15; break;
+			case 'B':
+			case 'G':
+			case 'K':
+			case 'X':
+			case 'b':
+			case 'g':
+			case 'k': state = S20; break;
+			case 'Q': state = S28; break;
+			case 'o': state = S29; break;
+			case 'c': state = S30; break;
+			case 'x': state = S32; break;
+			case '0': state = S33; break;
+			case 'R': state = S34; break;
+			case 'D':
+			case 'H':
+			case 'N':
+			case 'S':
+			case 'V':
+			case 'W':
+			case 'd':
+			case 'h':
+			case 's':
+			case 'v':
+			case 'w': state = S35; break;
 			case '$':
 			case '(':
 			case ')':
@@ -2076,316 +2057,106 @@ z7(struct lx_pcre_lx *lx)
 			case 'r':
 			case 't':
 			case '{':
-			case '|': state = S18; break;
-			case '0': state = S19; break;
+			case '|': state = S36; break;
+			case 'E': state = S37; break;
 			case '1':
 			case '2':
 			case '3':
 			case '4':
 			case '5':
 			case '6':
-			case '7': state = S20; break;
-			case 'B':
-			case 'G':
-			case 'K':
-			case 'X':
-			case 'b':
-			case 'g':
-			case 'k': state = S21; break;
-			case 'D':
-			case 'H':
-			case 'N':
-			case 'S':
-			case 'V':
-			case 'W':
-			case 'd':
-			case 'h':
-			case 's':
-			case 'v':
-			case 'w': state = S22; break;
-			case 'E': state = S23; break;
-			case 'Q': state = S24; break;
-			case 'R': state = S25; break;
-			case 'c': state = S26; break;
-			case 'o': state = S27; break;
-			case 'x': state = S28; break;
-			case 'z': state = S29; break;
-			default: state = S17; break;
+			case '7':
+			case '8':
+			case '9': state = S38; break;
+			case 'z': state = S39; break;
+			default: state = S31; break;
 			}
 			break;
 
-		case S14: /* e.g. "^" */
-			lx_pcre_ungetc(lx, c); return TOK_START;
+		case S3: /* e.g. "\\x0a" */
+			lx_pcre_ungetc(lx, c); return TOK_NEWLINE;
 
-		case S15: /* e.g. "{" */
+		case S4: /* e.g. "\\x09" */
+			lx_pcre_ungetc(lx, c); return TOK_WHITESPACE;
+
+		case S5: /* e.g. "#" */
+			lx_pcre_ungetc(lx, c); return TOK_MAYBE_COMMENT;
+
+		case S6: /* e.g. "{" */
 			lx_pcre_ungetc(lx, c); return lx->z = z1, TOK_OPENCOUNT;
 
-		case S16: /* e.g. "|" */
+		case S7: /* e.g. "[" */
+			switch ((unsigned char) c) {
+			case '^': state = S25; break;
+			case ']': state = S26; break;
+			default:  lx_pcre_ungetc(lx, c); return lx->z = z3, TOK_OPENGROUP;
+			}
+			break;
+
+		case S8: /* e.g. "(" */
+			switch ((unsigned char) c) {
+			case '?': state = S17; break;
+			case '*': state = S18; break;
+			default:  lx_pcre_ungetc(lx, c); return TOK_OPEN;
+			}
+			break;
+
+		case S9: /* e.g. "|" */
 			lx_pcre_ungetc(lx, c); return TOK_ALT;
 
-		case S17: /* e.g. "\\i" */
-			lx_pcre_ungetc(lx, c); return TOK_NOESC;
+		case S10: /* e.g. "." */
+			lx_pcre_ungetc(lx, c); return TOK_ANY;
 
-		case S18: /* e.g. "\\a" */
-			lx_pcre_ungetc(lx, c); return TOK_ESC;
+		case S11: /* e.g. "+" */
+			lx_pcre_ungetc(lx, c); return TOK_PLUS;
 
-		case S19: /* e.g. "\\0" */
+		case S12: /* e.g. "*" */
+			lx_pcre_ungetc(lx, c); return TOK_STAR;
+
+		case S13: /* e.g. "?" */
+			lx_pcre_ungetc(lx, c); return TOK_OPT;
+
+		case S14: /* e.g. "$" */
+			lx_pcre_ungetc(lx, c); return TOK_END__NL;
+
+		case S15: /* e.g. "^" */
+			lx_pcre_ungetc(lx, c); return TOK_START;
+
+		case S16: /* e.g. ")" */
+			lx_pcre_ungetc(lx, c); return TOK_CLOSE;
+
+		case S17: /* e.g. "(?" */
 			switch ((unsigned char) c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7': state = S38; break;
-			default:  lx_pcre_ungetc(lx, c); return TOK_OCT;
-			}
-			break;
-
-		case S20: /* e.g. "\\1" */
-			switch ((unsigned char) c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7': state = S38; break;
-			default:  lx_pcre_ungetc(lx, c); return TOK_UNSUPPORTED;
-			}
-			break;
-
-		case S21: /* e.g. "\\b" */
-			lx_pcre_ungetc(lx, c); return TOK_UNSUPPORTED;
-
-		case S22: /* e.g. "\\d" */
-			lx_pcre_ungetc(lx, c); return TOK_NAMED__CLASS;
-
-		case S23: /* e.g. "\\E" */
-			lx_pcre_ungetc(lx, c); return lx->z(lx);
-
-		case S24: /* e.g. "\\Q" */
-			lx_pcre_ungetc(lx, c); return lx->z = z0, lx->z(lx);
-
-		case S25: /* e.g. "\\R" */
-			lx_pcre_ungetc(lx, c); return TOK_EOL;
-
-		case S26: /* e.g. "\\c" */
-			state = S37; break;
-
-		case S27: /* e.g. "\\o" */
-			switch ((unsigned char) c) {
-			case '{': state = S34; break;
-			default:  lx_pcre_ungetc(lx, c); return TOK_NOESC;
-			}
-			break;
-
-		case S28: /* e.g. "\\x" */
-			switch ((unsigned char) c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9':
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F':
-			case 'a':
-			case 'b':
-			case 'c':
-			case 'd':
-			case 'e':
-			case 'f': state = S30; break;
-			case '{': state = S31; break;
-			default:  lx_pcre_ungetc(lx, c); return TOK_HEX;
-			}
-			break;
-
-		case S29: /* e.g. "\\z" */
-			lx_pcre_ungetc(lx, c); return TOK_END;
-
-		case S30: /* e.g. "\\xa" */
-			switch ((unsigned char) c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9':
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F':
-			case 'a':
-			case 'b':
-			case 'c':
-			case 'd':
-			case 'e':
-			case 'f': state = S33; break;
-			default:  lx_pcre_ungetc(lx, c); return TOK_HEX;
-			}
-			break;
-
-		case S31: /* e.g. "\\x{" */
-			switch ((unsigned char) c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9':
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F':
-			case 'a':
-			case 'b':
-			case 'c':
-			case 'd':
-			case 'e':
-			case 'f': state = S32; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S32: /* e.g. "\\x{a" */
-			switch ((unsigned char) c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9':
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F':
-			case 'a':
-			case 'b':
-			case 'c':
-			case 'd':
-			case 'e':
-			case 'f': break;
-			case '}': state = S33; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S33: /* e.g. "\\xaa" */
-			lx_pcre_ungetc(lx, c); return TOK_HEX;
-
-		case S34: /* e.g. "\\o{" */
-			switch ((unsigned char) c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7': state = S35; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S35: /* e.g. "\\o{0" */
-			switch ((unsigned char) c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7': break;
-			case '}': state = S36; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S36: /* e.g. "\\000" */
-			lx_pcre_ungetc(lx, c); return TOK_OCT;
-
-		case S37: /* e.g. "\\ca" */
-			lx_pcre_ungetc(lx, c); return TOK_CONTROL;
-
-		case S38: /* e.g. "\\00" */
-			switch ((unsigned char) c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7': state = S36; break;
-			default:  lx_pcre_ungetc(lx, c); return TOK_OCT;
-			}
-			break;
-
-		case S39: /* e.g. "[]" */
-			lx_pcre_ungetc(lx, c); return lx->z = z3, TOK_OPENGROUPCB;
-
-		case S40: /* e.g. "[^" */
-			switch ((unsigned char) c) {
-			case ']': state = S41; break;
-			default:  lx_pcre_ungetc(lx, c); return lx->z = z3, TOK_OPENGROUPINV;
-			}
-			break;
-
-		case S41: /* e.g. "[^]" */
-			lx_pcre_ungetc(lx, c); return lx->z = z3, TOK_OPENGROUPINVCB;
-
-		case S42: /* e.g. "(*" */
-			lx_pcre_ungetc(lx, c); return lx->z = z6, lx->z(lx);
-
-		case S43: /* e.g. "(?" */
-			switch ((unsigned char) c) {
+			case '#': state = S19; break;
 			case '!':
 			case '&':
-			case '=': state = S21; break;
-			case '#': state = S44; break;
-			case '<': state = S45; break;
-			case 'P': state = S46; break;
+			case '=': state = S20; break;
+			case 'P': state = S21; break;
+			case '<': state = S22; break;
 			default:  lx_pcre_ungetc(lx, c); return lx->z = z4, TOK_FLAGS;
 			}
 			break;
 
-		case S44: /* e.g. "(?#" */
+		case S18: /* e.g. "(*" */
+			lx_pcre_ungetc(lx, c); return lx->z = z6, lx->z(lx);
+
+		case S19: /* e.g. "(?#" */
 			lx_pcre_ungetc(lx, c); return lx->z = z5, lx->z(lx);
 
-		case S45: /* e.g. "(?<" */
+		case S20: /* e.g. "\\b" */
+			lx_pcre_ungetc(lx, c); return TOK_UNSUPPORTED;
+
+		case S21: /* e.g. "(?P" */
+			switch ((unsigned char) c) {
+			case '>': state = S20; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S22: /* e.g. "(?<" */
 			switch ((unsigned char) c) {
 			case '!':
-			case '=': state = S21; break;
+			case '=': state = S20; break;
 			case 'A':
 			case 'B':
 			case 'C':
@@ -2438,19 +2209,12 @@ z7(struct lx_pcre_lx *lx)
 			case 'w':
 			case 'x':
 			case 'y':
-			case 'z': state = S47; break;
+			case 'z': state = S23; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S46: /* e.g. "(?P" */
-			switch ((unsigned char) c) {
-			case '>': state = S21; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S47: /* e.g. "(?<a" */
+		case S23: /* e.g. "(?<a" */
 			switch ((unsigned char) c) {
 			case '0':
 			case '1':
@@ -2515,23 +2279,263 @@ z7(struct lx_pcre_lx *lx)
 			case 'x':
 			case 'y':
 			case 'z': break;
-			case '>': state = S48; break;
+			case '>': state = S24; break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
 			}
 			break;
 
-		case S48: /* e.g. "(?<a>" */
+		case S24: /* e.g. "(?<a>" */
 			lx_pcre_ungetc(lx, c); return TOK_OPENCAPTURE;
+
+		case S25: /* e.g. "[^" */
+			switch ((unsigned char) c) {
+			case ']': state = S27; break;
+			default:  lx_pcre_ungetc(lx, c); return lx->z = z3, TOK_OPENGROUPINV;
+			}
+			break;
+
+		case S26: /* e.g. "[]" */
+			lx_pcre_ungetc(lx, c); return lx->z = z3, TOK_OPENGROUPCB;
+
+		case S27: /* e.g. "[^]" */
+			lx_pcre_ungetc(lx, c); return lx->z = z3, TOK_OPENGROUPINVCB;
+
+		case S28: /* e.g. "\\Q" */
+			lx_pcre_ungetc(lx, c); return lx->z = z0, lx->z(lx);
+
+		case S29: /* e.g. "\\o" */
+			switch ((unsigned char) c) {
+			case '{': state = S47; break;
+			default:  lx_pcre_ungetc(lx, c); return TOK_NOESC;
+			}
+			break;
+
+		case S30: /* e.g. "\\c" */
+			state = S46; break;
+
+		case S31: /* e.g. "\\i" */
+			lx_pcre_ungetc(lx, c); return TOK_NOESC;
+
+		case S32: /* e.g. "\\x" */
+			switch ((unsigned char) c) {
+			case '{': state = S42; break;
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9':
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f': state = S43; break;
+			default:  lx_pcre_ungetc(lx, c); return TOK_HEX;
+			}
+			break;
+
+		case S33: /* e.g. "\\0" */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7': state = S40; break;
+			default:  lx_pcre_ungetc(lx, c); return TOK_OCT;
+			}
+			break;
+
+		case S34: /* e.g. "\\R" */
+			lx_pcre_ungetc(lx, c); return TOK_EOL;
+
+		case S35: /* e.g. "\\d" */
+			lx_pcre_ungetc(lx, c); return TOK_NAMED__CLASS;
+
+		case S36: /* e.g. "\\a" */
+			lx_pcre_ungetc(lx, c); return TOK_ESC;
+
+		case S37: /* e.g. "\\E" */
+			lx_pcre_ungetc(lx, c); return lx->z(lx);
+
+		case S38: /* e.g. "\\1" */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9': break;
+			default:  lx_pcre_ungetc(lx, c); return TOK_UNSUPPORTED;
+			}
+			break;
+
+		case S39: /* e.g. "\\z" */
+			lx_pcre_ungetc(lx, c); return TOK_END;
+
+		case S40: /* e.g. "\\00" */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7': state = S41; break;
+			default:  lx_pcre_ungetc(lx, c); return TOK_OCT;
+			}
+			break;
+
+		case S41: /* e.g. "\\000" */
+			lx_pcre_ungetc(lx, c); return TOK_OCT;
+
+		case S42: /* e.g. "\\x{" */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9':
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f': state = S45; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S43: /* e.g. "\\xa" */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9':
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f': state = S44; break;
+			default:  lx_pcre_ungetc(lx, c); return TOK_HEX;
+			}
+			break;
+
+		case S44: /* e.g. "\\xaa" */
+			lx_pcre_ungetc(lx, c); return TOK_HEX;
+
+		case S45: /* e.g. "\\x{a" */
+			switch ((unsigned char) c) {
+			case '}': state = S44; break;
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9':
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f': break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S46: /* e.g. "\\ca" */
+			lx_pcre_ungetc(lx, c); return TOK_CONTROL;
+
+		case S47: /* e.g. "\\o{" */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7': state = S48; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S48: /* e.g. "\\o{0" */
+			switch ((unsigned char) c) {
+			case '}': state = S41; break;
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7': break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
 
 		default:
 			; /* unreached */
 		}
 
 		switch (state) {
-		case S23:
-		case S24:
-		case S42:
-		case S44:
+		case S18:
+		case S19:
+		case S28:
+		case S37:
 			break;
 
 		default:
@@ -2550,46 +2554,46 @@ z7(struct lx_pcre_lx *lx)
 	switch (state) {
 	case NONE: return TOK_EOF;
 	case S1: return TOK_CHAR;
-	case S2: return TOK_WHITESPACE;
+	case S2: return TOK_INVALID;
 	case S3: return TOK_NEWLINE;
-	case S4: return TOK_MAYBE_COMMENT;
-	case S5: return TOK_END__NL;
-	case S6: return TOK_OPEN;
-	case S7: return TOK_CLOSE;
-	case S8: return TOK_STAR;
-	case S9: return TOK_PLUS;
+	case S4: return TOK_WHITESPACE;
+	case S5: return TOK_MAYBE_COMMENT;
+	case S6: return TOK_OPENCOUNT;
+	case S7: return TOK_OPENGROUP;
+	case S8: return TOK_OPEN;
+	case S9: return TOK_ALT;
 	case S10: return TOK_ANY;
-	case S11: return TOK_OPT;
-	case S12: return TOK_OPENGROUP;
-	case S13: return TOK_INVALID;
-	case S14: return TOK_START;
-	case S15: return TOK_OPENCOUNT;
-	case S16: return TOK_ALT;
-	case S17: return TOK_NOESC;
-	case S18: return TOK_ESC;
-	case S19: return TOK_OCT;
+	case S11: return TOK_PLUS;
+	case S12: return TOK_STAR;
+	case S13: return TOK_OPT;
+	case S14: return TOK_END__NL;
+	case S15: return TOK_START;
+	case S16: return TOK_CLOSE;
+	case S17: return TOK_FLAGS;
+	case S18: return TOK_EOF;
+	case S19: return TOK_EOF;
 	case S20: return TOK_UNSUPPORTED;
-	case S21: return TOK_UNSUPPORTED;
-	case S22: return TOK_NAMED__CLASS;
-	case S23: return TOK_EOF;
-	case S24: return TOK_EOF;
-	case S25: return TOK_EOL;
-	case S26: return TOK_NOESC;
-	case S27: return TOK_NOESC;
-	case S28: return TOK_HEX;
-	case S29: return TOK_END;
-	case S30: return TOK_HEX;
-	case S33: return TOK_HEX;
-	case S36: return TOK_OCT;
-	case S37: return TOK_CONTROL;
-	case S38: return TOK_OCT;
-	case S39: return TOK_OPENGROUPCB;
-	case S40: return TOK_OPENGROUPINV;
-	case S41: return TOK_OPENGROUPINVCB;
-	case S42: return TOK_EOF;
-	case S43: return TOK_FLAGS;
-	case S44: return TOK_EOF;
-	case S48: return TOK_OPENCAPTURE;
+	case S24: return TOK_OPENCAPTURE;
+	case S25: return TOK_OPENGROUPINV;
+	case S26: return TOK_OPENGROUPCB;
+	case S27: return TOK_OPENGROUPINVCB;
+	case S28: return TOK_EOF;
+	case S29: return TOK_NOESC;
+	case S30: return TOK_NOESC;
+	case S31: return TOK_NOESC;
+	case S32: return TOK_HEX;
+	case S33: return TOK_OCT;
+	case S34: return TOK_EOL;
+	case S35: return TOK_NAMED__CLASS;
+	case S36: return TOK_ESC;
+	case S37: return TOK_EOF;
+	case S38: return TOK_UNSUPPORTED;
+	case S39: return TOK_END;
+	case S40: return TOK_OCT;
+	case S41: return TOK_OCT;
+	case S43: return TOK_HEX;
+	case S44: return TOK_HEX;
+	case S46: return TOK_CONTROL;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
 }

--- a/src/libre/dialect/pcre/lexer.c
+++ b/src/libre/dialect/pcre/lexer.c
@@ -400,7 +400,7 @@ z3(struct lx_pcre_lx *lx)
 		S40, S41, S42, S43, S44, S45, S46, S47, S48, S49, 
 		S50, S51, S52, S53, S54, S55, S56, S57, S58, S59, 
 		S60, S61, S62, S63, S64, S65, S66, S67, S68, S69, 
-		S70, S71, NONE
+		S70, S71, S72, S73, NONE
 	} state;
 
 	assert(lx != NULL);
@@ -444,17 +444,19 @@ z3(struct lx_pcre_lx *lx)
 			case 'w': state = S24; break;
 			case 'Q': state = S55; break;
 			case 'E': state = S56; break;
-			case 'x': state = S57; break;
-			case '0':
 			case '1':
 			case '2':
 			case '3':
 			case '4':
 			case '5':
 			case '6':
-			case '7': state = S58; break;
-			case 'o': state = S59; break;
-			case 'c': state = S60; break;
+			case '7':
+			case '8':
+			case '9': state = S57; break;
+			case 'x': state = S58; break;
+			case '0': state = S59; break;
+			case 'o': state = S60; break;
+			case 'c': state = S61; break;
 			case '$':
 			case '(':
 			case '*':
@@ -473,8 +475,8 @@ z3(struct lx_pcre_lx *lx)
 			case 'r':
 			case 't':
 			case '{':
-			case '|': state = S62; break;
-			default: state = S61; break;
+			case '|': state = S63; break;
+			default: state = S62; break;
 			}
 			break;
 
@@ -852,115 +854,7 @@ z3(struct lx_pcre_lx *lx)
 		case S56: /* e.g. "\\E" */
 			lx_pcre_ungetc(lx, c); return lx->z(lx);
 
-		case S57: /* e.g. "\\x" */
-			switch ((unsigned char) c) {
-			case '{': state = S68; break;
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9':
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F':
-			case 'a':
-			case 'b':
-			case 'c':
-			case 'd':
-			case 'e':
-			case 'f': state = S69; break;
-			default:  lx_pcre_ungetc(lx, c); return TOK_NOESC;
-			}
-			break;
-
-		case S58: /* e.g. "\\0" */
-			switch ((unsigned char) c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7': state = S67; break;
-			default:  lx_pcre_ungetc(lx, c); return TOK_OCT;
-			}
-			break;
-
-		case S59: /* e.g. "\\o" */
-			switch ((unsigned char) c) {
-			case '{': state = S64; break;
-			default:  lx_pcre_ungetc(lx, c); return TOK_NOESC;
-			}
-			break;
-
-		case S60: /* e.g. "\\c" */
-			state = S63; break;
-
-		case S61: /* e.g. "\\g" */
-			lx_pcre_ungetc(lx, c); return TOK_NOESC;
-
-		case S62: /* e.g. "\\a" */
-			lx_pcre_ungetc(lx, c); return TOK_ESC;
-
-		case S63: /* e.g. "\\ca" */
-			lx_pcre_ungetc(lx, c); return TOK_CONTROL;
-
-		case S64: /* e.g. "\\o{" */
-			switch ((unsigned char) c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7': state = S65; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S65: /* e.g. "\\o{0" */
-			switch ((unsigned char) c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7': break;
-			case '}': state = S66; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
-			}
-			break;
-
-		case S66: /* e.g. "\\000" */
-			lx_pcre_ungetc(lx, c); return TOK_OCT;
-
-		case S67: /* e.g. "\\00" */
-			switch ((unsigned char) c) {
-			case '0':
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7': state = S66; break;
-			default:  lx_pcre_ungetc(lx, c); return TOK_OCT;
-			}
-			break;
-
-		case S68: /* e.g. "\\x{" */
+		case S57: /* e.g. "\\1" */
 			switch ((unsigned char) c) {
 			case '0':
 			case '1':
@@ -971,25 +865,14 @@ z3(struct lx_pcre_lx *lx)
 			case '6':
 			case '7':
 			case '8':
-			case '9':
-			case 'A':
-			case 'B':
-			case 'C':
-			case 'D':
-			case 'E':
-			case 'F':
-			case 'a':
-			case 'b':
-			case 'c':
-			case 'd':
-			case 'e':
-			case 'f': state = S71; break;
-			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			case '9': state = S73; break;
+			default:  lx_pcre_ungetc(lx, c); return TOK_UNSUPPORTED;
 			}
 			break;
 
-		case S69: /* e.g. "\\xa" */
+		case S58: /* e.g. "\\x" */
 			switch ((unsigned char) c) {
+			case '{': state = S69; break;
 			case '0':
 			case '1':
 			case '2':
@@ -1016,12 +899,147 @@ z3(struct lx_pcre_lx *lx)
 			}
 			break;
 
-		case S70: /* e.g. "\\xaa" */
+		case S59: /* e.g. "\\0" */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7': state = S68; break;
+			default:  lx_pcre_ungetc(lx, c); return TOK_OCT;
+			}
+			break;
+
+		case S60: /* e.g. "\\o" */
+			switch ((unsigned char) c) {
+			case '{': state = S65; break;
+			default:  lx_pcre_ungetc(lx, c); return TOK_NOESC;
+			}
+			break;
+
+		case S61: /* e.g. "\\c" */
+			state = S64; break;
+
+		case S62: /* e.g. "\\g" */
+			lx_pcre_ungetc(lx, c); return TOK_NOESC;
+
+		case S63: /* e.g. "\\a" */
+			lx_pcre_ungetc(lx, c); return TOK_ESC;
+
+		case S64: /* e.g. "\\ca" */
+			lx_pcre_ungetc(lx, c); return TOK_CONTROL;
+
+		case S65: /* e.g. "\\o{" */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7': state = S66; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S66: /* e.g. "\\o{0" */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7': break;
+			case '}': state = S67; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S67: /* e.g. "\\000" */
+			lx_pcre_ungetc(lx, c); return TOK_OCT;
+
+		case S68: /* e.g. "\\00" */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7': state = S67; break;
+			default:  lx_pcre_ungetc(lx, c); return TOK_OCT;
+			}
+			break;
+
+		case S69: /* e.g. "\\x{" */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9':
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f': state = S72; break;
+			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S70: /* e.g. "\\xa" */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9':
+			case 'A':
+			case 'B':
+			case 'C':
+			case 'D':
+			case 'E':
+			case 'F':
+			case 'a':
+			case 'b':
+			case 'c':
+			case 'd':
+			case 'e':
+			case 'f': state = S71; break;
+			default:  lx_pcre_ungetc(lx, c); return TOK_HEX;
+			}
+			break;
+
+		case S71: /* e.g. "\\xaa" */
 			lx_pcre_ungetc(lx, c); return TOK_HEX;
 
-		case S71: /* e.g. "\\x{a" */
+		case S72: /* e.g. "\\x{a" */
 			switch ((unsigned char) c) {
-			case '}': state = S70; break;
+			case '}': state = S71; break;
 			case '0':
 			case '1':
 			case '2':
@@ -1045,6 +1063,22 @@ z3(struct lx_pcre_lx *lx)
 			case 'e':
 			case 'f': break;
 			default:  lx->lgetc = NULL; return TOK_UNKNOWN;
+			}
+			break;
+
+		case S73: /* e.g. "\\10" */
+			switch ((unsigned char) c) {
+			case '0':
+			case '1':
+			case '2':
+			case '3':
+			case '4':
+			case '5':
+			case '6':
+			case '7':
+			case '8':
+			case '9': break;
+			default:  lx_pcre_ungetc(lx, c); return TOK_UNSUPPORTED;
 			}
 			break;
 
@@ -1081,17 +1115,19 @@ z3(struct lx_pcre_lx *lx)
 	case S24: return TOK_NAMED__CLASS;
 	case S55: return TOK_EOF;
 	case S56: return TOK_EOF;
-	case S57: return TOK_NOESC;
-	case S58: return TOK_OCT;
-	case S59: return TOK_NOESC;
+	case S57: return TOK_UNSUPPORTED;
+	case S58: return TOK_HEX;
+	case S59: return TOK_OCT;
 	case S60: return TOK_NOESC;
 	case S61: return TOK_NOESC;
-	case S62: return TOK_ESC;
-	case S63: return TOK_CONTROL;
-	case S66: return TOK_OCT;
+	case S62: return TOK_NOESC;
+	case S63: return TOK_ESC;
+	case S64: return TOK_CONTROL;
 	case S67: return TOK_OCT;
-	case S69: return TOK_HEX;
+	case S68: return TOK_OCT;
 	case S70: return TOK_HEX;
+	case S71: return TOK_HEX;
+	case S73: return TOK_UNSUPPORTED;
 	default: errno = EINVAL; return TOK_ERROR;
 	}
 }
@@ -1189,7 +1225,7 @@ z4(struct lx_pcre_lx *lx)
 			break;
 
 		case S3: /* e.g. "n" */
-			lx_pcre_ungetc(lx, c); return TOK_INVALID;
+			lx_pcre_ungetc(lx, c); return TOK_FLAG__IGNORE;
 
 		case S4: /* e.g. "x" */
 			switch ((unsigned char) c) {
@@ -1233,7 +1269,7 @@ z4(struct lx_pcre_lx *lx)
 	case NONE: return TOK_EOF;
 	case S1: return TOK_UNSUPPORTED;
 	case S2: return TOK_UNSUPPORTED;
-	case S3: return TOK_INVALID;
+	case S3: return TOK_FLAG__IGNORE;
 	case S4: return TOK_FLAG__EXTENDED;
 	case S5: return TOK_FLAG__SINGLE;
 	case S6: return TOK_FLAG__INSENSITIVE;

--- a/src/libre/dialect/pcre/lexer.lx
+++ b/src/libre/dialect/pcre/lexer.lx
@@ -268,10 +268,25 @@
 	'\w' -> $named__class;
 	'\W' -> $named__class;
 
-	'\'   /[0-7]{1,3}/     -> $oct;
 	'\o{' /[0-7]+/i '}'    -> $oct;
-	'\x'  /[0-9a-f]{1,2}/i -> $hex;
+	'\x'  /[0-9a-f]{0,2}/i -> $hex;
 	'\x{' /[0-9a-f]+/i '}' -> $hex;
+
+	'\0'  /[0-7]{0,2}/     -> $oct;
+
+	# "Inside a character class, or if the decimal number following \ is
+	# greater than 7 and there have not been that many capturing subpatterns,
+	# PCRE handles \8 and \9 as the literal characters "8" and "9", and
+	# otherwise re-reads up to three octal digits following the backslash,
+	# using them to generate a data character. Any subsequent digits stand
+	# for themselves. For example:"
+	#
+	# " \81    is either a back reference, or the two characters "8" and "1""
+	#
+	# For this reason I do not think we can ever lex correctly here, because
+	# we would need to produce either one or two tokens, depending on the
+	# presence of capturing groups.
+	'\'   /[1-9][0-9]*/     -> $unsupported;
 
 	'\' /./ - ($esc | $control | $oct | $hex | '\Q' | '\E' | '\B' | '\N' | '\R' | '\X' | $named__class) -> $noesc;
 	'\' -> $invalid;

--- a/src/libre/dialect/pcre/lexer.lx
+++ b/src/libre/dialect/pcre/lexer.lx
@@ -99,17 +99,38 @@
 # configurable line ending
 '\R' -> $eol;
 
-'\'   /[0-7]{2,3}/     -> $oct;
-'\0'                   -> $oct;
+'\o{' /[0-7]+/i '}'    -> $oct;
+'\x'  /[0-9a-f]{0,2}/i -> $hex;
+'\x{' /[0-9a-f]+/i '}' -> $hex;
 
-# PCRE treats \1 ... \7 as back references outside of a character class
+# "After \0 up to two further octal digits are read. If there are fewer
+# than two digits, just those that are present are used.
+# Thus the sequence \0\x\015 specifies two binary zeros followed by a
+# CR character (code value 13)."
+'\0'  /[0-7]{0,2}/     -> $oct;
+
+# "Outside a character class, a backslash followed by a digit greater than 0
+# (and possibly further digits) is a back reference to a capturing subpattern
+# earlier (that is, to its left) in the pattern, provided there have been that
+# many previous capturing left parentheses."
 #
-# It's actually more complicated than that.  \<digits> is treated as a
-# backref as long as there are _already_ that many capture groups in the
-# expression.  Given that back references are unsupported, this seems
-# like a overkill for a seldom-used feature.  However, it's nice to
-# indicate that the usual backrefs aren't supported.
-'\'   /[1-7]/          -> $unsupported;
+# "... PCRE reads the digit and any following digits as a decimal number."
+#
+# "However, if the decimal number following the backslash is less than 10,
+# it is always taken as a back reference, and causes an error only if there
+# are not that many capturing left parentheses in the entire pattern.
+# In other words, the parentheses that are referenced need not be to the left
+# of the reference for numbers less than 10. ... It is not possible to have a
+# numerical "forward back reference" to a subpattern whose number is 10 or more
+# using this syntax because a sequence such as \50 is interpreted as a character
+# defined in octal."
+#
+# So I take the pattern below to mean a decimal sequence which may be either
+# a backreference or something else (I presume a base 10 literal). Either way
+# I'm disallowing both of these here for now. I think it is possible that we
+# could lex and parse these eventually though (which I do not think we could
+# do for the same sequence inside a character class).
+'\'   /[1-9][0-9]*/    -> $unsupported;
 
 # the new and proper way for back references
 '\g' -> $unsupported;
@@ -157,10 +178,6 @@
 # supported
 '\b' -> $unsupported;
 '\B' -> $unsupported;
-
-'\o{' /[0-7]+/i '}'    -> $oct;
-'\x'  /[0-9a-f]{0,2}/i -> $hex;
-'\x{' /[0-9a-f]+/i '}' -> $hex;
 
 '\' /./ - ($esc | $control | $oct | $hex | '\Q' | '\A' | '\Z' | '\z' | '\E' | '\R' | $named__class | $unsupported) -> $noesc;
 '\' -> $invalid;

--- a/src/libre/dialect/pcre/parser.c
+++ b/src/libre/dialect/pcre/parser.c
@@ -300,25 +300,25 @@ static void p_expr_C_Cflags_C_Cflag__set(flags, lex_state, act_state, err, t_re_
 static void p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags, lex_state, act_state, err, t_endpoint *, t_pos *, t_pos *);
 static void p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms(flags, lex_state, act_state, err, t_ast__expr);
 static void p_expr_C_Clist_Hof_Hpieces(flags, lex_state, act_state, err, t_ast__expr);
-static void p_166(flags, lex_state, act_state, err);
-static void p_294(flags, lex_state, act_state, err, t_ast__class__id *, t_pos *, t_ast__expr *);
+static void p_168(flags, lex_state, act_state, err);
+static void p_296(flags, lex_state, act_state, err, t_ast__class__id *, t_pos *, t_ast__expr *);
 static void p_expr_C_Cliteral(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Ccomment(flags, lex_state, act_state, err);
 static void p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hclass(flags, lex_state, act_state, err, t_endpoint *, t_pos *, t_pos *);
 static void p_expr_C_Ccharacter_Hclass(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_Hend(flags, lex_state, act_state, err, t_endpoint *, t_pos *);
-static void p_314(flags, lex_state, act_state, err, t_char *, t_pos *, t_ast__expr *);
-static void p_317(flags, lex_state, act_state, err, t_pos *, t_unsigned *, t_ast__count *);
-static void p_318(flags, lex_state, act_state, err, t_pos *, t_unsigned *, t_ast__count *);
-static void p_192(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Cpiece(flags, lex_state, act_state, err, t_ast__expr *);
+static void p_320(flags, lex_state, act_state, err, t_char *, t_pos *, t_ast__expr *);
 static void p_expr(flags, lex_state, act_state, err, t_ast__expr *);
+static void p_194(flags, lex_state, act_state, err, t_ast__expr *);
+static void p_323(flags, lex_state, act_state, err, t_pos *, t_unsigned *, t_ast__count *);
+static void p_324(flags, lex_state, act_state, err, t_pos *, t_unsigned *, t_ast__count *);
 static void p_expr_C_Cflags(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Cpiece_C_Clist_Hof_Hcounts(flags, lex_state, act_state, err, t_ast__expr, t_ast__expr *);
 static void p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint(flags, lex_state, act_state, err, t_endpoint *, t_pos *, t_pos *);
-static void p_207(flags, lex_state, act_state, err, t_pos *, t_char *, t_ast__expr *);
 static void p_class_Hnamed(flags, lex_state, act_state, err, t_ast__expr *, t_pos *, t_pos *);
+static void p_209(flags, lex_state, act_state, err, t_pos *, t_char *, t_ast__expr *);
 static void p_expr_C_Clist_Hof_Halts(flags, lex_state, act_state, err, t_ast__expr);
 static void p_expr_C_Cpiece_C_Ccount(flags, lex_state, act_state, err, t_ast__count *);
 extern void p_re__pcre(flags, lex_state, act_state, err, t_ast__expr *);
@@ -462,7 +462,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 	{
 		t_char ZIc;
 
-		/* BEGINNING OF INLINE: 153 */
+		/* BEGINNING OF INLINE: 155 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CHAR):
@@ -679,11 +679,46 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 					ADVANCE_LEXER;
 				}
 				break;
+			case (TOK_UNSUPPORTED):
+				{
+					/* BEGINNING OF EXTRACT: UNSUPPORTED */
+					{
+#line 403 "src/libre/parser.act"
+
+		/* handle \1-\9 back references */
+		if (lex_state->buf.a[0] == '\\' && lex_state->buf.a[1] != '\0' && lex_state->buf.a[2] == '\0') {
+			ZIc = lex_state->buf.a[1];
+		}
+		else {
+			ZIc = lex_state->buf.a[0];
+		}
+
+		ZIstart = lex_state->lx.start;
+		ZIend   = lex_state->lx.end;
+	
+#line 700 "src/libre/dialect/pcre/parser.c"
+					}
+					/* END OF EXTRACT: UNSUPPORTED */
+					ADVANCE_LEXER;
+					/* BEGINNING OF ACTION: err-unsupported */
+					{
+#line 706 "src/libre/parser.act"
+
+		if (err->e == RE_ESUCCESS) {
+			err->e = RE_EXUNSUPPORTD;
+		}
+		goto ZL1;
+	
+#line 713 "src/libre/dialect/pcre/parser.c"
+					}
+					/* END OF ACTION: err-unsupported */
+				}
+				break;
 			default:
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 153 */
+		/* END OF INLINE: 155 */
 		/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 		{
 #line 802 "src/libre/parser.act"
@@ -691,7 +726,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 		(ZIr).type = AST_ENDPOINT_LITERAL;
 		(ZIr).u.literal.c = (ZIc);
 	
-#line 695 "src/libre/dialect/pcre/parser.c"
+#line 730 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-range-endpoint-literal */
 	}
@@ -711,7 +746,7 @@ p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms(flags flags, lex_state lex_
 ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 	switch (CURRENT_TERMINAL) {
 	case (TOK_NAMED__CLASS): case (TOK_ESC): case (TOK_NOESC): case (TOK_CONTROL):
-	case (TOK_OCT): case (TOK_HEX): case (TOK_CHAR):
+	case (TOK_OCT): case (TOK_HEX): case (TOK_CHAR): case (TOK_UNSUPPORTED):
 		{
 			t_ast__expr ZInode;
 
@@ -728,7 +763,7 @@ ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 			goto ZL1;
 		}
 	
-#line 732 "src/libre/dialect/pcre/parser.c"
+#line 767 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 			/* BEGINNING OF INLINE: expr::character-class::list-of-class-terms */
@@ -755,7 +790,7 @@ p_expr_C_Clist_Hof_Hpieces(flags flags, lex_state lex_state, act_state act_state
 	}
 ZL2_expr_C_Clist_Hof_Hpieces:;
 	{
-		/* BEGINNING OF INLINE: 271 */
+		/* BEGINNING OF INLINE: 273 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_INVALID__COMMENT):
@@ -788,7 +823,7 @@ ZL2_expr_C_Clist_Hof_Hpieces:;
 			goto ZL1;
 		}
 	
-#line 792 "src/libre/dialect/pcre/parser.c"
+#line 827 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-add-concat */
 				}
@@ -797,8 +832,8 @@ ZL2_expr_C_Clist_Hof_Hpieces:;
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 271 */
-		/* BEGINNING OF INLINE: 272 */
+		/* END OF INLINE: 273 */
+		/* BEGINNING OF INLINE: 274 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_EOL): case (TOK_START): case (TOK_END):
@@ -816,7 +851,7 @@ ZL2_expr_C_Clist_Hof_Hpieces:;
 				break;
 			}
 		}
-		/* END OF INLINE: 272 */
+		/* END OF INLINE: 274 */
 	}
 	return;
 ZL1:;
@@ -825,15 +860,15 @@ ZL1:;
 }
 
 static void
-p_166(flags flags, lex_state lex_state, act_state act_state, err err)
+p_168(flags flags, lex_state lex_state, act_state act_state, err err)
 {
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 		return;
 	}
 	{
-		t_char ZI167;
-		t_pos ZI168;
-		t_pos ZI169;
+		t_char ZI169;
+		t_pos ZI170;
+		t_pos ZI171;
 
 		switch (CURRENT_TERMINAL) {
 		case (TOK_RANGE):
@@ -841,11 +876,11 @@ p_166(flags flags, lex_state lex_state, act_state act_state, err err)
 			{
 #line 319 "src/libre/parser.act"
 
-		ZI167 = '-';
-		ZI168 = lex_state->lx.start;
-		ZI169   = lex_state->lx.end;
+		ZI169 = '-';
+		ZI170 = lex_state->lx.start;
+		ZI171   = lex_state->lx.end;
 	
-#line 849 "src/libre/dialect/pcre/parser.c"
+#line 884 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			break;
@@ -866,7 +901,7 @@ ZL1:;
 		}
 		goto ZL2;
 	
-#line 870 "src/libre/dialect/pcre/parser.c"
+#line 905 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-expected-range */
 	}
@@ -878,7 +913,7 @@ ZL0:;
 }
 
 static void
-p_294(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class__id *ZI291, t_pos *ZI292, t_ast__expr *ZOnode)
+p_296(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class__id *ZI293, t_pos *ZI294, t_ast__expr *ZOnode)
 {
 	t_ast__expr ZInode;
 
@@ -889,12 +924,12 @@ p_294(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 			{
 #line 990 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_named(act_state->poolp, *flags, (*ZI291));
+		(ZInode) = ast_make_expr_named(act_state->poolp, *flags, (*ZI293));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 898 "src/libre/dialect/pcre/parser.c"
+#line 933 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 		}
@@ -910,12 +945,12 @@ p_294(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 #line 807 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_NAMED;
-		(ZIlower).u.named.class = (*ZI291);
+		(ZIlower).u.named.class = (*ZI293);
 	
-#line 916 "src/libre/dialect/pcre/parser.c"
+#line 951 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-class */
-			p_166 (flags, lex_state, act_state, err);
+			p_168 (flags, lex_state, act_state, err);
 			p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_Hend (flags, lex_state, act_state, err, &ZIupper, &ZIend);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
@@ -925,10 +960,10 @@ p_294(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 			{
 #line 715 "src/libre/parser.act"
 
-		mark(&act_state->rangestart, &(*ZI292));
+		mark(&act_state->rangestart, &(*ZI294));
 		mark(&act_state->rangeend,   &(ZIend));
 	
-#line 932 "src/libre/dialect/pcre/parser.c"
+#line 967 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-make-range */
@@ -938,7 +973,7 @@ p_294(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI292));
+		AST_POS_OF_LX_POS(ast_start, (*ZI294));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		if ((ZIlower).type != AST_ENDPOINT_LITERAL ||
@@ -966,7 +1001,7 @@ p_294(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 			goto ZL1;
 		}
 	
-#line 970 "src/libre/dialect/pcre/parser.c"
+#line 1005 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -1013,7 +1048,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 1017 "src/libre/dialect/pcre/parser.c"
+#line 1052 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CHAR */
 					ADVANCE_LEXER;
@@ -1060,7 +1095,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		ZI123 = lex_state->lx.start;
 		ZI124   = lex_state->lx.end;
 	
-#line 1064 "src/libre/dialect/pcre/parser.c"
+#line 1099 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CONTROL */
 					ADVANCE_LEXER;
@@ -1096,7 +1131,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		ZI113 = lex_state->lx.start;
 		ZI114   = lex_state->lx.end;
 	
-#line 1100 "src/libre/dialect/pcre/parser.c"
+#line 1135 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: ESC */
 					ADVANCE_LEXER;
@@ -1154,7 +1189,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 1158 "src/libre/dialect/pcre/parser.c"
+#line 1193 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: HEX */
 					ADVANCE_LEXER;
@@ -1178,7 +1213,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		ZI115 = lex_state->lx.start;
 		ZI116   = lex_state->lx.end;
 	
-#line 1182 "src/libre/dialect/pcre/parser.c"
+#line 1217 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: NOESC */
 					ADVANCE_LEXER;
@@ -1231,7 +1266,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 1235 "src/libre/dialect/pcre/parser.c"
+#line 1270 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OCT */
 					ADVANCE_LEXER;
@@ -1257,7 +1292,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		ZI125 = lex_state->lx.start;
 		ZI126   = lex_state->lx.end;
 	
-#line 1261 "src/libre/dialect/pcre/parser.c"
+#line 1296 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: UNSUPPORTED */
 					ADVANCE_LEXER;
@@ -1270,7 +1305,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		}
 		goto ZL1;
 	
-#line 1274 "src/libre/dialect/pcre/parser.c"
+#line 1309 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: err-unsupported */
 				}
@@ -1289,7 +1324,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 			goto ZL1;
 		}
 	
-#line 1293 "src/libre/dialect/pcre/parser.c"
+#line 1328 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-literal */
 	}
@@ -1309,9 +1344,9 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CHAR):
 		{
-			t_char ZI307;
-			t_pos ZI308;
-			t_pos ZI309;
+			t_char ZI309;
+			t_pos ZI310;
+			t_pos ZI311;
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
@@ -1320,16 +1355,16 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI308 = lex_state->lx.start;
-		ZI309   = lex_state->lx.end;
+		ZI310 = lex_state->lx.start;
+		ZI311   = lex_state->lx.end;
 
-		ZI307 = lex_state->buf.a[0];
+		ZI309 = lex_state->buf.a[0];
 	
-#line 1329 "src/libre/dialect/pcre/parser.c"
+#line 1364 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
-			p_314 (flags, lex_state, act_state, err, &ZI307, &ZI308, &ZInode);
+			p_320 (flags, lex_state, act_state, err, &ZI309, &ZI310, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1338,9 +1373,9 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		break;
 	case (TOK_CONTROL):
 		{
-			t_char ZI311;
-			t_pos ZI312;
-			t_pos ZI313;
+			t_char ZI313;
+			t_pos ZI314;
+			t_pos ZI315;
 
 			/* BEGINNING OF EXTRACT: CONTROL */
 			{
@@ -1351,7 +1386,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		assert(lex_state->buf.a[2] != '\0');
 		assert(lex_state->buf.a[3] == '\0');
 
-		ZI311 = lex_state->buf.a[2];
+		ZI313 = lex_state->buf.a[2];
 		/* from http://www.pcre.org/current/doc/html/pcre2pattern.html#SEC5
 		 * 
 		 *  The precise effect of \cx on ASCII characters is as follows: if x is a lower case letter, it is converted to
@@ -1361,7 +1396,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		 */
 
 		{
-			unsigned char cc = (unsigned char)ZI311;
+			unsigned char cc = (unsigned char)ZI313;
 			if (cc > 126 || cc < 32) {
 				goto ZL1;
 			}
@@ -1372,13 +1407,13 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			cc ^= 0x40;
 
-			ZI311 = cc;
+			ZI313 = cc;
 		}
 
-		ZI312 = lex_state->lx.start;
-		ZI313   = lex_state->lx.end;
+		ZI314 = lex_state->lx.start;
+		ZI315   = lex_state->lx.end;
 	
-#line 1382 "src/libre/dialect/pcre/parser.c"
+#line 1417 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: CONTROL */
 			ADVANCE_LEXER;
@@ -1391,10 +1426,10 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		}
 		goto ZL1;
 	
-#line 1395 "src/libre/dialect/pcre/parser.c"
+#line 1430 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: err-unsupported */
-			p_314 (flags, lex_state, act_state, err, &ZI311, &ZI312, &ZInode);
+			p_320 (flags, lex_state, act_state, err, &ZI313, &ZI314, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1403,9 +1438,9 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		break;
 	case (TOK_ESC):
 		{
-			t_char ZI295;
-			t_pos ZI296;
-			t_pos ZI297;
+			t_char ZI297;
+			t_pos ZI298;
+			t_pos ZI299;
 
 			/* BEGINNING OF EXTRACT: ESC */
 			{
@@ -1415,28 +1450,28 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		assert(lex_state->buf.a[1] != '\0');
 		assert(lex_state->buf.a[2] == '\0');
 
-		ZI295 = lex_state->buf.a[1];
+		ZI297 = lex_state->buf.a[1];
 
-		switch (ZI295) {
-		case 'a': ZI295 = '\a'; break;
-		case 'b': ZI295 = '\b'; break;
-		case 'e': ZI295 = '\033'; break;
-		case 'f': ZI295 = '\f'; break;
-		case 'n': ZI295 = '\n'; break;
-		case 'r': ZI295 = '\r'; break;
-		case 't': ZI295 = '\t'; break;
-		case 'v': ZI295 = '\v'; break;
+		switch (ZI297) {
+		case 'a': ZI297 = '\a'; break;
+		case 'b': ZI297 = '\b'; break;
+		case 'e': ZI297 = '\033'; break;
+		case 'f': ZI297 = '\f'; break;
+		case 'n': ZI297 = '\n'; break;
+		case 'r': ZI297 = '\r'; break;
+		case 't': ZI297 = '\t'; break;
+		case 'v': ZI297 = '\v'; break;
 		default:             break;
 		}
 
-		ZI296 = lex_state->lx.start;
-		ZI297   = lex_state->lx.end;
+		ZI298 = lex_state->lx.start;
+		ZI299   = lex_state->lx.end;
 	
-#line 1436 "src/libre/dialect/pcre/parser.c"
+#line 1471 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: ESC */
 			ADVANCE_LEXER;
-			p_314 (flags, lex_state, act_state, err, &ZI295, &ZI296, &ZInode);
+			p_320 (flags, lex_state, act_state, err, &ZI297, &ZI298, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1445,9 +1480,9 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		break;
 	case (TOK_HEX):
 		{
-			t_char ZI303;
-			t_pos ZI304;
-			t_pos ZI305;
+			t_char ZI305;
+			t_pos ZI306;
+			t_pos ZI307;
 
 			/* BEGINNING OF EXTRACT: HEX */
 			{
@@ -1460,8 +1495,8 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		assert(0 == strncmp(lex_state->buf.a, "\\x", 2));
 		assert(strlen(lex_state->buf.a) >= 2);  /* pcre allows \x without a suffix */
 
-		ZI304 = lex_state->lx.start;
-		ZI305   = lex_state->lx.end;
+		ZI306 = lex_state->lx.start;
+		ZI307   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -1494,13 +1529,13 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 			goto ZL1;
 		}
 
-		ZI303 = (char) (unsigned char) u;
+		ZI305 = (char) (unsigned char) u;
 	
-#line 1500 "src/libre/dialect/pcre/parser.c"
+#line 1535 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: HEX */
 			ADVANCE_LEXER;
-			p_314 (flags, lex_state, act_state, err, &ZI303, &ZI304, &ZInode);
+			p_320 (flags, lex_state, act_state, err, &ZI305, &ZI306, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1509,28 +1544,28 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		break;
 	case (TOK_NAMED__CLASS):
 		{
-			t_ast__class__id ZI291;
-			t_pos ZI292;
-			t_pos ZI293;
+			t_ast__class__id ZI293;
+			t_pos ZI294;
+			t_pos ZI295;
 
 			/* BEGINNING OF EXTRACT: NAMED_CLASS */
 			{
 #line 593 "src/libre/parser.act"
 
-		ZI291 = DIALECT_CLASS(lex_state->buf.a);
-		if (ZI291 == NULL) {
+		ZI293 = DIALECT_CLASS(lex_state->buf.a);
+		if (ZI293 == NULL) {
 			/* syntax error -- unrecognized class */
 			goto ZL1;
 		}
 
-		ZI292 = lex_state->lx.start;
-		ZI293   = lex_state->lx.end;
+		ZI294 = lex_state->lx.start;
+		ZI295   = lex_state->lx.end;
 	
-#line 1530 "src/libre/dialect/pcre/parser.c"
+#line 1565 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			ADVANCE_LEXER;
-			p_294 (flags, lex_state, act_state, err, &ZI291, &ZI292, &ZInode);
+			p_296 (flags, lex_state, act_state, err, &ZI293, &ZI294, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1556,7 +1591,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		ZI134 = lex_state->lx.start;
 		ZI135   = lex_state->lx.end;
 	
-#line 1560 "src/libre/dialect/pcre/parser.c"
+#line 1595 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: NOESC */
 			ADVANCE_LEXER;
@@ -1569,16 +1604,16 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 			goto ZL1;
 		}
 	
-#line 1573 "src/libre/dialect/pcre/parser.c"
+#line 1608 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
 		break;
 	case (TOK_OCT):
 		{
-			t_char ZI299;
-			t_pos ZI300;
-			t_pos ZI301;
+			t_char ZI301;
+			t_pos ZI302;
+			t_pos ZI303;
 
 			/* BEGINNING OF EXTRACT: OCT */
 			{
@@ -1591,8 +1626,8 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
 		assert(strlen(lex_state->buf.a) >= 2);
 
-		ZI300 = lex_state->lx.start;
-		ZI301   = lex_state->lx.end;
+		ZI302 = lex_state->lx.start;
+		ZI303   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -1620,13 +1655,57 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 			goto ZL1;
 		}
 
-		ZI299 = (char) (unsigned char) u;
+		ZI301 = (char) (unsigned char) u;
 	
-#line 1626 "src/libre/dialect/pcre/parser.c"
+#line 1661 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: OCT */
 			ADVANCE_LEXER;
-			p_314 (flags, lex_state, act_state, err, &ZI299, &ZI300, &ZInode);
+			p_320 (flags, lex_state, act_state, err, &ZI301, &ZI302, &ZInode);
+			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+				RESTORE_LEXER;
+				goto ZL1;
+			}
+		}
+		break;
+	case (TOK_UNSUPPORTED):
+		{
+			t_char ZI317;
+			t_pos ZI318;
+			t_pos ZI319;
+
+			/* BEGINNING OF EXTRACT: UNSUPPORTED */
+			{
+#line 403 "src/libre/parser.act"
+
+		/* handle \1-\9 back references */
+		if (lex_state->buf.a[0] == '\\' && lex_state->buf.a[1] != '\0' && lex_state->buf.a[2] == '\0') {
+			ZI317 = lex_state->buf.a[1];
+		}
+		else {
+			ZI317 = lex_state->buf.a[0];
+		}
+
+		ZI318 = lex_state->lx.start;
+		ZI319   = lex_state->lx.end;
+	
+#line 1693 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF EXTRACT: UNSUPPORTED */
+			ADVANCE_LEXER;
+			/* BEGINNING OF ACTION: err-unsupported */
+			{
+#line 706 "src/libre/parser.act"
+
+		if (err->e == RE_ESUCCESS) {
+			err->e = RE_EXUNSUPPORTD;
+		}
+		goto ZL1;
+	
+#line 1706 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: err-unsupported */
+			p_320 (flags, lex_state, act_state, err, &ZI317, &ZI318, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1669,7 +1748,7 @@ p_expr_C_Ccomment(flags flags, lex_state lex_state, act_state act_state, err err
 		}
 		goto ZL1;
 	
-#line 1673 "src/libre/dialect/pcre/parser.c"
+#line 1752 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-invalid-comment */
 	}
@@ -1707,7 +1786,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hclass(flags fl
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1711 "src/libre/dialect/pcre/parser.c"
+#line 1790 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			break;
@@ -1722,7 +1801,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hclass(flags fl
 		(ZIr).type = AST_ENDPOINT_NAMED;
 		(ZIr).u.named.class = (ZIid);
 	
-#line 1726 "src/libre/dialect/pcre/parser.c"
+#line 1805 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-range-endpoint-class */
 	}
@@ -1749,21 +1828,21 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		t_ast__expr ZItmp;
 		t_pos ZIend;
 
-		/* BEGINNING OF INLINE: 178 */
+		/* BEGINNING OF INLINE: 180 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_OPENGROUP):
 				{
-					t_pos ZI179;
+					t_pos ZI181;
 
 					/* BEGINNING OF EXTRACT: OPENGROUP */
 					{
 #line 325 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
-		ZI179   = lex_state->lx.end;
+		ZI181   = lex_state->lx.end;
 	
-#line 1767 "src/libre/dialect/pcre/parser.c"
+#line 1846 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OPENGROUP */
 					ADVANCE_LEXER;
@@ -1776,11 +1855,11 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			goto ZL1;
 		}
 	
-#line 1780 "src/libre/dialect/pcre/parser.c"
+#line 1859 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-alt */
 					ZItmp = ZInode;
-					p_192 (flags, lex_state, act_state, err, &ZItmp);
+					p_194 (flags, lex_state, act_state, err, &ZItmp);
 					p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, ZItmp);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
@@ -1790,7 +1869,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 				break;
 			case (TOK_OPENGROUPCB):
 				{
-					t_pos ZI198;
+					t_pos ZI200;
 					t_char ZIcbrak;
 					t_ast__expr ZInode1;
 
@@ -1799,9 +1878,9 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 #line 335 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
-		ZI198   = lex_state->lx.end;
+		ZI200   = lex_state->lx.end;
 	
-#line 1805 "src/libre/dialect/pcre/parser.c"
+#line 1884 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OPENGROUPCB */
 					ADVANCE_LEXER;
@@ -1814,7 +1893,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			goto ZL1;
 		}
 	
-#line 1818 "src/libre/dialect/pcre/parser.c"
+#line 1897 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-alt */
 					ZItmp = ZInode;
@@ -1824,10 +1903,10 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 		(ZIcbrak) = ']';
 	
-#line 1828 "src/libre/dialect/pcre/parser.c"
+#line 1907 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: make-literal-cbrak */
-					p_207 (flags, lex_state, act_state, err, &ZIstart, &ZIcbrak, &ZInode1);
+					p_209 (flags, lex_state, act_state, err, &ZIstart, &ZIcbrak, &ZInode1);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL1;
@@ -1840,7 +1919,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			goto ZL1;
 		}
 	
-#line 1844 "src/libre/dialect/pcre/parser.c"
+#line 1923 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-add-alt */
 					p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, ZItmp);
@@ -1852,16 +1931,16 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 				break;
 			case (TOK_OPENGROUPINV):
 				{
-					t_pos ZI190;
+					t_pos ZI192;
 
 					/* BEGINNING OF EXTRACT: OPENGROUPINV */
 					{
 #line 330 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
-		ZI190   = lex_state->lx.end;
+		ZI192   = lex_state->lx.end;
 	
-#line 1865 "src/libre/dialect/pcre/parser.c"
+#line 1944 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OPENGROUPINV */
 					ADVANCE_LEXER;
@@ -1874,7 +1953,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			goto ZL1;
 		}
 	
-#line 1878 "src/libre/dialect/pcre/parser.c"
+#line 1957 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-alt */
 					ZItmp = ZInode;
@@ -1918,10 +1997,10 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			goto ZL1;
 		}
 	
-#line 1922 "src/libre/dialect/pcre/parser.c"
+#line 2001 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-invert */
-					p_192 (flags, lex_state, act_state, err, &ZItmp);
+					p_194 (flags, lex_state, act_state, err, &ZItmp);
 					p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, ZItmp);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
@@ -1931,7 +2010,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 				break;
 			case (TOK_OPENGROUPINVCB):
 				{
-					t_pos ZI205;
+					t_pos ZI207;
 					t_char ZIcbrak;
 					t_ast__expr ZInode1;
 
@@ -1940,9 +2019,9 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 #line 340 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
-		ZI205   = lex_state->lx.end;
+		ZI207   = lex_state->lx.end;
 	
-#line 1946 "src/libre/dialect/pcre/parser.c"
+#line 2025 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OPENGROUPINVCB */
 					ADVANCE_LEXER;
@@ -1955,7 +2034,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			goto ZL1;
 		}
 	
-#line 1959 "src/libre/dialect/pcre/parser.c"
+#line 2038 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-alt */
 					ZItmp = ZInode;
@@ -1999,7 +2078,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			goto ZL1;
 		}
 	
-#line 2003 "src/libre/dialect/pcre/parser.c"
+#line 2082 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-invert */
 					/* BEGINNING OF ACTION: make-literal-cbrak */
@@ -2008,10 +2087,10 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 		(ZIcbrak) = ']';
 	
-#line 2012 "src/libre/dialect/pcre/parser.c"
+#line 2091 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: make-literal-cbrak */
-					p_207 (flags, lex_state, act_state, err, &ZIstart, &ZIcbrak, &ZInode1);
+					p_209 (flags, lex_state, act_state, err, &ZIstart, &ZIcbrak, &ZInode1);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL1;
@@ -2024,7 +2103,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			goto ZL1;
 		}
 	
-#line 2028 "src/libre/dialect/pcre/parser.c"
+#line 2107 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-add-alt */
 					p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, ZItmp);
@@ -2038,24 +2117,24 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 178 */
-		/* BEGINNING OF INLINE: 211 */
+		/* END OF INLINE: 180 */
+		/* BEGINNING OF INLINE: 213 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CLOSEGROUP):
 				{
-					t_char ZI212;
-					t_pos ZI213;
+					t_char ZI214;
+					t_pos ZI215;
 
 					/* BEGINNING OF EXTRACT: CLOSEGROUP */
 					{
 #line 345 "src/libre/parser.act"
 
-		ZI212 = ']';
-		ZI213 = lex_state->lx.start;
+		ZI214 = ']';
+		ZI215 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 2059 "src/libre/dialect/pcre/parser.c"
+#line 2138 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CLOSEGROUP */
 					ADVANCE_LEXER;
@@ -2066,7 +2145,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		mark(&act_state->groupstart, &(ZIstart));
 		mark(&act_state->groupend,   &(ZIend));
 	
-#line 2070 "src/libre/dialect/pcre/parser.c"
+#line 2149 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: mark-group */
 				}
@@ -2074,7 +2153,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			case (TOK_CLOSEGROUPRANGE):
 				{
 					t_char ZIcrange;
-					t_pos ZI215;
+					t_pos ZI217;
 					t_ast__expr ZIrange;
 
 					/* BEGINNING OF EXTRACT: CLOSEGROUPRANGE */
@@ -2082,10 +2161,10 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 #line 351 "src/libre/parser.act"
 
 		ZIcrange = '-';
-		ZI215 = lex_state->lx.start;
+		ZI217 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 2089 "src/libre/dialect/pcre/parser.c"
+#line 2168 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CLOSEGROUPRANGE */
 					ADVANCE_LEXER;
@@ -2098,7 +2177,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			goto ZL4;
 		}
 	
-#line 2102 "src/libre/dialect/pcre/parser.c"
+#line 2181 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-literal */
 					/* BEGINNING OF ACTION: ast-add-alt */
@@ -2109,7 +2188,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			goto ZL4;
 		}
 	
-#line 2113 "src/libre/dialect/pcre/parser.c"
+#line 2192 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-add-alt */
 					/* BEGINNING OF ACTION: mark-group */
@@ -2119,7 +2198,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		mark(&act_state->groupstart, &(ZIstart));
 		mark(&act_state->groupend,   &(ZIend));
 	
-#line 2123 "src/libre/dialect/pcre/parser.c"
+#line 2202 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: mark-group */
 				}
@@ -2139,14 +2218,14 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		}
 		goto ZL1;
 	
-#line 2143 "src/libre/dialect/pcre/parser.c"
+#line 2222 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: err-expected-closegroup */
 				ZIend = ZIstart;
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 211 */
+		/* END OF INLINE: 213 */
 		/* BEGINNING OF ACTION: mark-expr */
 		{
 #line 727 "src/libre/parser.act"
@@ -2164,7 +2243,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		(ZItmp)->u.class.end   = ast_end;
 */
 	
-#line 2168 "src/libre/dialect/pcre/parser.c"
+#line 2247 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: mark-expr */
 	}
@@ -2186,23 +2265,23 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_Hend(flags flags, lex_state lex_st
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 159 */
+		/* BEGINNING OF INLINE: 161 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_RANGE):
 				{
 					t_char ZIc;
-					t_pos ZI161;
+					t_pos ZI163;
 
 					/* BEGINNING OF EXTRACT: RANGE */
 					{
 #line 319 "src/libre/parser.act"
 
 		ZIc = '-';
-		ZI161 = lex_state->lx.start;
+		ZI163 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 2206 "src/libre/dialect/pcre/parser.c"
+#line 2285 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: RANGE */
 					ADVANCE_LEXER;
@@ -2213,17 +2292,17 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_Hend(flags flags, lex_state lex_st
 		(ZIr).type = AST_ENDPOINT_LITERAL;
 		(ZIr).u.literal.c = (ZIc);
 	
-#line 2217 "src/libre/dialect/pcre/parser.c"
+#line 2296 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-range-endpoint-literal */
 				}
 				break;
 			case (TOK_NAMED__CLASS): case (TOK_ESC): case (TOK_CONTROL): case (TOK_OCT):
-			case (TOK_HEX): case (TOK_CHAR):
+			case (TOK_HEX): case (TOK_CHAR): case (TOK_UNSUPPORTED):
 				{
-					t_pos ZI160;
+					t_pos ZI162;
 
-					p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint (flags, lex_state, act_state, err, &ZIr, &ZI160, &ZIend);
+					p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint (flags, lex_state, act_state, err, &ZIr, &ZI162, &ZIend);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL1;
@@ -2234,7 +2313,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_Hend(flags flags, lex_state lex_st
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 159 */
+		/* END OF INLINE: 161 */
 	}
 	goto ZL0;
 ZL1:;
@@ -2246,7 +2325,80 @@ ZL0:;
 }
 
 static void
-p_314(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI311, t_pos *ZI312, t_ast__expr *ZOnode)
+p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
+{
+	t_ast__expr ZInode;
+
+	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+		return;
+	}
+	{
+		t_ast__expr ZIe;
+
+		p_expr_C_Cpiece_C_Catom (flags, lex_state, act_state, err, &ZIe);
+		/* BEGINNING OF INLINE: 267 */
+		{
+			switch (CURRENT_TERMINAL) {
+			case (TOK_OPT): case (TOK_PLUS): case (TOK_STAR): case (TOK_OPENCOUNT):
+				{
+					p_expr_C_Cpiece_C_Clist_Hof_Hcounts (flags, lex_state, act_state, err, ZIe, &ZInode);
+					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+						RESTORE_LEXER;
+						goto ZL1;
+					}
+				}
+				break;
+			default:
+				{
+					t_ast__count ZIc;
+
+					/* BEGINNING OF ACTION: count-one */
+					{
+#line 778 "src/libre/parser.act"
+
+		(ZIc) = ast_make_count(1, NULL, 1, NULL);
+	
+#line 2362 "src/libre/dialect/pcre/parser.c"
+					}
+					/* END OF ACTION: count-one */
+					/* BEGINNING OF ACTION: ast-make-piece */
+					{
+#line 860 "src/libre/parser.act"
+
+		if ((ZIc).min == 0 && (ZIc).max == 0) {
+			(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
+		} else if ((ZIc).min == 1 && (ZIc).max == 1) {
+			(ZInode) = (ZIe);
+		} else {
+			(ZInode) = ast_make_expr_repeat(act_state->poolp, *flags, (ZIe), (ZIc));
+		}
+		if ((ZInode) == NULL) {
+			err->e = RE_EXEOF;
+			goto ZL1;
+		}
+	
+#line 2381 "src/libre/dialect/pcre/parser.c"
+					}
+					/* END OF ACTION: ast-make-piece */
+				}
+				break;
+			case (ERROR_TERMINAL):
+				RESTORE_LEXER;
+				goto ZL1;
+			}
+		}
+		/* END OF INLINE: 267 */
+	}
+	goto ZL0;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+ZL0:;
+	*ZOnode = ZInode;
+}
+
+static void
+p_320(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI317, t_pos *ZI318, t_ast__expr *ZOnode)
 {
 	t_ast__expr ZInode;
 
@@ -2257,12 +2409,12 @@ p_314(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			{
 #line 837 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (*ZI311));
+		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (*ZI317));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2266 "src/libre/dialect/pcre/parser.c"
+#line 2418 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -2278,12 +2430,12 @@ p_314(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 #line 802 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_LITERAL;
-		(ZIlower).u.literal.c = (*ZI311);
+		(ZIlower).u.literal.c = (*ZI317);
 	
-#line 2284 "src/libre/dialect/pcre/parser.c"
+#line 2436 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
-			p_166 (flags, lex_state, act_state, err);
+			p_168 (flags, lex_state, act_state, err);
 			p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_Hend (flags, lex_state, act_state, err, &ZIupper, &ZIend);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
@@ -2293,10 +2445,10 @@ p_314(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			{
 #line 715 "src/libre/parser.act"
 
-		mark(&act_state->rangestart, &(*ZI312));
+		mark(&act_state->rangestart, &(*ZI318));
 		mark(&act_state->rangeend,   &(ZIend));
 	
-#line 2300 "src/libre/dialect/pcre/parser.c"
+#line 2452 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-make-range */
@@ -2306,7 +2458,7 @@ p_314(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI312));
+		AST_POS_OF_LX_POS(ast_start, (*ZI318));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		if ((ZIlower).type != AST_ENDPOINT_LITERAL ||
@@ -2334,7 +2486,7 @@ p_314(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			goto ZL1;
 		}
 	
-#line 2338 "src/libre/dialect/pcre/parser.c"
+#line 2490 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -2351,264 +2503,77 @@ ZL0:;
 }
 
 static void
-p_317(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI315, t_unsigned *ZIm, t_ast__count *ZOc)
+p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
 {
-	t_ast__count ZIc;
+	t_ast__expr ZInode;
 
-	switch (CURRENT_TERMINAL) {
-	case (TOK_CLOSECOUNT):
+	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+		return;
+	}
+	{
+		/* BEGINNING OF ACTION: ast-make-alt */
 		{
-			t_pos ZI256;
-			t_pos ZIend;
+#line 830 "src/libre/parser.act"
 
-			/* BEGINNING OF EXTRACT: CLOSECOUNT */
-			{
-#line 362 "src/libre/parser.act"
-
-		ZI256 = lex_state->lx.start;
-		ZIend   = lex_state->lx.end;
-	
-#line 2372 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF EXTRACT: CLOSECOUNT */
-			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: mark-count */
-			{
-#line 720 "src/libre/parser.act"
-
-		mark(&act_state->countstart, &(*ZI315));
-		mark(&act_state->countend,   &(ZIend));
-	
-#line 2383 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: mark-count */
-			/* BEGINNING OF ACTION: count-range */
-			{
-#line 784 "src/libre/parser.act"
-
-		struct ast_pos ast_start, ast_end;
-
-		if ((*ZIm) < (*ZIm)) {
-			err->e = RE_ENEGCOUNT;
-			err->m = (*ZIm);
-			err->n = (*ZIm);
-
-			mark(&act_state->countstart, &(*ZI315));
-			mark(&act_state->countend,   &(ZIend));
-
+		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
+		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
-
-		AST_POS_OF_LX_POS(ast_start, (*ZI315));
-		AST_POS_OF_LX_POS(ast_end, (ZIend));
-
-		(ZIc) = ast_make_count((*ZIm), &ast_start, (*ZIm), &ast_end);
 	
-#line 2408 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: count-range */
+#line 2524 "src/libre/dialect/pcre/parser.c"
 		}
-		break;
-	case (TOK_SEP):
-		{
-			ADVANCE_LEXER;
-			p_318 (flags, lex_state, act_state, err, ZI315, ZIm, &ZIc);
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			}
+		/* END OF ACTION: ast-make-alt */
+		p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, ZInode);
+		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+			RESTORE_LEXER;
+			goto ZL1;
 		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
-	default:
-		goto ZL1;
 	}
 	goto ZL0;
 ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOc = ZIc;
-}
-
-static void
-p_318(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI315, t_unsigned *ZIm, t_ast__count *ZOc)
-{
-	t_ast__count ZIc;
-
-	switch (CURRENT_TERMINAL) {
-	case (TOK_CLOSECOUNT):
+	{
+		/* BEGINNING OF ACTION: err-expected-alts */
 		{
-			t_pos ZI261;
-			t_pos ZIend;
-			t_unsigned ZIn;
+#line 657 "src/libre/parser.act"
 
-			/* BEGINNING OF EXTRACT: CLOSECOUNT */
-			{
-#line 362 "src/libre/parser.act"
-
-		ZI261 = lex_state->lx.start;
-		ZIend   = lex_state->lx.end;
-	
-#line 2455 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF EXTRACT: CLOSECOUNT */
-			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: mark-count */
-			{
-#line 720 "src/libre/parser.act"
-
-		mark(&act_state->countstart, &(*ZI315));
-		mark(&act_state->countend,   &(ZIend));
-	
-#line 2466 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: mark-count */
-			/* BEGINNING OF ACTION: count-unbounded */
-			{
-#line 762 "src/libre/parser.act"
-
-		(ZIn) = AST_COUNT_UNBOUNDED;
-	
-#line 2475 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: count-unbounded */
-			/* BEGINNING OF ACTION: count-range */
-			{
-#line 784 "src/libre/parser.act"
-
-		struct ast_pos ast_start, ast_end;
-
-		if ((ZIn) < (*ZIm)) {
-			err->e = RE_ENEGCOUNT;
-			err->m = (*ZIm);
-			err->n = (ZIn);
-
-			mark(&act_state->countstart, &(*ZI315));
-			mark(&act_state->countend,   &(ZIend));
-
-			goto ZL1;
+		if (err->e == RE_ESUCCESS) {
+			err->e = RE_EXALTS;
 		}
-
-		AST_POS_OF_LX_POS(ast_start, (*ZI315));
-		AST_POS_OF_LX_POS(ast_end, (ZIend));
-
-		(ZIc) = ast_make_count((*ZIm), &ast_start, (ZIn), &ast_end);
+		goto ZL2;
 	
-#line 2500 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: count-range */
+#line 2545 "src/libre/dialect/pcre/parser.c"
 		}
-		break;
-	case (TOK_COUNT):
+		/* END OF ACTION: err-expected-alts */
+		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-			t_unsigned ZIn;
-			t_pos ZI259;
-			t_pos ZIend;
+#line 816 "src/libre/parser.act"
 
-			/* BEGINNING OF EXTRACT: COUNT */
-			{
-#line 581 "src/libre/parser.act"
-
-		unsigned long u;
-		char *e;
-
-		u = strtoul(lex_state->buf.a, &e, 10);
-
-		if ((u == ULONG_MAX && errno == ERANGE) || u > UINT_MAX) {
-			err->e = RE_ECOUNTRANGE;
-			snprintdots(err->esc, sizeof err->esc, lex_state->buf.a);
-			goto ZL1;
+		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
+		if ((ZInode) == NULL) {
+			goto ZL2;
 		}
-
-		if ((u == ULONG_MAX && errno != 0) || *e != '\0') {
-			err->e = RE_EXCOUNT;
-			goto ZL1;
+	
+#line 2557 "src/libre/dialect/pcre/parser.c"
 		}
-
-		ZIn = (unsigned int) u;
-	
-#line 2533 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF EXTRACT: COUNT */
-			ADVANCE_LEXER;
-			switch (CURRENT_TERMINAL) {
-			case (TOK_CLOSECOUNT):
-				/* BEGINNING OF EXTRACT: CLOSECOUNT */
-				{
-#line 362 "src/libre/parser.act"
-
-		ZI259 = lex_state->lx.start;
-		ZIend   = lex_state->lx.end;
-	
-#line 2546 "src/libre/dialect/pcre/parser.c"
-				}
-				/* END OF EXTRACT: CLOSECOUNT */
-				break;
-			default:
-				goto ZL1;
-			}
-			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: mark-count */
-			{
-#line 720 "src/libre/parser.act"
-
-		mark(&act_state->countstart, &(*ZI315));
-		mark(&act_state->countend,   &(ZIend));
-	
-#line 2561 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: mark-count */
-			/* BEGINNING OF ACTION: count-range */
-			{
-#line 784 "src/libre/parser.act"
-
-		struct ast_pos ast_start, ast_end;
-
-		if ((ZIn) < (*ZIm)) {
-			err->e = RE_ENEGCOUNT;
-			err->m = (*ZIm);
-			err->n = (ZIn);
-
-			mark(&act_state->countstart, &(*ZI315));
-			mark(&act_state->countend,   &(ZIend));
-
-			goto ZL1;
-		}
-
-		AST_POS_OF_LX_POS(ast_start, (*ZI315));
-		AST_POS_OF_LX_POS(ast_end, (ZIend));
-
-		(ZIc) = ast_make_count((*ZIm), &ast_start, (ZIn), &ast_end);
-	
-#line 2586 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: count-range */
-		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
-	default:
-		goto ZL1;
+		/* END OF ACTION: ast-make-empty */
 	}
 	goto ZL0;
-ZL1:;
+ZL2:;
 	SAVE_LEXER ((ERROR_TERMINAL));
 	return;
 ZL0:;
-	*ZOc = ZIc;
+	*ZOnode = ZInode;
 }
 
 static void
-p_192(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZItmp)
+p_194(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZItmp)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_RANGE):
 		{
 			t_char ZIc;
 			t_pos ZIrstart;
-			t_pos ZI193;
+			t_pos ZI195;
 			t_ast__expr ZInode1;
 
 			/* BEGINNING OF EXTRACT: RANGE */
@@ -2617,13 +2582,13 @@ p_192(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 
 		ZIc = '-';
 		ZIrstart = lex_state->lx.start;
-		ZI193   = lex_state->lx.end;
+		ZI195   = lex_state->lx.end;
 	
-#line 2623 "src/libre/dialect/pcre/parser.c"
+#line 2588 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
-			/* BEGINNING OF INLINE: 194 */
+			/* BEGINNING OF INLINE: 196 */
 			{
 				switch (CURRENT_TERMINAL) {
 				default:
@@ -2637,7 +2602,7 @@ p_192(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			goto ZL1;
 		}
 	
-#line 2641 "src/libre/dialect/pcre/parser.c"
+#line 2606 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF ACTION: ast-make-literal */
 					}
@@ -2645,9 +2610,9 @@ p_192(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 				case (TOK_RANGE):
 					{
 						t_endpoint ZIlower;
-						t_char ZI195;
-						t_pos ZI196;
-						t_pos ZI197;
+						t_char ZI197;
+						t_pos ZI198;
+						t_pos ZI199;
 						t_endpoint ZIupper;
 						t_pos ZIend;
 
@@ -2658,18 +2623,18 @@ p_192(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 		(ZIlower).type = AST_ENDPOINT_LITERAL;
 		(ZIlower).u.literal.c = (ZIc);
 	
-#line 2662 "src/libre/dialect/pcre/parser.c"
+#line 2627 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF ACTION: ast-range-endpoint-literal */
 						/* BEGINNING OF EXTRACT: RANGE */
 						{
 #line 319 "src/libre/parser.act"
 
-		ZI195 = '-';
-		ZI196 = lex_state->lx.start;
-		ZI197   = lex_state->lx.end;
+		ZI197 = '-';
+		ZI198 = lex_state->lx.start;
+		ZI199   = lex_state->lx.end;
 	
-#line 2673 "src/libre/dialect/pcre/parser.c"
+#line 2638 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF EXTRACT: RANGE */
 						ADVANCE_LEXER;
@@ -2713,14 +2678,14 @@ p_192(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			goto ZL1;
 		}
 	
-#line 2717 "src/libre/dialect/pcre/parser.c"
+#line 2682 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF ACTION: ast-make-range */
 					}
 					break;
 				}
 			}
-			/* END OF INLINE: 194 */
+			/* END OF INLINE: 196 */
 			/* BEGINNING OF ACTION: ast-add-alt */
 			{
 #line 1003 "src/libre/parser.act"
@@ -2729,7 +2694,7 @@ p_192(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			goto ZL1;
 		}
 	
-#line 2733 "src/libre/dialect/pcre/parser.c"
+#line 2698 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 		}
@@ -2746,139 +2711,253 @@ ZL1:;
 }
 
 static void
-p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
+p_323(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI321, t_unsigned *ZIm, t_ast__count *ZOc)
 {
-	t_ast__expr ZInode;
+	t_ast__count ZIc;
 
-	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-		return;
-	}
-	{
-		t_ast__expr ZIe;
-
-		p_expr_C_Cpiece_C_Catom (flags, lex_state, act_state, err, &ZIe);
-		/* BEGINNING OF INLINE: 265 */
+	switch (CURRENT_TERMINAL) {
+	case (TOK_CLOSECOUNT):
 		{
-			switch (CURRENT_TERMINAL) {
-			case (TOK_OPT): case (TOK_PLUS): case (TOK_STAR): case (TOK_OPENCOUNT):
-				{
-					p_expr_C_Cpiece_C_Clist_Hof_Hcounts (flags, lex_state, act_state, err, ZIe, &ZInode);
-					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-						RESTORE_LEXER;
-						goto ZL1;
-					}
-				}
-				break;
-			default:
-				{
-					t_ast__count ZIc;
+			t_pos ZI258;
+			t_pos ZIend;
 
-					/* BEGINNING OF ACTION: count-one */
-					{
-#line 778 "src/libre/parser.act"
+			/* BEGINNING OF EXTRACT: CLOSECOUNT */
+			{
+#line 362 "src/libre/parser.act"
 
-		(ZIc) = ast_make_count(1, NULL, 1, NULL);
+		ZI258 = lex_state->lx.start;
+		ZIend   = lex_state->lx.end;
 	
-#line 2783 "src/libre/dialect/pcre/parser.c"
-					}
-					/* END OF ACTION: count-one */
-					/* BEGINNING OF ACTION: ast-make-piece */
-					{
-#line 860 "src/libre/parser.act"
+#line 2732 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF EXTRACT: CLOSECOUNT */
+			ADVANCE_LEXER;
+			/* BEGINNING OF ACTION: mark-count */
+			{
+#line 720 "src/libre/parser.act"
 
-		if ((ZIc).min == 0 && (ZIc).max == 0) {
-			(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
-		} else if ((ZIc).min == 1 && (ZIc).max == 1) {
-			(ZInode) = (ZIe);
-		} else {
-			(ZInode) = ast_make_expr_repeat(act_state->poolp, *flags, (ZIe), (ZIc));
-		}
-		if ((ZInode) == NULL) {
-			err->e = RE_EXEOF;
+		mark(&act_state->countstart, &(*ZI321));
+		mark(&act_state->countend,   &(ZIend));
+	
+#line 2743 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: mark-count */
+			/* BEGINNING OF ACTION: count-range */
+			{
+#line 784 "src/libre/parser.act"
+
+		struct ast_pos ast_start, ast_end;
+
+		if ((*ZIm) < (*ZIm)) {
+			err->e = RE_ENEGCOUNT;
+			err->m = (*ZIm);
+			err->n = (*ZIm);
+
+			mark(&act_state->countstart, &(*ZI321));
+			mark(&act_state->countend,   &(ZIend));
+
 			goto ZL1;
 		}
+
+		AST_POS_OF_LX_POS(ast_start, (*ZI321));
+		AST_POS_OF_LX_POS(ast_end, (ZIend));
+
+		(ZIc) = ast_make_count((*ZIm), &ast_start, (*ZIm), &ast_end);
 	
-#line 2802 "src/libre/dialect/pcre/parser.c"
-					}
-					/* END OF ACTION: ast-make-piece */
-				}
-				break;
-			case (ERROR_TERMINAL):
+#line 2768 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: count-range */
+		}
+		break;
+	case (TOK_SEP):
+		{
+			ADVANCE_LEXER;
+			p_324 (flags, lex_state, act_state, err, ZI321, ZIm, &ZIc);
+			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 265 */
+		break;
+	case (ERROR_TERMINAL):
+		return;
+	default:
+		goto ZL1;
 	}
 	goto ZL0;
 ZL1:;
 	SAVE_LEXER ((ERROR_TERMINAL));
 	return;
 ZL0:;
-	*ZOnode = ZInode;
+	*ZOc = ZIc;
 }
 
 static void
-p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
+p_324(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI321, t_unsigned *ZIm, t_ast__count *ZOc)
 {
-	t_ast__expr ZInode;
+	t_ast__count ZIc;
 
-	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-		return;
-	}
-	{
-		/* BEGINNING OF ACTION: ast-make-alt */
+	switch (CURRENT_TERMINAL) {
+	case (TOK_CLOSECOUNT):
 		{
-#line 830 "src/libre/parser.act"
+			t_pos ZI263;
+			t_pos ZIend;
+			t_unsigned ZIn;
 
-		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
+			/* BEGINNING OF EXTRACT: CLOSECOUNT */
+			{
+#line 362 "src/libre/parser.act"
+
+		ZI263 = lex_state->lx.start;
+		ZIend   = lex_state->lx.end;
 	
-#line 2840 "src/libre/dialect/pcre/parser.c"
-		}
-		/* END OF ACTION: ast-make-alt */
-		p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, ZInode);
-		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-			RESTORE_LEXER;
+#line 2815 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF EXTRACT: CLOSECOUNT */
+			ADVANCE_LEXER;
+			/* BEGINNING OF ACTION: mark-count */
+			{
+#line 720 "src/libre/parser.act"
+
+		mark(&act_state->countstart, &(*ZI321));
+		mark(&act_state->countend,   &(ZIend));
+	
+#line 2826 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: mark-count */
+			/* BEGINNING OF ACTION: count-unbounded */
+			{
+#line 762 "src/libre/parser.act"
+
+		(ZIn) = AST_COUNT_UNBOUNDED;
+	
+#line 2835 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: count-unbounded */
+			/* BEGINNING OF ACTION: count-range */
+			{
+#line 784 "src/libre/parser.act"
+
+		struct ast_pos ast_start, ast_end;
+
+		if ((ZIn) < (*ZIm)) {
+			err->e = RE_ENEGCOUNT;
+			err->m = (*ZIm);
+			err->n = (ZIn);
+
+			mark(&act_state->countstart, &(*ZI321));
+			mark(&act_state->countend,   &(ZIend));
+
 			goto ZL1;
 		}
+
+		AST_POS_OF_LX_POS(ast_start, (*ZI321));
+		AST_POS_OF_LX_POS(ast_end, (ZIend));
+
+		(ZIc) = ast_make_count((*ZIm), &ast_start, (ZIn), &ast_end);
+	
+#line 2860 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: count-range */
+		}
+		break;
+	case (TOK_COUNT):
+		{
+			t_unsigned ZIn;
+			t_pos ZI261;
+			t_pos ZIend;
+
+			/* BEGINNING OF EXTRACT: COUNT */
+			{
+#line 581 "src/libre/parser.act"
+
+		unsigned long u;
+		char *e;
+
+		u = strtoul(lex_state->buf.a, &e, 10);
+
+		if ((u == ULONG_MAX && errno == ERANGE) || u > UINT_MAX) {
+			err->e = RE_ECOUNTRANGE;
+			snprintdots(err->esc, sizeof err->esc, lex_state->buf.a);
+			goto ZL1;
+		}
+
+		if ((u == ULONG_MAX && errno != 0) || *e != '\0') {
+			err->e = RE_EXCOUNT;
+			goto ZL1;
+		}
+
+		ZIn = (unsigned int) u;
+	
+#line 2893 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF EXTRACT: COUNT */
+			ADVANCE_LEXER;
+			switch (CURRENT_TERMINAL) {
+			case (TOK_CLOSECOUNT):
+				/* BEGINNING OF EXTRACT: CLOSECOUNT */
+				{
+#line 362 "src/libre/parser.act"
+
+		ZI261 = lex_state->lx.start;
+		ZIend   = lex_state->lx.end;
+	
+#line 2906 "src/libre/dialect/pcre/parser.c"
+				}
+				/* END OF EXTRACT: CLOSECOUNT */
+				break;
+			default:
+				goto ZL1;
+			}
+			ADVANCE_LEXER;
+			/* BEGINNING OF ACTION: mark-count */
+			{
+#line 720 "src/libre/parser.act"
+
+		mark(&act_state->countstart, &(*ZI321));
+		mark(&act_state->countend,   &(ZIend));
+	
+#line 2921 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: mark-count */
+			/* BEGINNING OF ACTION: count-range */
+			{
+#line 784 "src/libre/parser.act"
+
+		struct ast_pos ast_start, ast_end;
+
+		if ((ZIn) < (*ZIm)) {
+			err->e = RE_ENEGCOUNT;
+			err->m = (*ZIm);
+			err->n = (ZIn);
+
+			mark(&act_state->countstart, &(*ZI321));
+			mark(&act_state->countend,   &(ZIend));
+
+			goto ZL1;
+		}
+
+		AST_POS_OF_LX_POS(ast_start, (*ZI321));
+		AST_POS_OF_LX_POS(ast_end, (ZIend));
+
+		(ZIc) = ast_make_count((*ZIm), &ast_start, (ZIn), &ast_end);
+	
+#line 2946 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: count-range */
+		}
+		break;
+	case (ERROR_TERMINAL):
+		return;
+	default:
+		goto ZL1;
 	}
 	goto ZL0;
 ZL1:;
-	{
-		/* BEGINNING OF ACTION: err-expected-alts */
-		{
-#line 657 "src/libre/parser.act"
-
-		if (err->e == RE_ESUCCESS) {
-			err->e = RE_EXALTS;
-		}
-		goto ZL2;
-	
-#line 2861 "src/libre/dialect/pcre/parser.c"
-		}
-		/* END OF ACTION: err-expected-alts */
-		/* BEGINNING OF ACTION: ast-make-empty */
-		{
-#line 816 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
-		if ((ZInode) == NULL) {
-			goto ZL2;
-		}
-	
-#line 2873 "src/libre/dialect/pcre/parser.c"
-		}
-		/* END OF ACTION: ast-make-empty */
-	}
-	goto ZL0;
-ZL2:;
 	SAVE_LEXER ((ERROR_TERMINAL));
 	return;
 ZL0:;
-	*ZOnode = ZInode;
+	*ZOc = ZIc;
 }
 
 static void
@@ -2908,7 +2987,7 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 
 		(ZIempty__pos) = RE_FLAGS_NONE;
 	
-#line 2912 "src/libre/dialect/pcre/parser.c"
+#line 2991 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: re-flag-none */
 		/* BEGINNING OF ACTION: re-flag-none */
@@ -2917,10 +2996,10 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 
 		(ZIempty__neg) = RE_FLAGS_NONE;
 	
-#line 2921 "src/libre/dialect/pcre/parser.c"
+#line 3000 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: re-flag-none */
-		/* BEGINNING OF INLINE: 230 */
+		/* BEGINNING OF INLINE: 232 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_FLAG__IGNORE): case (TOK_FLAG__UNKNOWN): case (TOK_FLAG__INSENSITIVE): case (TOK_FLAG__EXTENDED):
@@ -2940,8 +3019,8 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 				break;
 			}
 		}
-		/* END OF INLINE: 230 */
-		/* BEGINNING OF INLINE: 232 */
+		/* END OF INLINE: 232 */
+		/* BEGINNING OF INLINE: 234 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_NEGATE):
@@ -2961,8 +3040,8 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 				break;
 			}
 		}
-		/* END OF INLINE: 232 */
-		/* BEGINNING OF INLINE: 235 */
+		/* END OF INLINE: 234 */
+		/* BEGINNING OF INLINE: 237 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CLOSE):
@@ -2979,7 +3058,7 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 		*flags |= (ZIpos);
 		*flags &= ~(ZIneg);
 	
-#line 2983 "src/libre/dialect/pcre/parser.c"
+#line 3062 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-mask-re-flags */
 					/* BEGINNING OF ACTION: ast-make-empty */
@@ -2991,7 +3070,7 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 			goto ZL5;
 		}
 	
-#line 2995 "src/libre/dialect/pcre/parser.c"
+#line 3074 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-empty */
 				}
@@ -3008,7 +3087,7 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 
 		(ZIflags) = *flags;
 	
-#line 3012 "src/libre/dialect/pcre/parser.c"
+#line 3091 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-get-re-flags */
 					/* BEGINNING OF ACTION: ast-mask-re-flags */
@@ -3022,7 +3101,7 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 		*flags |= (ZIpos);
 		*flags &= ~(ZIneg);
 	
-#line 3026 "src/libre/dialect/pcre/parser.c"
+#line 3105 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-mask-re-flags */
 					p_expr (flags, lex_state, act_state, err, &ZIe);
@@ -3036,7 +3115,7 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 
 		*flags = (ZIflags);
 	
-#line 3040 "src/libre/dialect/pcre/parser.c"
+#line 3119 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-set-re-flags */
 					switch (CURRENT_TERMINAL) {
@@ -3064,7 +3143,7 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 		}
 		goto ZL1;
 	
-#line 3068 "src/libre/dialect/pcre/parser.c"
+#line 3147 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: err-expected-closeflags */
 				/* BEGINNING OF ACTION: ast-make-empty */
@@ -3076,13 +3155,13 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 			goto ZL1;
 		}
 	
-#line 3080 "src/libre/dialect/pcre/parser.c"
+#line 3159 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: ast-make-empty */
 			}
 		ZL4:;
 		}
-		/* END OF INLINE: 235 */
+		/* END OF INLINE: 237 */
 	}
 	goto ZL0;
 ZL1:;
@@ -3124,10 +3203,10 @@ p_expr_C_Cpiece_C_Clist_Hof_Hcounts(flags flags, lex_state lex_state, act_state 
 			goto ZL1;
 		}
 	
-#line 3128 "src/libre/dialect/pcre/parser.c"
+#line 3207 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-piece */
-		/* BEGINNING OF INLINE: 264 */
+		/* BEGINNING OF INLINE: 266 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_OPT):
@@ -3142,7 +3221,7 @@ p_expr_C_Cpiece_C_Clist_Hof_Hcounts(flags flags, lex_state lex_state, act_state 
 		}
 		goto ZL1;
 	
-#line 3146 "src/libre/dialect/pcre/parser.c"
+#line 3225 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: err-unsupported */
 				}
@@ -3159,7 +3238,7 @@ p_expr_C_Cpiece_C_Clist_Hof_Hcounts(flags flags, lex_state lex_state, act_state 
 		}
 		goto ZL1;
 	
-#line 3163 "src/libre/dialect/pcre/parser.c"
+#line 3242 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: err-unsupported */
 				}
@@ -3168,7 +3247,7 @@ p_expr_C_Cpiece_C_Clist_Hof_Hcounts(flags flags, lex_state lex_state, act_state 
 				break;
 			}
 		}
-		/* END OF INLINE: 264 */
+		/* END OF INLINE: 266 */
 	}
 	goto ZL0;
 ZL1:;
@@ -3189,7 +3268,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint(flags flags, lex_state lex_state, 
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 156 */
+		/* BEGINNING OF INLINE: 158 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_NAMED__CLASS):
@@ -3202,7 +3281,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint(flags flags, lex_state lex_state, 
 				}
 				break;
 			case (TOK_ESC): case (TOK_CONTROL): case (TOK_OCT): case (TOK_HEX):
-			case (TOK_CHAR):
+			case (TOK_CHAR): case (TOK_UNSUPPORTED):
 				{
 					p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral (flags, lex_state, act_state, err, &ZIr, &ZIstart, &ZIend);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
@@ -3215,7 +3294,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint(flags flags, lex_state lex_state, 
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 156 */
+		/* END OF INLINE: 158 */
 	}
 	goto ZL0;
 ZL1:;
@@ -3228,7 +3307,66 @@ ZL0:;
 }
 
 static void
-p_207(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIstart, t_char *ZIcbrak, t_ast__expr *ZOnode1)
+p_class_Hnamed(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode, t_pos *ZOstart, t_pos *ZOend)
+{
+	t_ast__expr ZInode;
+	t_pos ZIstart;
+	t_pos ZIend;
+
+	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+		return;
+	}
+	{
+		t_ast__class__id ZIid;
+
+		switch (CURRENT_TERMINAL) {
+		case (TOK_NAMED__CLASS):
+			/* BEGINNING OF EXTRACT: NAMED_CLASS */
+			{
+#line 593 "src/libre/parser.act"
+
+		ZIid = DIALECT_CLASS(lex_state->buf.a);
+		if (ZIid == NULL) {
+			/* syntax error -- unrecognized class */
+			goto ZL1;
+		}
+
+		ZIstart = lex_state->lx.start;
+		ZIend   = lex_state->lx.end;
+	
+#line 3338 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF EXTRACT: NAMED_CLASS */
+			break;
+		default:
+			goto ZL1;
+		}
+		ADVANCE_LEXER;
+		/* BEGINNING OF ACTION: ast-make-named */
+		{
+#line 990 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_named(act_state->poolp, *flags, (ZIid));
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 3355 "src/libre/dialect/pcre/parser.c"
+		}
+		/* END OF ACTION: ast-make-named */
+	}
+	goto ZL0;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+ZL0:;
+	*ZOnode = ZInode;
+	*ZOstart = ZIstart;
+	*ZOend = ZIend;
+}
+
+static void
+p_209(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIstart, t_char *ZIcbrak, t_ast__expr *ZOnode1)
 {
 	t_ast__expr ZInode1;
 
@@ -3244,7 +3382,7 @@ p_207(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 			goto ZL1;
 		}
 	
-#line 3248 "src/libre/dialect/pcre/parser.c"
+#line 3386 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -3252,9 +3390,9 @@ p_207(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 	case (TOK_RANGE):
 		{
 			t_endpoint ZIr;
-			t_char ZI208;
-			t_pos ZI209;
-			t_pos ZI210;
+			t_char ZI210;
+			t_pos ZI211;
+			t_pos ZI212;
 			t_endpoint ZIupper;
 			t_pos ZIend;
 			t_endpoint ZIlower;
@@ -3266,18 +3404,18 @@ p_207(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 		(ZIr).type = AST_ENDPOINT_LITERAL;
 		(ZIr).u.literal.c = (*ZIcbrak);
 	
-#line 3270 "src/libre/dialect/pcre/parser.c"
+#line 3408 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
 #line 319 "src/libre/parser.act"
 
-		ZI208 = '-';
-		ZI209 = lex_state->lx.start;
-		ZI210   = lex_state->lx.end;
+		ZI210 = '-';
+		ZI211 = lex_state->lx.start;
+		ZI212   = lex_state->lx.end;
 	
-#line 3281 "src/libre/dialect/pcre/parser.c"
+#line 3419 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
@@ -3293,7 +3431,7 @@ p_207(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 		(ZIlower).type = AST_ENDPOINT_LITERAL;
 		(ZIlower).u.literal.c = (*ZIcbrak);
 	
-#line 3297 "src/libre/dialect/pcre/parser.c"
+#line 3435 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF ACTION: ast-make-range */
@@ -3331,7 +3469,7 @@ p_207(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 			goto ZL1;
 		}
 	
-#line 3335 "src/libre/dialect/pcre/parser.c"
+#line 3473 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -3345,65 +3483,6 @@ ZL1:;
 	return;
 ZL0:;
 	*ZOnode1 = ZInode1;
-}
-
-static void
-p_class_Hnamed(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode, t_pos *ZOstart, t_pos *ZOend)
-{
-	t_ast__expr ZInode;
-	t_pos ZIstart;
-	t_pos ZIend;
-
-	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-		return;
-	}
-	{
-		t_ast__class__id ZIid;
-
-		switch (CURRENT_TERMINAL) {
-		case (TOK_NAMED__CLASS):
-			/* BEGINNING OF EXTRACT: NAMED_CLASS */
-			{
-#line 593 "src/libre/parser.act"
-
-		ZIid = DIALECT_CLASS(lex_state->buf.a);
-		if (ZIid == NULL) {
-			/* syntax error -- unrecognized class */
-			goto ZL1;
-		}
-
-		ZIstart = lex_state->lx.start;
-		ZIend   = lex_state->lx.end;
-	
-#line 3379 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF EXTRACT: NAMED_CLASS */
-			break;
-		default:
-			goto ZL1;
-		}
-		ADVANCE_LEXER;
-		/* BEGINNING OF ACTION: ast-make-named */
-		{
-#line 990 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_named(act_state->poolp, *flags, (ZIid));
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 3396 "src/libre/dialect/pcre/parser.c"
-		}
-		/* END OF ACTION: ast-make-named */
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOnode = ZInode;
-	*ZOstart = ZIstart;
-	*ZOend = ZIend;
 }
 
 static void
@@ -3429,10 +3508,10 @@ ZL2_expr_C_Clist_Hof_Halts:;
 			goto ZL1;
 		}
 	
-#line 3433 "src/libre/dialect/pcre/parser.c"
+#line 3512 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-add-alt */
-		/* BEGINNING OF INLINE: 278 */
+		/* BEGINNING OF INLINE: 280 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ALT):
@@ -3447,7 +3526,7 @@ ZL2_expr_C_Clist_Hof_Halts:;
 				break;
 			}
 		}
-		/* END OF INLINE: 278 */
+		/* END OF INLINE: 280 */
 	}
 	return;
 ZL1:;
@@ -3461,7 +3540,7 @@ ZL1:;
 		}
 		goto ZL4;
 	
-#line 3465 "src/libre/dialect/pcre/parser.c"
+#line 3544 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
 	}
@@ -3480,18 +3559,18 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 	switch (CURRENT_TERMINAL) {
 	case (TOK_OPENCOUNT):
 		{
-			t_pos ZI315;
-			t_pos ZI316;
+			t_pos ZI321;
+			t_pos ZI322;
 			t_unsigned ZIm;
 
 			/* BEGINNING OF EXTRACT: OPENCOUNT */
 			{
 #line 357 "src/libre/parser.act"
 
-		ZI315 = lex_state->lx.start;
-		ZI316   = lex_state->lx.end;
+		ZI321 = lex_state->lx.start;
+		ZI322   = lex_state->lx.end;
 	
-#line 3495 "src/libre/dialect/pcre/parser.c"
+#line 3574 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: OPENCOUNT */
 			ADVANCE_LEXER;
@@ -3519,7 +3598,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		ZIm = (unsigned int) u;
 	
-#line 3523 "src/libre/dialect/pcre/parser.c"
+#line 3602 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -3527,7 +3606,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 				goto ZL1;
 			}
 			ADVANCE_LEXER;
-			p_317 (flags, lex_state, act_state, err, &ZI315, &ZIm, &ZIc);
+			p_323 (flags, lex_state, act_state, err, &ZI321, &ZIm, &ZIc);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -3543,7 +3622,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		(ZIc) = ast_make_count(0, NULL, 1, NULL);
 	
-#line 3547 "src/libre/dialect/pcre/parser.c"
+#line 3626 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-one */
 		}
@@ -3557,7 +3636,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		(ZIc) = ast_make_count(1, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 3561 "src/libre/dialect/pcre/parser.c"
+#line 3640 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-one-or-more */
 		}
@@ -3571,7 +3650,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 3575 "src/libre/dialect/pcre/parser.c"
+#line 3654 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 		}
@@ -3593,7 +3672,7 @@ ZL1:;
 		}
 		goto ZL2;
 	
-#line 3597 "src/libre/dialect/pcre/parser.c"
+#line 3676 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-expected-count */
 		/* BEGINNING OF ACTION: count-one */
@@ -3602,7 +3681,7 @@ ZL1:;
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 3606 "src/libre/dialect/pcre/parser.c"
+#line 3685 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: count-one */
 	}
@@ -3623,7 +3702,7 @@ p_re__pcre(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 280 */
+		/* BEGINNING OF INLINE: 282 */
 		{
 			{
 				p_expr (flags, lex_state, act_state, err, &ZInode);
@@ -3633,8 +3712,8 @@ p_re__pcre(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 				}
 			}
 		}
-		/* END OF INLINE: 280 */
-		/* BEGINNING OF INLINE: 281 */
+		/* END OF INLINE: 282 */
+		/* BEGINNING OF INLINE: 283 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -3657,13 +3736,13 @@ p_re__pcre(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 		}
 		goto ZL1;
 	
-#line 3661 "src/libre/dialect/pcre/parser.c"
+#line 3740 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 281 */
+		/* END OF INLINE: 283 */
 	}
 	goto ZL0;
 ZL1:;
@@ -3691,7 +3770,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 		/* TODO: or the unicode equivalent */
 		(ZIa) = (*flags & RE_SINGLE) ? &class_any : &class_notnl;
 	
-#line 3695 "src/libre/dialect/pcre/parser.c"
+#line 3774 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
@@ -3703,7 +3782,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 3707 "src/libre/dialect/pcre/parser.c"
+#line 3786 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 		}
@@ -3720,7 +3799,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 3724 "src/libre/dialect/pcre/parser.c"
+#line 3803 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-end */
 		}
@@ -3740,7 +3819,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 
 		(ZInl) = '\n';
 	
-#line 3744 "src/libre/dialect/pcre/parser.c"
+#line 3823 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: make-literal-nl */
 			/* BEGINNING OF ACTION: ast-make-literal */
@@ -3752,7 +3831,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 3756 "src/libre/dialect/pcre/parser.c"
+#line 3835 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 			/* BEGINNING OF ACTION: count-zero-or-one */
@@ -3761,7 +3840,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 
 		(ZIc) = ast_make_count(0, NULL, 1, NULL);
 	
-#line 3765 "src/libre/dialect/pcre/parser.c"
+#line 3844 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-one */
 			/* BEGINNING OF ACTION: ast-make-piece */
@@ -3780,7 +3859,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 3784 "src/libre/dialect/pcre/parser.c"
+#line 3863 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-piece */
 			/* BEGINNING OF ACTION: ast-make-anchor-end */
@@ -3792,7 +3871,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 3796 "src/libre/dialect/pcre/parser.c"
+#line 3875 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-end */
 			/* BEGINNING OF ACTION: ast-make-concat */
@@ -3804,7 +3883,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 3808 "src/libre/dialect/pcre/parser.c"
+#line 3887 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-concat */
 			/* BEGINNING OF ACTION: ast-add-concat */
@@ -3815,7 +3894,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 3819 "src/libre/dialect/pcre/parser.c"
+#line 3898 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-concat */
 			/* BEGINNING OF ACTION: ast-add-concat */
@@ -3826,7 +3905,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 3830 "src/libre/dialect/pcre/parser.c"
+#line 3909 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-concat */
 		}
@@ -3849,7 +3928,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 		/* TODO: or the unicode equivalent */
 		(ZIclass__bsr) = &class_bsr;
 	
-#line 3853 "src/libre/dialect/pcre/parser.c"
+#line 3932 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: class-bsr */
 			/* BEGINNING OF ACTION: ast-make-named */
@@ -3861,7 +3940,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 3865 "src/libre/dialect/pcre/parser.c"
+#line 3944 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 			/* BEGINNING OF ACTION: ast-make-concat */
@@ -3873,7 +3952,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 3877 "src/libre/dialect/pcre/parser.c"
+#line 3956 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-concat */
 			/* BEGINNING OF ACTION: make-literal-cr */
@@ -3882,7 +3961,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 
 		(ZIcr) = '\r';
 	
-#line 3886 "src/libre/dialect/pcre/parser.c"
+#line 3965 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: make-literal-cr */
 			/* BEGINNING OF ACTION: ast-make-literal */
@@ -3894,7 +3973,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 3898 "src/libre/dialect/pcre/parser.c"
+#line 3977 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 			/* BEGINNING OF ACTION: make-literal-nl */
@@ -3903,7 +3982,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 
 		(ZInl) = '\n';
 	
-#line 3907 "src/libre/dialect/pcre/parser.c"
+#line 3986 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: make-literal-nl */
 			/* BEGINNING OF ACTION: ast-make-literal */
@@ -3915,7 +3994,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 3919 "src/libre/dialect/pcre/parser.c"
+#line 3998 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 			/* BEGINNING OF ACTION: ast-add-concat */
@@ -3926,7 +4005,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 3930 "src/libre/dialect/pcre/parser.c"
+#line 4009 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-concat */
 			/* BEGINNING OF ACTION: ast-add-concat */
@@ -3937,7 +4016,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 3941 "src/libre/dialect/pcre/parser.c"
+#line 4020 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-concat */
 			/* BEGINNING OF ACTION: ast-make-alt */
@@ -3949,7 +4028,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 3953 "src/libre/dialect/pcre/parser.c"
+#line 4032 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-alt */
 			/* BEGINNING OF ACTION: ast-add-alt */
@@ -3960,7 +4039,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 3964 "src/libre/dialect/pcre/parser.c"
+#line 4043 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 			/* BEGINNING OF ACTION: ast-add-alt */
@@ -3971,7 +4050,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 3975 "src/libre/dialect/pcre/parser.c"
+#line 4054 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 		}
@@ -3989,7 +4068,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 
 		(ZIflags) = *flags;
 	
-#line 3993 "src/libre/dialect/pcre/parser.c"
+#line 4072 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-get-re-flags */
 			/* BEGINNING OF ACTION: make-group-id */
@@ -3998,7 +4077,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 
 		(ZIid) = act_state->group_id++;
 	
-#line 4002 "src/libre/dialect/pcre/parser.c"
+#line 4081 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: make-group-id */
 			p_expr (flags, lex_state, act_state, err, &ZIg);
@@ -4012,7 +4091,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 
 		*flags = (ZIflags);
 	
-#line 4016 "src/libre/dialect/pcre/parser.c"
+#line 4095 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-set-re-flags */
 			/* BEGINNING OF ACTION: ast-make-group */
@@ -4024,7 +4103,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 4028 "src/libre/dialect/pcre/parser.c"
+#line 4107 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-group */
 			switch (CURRENT_TERMINAL) {
@@ -4048,7 +4127,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 4052 "src/libre/dialect/pcre/parser.c"
+#line 4131 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-start */
 		}
@@ -4107,7 +4186,7 @@ ZL1:;
 		}
 		goto ZL2;
 	
-#line 4111 "src/libre/dialect/pcre/parser.c"
+#line 4190 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-empty */
@@ -4119,7 +4198,7 @@ ZL1:;
 			goto ZL2;
 		}
 	
-#line 4123 "src/libre/dialect/pcre/parser.c"
+#line 4202 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -4152,7 +4231,7 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 			goto ZL1;
 		}
 	
-#line 4156 "src/libre/dialect/pcre/parser.c"
+#line 4235 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-concat */
 			p_expr_C_Clist_Hof_Hpieces (flags, lex_state, act_state, err, ZInode);
@@ -4173,7 +4252,7 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 			goto ZL1;
 		}
 	
-#line 4177 "src/libre/dialect/pcre/parser.c"
+#line 4256 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-empty */
 		}
@@ -4216,7 +4295,7 @@ p_expr_C_Ctype(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL1;
 		}
 	
-#line 4220 "src/libre/dialect/pcre/parser.c"
+#line 4299 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-alt */
 		/* BEGINNING OF ACTION: ast-add-alt */
@@ -4227,7 +4306,7 @@ p_expr_C_Ctype(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL1;
 		}
 	
-#line 4231 "src/libre/dialect/pcre/parser.c"
+#line 4310 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-add-alt */
 		/* BEGINNING OF ACTION: mark-expr */
@@ -4247,7 +4326,7 @@ p_expr_C_Ctype(flags flags, lex_state lex_state, act_state act_state, err err, t
 		(ZInode)->u.class.end   = ast_end;
 */
 	
-#line 4251 "src/libre/dialect/pcre/parser.c"
+#line 4330 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: mark-expr */
 	}
@@ -4409,6 +4488,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 4413 "src/libre/dialect/pcre/parser.c"
+#line 4492 "src/libre/dialect/pcre/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/pcre/parser.c
+++ b/src/libre/dialect/pcre/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 142 "src/libre/parser.act"
+#line 149 "src/libre/parser.act"
 
 
 	#include <assert.h>
@@ -90,6 +90,7 @@
 	typedef const struct class * t_ast__class__id;
 	typedef struct ast_count t_ast__count;
 	typedef struct ast_endpoint t_endpoint;
+	typedef unsigned t_group__id;
 
 	struct act_state {
 		struct ast_expr_pool **poolp;
@@ -112,6 +113,12 @@
 		struct re_pos groupstart; struct re_pos groupend;
 		struct re_pos rangestart; struct re_pos rangeend;
 		struct re_pos countstart; struct re_pos countend;
+
+		/*
+		 * Numbering for capturing groups. By convention these start from 1,
+		 * and 0 represents the entire matching text.
+		 */
+		unsigned group_id;
 	};
 
 	struct lex_state {
@@ -148,7 +155,6 @@
 	{
 		enum re_flags fl = (lex_state->flags_ptr != NULL) ? lex_state->flags_ptr[0] : 0;
 		enum LX_TOKEN tok;
-
 
 		if ((fl & RE_EXTENDED) == 0) {
 			tok = act_state->lex_tok;
@@ -281,7 +287,7 @@
 		return s;
 	}
 
-#line 285 "src/libre/dialect/pcre/parser.c"
+#line 291 "src/libre/dialect/pcre/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -293,25 +299,25 @@
 static void p_expr_C_Cflags_C_Cflag__set(flags, lex_state, act_state, err, t_re__flags, t_re__flags *);
 static void p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags, lex_state, act_state, err, t_endpoint *, t_pos *, t_pos *);
 static void p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms(flags, lex_state, act_state, err, t_ast__expr);
-static void p_164(flags, lex_state, act_state, err);
-static void p_292(flags, lex_state, act_state, err, t_ast__class__id *, t_pos *, t_ast__expr *);
 static void p_expr_C_Clist_Hof_Hpieces(flags, lex_state, act_state, err, t_ast__expr);
+static void p_166(flags, lex_state, act_state, err);
+static void p_294(flags, lex_state, act_state, err, t_ast__class__id *, t_pos *, t_ast__expr *);
 static void p_expr_C_Cliteral(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Ccomment(flags, lex_state, act_state, err);
 static void p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hclass(flags, lex_state, act_state, err, t_endpoint *, t_pos *, t_pos *);
 static void p_expr_C_Ccharacter_Hclass(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_Hend(flags, lex_state, act_state, err, t_endpoint *, t_pos *);
-static void p_312(flags, lex_state, act_state, err, t_char *, t_pos *, t_ast__expr *);
-static void p_315(flags, lex_state, act_state, err, t_pos *, t_unsigned *, t_ast__count *);
-static void p_316(flags, lex_state, act_state, err, t_pos *, t_unsigned *, t_ast__count *);
-static void p_190(flags, lex_state, act_state, err, t_ast__expr *);
+static void p_314(flags, lex_state, act_state, err, t_char *, t_pos *, t_ast__expr *);
+static void p_317(flags, lex_state, act_state, err, t_pos *, t_unsigned *, t_ast__count *);
+static void p_318(flags, lex_state, act_state, err, t_pos *, t_unsigned *, t_ast__count *);
+static void p_192(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Cpiece(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Cflags(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Cpiece_C_Clist_Hof_Hcounts(flags, lex_state, act_state, err, t_ast__expr, t_ast__expr *);
-static void p_205(flags, lex_state, act_state, err, t_pos *, t_char *, t_ast__expr *);
 static void p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint(flags, lex_state, act_state, err, t_endpoint *, t_pos *, t_pos *);
+static void p_207(flags, lex_state, act_state, err, t_pos *, t_char *, t_ast__expr *);
 static void p_class_Hnamed(flags, lex_state, act_state, err, t_ast__expr *, t_pos *, t_pos *);
 static void p_expr_C_Clist_Hof_Halts(flags, lex_state, act_state, err, t_ast__expr);
 static void p_expr_C_Cpiece_C_Ccount(flags, lex_state, act_state, err, t_ast__count *);
@@ -337,21 +343,21 @@ p_expr_C_Cflags_C_Cflag__set(flags flags, lex_state lex_state, act_state act_sta
 
 			/* BEGINNING OF EXTRACT: FLAG_EXTENDED */
 			{
-#line 602 "src/libre/parser.act"
+#line 608 "src/libre/parser.act"
 
 		ZIc = RE_EXTENDED;
 	
-#line 345 "src/libre/dialect/pcre/parser.c"
+#line 351 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: FLAG_EXTENDED */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: re-flag-union */
 			{
-#line 752 "src/libre/parser.act"
+#line 758 "src/libre/parser.act"
 
 		(ZIo) = (ZIi) | (ZIc);
 	
-#line 355 "src/libre/dialect/pcre/parser.c"
+#line 361 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: re-flag-union */
 		}
@@ -368,21 +374,21 @@ p_expr_C_Cflags_C_Cflag__set(flags flags, lex_state lex_state, act_state act_sta
 
 			/* BEGINNING OF EXTRACT: FLAG_INSENSITIVE */
 			{
-#line 598 "src/libre/parser.act"
+#line 604 "src/libre/parser.act"
 
 		ZIc = RE_ICASE;
 	
-#line 376 "src/libre/dialect/pcre/parser.c"
+#line 382 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: FLAG_INSENSITIVE */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: re-flag-union */
 			{
-#line 752 "src/libre/parser.act"
+#line 758 "src/libre/parser.act"
 
 		(ZIo) = (ZIi) | (ZIc);
 	
-#line 386 "src/libre/dialect/pcre/parser.c"
+#line 392 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: re-flag-union */
 		}
@@ -393,21 +399,21 @@ p_expr_C_Cflags_C_Cflag__set(flags flags, lex_state lex_state, act_state act_sta
 
 			/* BEGINNING OF EXTRACT: FLAG_SINGLE */
 			{
-#line 606 "src/libre/parser.act"
+#line 612 "src/libre/parser.act"
 
 		ZIc = RE_SINGLE;
 	
-#line 401 "src/libre/dialect/pcre/parser.c"
+#line 407 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: FLAG_SINGLE */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: re-flag-union */
 			{
-#line 752 "src/libre/parser.act"
+#line 758 "src/libre/parser.act"
 
 		(ZIo) = (ZIi) | (ZIc);
 	
-#line 411 "src/libre/dialect/pcre/parser.c"
+#line 417 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: re-flag-union */
 		}
@@ -418,14 +424,14 @@ p_expr_C_Cflags_C_Cflag__set(flags flags, lex_state lex_state, act_state act_sta
 			ZIo = ZIi;
 			/* BEGINNING OF ACTION: err-unknown-flag */
 			{
-#line 679 "src/libre/parser.act"
+#line 685 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EFLAG;
 		}
 		goto ZL1;
 	
-#line 429 "src/libre/dialect/pcre/parser.c"
+#line 435 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: err-unknown-flag */
 		}
@@ -456,14 +462,14 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 	{
 		t_char ZIc;
 
-		/* BEGINNING OF INLINE: 151 */
+		/* BEGINNING OF INLINE: 153 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CHAR):
 				{
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
-#line 530 "src/libre/parser.act"
+#line 536 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -473,7 +479,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 477 "src/libre/dialect/pcre/parser.c"
+#line 483 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CHAR */
 					ADVANCE_LEXER;
@@ -483,7 +489,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 				{
 					/* BEGINNING OF EXTRACT: CONTROL */
 					{
-#line 413 "src/libre/parser.act"
+#line 419 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] == 'c');
@@ -517,20 +523,20 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 521 "src/libre/dialect/pcre/parser.c"
+#line 527 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CONTROL */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: err-unsupported */
 					{
-#line 700 "src/libre/parser.act"
+#line 706 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXUNSUPPORTD;
 		}
 		goto ZL1;
 	
-#line 534 "src/libre/dialect/pcre/parser.c"
+#line 540 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: err-unsupported */
 				}
@@ -539,7 +545,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 				{
 					/* BEGINNING OF EXTRACT: ESC */
 					{
-#line 365 "src/libre/parser.act"
+#line 371 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -562,7 +568,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 566 "src/libre/dialect/pcre/parser.c"
+#line 572 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: ESC */
 					ADVANCE_LEXER;
@@ -572,7 +578,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 				{
 					/* BEGINNING OF EXTRACT: HEX */
 					{
-#line 489 "src/libre/parser.act"
+#line 495 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -617,7 +623,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 621 "src/libre/dialect/pcre/parser.c"
+#line 627 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: HEX */
 					ADVANCE_LEXER;
@@ -627,7 +633,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 				{
 					/* BEGINNING OF EXTRACT: OCT */
 					{
-#line 449 "src/libre/parser.act"
+#line 455 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -667,7 +673,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 671 "src/libre/dialect/pcre/parser.c"
+#line 677 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OCT */
 					ADVANCE_LEXER;
@@ -677,15 +683,15 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 151 */
+		/* END OF INLINE: 153 */
 		/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 		{
-#line 796 "src/libre/parser.act"
+#line 802 "src/libre/parser.act"
 
 		(ZIr).type = AST_ENDPOINT_LITERAL;
 		(ZIr).u.literal.c = (ZIc);
 	
-#line 689 "src/libre/dialect/pcre/parser.c"
+#line 695 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-range-endpoint-literal */
 	}
@@ -716,13 +722,13 @@ ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 			}
 			/* BEGINNING OF ACTION: ast-add-alt */
 			{
-#line 993 "src/libre/parser.act"
+#line 1003 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIclass), (ZInode))) {
 			goto ZL1;
 		}
 	
-#line 726 "src/libre/dialect/pcre/parser.c"
+#line 732 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 			/* BEGINNING OF INLINE: expr::character-class::list-of-class-terms */
@@ -742,27 +748,104 @@ ZL1:;
 }
 
 static void
-p_164(flags flags, lex_state lex_state, act_state act_state, err err)
+p_expr_C_Clist_Hof_Hpieces(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr ZIcat)
+{
+	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+		return;
+	}
+ZL2_expr_C_Clist_Hof_Hpieces:;
+	{
+		/* BEGINNING OF INLINE: 271 */
+		{
+			switch (CURRENT_TERMINAL) {
+			case (TOK_INVALID__COMMENT):
+				{
+					p_expr_C_Ccomment (flags, lex_state, act_state, err);
+					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+						RESTORE_LEXER;
+						goto ZL1;
+					}
+				}
+				break;
+			case (TOK_ANY): case (TOK_EOL): case (TOK_START): case (TOK_END):
+			case (TOK_END__NL): case (TOK_OPEN): case (TOK_OPENGROUP): case (TOK_OPENGROUPINV):
+			case (TOK_OPENGROUPCB): case (TOK_OPENGROUPINVCB): case (TOK_NAMED__CLASS): case (TOK_FLAGS):
+			case (TOK_ESC): case (TOK_NOESC): case (TOK_CONTROL): case (TOK_OCT):
+			case (TOK_HEX): case (TOK_CHAR): case (TOK_UNSUPPORTED):
+				{
+					t_ast__expr ZIa;
+
+					p_expr_C_Cpiece (flags, lex_state, act_state, err, &ZIa);
+					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+						RESTORE_LEXER;
+						goto ZL1;
+					}
+					/* BEGINNING OF ACTION: ast-add-concat */
+					{
+#line 997 "src/libre/parser.act"
+
+		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
+			goto ZL1;
+		}
+	
+#line 792 "src/libre/dialect/pcre/parser.c"
+					}
+					/* END OF ACTION: ast-add-concat */
+				}
+				break;
+			default:
+				goto ZL1;
+			}
+		}
+		/* END OF INLINE: 271 */
+		/* BEGINNING OF INLINE: 272 */
+		{
+			switch (CURRENT_TERMINAL) {
+			case (TOK_ANY): case (TOK_EOL): case (TOK_START): case (TOK_END):
+			case (TOK_END__NL): case (TOK_OPEN): case (TOK_OPENGROUP): case (TOK_OPENGROUPINV):
+			case (TOK_OPENGROUPCB): case (TOK_OPENGROUPINVCB): case (TOK_NAMED__CLASS): case (TOK_FLAGS):
+			case (TOK_ESC): case (TOK_NOESC): case (TOK_CONTROL): case (TOK_OCT):
+			case (TOK_HEX): case (TOK_CHAR): case (TOK_UNSUPPORTED): case (TOK_INVALID__COMMENT):
+				{
+					/* BEGINNING OF INLINE: expr::list-of-pieces */
+					goto ZL2_expr_C_Clist_Hof_Hpieces;
+					/* END OF INLINE: expr::list-of-pieces */
+				}
+				/*UNREACHED*/
+			default:
+				break;
+			}
+		}
+		/* END OF INLINE: 272 */
+	}
+	return;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+}
+
+static void
+p_166(flags flags, lex_state lex_state, act_state act_state, err err)
 {
 	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 		return;
 	}
 	{
-		t_char ZI165;
-		t_pos ZI166;
-		t_pos ZI167;
+		t_char ZI167;
+		t_pos ZI168;
+		t_pos ZI169;
 
 		switch (CURRENT_TERMINAL) {
 		case (TOK_RANGE):
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 313 "src/libre/parser.act"
+#line 319 "src/libre/parser.act"
 
-		ZI165 = '-';
-		ZI166 = lex_state->lx.start;
-		ZI167   = lex_state->lx.end;
+		ZI167 = '-';
+		ZI168 = lex_state->lx.start;
+		ZI169   = lex_state->lx.end;
 	
-#line 766 "src/libre/dialect/pcre/parser.c"
+#line 849 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			break;
@@ -776,14 +859,14 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-range */
 		{
-#line 658 "src/libre/parser.act"
+#line 664 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXRANGE;
 		}
 		goto ZL2;
 	
-#line 787 "src/libre/dialect/pcre/parser.c"
+#line 870 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-expected-range */
 	}
@@ -795,7 +878,7 @@ ZL0:;
 }
 
 static void
-p_292(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class__id *ZI289, t_pos *ZI290, t_ast__expr *ZOnode)
+p_294(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class__id *ZI291, t_pos *ZI292, t_ast__expr *ZOnode)
 {
 	t_ast__expr ZInode;
 
@@ -804,14 +887,14 @@ p_292(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 		{
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 980 "src/libre/parser.act"
+#line 990 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_named(act_state->poolp, *flags, (*ZI289));
+		(ZInode) = ast_make_expr_named(act_state->poolp, *flags, (*ZI291));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 815 "src/libre/dialect/pcre/parser.c"
+#line 898 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 		}
@@ -824,15 +907,15 @@ p_292(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-class */
 			{
-#line 801 "src/libre/parser.act"
+#line 807 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_NAMED;
-		(ZIlower).u.named.class = (*ZI289);
+		(ZIlower).u.named.class = (*ZI291);
 	
-#line 833 "src/libre/dialect/pcre/parser.c"
+#line 916 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-class */
-			p_164 (flags, lex_state, act_state, err);
+			p_166 (flags, lex_state, act_state, err);
 			p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_Hend (flags, lex_state, act_state, err, &ZIupper, &ZIend);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
@@ -840,22 +923,22 @@ p_292(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 			}
 			/* BEGINNING OF ACTION: mark-range */
 			{
-#line 709 "src/libre/parser.act"
+#line 715 "src/libre/parser.act"
 
-		mark(&act_state->rangestart, &(*ZI290));
+		mark(&act_state->rangestart, &(*ZI292));
 		mark(&act_state->rangeend,   &(ZIend));
 	
-#line 849 "src/libre/dialect/pcre/parser.c"
+#line 932 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 950 "src/libre/parser.act"
+#line 960 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI290));
+		AST_POS_OF_LX_POS(ast_start, (*ZI292));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		if ((ZIlower).type != AST_ENDPOINT_LITERAL ||
@@ -883,7 +966,7 @@ p_292(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 			goto ZL1;
 		}
 	
-#line 887 "src/libre/dialect/pcre/parser.c"
+#line 970 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -900,83 +983,6 @@ ZL0:;
 }
 
 static void
-p_expr_C_Clist_Hof_Hpieces(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr ZIcat)
-{
-	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-		return;
-	}
-ZL2_expr_C_Clist_Hof_Hpieces:;
-	{
-		/* BEGINNING OF INLINE: 269 */
-		{
-			switch (CURRENT_TERMINAL) {
-			case (TOK_INVALID__COMMENT):
-				{
-					p_expr_C_Ccomment (flags, lex_state, act_state, err);
-					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-						RESTORE_LEXER;
-						goto ZL1;
-					}
-				}
-				break;
-			case (TOK_ANY): case (TOK_EOL): case (TOK_START): case (TOK_END):
-			case (TOK_END__NL): case (TOK_OPEN): case (TOK_OPENGROUP): case (TOK_OPENGROUPINV):
-			case (TOK_OPENGROUPCB): case (TOK_OPENGROUPINVCB): case (TOK_NAMED__CLASS): case (TOK_FLAGS):
-			case (TOK_ESC): case (TOK_NOESC): case (TOK_CONTROL): case (TOK_OCT):
-			case (TOK_HEX): case (TOK_CHAR): case (TOK_UNSUPPORTED):
-				{
-					t_ast__expr ZIa;
-
-					p_expr_C_Cpiece (flags, lex_state, act_state, err, &ZIa);
-					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-						RESTORE_LEXER;
-						goto ZL1;
-					}
-					/* BEGINNING OF ACTION: ast-add-concat */
-					{
-#line 987 "src/libre/parser.act"
-
-		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
-			goto ZL1;
-		}
-	
-#line 944 "src/libre/dialect/pcre/parser.c"
-					}
-					/* END OF ACTION: ast-add-concat */
-				}
-				break;
-			default:
-				goto ZL1;
-			}
-		}
-		/* END OF INLINE: 269 */
-		/* BEGINNING OF INLINE: 270 */
-		{
-			switch (CURRENT_TERMINAL) {
-			case (TOK_ANY): case (TOK_EOL): case (TOK_START): case (TOK_END):
-			case (TOK_END__NL): case (TOK_OPEN): case (TOK_OPENGROUP): case (TOK_OPENGROUPINV):
-			case (TOK_OPENGROUPCB): case (TOK_OPENGROUPINVCB): case (TOK_NAMED__CLASS): case (TOK_FLAGS):
-			case (TOK_ESC): case (TOK_NOESC): case (TOK_CONTROL): case (TOK_OCT):
-			case (TOK_HEX): case (TOK_CHAR): case (TOK_UNSUPPORTED): case (TOK_INVALID__COMMENT):
-				{
-					/* BEGINNING OF INLINE: expr::list-of-pieces */
-					goto ZL2_expr_C_Clist_Hof_Hpieces;
-					/* END OF INLINE: expr::list-of-pieces */
-				}
-				/*UNREACHED*/
-			default:
-				break;
-			}
-		}
-		/* END OF INLINE: 270 */
-	}
-	return;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-}
-
-static void
 p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
 {
 	t_ast__expr ZInode;
@@ -987,27 +993,27 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 	{
 		t_char ZIc;
 
-		/* BEGINNING OF INLINE: 109 */
+		/* BEGINNING OF INLINE: 111 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CHAR):
 				{
-					t_pos ZI119;
-					t_pos ZI120;
+					t_pos ZI121;
+					t_pos ZI122;
 
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
-#line 530 "src/libre/parser.act"
+#line 536 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI119 = lex_state->lx.start;
-		ZI120   = lex_state->lx.end;
+		ZI121 = lex_state->lx.start;
+		ZI122   = lex_state->lx.end;
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 1011 "src/libre/dialect/pcre/parser.c"
+#line 1017 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CHAR */
 					ADVANCE_LEXER;
@@ -1015,12 +1021,12 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				break;
 			case (TOK_CONTROL):
 				{
-					t_pos ZI121;
-					t_pos ZI122;
+					t_pos ZI123;
+					t_pos ZI124;
 
 					/* BEGINNING OF EXTRACT: CONTROL */
 					{
-#line 413 "src/libre/parser.act"
+#line 419 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] == 'c');
@@ -1051,10 +1057,10 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 			ZIc = cc;
 		}
 
-		ZI121 = lex_state->lx.start;
-		ZI122   = lex_state->lx.end;
+		ZI123 = lex_state->lx.start;
+		ZI124   = lex_state->lx.end;
 	
-#line 1058 "src/libre/dialect/pcre/parser.c"
+#line 1064 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CONTROL */
 					ADVANCE_LEXER;
@@ -1062,12 +1068,12 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				break;
 			case (TOK_ESC):
 				{
-					t_pos ZI111;
-					t_pos ZI112;
+					t_pos ZI113;
+					t_pos ZI114;
 
 					/* BEGINNING OF EXTRACT: ESC */
 					{
-#line 365 "src/libre/parser.act"
+#line 371 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -1087,10 +1093,10 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		default:             break;
 		}
 
-		ZI111 = lex_state->lx.start;
-		ZI112   = lex_state->lx.end;
+		ZI113 = lex_state->lx.start;
+		ZI114   = lex_state->lx.end;
 	
-#line 1094 "src/libre/dialect/pcre/parser.c"
+#line 1100 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: ESC */
 					ADVANCE_LEXER;
@@ -1098,12 +1104,12 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				break;
 			case (TOK_HEX):
 				{
-					t_pos ZI117;
-					t_pos ZI118;
+					t_pos ZI119;
+					t_pos ZI120;
 
 					/* BEGINNING OF EXTRACT: HEX */
 					{
-#line 489 "src/libre/parser.act"
+#line 495 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -1112,8 +1118,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		assert(0 == strncmp(lex_state->buf.a, "\\x", 2));
 		assert(strlen(lex_state->buf.a) >= 2);  /* pcre allows \x without a suffix */
 
-		ZI117 = lex_state->lx.start;
-		ZI118   = lex_state->lx.end;
+		ZI119 = lex_state->lx.start;
+		ZI120   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -1148,7 +1154,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 1152 "src/libre/dialect/pcre/parser.c"
+#line 1158 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: HEX */
 					ADVANCE_LEXER;
@@ -1156,12 +1162,12 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				break;
 			case (TOK_NOESC):
 				{
-					t_pos ZI113;
-					t_pos ZI114;
+					t_pos ZI115;
+					t_pos ZI116;
 
 					/* BEGINNING OF EXTRACT: NOESC */
 					{
-#line 388 "src/libre/parser.act"
+#line 394 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -1169,10 +1175,10 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZIc = lex_state->buf.a[1];
 
-		ZI113 = lex_state->lx.start;
-		ZI114   = lex_state->lx.end;
+		ZI115 = lex_state->lx.start;
+		ZI116   = lex_state->lx.end;
 	
-#line 1176 "src/libre/dialect/pcre/parser.c"
+#line 1182 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: NOESC */
 					ADVANCE_LEXER;
@@ -1180,12 +1186,12 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				break;
 			case (TOK_OCT):
 				{
-					t_pos ZI115;
-					t_pos ZI116;
+					t_pos ZI117;
+					t_pos ZI118;
 
 					/* BEGINNING OF EXTRACT: OCT */
 					{
-#line 449 "src/libre/parser.act"
+#line 455 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -1194,8 +1200,8 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
 		assert(strlen(lex_state->buf.a) >= 2);
 
-		ZI115 = lex_state->lx.start;
-		ZI116   = lex_state->lx.end;
+		ZI117 = lex_state->lx.start;
+		ZI118   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -1225,7 +1231,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 1229 "src/libre/dialect/pcre/parser.c"
+#line 1235 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OCT */
 					ADVANCE_LEXER;
@@ -1233,12 +1239,12 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				break;
 			case (TOK_UNSUPPORTED):
 				{
-					t_pos ZI123;
-					t_pos ZI124;
+					t_pos ZI125;
+					t_pos ZI126;
 
 					/* BEGINNING OF EXTRACT: UNSUPPORTED */
 					{
-#line 397 "src/libre/parser.act"
+#line 403 "src/libre/parser.act"
 
 		/* handle \1-\9 back references */
 		if (lex_state->buf.a[0] == '\\' && lex_state->buf.a[1] != '\0' && lex_state->buf.a[2] == '\0') {
@@ -1248,23 +1254,23 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 			ZIc = lex_state->buf.a[0];
 		}
 
-		ZI123 = lex_state->lx.start;
-		ZI124   = lex_state->lx.end;
+		ZI125 = lex_state->lx.start;
+		ZI126   = lex_state->lx.end;
 	
-#line 1255 "src/libre/dialect/pcre/parser.c"
+#line 1261 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: UNSUPPORTED */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: err-unsupported */
 					{
-#line 700 "src/libre/parser.act"
+#line 706 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXUNSUPPORTD;
 		}
 		goto ZL1;
 	
-#line 1268 "src/libre/dialect/pcre/parser.c"
+#line 1274 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: err-unsupported */
 				}
@@ -1273,17 +1279,17 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 109 */
+		/* END OF INLINE: 111 */
 		/* BEGINNING OF ACTION: ast-make-literal */
 		{
-#line 831 "src/libre/parser.act"
+#line 837 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1287 "src/libre/dialect/pcre/parser.c"
+#line 1293 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-literal */
 	}
@@ -1303,27 +1309,27 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CHAR):
 		{
-			t_char ZI305;
-			t_pos ZI306;
-			t_pos ZI307;
+			t_char ZI307;
+			t_pos ZI308;
+			t_pos ZI309;
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
-#line 530 "src/libre/parser.act"
+#line 536 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI306 = lex_state->lx.start;
-		ZI307   = lex_state->lx.end;
+		ZI308 = lex_state->lx.start;
+		ZI309   = lex_state->lx.end;
 
-		ZI305 = lex_state->buf.a[0];
+		ZI307 = lex_state->buf.a[0];
 	
-#line 1323 "src/libre/dialect/pcre/parser.c"
+#line 1329 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
-			p_312 (flags, lex_state, act_state, err, &ZI305, &ZI306, &ZInode);
+			p_314 (flags, lex_state, act_state, err, &ZI307, &ZI308, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1332,20 +1338,20 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		break;
 	case (TOK_CONTROL):
 		{
-			t_char ZI309;
-			t_pos ZI310;
-			t_pos ZI311;
+			t_char ZI311;
+			t_pos ZI312;
+			t_pos ZI313;
 
 			/* BEGINNING OF EXTRACT: CONTROL */
 			{
-#line 413 "src/libre/parser.act"
+#line 419 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] == 'c');
 		assert(lex_state->buf.a[2] != '\0');
 		assert(lex_state->buf.a[3] == '\0');
 
-		ZI309 = lex_state->buf.a[2];
+		ZI311 = lex_state->buf.a[2];
 		/* from http://www.pcre.org/current/doc/html/pcre2pattern.html#SEC5
 		 * 
 		 *  The precise effect of \cx on ASCII characters is as follows: if x is a lower case letter, it is converted to
@@ -1355,7 +1361,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		 */
 
 		{
-			unsigned char cc = (unsigned char)ZI309;
+			unsigned char cc = (unsigned char)ZI311;
 			if (cc > 126 || cc < 32) {
 				goto ZL1;
 			}
@@ -1366,29 +1372,29 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			cc ^= 0x40;
 
-			ZI309 = cc;
+			ZI311 = cc;
 		}
 
-		ZI310 = lex_state->lx.start;
-		ZI311   = lex_state->lx.end;
+		ZI312 = lex_state->lx.start;
+		ZI313   = lex_state->lx.end;
 	
-#line 1376 "src/libre/dialect/pcre/parser.c"
+#line 1382 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: CONTROL */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: err-unsupported */
 			{
-#line 700 "src/libre/parser.act"
+#line 706 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXUNSUPPORTD;
 		}
 		goto ZL1;
 	
-#line 1389 "src/libre/dialect/pcre/parser.c"
+#line 1395 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: err-unsupported */
-			p_312 (flags, lex_state, act_state, err, &ZI309, &ZI310, &ZInode);
+			p_314 (flags, lex_state, act_state, err, &ZI311, &ZI312, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1397,40 +1403,40 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		break;
 	case (TOK_ESC):
 		{
-			t_char ZI293;
-			t_pos ZI294;
-			t_pos ZI295;
+			t_char ZI295;
+			t_pos ZI296;
+			t_pos ZI297;
 
 			/* BEGINNING OF EXTRACT: ESC */
 			{
-#line 365 "src/libre/parser.act"
+#line 371 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
 		assert(lex_state->buf.a[2] == '\0');
 
-		ZI293 = lex_state->buf.a[1];
+		ZI295 = lex_state->buf.a[1];
 
-		switch (ZI293) {
-		case 'a': ZI293 = '\a'; break;
-		case 'b': ZI293 = '\b'; break;
-		case 'e': ZI293 = '\033'; break;
-		case 'f': ZI293 = '\f'; break;
-		case 'n': ZI293 = '\n'; break;
-		case 'r': ZI293 = '\r'; break;
-		case 't': ZI293 = '\t'; break;
-		case 'v': ZI293 = '\v'; break;
+		switch (ZI295) {
+		case 'a': ZI295 = '\a'; break;
+		case 'b': ZI295 = '\b'; break;
+		case 'e': ZI295 = '\033'; break;
+		case 'f': ZI295 = '\f'; break;
+		case 'n': ZI295 = '\n'; break;
+		case 'r': ZI295 = '\r'; break;
+		case 't': ZI295 = '\t'; break;
+		case 'v': ZI295 = '\v'; break;
 		default:             break;
 		}
 
-		ZI294 = lex_state->lx.start;
-		ZI295   = lex_state->lx.end;
+		ZI296 = lex_state->lx.start;
+		ZI297   = lex_state->lx.end;
 	
-#line 1430 "src/libre/dialect/pcre/parser.c"
+#line 1436 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: ESC */
 			ADVANCE_LEXER;
-			p_312 (flags, lex_state, act_state, err, &ZI293, &ZI294, &ZInode);
+			p_314 (flags, lex_state, act_state, err, &ZI295, &ZI296, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1439,13 +1445,13 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		break;
 	case (TOK_HEX):
 		{
-			t_char ZI301;
-			t_pos ZI302;
-			t_pos ZI303;
+			t_char ZI303;
+			t_pos ZI304;
+			t_pos ZI305;
 
 			/* BEGINNING OF EXTRACT: HEX */
 			{
-#line 489 "src/libre/parser.act"
+#line 495 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -1454,8 +1460,8 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		assert(0 == strncmp(lex_state->buf.a, "\\x", 2));
 		assert(strlen(lex_state->buf.a) >= 2);  /* pcre allows \x without a suffix */
 
-		ZI302 = lex_state->lx.start;
-		ZI303   = lex_state->lx.end;
+		ZI304 = lex_state->lx.start;
+		ZI305   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -1488,13 +1494,13 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 			goto ZL1;
 		}
 
-		ZI301 = (char) (unsigned char) u;
+		ZI303 = (char) (unsigned char) u;
 	
-#line 1494 "src/libre/dialect/pcre/parser.c"
+#line 1500 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: HEX */
 			ADVANCE_LEXER;
-			p_312 (flags, lex_state, act_state, err, &ZI301, &ZI302, &ZInode);
+			p_314 (flags, lex_state, act_state, err, &ZI303, &ZI304, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1503,28 +1509,28 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		break;
 	case (TOK_NAMED__CLASS):
 		{
-			t_ast__class__id ZI289;
-			t_pos ZI290;
-			t_pos ZI291;
+			t_ast__class__id ZI291;
+			t_pos ZI292;
+			t_pos ZI293;
 
 			/* BEGINNING OF EXTRACT: NAMED_CLASS */
 			{
-#line 587 "src/libre/parser.act"
+#line 593 "src/libre/parser.act"
 
-		ZI289 = DIALECT_CLASS(lex_state->buf.a);
-		if (ZI289 == NULL) {
+		ZI291 = DIALECT_CLASS(lex_state->buf.a);
+		if (ZI291 == NULL) {
 			/* syntax error -- unrecognized class */
 			goto ZL1;
 		}
 
-		ZI290 = lex_state->lx.start;
-		ZI291   = lex_state->lx.end;
+		ZI292 = lex_state->lx.start;
+		ZI293   = lex_state->lx.end;
 	
-#line 1524 "src/libre/dialect/pcre/parser.c"
+#line 1530 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			ADVANCE_LEXER;
-			p_292 (flags, lex_state, act_state, err, &ZI289, &ZI290, &ZInode);
+			p_294 (flags, lex_state, act_state, err, &ZI291, &ZI292, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1534,12 +1540,12 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 	case (TOK_NOESC):
 		{
 			t_char ZIc;
-			t_pos ZI132;
-			t_pos ZI133;
+			t_pos ZI134;
+			t_pos ZI135;
 
 			/* BEGINNING OF EXTRACT: NOESC */
 			{
-#line 388 "src/libre/parser.act"
+#line 394 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -1547,36 +1553,36 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 		ZIc = lex_state->buf.a[1];
 
-		ZI132 = lex_state->lx.start;
-		ZI133   = lex_state->lx.end;
+		ZI134 = lex_state->lx.start;
+		ZI135   = lex_state->lx.end;
 	
-#line 1554 "src/libre/dialect/pcre/parser.c"
+#line 1560 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: NOESC */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 831 "src/libre/parser.act"
+#line 837 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1567 "src/libre/dialect/pcre/parser.c"
+#line 1573 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
 		break;
 	case (TOK_OCT):
 		{
-			t_char ZI297;
-			t_pos ZI298;
-			t_pos ZI299;
+			t_char ZI299;
+			t_pos ZI300;
+			t_pos ZI301;
 
 			/* BEGINNING OF EXTRACT: OCT */
 			{
-#line 449 "src/libre/parser.act"
+#line 455 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -1585,8 +1591,8 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
 		assert(strlen(lex_state->buf.a) >= 2);
 
-		ZI298 = lex_state->lx.start;
-		ZI299   = lex_state->lx.end;
+		ZI300 = lex_state->lx.start;
+		ZI301   = lex_state->lx.end;
 
 		errno = 0;
 
@@ -1614,13 +1620,13 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 			goto ZL1;
 		}
 
-		ZI297 = (char) (unsigned char) u;
+		ZI299 = (char) (unsigned char) u;
 	
-#line 1620 "src/libre/dialect/pcre/parser.c"
+#line 1626 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: OCT */
 			ADVANCE_LEXER;
-			p_312 (flags, lex_state, act_state, err, &ZI297, &ZI298, &ZInode);
+			p_314 (flags, lex_state, act_state, err, &ZI299, &ZI300, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1656,14 +1662,14 @@ p_expr_C_Ccomment(flags flags, lex_state lex_state, act_state act_state, err err
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: err-invalid-comment */
 		{
-#line 623 "src/libre/parser.act"
+#line 629 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EBADCOMMENT;
 		}
 		goto ZL1;
 	
-#line 1667 "src/libre/dialect/pcre/parser.c"
+#line 1673 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-invalid-comment */
 	}
@@ -1690,7 +1696,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hclass(flags fl
 		case (TOK_NAMED__CLASS):
 			/* BEGINNING OF EXTRACT: NAMED_CLASS */
 			{
-#line 587 "src/libre/parser.act"
+#line 593 "src/libre/parser.act"
 
 		ZIid = DIALECT_CLASS(lex_state->buf.a);
 		if (ZIid == NULL) {
@@ -1701,7 +1707,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hclass(flags fl
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1705 "src/libre/dialect/pcre/parser.c"
+#line 1711 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			break;
@@ -1711,12 +1717,12 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hclass(flags fl
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-range-endpoint-class */
 		{
-#line 801 "src/libre/parser.act"
+#line 807 "src/libre/parser.act"
 
 		(ZIr).type = AST_ENDPOINT_NAMED;
 		(ZIr).u.named.class = (ZIid);
 	
-#line 1720 "src/libre/dialect/pcre/parser.c"
+#line 1726 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-range-endpoint-class */
 	}
@@ -1743,38 +1749,38 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		t_ast__expr ZItmp;
 		t_pos ZIend;
 
-		/* BEGINNING OF INLINE: 176 */
+		/* BEGINNING OF INLINE: 178 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_OPENGROUP):
 				{
-					t_pos ZI177;
+					t_pos ZI179;
 
 					/* BEGINNING OF EXTRACT: OPENGROUP */
 					{
-#line 319 "src/libre/parser.act"
+#line 325 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
-		ZI177   = lex_state->lx.end;
+		ZI179   = lex_state->lx.end;
 	
-#line 1761 "src/libre/dialect/pcre/parser.c"
+#line 1767 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OPENGROUP */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-alt */
 					{
-#line 824 "src/libre/parser.act"
+#line 830 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1774 "src/libre/dialect/pcre/parser.c"
+#line 1780 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-alt */
 					ZItmp = ZInode;
-					p_190 (flags, lex_state, act_state, err, &ZItmp);
+					p_192 (flags, lex_state, act_state, err, &ZItmp);
 					p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, ZItmp);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
@@ -1784,57 +1790,57 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 				break;
 			case (TOK_OPENGROUPCB):
 				{
-					t_pos ZI196;
+					t_pos ZI198;
 					t_char ZIcbrak;
 					t_ast__expr ZInode1;
 
 					/* BEGINNING OF EXTRACT: OPENGROUPCB */
 					{
-#line 329 "src/libre/parser.act"
+#line 335 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
-		ZI196   = lex_state->lx.end;
+		ZI198   = lex_state->lx.end;
 	
-#line 1799 "src/libre/dialect/pcre/parser.c"
+#line 1805 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OPENGROUPCB */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-alt */
 					{
-#line 824 "src/libre/parser.act"
+#line 830 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1812 "src/libre/dialect/pcre/parser.c"
+#line 1818 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-alt */
 					ZItmp = ZInode;
 					/* BEGINNING OF ACTION: make-literal-cbrak */
 					{
-#line 838 "src/libre/parser.act"
+#line 848 "src/libre/parser.act"
 
 		(ZIcbrak) = ']';
 	
-#line 1822 "src/libre/dialect/pcre/parser.c"
+#line 1828 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: make-literal-cbrak */
-					p_205 (flags, lex_state, act_state, err, &ZIstart, &ZIcbrak, &ZInode1);
+					p_207 (flags, lex_state, act_state, err, &ZIstart, &ZIcbrak, &ZInode1);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL1;
 					}
 					/* BEGINNING OF ACTION: ast-add-alt */
 					{
-#line 993 "src/libre/parser.act"
+#line 1003 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZItmp), (ZInode1))) {
 			goto ZL1;
 		}
 	
-#line 1838 "src/libre/dialect/pcre/parser.c"
+#line 1844 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-add-alt */
 					p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, ZItmp);
@@ -1846,35 +1852,35 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 				break;
 			case (TOK_OPENGROUPINV):
 				{
-					t_pos ZI188;
+					t_pos ZI190;
 
 					/* BEGINNING OF EXTRACT: OPENGROUPINV */
 					{
-#line 324 "src/libre/parser.act"
+#line 330 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
-		ZI188   = lex_state->lx.end;
+		ZI190   = lex_state->lx.end;
 	
-#line 1859 "src/libre/dialect/pcre/parser.c"
+#line 1865 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OPENGROUPINV */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-alt */
 					{
-#line 824 "src/libre/parser.act"
+#line 830 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1872 "src/libre/dialect/pcre/parser.c"
+#line 1878 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-alt */
 					ZItmp = ZInode;
 					/* BEGINNING OF ACTION: ast-make-invert */
 					{
-#line 937 "src/libre/parser.act"
+#line 947 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -1912,10 +1918,10 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			goto ZL1;
 		}
 	
-#line 1916 "src/libre/dialect/pcre/parser.c"
+#line 1922 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-invert */
-					p_190 (flags, lex_state, act_state, err, &ZItmp);
+					p_192 (flags, lex_state, act_state, err, &ZItmp);
 					p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, ZItmp);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
@@ -1925,37 +1931,37 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 				break;
 			case (TOK_OPENGROUPINVCB):
 				{
-					t_pos ZI203;
+					t_pos ZI205;
 					t_char ZIcbrak;
 					t_ast__expr ZInode1;
 
 					/* BEGINNING OF EXTRACT: OPENGROUPINVCB */
 					{
-#line 334 "src/libre/parser.act"
+#line 340 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
-		ZI203   = lex_state->lx.end;
+		ZI205   = lex_state->lx.end;
 	
-#line 1940 "src/libre/dialect/pcre/parser.c"
+#line 1946 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OPENGROUPINVCB */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-alt */
 					{
-#line 824 "src/libre/parser.act"
+#line 830 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1953 "src/libre/dialect/pcre/parser.c"
+#line 1959 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-alt */
 					ZItmp = ZInode;
 					/* BEGINNING OF ACTION: ast-make-invert */
 					{
-#line 937 "src/libre/parser.act"
+#line 947 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -1993,32 +1999,32 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			goto ZL1;
 		}
 	
-#line 1997 "src/libre/dialect/pcre/parser.c"
+#line 2003 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-invert */
 					/* BEGINNING OF ACTION: make-literal-cbrak */
 					{
-#line 838 "src/libre/parser.act"
+#line 848 "src/libre/parser.act"
 
 		(ZIcbrak) = ']';
 	
-#line 2006 "src/libre/dialect/pcre/parser.c"
+#line 2012 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: make-literal-cbrak */
-					p_205 (flags, lex_state, act_state, err, &ZIstart, &ZIcbrak, &ZInode1);
+					p_207 (flags, lex_state, act_state, err, &ZIstart, &ZIcbrak, &ZInode1);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL1;
 					}
 					/* BEGINNING OF ACTION: ast-add-alt */
 					{
-#line 993 "src/libre/parser.act"
+#line 1003 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZItmp), (ZInode1))) {
 			goto ZL1;
 		}
 	
-#line 2022 "src/libre/dialect/pcre/parser.c"
+#line 2028 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-add-alt */
 					p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, ZItmp);
@@ -2032,35 +2038,35 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 176 */
-		/* BEGINNING OF INLINE: 209 */
+		/* END OF INLINE: 178 */
+		/* BEGINNING OF INLINE: 211 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CLOSEGROUP):
 				{
-					t_char ZI210;
-					t_pos ZI211;
+					t_char ZI212;
+					t_pos ZI213;
 
 					/* BEGINNING OF EXTRACT: CLOSEGROUP */
 					{
-#line 339 "src/libre/parser.act"
+#line 345 "src/libre/parser.act"
 
-		ZI210 = ']';
-		ZI211 = lex_state->lx.start;
+		ZI212 = ']';
+		ZI213 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 2053 "src/libre/dialect/pcre/parser.c"
+#line 2059 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CLOSEGROUP */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: mark-group */
 					{
-#line 704 "src/libre/parser.act"
+#line 710 "src/libre/parser.act"
 
 		mark(&act_state->groupstart, &(ZIstart));
 		mark(&act_state->groupend,   &(ZIend));
 	
-#line 2064 "src/libre/dialect/pcre/parser.c"
+#line 2070 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: mark-group */
 				}
@@ -2068,52 +2074,52 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			case (TOK_CLOSEGROUPRANGE):
 				{
 					t_char ZIcrange;
-					t_pos ZI213;
+					t_pos ZI215;
 					t_ast__expr ZIrange;
 
 					/* BEGINNING OF EXTRACT: CLOSEGROUPRANGE */
 					{
-#line 345 "src/libre/parser.act"
+#line 351 "src/libre/parser.act"
 
 		ZIcrange = '-';
-		ZI213 = lex_state->lx.start;
+		ZI215 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 2083 "src/libre/dialect/pcre/parser.c"
+#line 2089 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CLOSEGROUPRANGE */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-literal */
 					{
-#line 831 "src/libre/parser.act"
+#line 837 "src/libre/parser.act"
 
 		(ZIrange) = ast_make_expr_literal(act_state->poolp, *flags, (ZIcrange));
 		if ((ZIrange) == NULL) {
 			goto ZL4;
 		}
 	
-#line 2096 "src/libre/dialect/pcre/parser.c"
+#line 2102 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-literal */
 					/* BEGINNING OF ACTION: ast-add-alt */
 					{
-#line 993 "src/libre/parser.act"
+#line 1003 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZItmp), (ZIrange))) {
 			goto ZL4;
 		}
 	
-#line 2107 "src/libre/dialect/pcre/parser.c"
+#line 2113 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-add-alt */
 					/* BEGINNING OF ACTION: mark-group */
 					{
-#line 704 "src/libre/parser.act"
+#line 710 "src/libre/parser.act"
 
 		mark(&act_state->groupstart, &(ZIstart));
 		mark(&act_state->groupend,   &(ZIend));
 	
-#line 2117 "src/libre/dialect/pcre/parser.c"
+#line 2123 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: mark-group */
 				}
@@ -2126,24 +2132,24 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			{
 				/* BEGINNING OF ACTION: err-expected-closegroup */
 				{
-#line 665 "src/libre/parser.act"
+#line 671 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCLOSEGROUP;
 		}
 		goto ZL1;
 	
-#line 2137 "src/libre/dialect/pcre/parser.c"
+#line 2143 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: err-expected-closegroup */
 				ZIend = ZIstart;
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 209 */
+		/* END OF INLINE: 211 */
 		/* BEGINNING OF ACTION: mark-expr */
 		{
-#line 721 "src/libre/parser.act"
+#line 727 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -2158,7 +2164,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		(ZItmp)->u.class.end   = ast_end;
 */
 	
-#line 2162 "src/libre/dialect/pcre/parser.c"
+#line 2168 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: mark-expr */
 	}
@@ -2180,34 +2186,34 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_Hend(flags flags, lex_state lex_st
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 157 */
+		/* BEGINNING OF INLINE: 159 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_RANGE):
 				{
 					t_char ZIc;
-					t_pos ZI159;
+					t_pos ZI161;
 
 					/* BEGINNING OF EXTRACT: RANGE */
 					{
-#line 313 "src/libre/parser.act"
+#line 319 "src/libre/parser.act"
 
 		ZIc = '-';
-		ZI159 = lex_state->lx.start;
+		ZI161 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 2200 "src/libre/dialect/pcre/parser.c"
+#line 2206 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: RANGE */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 					{
-#line 796 "src/libre/parser.act"
+#line 802 "src/libre/parser.act"
 
 		(ZIr).type = AST_ENDPOINT_LITERAL;
 		(ZIr).u.literal.c = (ZIc);
 	
-#line 2211 "src/libre/dialect/pcre/parser.c"
+#line 2217 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-range-endpoint-literal */
 				}
@@ -2215,9 +2221,9 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_Hend(flags flags, lex_state lex_st
 			case (TOK_NAMED__CLASS): case (TOK_ESC): case (TOK_CONTROL): case (TOK_OCT):
 			case (TOK_HEX): case (TOK_CHAR):
 				{
-					t_pos ZI158;
+					t_pos ZI160;
 
-					p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint (flags, lex_state, act_state, err, &ZIr, &ZI158, &ZIend);
+					p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint (flags, lex_state, act_state, err, &ZIr, &ZI160, &ZIend);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL1;
@@ -2228,7 +2234,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_Hend(flags flags, lex_state lex_st
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 157 */
+		/* END OF INLINE: 159 */
 	}
 	goto ZL0;
 ZL1:;
@@ -2240,7 +2246,7 @@ ZL0:;
 }
 
 static void
-p_312(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI309, t_pos *ZI310, t_ast__expr *ZOnode)
+p_314(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI311, t_pos *ZI312, t_ast__expr *ZOnode)
 {
 	t_ast__expr ZInode;
 
@@ -2249,14 +2255,14 @@ p_312(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		{
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 831 "src/libre/parser.act"
+#line 837 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (*ZI309));
+		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (*ZI311));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2260 "src/libre/dialect/pcre/parser.c"
+#line 2266 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -2269,15 +2275,15 @@ p_312(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 796 "src/libre/parser.act"
+#line 802 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_LITERAL;
-		(ZIlower).u.literal.c = (*ZI309);
+		(ZIlower).u.literal.c = (*ZI311);
 	
-#line 2278 "src/libre/dialect/pcre/parser.c"
+#line 2284 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
-			p_164 (flags, lex_state, act_state, err);
+			p_166 (flags, lex_state, act_state, err);
 			p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_Hend (flags, lex_state, act_state, err, &ZIupper, &ZIend);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
@@ -2285,22 +2291,22 @@ p_312(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			}
 			/* BEGINNING OF ACTION: mark-range */
 			{
-#line 709 "src/libre/parser.act"
+#line 715 "src/libre/parser.act"
 
-		mark(&act_state->rangestart, &(*ZI310));
+		mark(&act_state->rangestart, &(*ZI312));
 		mark(&act_state->rangeend,   &(ZIend));
 	
-#line 2294 "src/libre/dialect/pcre/parser.c"
+#line 2300 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 950 "src/libre/parser.act"
+#line 960 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI310));
+		AST_POS_OF_LX_POS(ast_start, (*ZI312));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		if ((ZIlower).type != AST_ENDPOINT_LITERAL ||
@@ -2328,7 +2334,7 @@ p_312(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			goto ZL1;
 		}
 	
-#line 2332 "src/libre/dialect/pcre/parser.c"
+#line 2338 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -2345,40 +2351,40 @@ ZL0:;
 }
 
 static void
-p_315(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI313, t_unsigned *ZIm, t_ast__count *ZOc)
+p_317(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI315, t_unsigned *ZIm, t_ast__count *ZOc)
 {
 	t_ast__count ZIc;
 
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CLOSECOUNT):
 		{
-			t_pos ZI254;
+			t_pos ZI256;
 			t_pos ZIend;
 
 			/* BEGINNING OF EXTRACT: CLOSECOUNT */
 			{
-#line 356 "src/libre/parser.act"
+#line 362 "src/libre/parser.act"
 
-		ZI254 = lex_state->lx.start;
+		ZI256 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 2366 "src/libre/dialect/pcre/parser.c"
+#line 2372 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: CLOSECOUNT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 714 "src/libre/parser.act"
+#line 720 "src/libre/parser.act"
 
-		mark(&act_state->countstart, &(*ZI313));
+		mark(&act_state->countstart, &(*ZI315));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 2377 "src/libre/dialect/pcre/parser.c"
+#line 2383 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 778 "src/libre/parser.act"
+#line 784 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -2387,18 +2393,18 @@ p_315(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI3
 			err->m = (*ZIm);
 			err->n = (*ZIm);
 
-			mark(&act_state->countstart, &(*ZI313));
+			mark(&act_state->countstart, &(*ZI315));
 			mark(&act_state->countend,   &(ZIend));
 
 			goto ZL1;
 		}
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI313));
+		AST_POS_OF_LX_POS(ast_start, (*ZI315));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (*ZIm), &ast_end);
 	
-#line 2402 "src/libre/dialect/pcre/parser.c"
+#line 2408 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-range */
 		}
@@ -2406,7 +2412,7 @@ p_315(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI3
 	case (TOK_SEP):
 		{
 			ADVANCE_LEXER;
-			p_316 (flags, lex_state, act_state, err, ZI313, ZIm, &ZIc);
+			p_318 (flags, lex_state, act_state, err, ZI315, ZIm, &ZIc);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -2427,50 +2433,50 @@ ZL0:;
 }
 
 static void
-p_316(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI313, t_unsigned *ZIm, t_ast__count *ZOc)
+p_318(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI315, t_unsigned *ZIm, t_ast__count *ZOc)
 {
 	t_ast__count ZIc;
 
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CLOSECOUNT):
 		{
-			t_pos ZI259;
+			t_pos ZI261;
 			t_pos ZIend;
 			t_unsigned ZIn;
 
 			/* BEGINNING OF EXTRACT: CLOSECOUNT */
 			{
-#line 356 "src/libre/parser.act"
+#line 362 "src/libre/parser.act"
 
-		ZI259 = lex_state->lx.start;
+		ZI261 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 2449 "src/libre/dialect/pcre/parser.c"
+#line 2455 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: CLOSECOUNT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 714 "src/libre/parser.act"
+#line 720 "src/libre/parser.act"
 
-		mark(&act_state->countstart, &(*ZI313));
+		mark(&act_state->countstart, &(*ZI315));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 2460 "src/libre/dialect/pcre/parser.c"
+#line 2466 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-unbounded */
 			{
-#line 756 "src/libre/parser.act"
+#line 762 "src/libre/parser.act"
 
 		(ZIn) = AST_COUNT_UNBOUNDED;
 	
-#line 2469 "src/libre/dialect/pcre/parser.c"
+#line 2475 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-unbounded */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 778 "src/libre/parser.act"
+#line 784 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -2479,18 +2485,18 @@ p_316(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI3
 			err->m = (*ZIm);
 			err->n = (ZIn);
 
-			mark(&act_state->countstart, &(*ZI313));
+			mark(&act_state->countstart, &(*ZI315));
 			mark(&act_state->countend,   &(ZIend));
 
 			goto ZL1;
 		}
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI313));
+		AST_POS_OF_LX_POS(ast_start, (*ZI315));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (ZIn), &ast_end);
 	
-#line 2494 "src/libre/dialect/pcre/parser.c"
+#line 2500 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-range */
 		}
@@ -2498,12 +2504,12 @@ p_316(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI3
 	case (TOK_COUNT):
 		{
 			t_unsigned ZIn;
-			t_pos ZI257;
+			t_pos ZI259;
 			t_pos ZIend;
 
 			/* BEGINNING OF EXTRACT: COUNT */
 			{
-#line 575 "src/libre/parser.act"
+#line 581 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -2523,7 +2529,7 @@ p_316(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI3
 
 		ZIn = (unsigned int) u;
 	
-#line 2527 "src/libre/dialect/pcre/parser.c"
+#line 2533 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: COUNT */
 			ADVANCE_LEXER;
@@ -2531,12 +2537,12 @@ p_316(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI3
 			case (TOK_CLOSECOUNT):
 				/* BEGINNING OF EXTRACT: CLOSECOUNT */
 				{
-#line 356 "src/libre/parser.act"
+#line 362 "src/libre/parser.act"
 
-		ZI257 = lex_state->lx.start;
+		ZI259 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 2540 "src/libre/dialect/pcre/parser.c"
+#line 2546 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF EXTRACT: CLOSECOUNT */
 				break;
@@ -2546,17 +2552,17 @@ p_316(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI3
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 714 "src/libre/parser.act"
+#line 720 "src/libre/parser.act"
 
-		mark(&act_state->countstart, &(*ZI313));
+		mark(&act_state->countstart, &(*ZI315));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 2555 "src/libre/dialect/pcre/parser.c"
+#line 2561 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 778 "src/libre/parser.act"
+#line 784 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -2565,18 +2571,18 @@ p_316(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI3
 			err->m = (*ZIm);
 			err->n = (ZIn);
 
-			mark(&act_state->countstart, &(*ZI313));
+			mark(&act_state->countstart, &(*ZI315));
 			mark(&act_state->countend,   &(ZIend));
 
 			goto ZL1;
 		}
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI313));
+		AST_POS_OF_LX_POS(ast_start, (*ZI315));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (ZIn), &ast_end);
 	
-#line 2580 "src/libre/dialect/pcre/parser.c"
+#line 2586 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-range */
 		}
@@ -2595,43 +2601,43 @@ ZL0:;
 }
 
 static void
-p_190(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZItmp)
+p_192(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZItmp)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_RANGE):
 		{
 			t_char ZIc;
 			t_pos ZIrstart;
-			t_pos ZI191;
+			t_pos ZI193;
 			t_ast__expr ZInode1;
 
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 313 "src/libre/parser.act"
+#line 319 "src/libre/parser.act"
 
 		ZIc = '-';
 		ZIrstart = lex_state->lx.start;
-		ZI191   = lex_state->lx.end;
+		ZI193   = lex_state->lx.end;
 	
-#line 2617 "src/libre/dialect/pcre/parser.c"
+#line 2623 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
-			/* BEGINNING OF INLINE: 192 */
+			/* BEGINNING OF INLINE: 194 */
 			{
 				switch (CURRENT_TERMINAL) {
 				default:
 					{
 						/* BEGINNING OF ACTION: ast-make-literal */
 						{
-#line 831 "src/libre/parser.act"
+#line 837 "src/libre/parser.act"
 
 		(ZInode1) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZInode1) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2635 "src/libre/dialect/pcre/parser.c"
+#line 2641 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF ACTION: ast-make-literal */
 					}
@@ -2639,31 +2645,31 @@ p_190(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 				case (TOK_RANGE):
 					{
 						t_endpoint ZIlower;
-						t_char ZI193;
-						t_pos ZI194;
-						t_pos ZI195;
+						t_char ZI195;
+						t_pos ZI196;
+						t_pos ZI197;
 						t_endpoint ZIupper;
 						t_pos ZIend;
 
 						/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 						{
-#line 796 "src/libre/parser.act"
+#line 802 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_LITERAL;
 		(ZIlower).u.literal.c = (ZIc);
 	
-#line 2656 "src/libre/dialect/pcre/parser.c"
+#line 2662 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF ACTION: ast-range-endpoint-literal */
 						/* BEGINNING OF EXTRACT: RANGE */
 						{
-#line 313 "src/libre/parser.act"
+#line 319 "src/libre/parser.act"
 
-		ZI193 = '-';
-		ZI194 = lex_state->lx.start;
-		ZI195   = lex_state->lx.end;
+		ZI195 = '-';
+		ZI196 = lex_state->lx.start;
+		ZI197   = lex_state->lx.end;
 	
-#line 2667 "src/libre/dialect/pcre/parser.c"
+#line 2673 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF EXTRACT: RANGE */
 						ADVANCE_LEXER;
@@ -2674,7 +2680,7 @@ p_190(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 						}
 						/* BEGINNING OF ACTION: ast-make-range */
 						{
-#line 950 "src/libre/parser.act"
+#line 960 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -2707,23 +2713,23 @@ p_190(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			goto ZL1;
 		}
 	
-#line 2711 "src/libre/dialect/pcre/parser.c"
+#line 2717 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF ACTION: ast-make-range */
 					}
 					break;
 				}
 			}
-			/* END OF INLINE: 192 */
+			/* END OF INLINE: 194 */
 			/* BEGINNING OF ACTION: ast-add-alt */
 			{
-#line 993 "src/libre/parser.act"
+#line 1003 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((*ZItmp), (ZInode1))) {
 			goto ZL1;
 		}
 	
-#line 2727 "src/libre/dialect/pcre/parser.c"
+#line 2733 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 		}
@@ -2751,7 +2757,7 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 		t_ast__expr ZIe;
 
 		p_expr_C_Cpiece_C_Catom (flags, lex_state, act_state, err, &ZIe);
-		/* BEGINNING OF INLINE: 263 */
+		/* BEGINNING OF INLINE: 265 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_OPT): case (TOK_PLUS): case (TOK_STAR): case (TOK_OPENCOUNT):
@@ -2769,16 +2775,16 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 
 					/* BEGINNING OF ACTION: count-one */
 					{
-#line 772 "src/libre/parser.act"
+#line 778 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 2777 "src/libre/dialect/pcre/parser.c"
+#line 2783 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: count-one */
 					/* BEGINNING OF ACTION: ast-make-piece */
 					{
-#line 850 "src/libre/parser.act"
+#line 860 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
@@ -2792,7 +2798,7 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 			goto ZL1;
 		}
 	
-#line 2796 "src/libre/dialect/pcre/parser.c"
+#line 2802 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-piece */
 				}
@@ -2802,7 +2808,7 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 				goto ZL1;
 			}
 		}
-		/* END OF INLINE: 263 */
+		/* END OF INLINE: 265 */
 	}
 	goto ZL0;
 ZL1:;
@@ -2823,14 +2829,14 @@ p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__ex
 	{
 		/* BEGINNING OF ACTION: ast-make-alt */
 		{
-#line 824 "src/libre/parser.act"
+#line 830 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2834 "src/libre/dialect/pcre/parser.c"
+#line 2840 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-alt */
 		p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, ZInode);
@@ -2844,26 +2850,26 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-alts */
 		{
-#line 651 "src/libre/parser.act"
+#line 657 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXALTS;
 		}
 		goto ZL2;
 	
-#line 2855 "src/libre/dialect/pcre/parser.c"
+#line 2861 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 810 "src/libre/parser.act"
+#line 816 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL2;
 		}
 	
-#line 2867 "src/libre/dialect/pcre/parser.c"
+#line 2873 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -2898,23 +2904,23 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: re-flag-none */
 		{
-#line 748 "src/libre/parser.act"
+#line 754 "src/libre/parser.act"
 
 		(ZIempty__pos) = RE_FLAGS_NONE;
 	
-#line 2906 "src/libre/dialect/pcre/parser.c"
+#line 2912 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: re-flag-none */
 		/* BEGINNING OF ACTION: re-flag-none */
 		{
-#line 748 "src/libre/parser.act"
+#line 754 "src/libre/parser.act"
 
 		(ZIempty__neg) = RE_FLAGS_NONE;
 	
-#line 2915 "src/libre/dialect/pcre/parser.c"
+#line 2921 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: re-flag-none */
-		/* BEGINNING OF INLINE: 228 */
+		/* BEGINNING OF INLINE: 230 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_FLAG__IGNORE): case (TOK_FLAG__UNKNOWN): case (TOK_FLAG__INSENSITIVE): case (TOK_FLAG__EXTENDED):
@@ -2934,8 +2940,8 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 				break;
 			}
 		}
-		/* END OF INLINE: 228 */
-		/* BEGINNING OF INLINE: 230 */
+		/* END OF INLINE: 230 */
+		/* BEGINNING OF INLINE: 232 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_NEGATE):
@@ -2955,8 +2961,8 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 				break;
 			}
 		}
-		/* END OF INLINE: 230 */
-		/* BEGINNING OF INLINE: 233 */
+		/* END OF INLINE: 232 */
+		/* BEGINNING OF INLINE: 235 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CLOSE):
@@ -2964,7 +2970,7 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-mask-re-flags */
 					{
-#line 883 "src/libre/parser.act"
+#line 893 "src/libre/parser.act"
 
 		/*
 		 * Note: in cases like `(?i-i)`, the negative is
@@ -2973,19 +2979,19 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 		*flags |= (ZIpos);
 		*flags &= ~(ZIneg);
 	
-#line 2977 "src/libre/dialect/pcre/parser.c"
+#line 2983 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-mask-re-flags */
 					/* BEGINNING OF ACTION: ast-make-empty */
 					{
-#line 810 "src/libre/parser.act"
+#line 816 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL5;
 		}
 	
-#line 2989 "src/libre/dialect/pcre/parser.c"
+#line 2995 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-empty */
 				}
@@ -2998,16 +3004,16 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-get-re-flags */
 					{
-#line 871 "src/libre/parser.act"
+#line 881 "src/libre/parser.act"
 
 		(ZIflags) = *flags;
 	
-#line 3006 "src/libre/dialect/pcre/parser.c"
+#line 3012 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-get-re-flags */
 					/* BEGINNING OF ACTION: ast-mask-re-flags */
 					{
-#line 883 "src/libre/parser.act"
+#line 893 "src/libre/parser.act"
 
 		/*
 		 * Note: in cases like `(?i-i)`, the negative is
@@ -3016,7 +3022,7 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 		*flags |= (ZIpos);
 		*flags &= ~(ZIneg);
 	
-#line 3020 "src/libre/dialect/pcre/parser.c"
+#line 3026 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-mask-re-flags */
 					p_expr (flags, lex_state, act_state, err, &ZIe);
@@ -3026,11 +3032,11 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 					}
 					/* BEGINNING OF ACTION: ast-set-re-flags */
 					{
-#line 875 "src/libre/parser.act"
+#line 885 "src/libre/parser.act"
 
 		*flags = (ZIflags);
 	
-#line 3034 "src/libre/dialect/pcre/parser.c"
+#line 3040 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-set-re-flags */
 					switch (CURRENT_TERMINAL) {
@@ -3051,32 +3057,32 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 			{
 				/* BEGINNING OF ACTION: err-expected-closeflags */
 				{
-#line 686 "src/libre/parser.act"
+#line 692 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCLOSEFLAGS;
 		}
 		goto ZL1;
 	
-#line 3062 "src/libre/dialect/pcre/parser.c"
+#line 3068 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: err-expected-closeflags */
 				/* BEGINNING OF ACTION: ast-make-empty */
 				{
-#line 810 "src/libre/parser.act"
+#line 816 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3074 "src/libre/dialect/pcre/parser.c"
+#line 3080 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: ast-make-empty */
 			}
 		ZL4:;
 		}
-		/* END OF INLINE: 233 */
+		/* END OF INLINE: 235 */
 	}
 	goto ZL0;
 ZL1:;
@@ -3104,7 +3110,7 @@ p_expr_C_Cpiece_C_Clist_Hof_Hcounts(flags flags, lex_state lex_state, act_state 
 		}
 		/* BEGINNING OF ACTION: ast-make-piece */
 		{
-#line 850 "src/libre/parser.act"
+#line 860 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
@@ -3118,10 +3124,10 @@ p_expr_C_Cpiece_C_Clist_Hof_Hcounts(flags flags, lex_state lex_state, act_state 
 			goto ZL1;
 		}
 	
-#line 3122 "src/libre/dialect/pcre/parser.c"
+#line 3128 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-piece */
-		/* BEGINNING OF INLINE: 262 */
+		/* BEGINNING OF INLINE: 264 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_OPT):
@@ -3129,14 +3135,14 @@ p_expr_C_Cpiece_C_Clist_Hof_Hcounts(flags flags, lex_state lex_state, act_state 
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: err-unsupported */
 					{
-#line 700 "src/libre/parser.act"
+#line 706 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXUNSUPPORTD;
 		}
 		goto ZL1;
 	
-#line 3140 "src/libre/dialect/pcre/parser.c"
+#line 3146 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: err-unsupported */
 				}
@@ -3146,14 +3152,14 @@ p_expr_C_Cpiece_C_Clist_Hof_Hcounts(flags flags, lex_state lex_state, act_state 
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: err-unsupported */
 					{
-#line 700 "src/libre/parser.act"
+#line 706 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXUNSUPPORTD;
 		}
 		goto ZL1;
 	
-#line 3157 "src/libre/dialect/pcre/parser.c"
+#line 3163 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: err-unsupported */
 				}
@@ -3162,7 +3168,7 @@ p_expr_C_Cpiece_C_Clist_Hof_Hcounts(flags flags, lex_state lex_state, act_state 
 				break;
 			}
 		}
-		/* END OF INLINE: 262 */
+		/* END OF INLINE: 264 */
 	}
 	goto ZL0;
 ZL1:;
@@ -3173,7 +3179,56 @@ ZL0:;
 }
 
 static void
-p_205(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIstart, t_char *ZIcbrak, t_ast__expr *ZOnode1)
+p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint(flags flags, lex_state lex_state, act_state act_state, err err, t_endpoint *ZOr, t_pos *ZOstart, t_pos *ZOend)
+{
+	t_endpoint ZIr;
+	t_pos ZIstart;
+	t_pos ZIend;
+
+	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+		return;
+	}
+	{
+		/* BEGINNING OF INLINE: 156 */
+		{
+			switch (CURRENT_TERMINAL) {
+			case (TOK_NAMED__CLASS):
+				{
+					p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hclass (flags, lex_state, act_state, err, &ZIr, &ZIstart, &ZIend);
+					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+						RESTORE_LEXER;
+						goto ZL1;
+					}
+				}
+				break;
+			case (TOK_ESC): case (TOK_CONTROL): case (TOK_OCT): case (TOK_HEX):
+			case (TOK_CHAR):
+				{
+					p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral (flags, lex_state, act_state, err, &ZIr, &ZIstart, &ZIend);
+					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+						RESTORE_LEXER;
+						goto ZL1;
+					}
+				}
+				break;
+			default:
+				goto ZL1;
+			}
+		}
+		/* END OF INLINE: 156 */
+	}
+	goto ZL0;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+ZL0:;
+	*ZOr = ZIr;
+	*ZOstart = ZIstart;
+	*ZOend = ZIend;
+}
+
+static void
+p_207(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIstart, t_char *ZIcbrak, t_ast__expr *ZOnode1)
 {
 	t_ast__expr ZInode1;
 
@@ -3182,14 +3237,14 @@ p_205(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 		{
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 831 "src/libre/parser.act"
+#line 837 "src/libre/parser.act"
 
 		(ZInode1) = ast_make_expr_literal(act_state->poolp, *flags, (*ZIcbrak));
 		if ((ZInode1) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3193 "src/libre/dialect/pcre/parser.c"
+#line 3248 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -3197,32 +3252,32 @@ p_205(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 	case (TOK_RANGE):
 		{
 			t_endpoint ZIr;
-			t_char ZI206;
-			t_pos ZI207;
-			t_pos ZI208;
+			t_char ZI208;
+			t_pos ZI209;
+			t_pos ZI210;
 			t_endpoint ZIupper;
 			t_pos ZIend;
 			t_endpoint ZIlower;
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 796 "src/libre/parser.act"
+#line 802 "src/libre/parser.act"
 
 		(ZIr).type = AST_ENDPOINT_LITERAL;
 		(ZIr).u.literal.c = (*ZIcbrak);
 	
-#line 3215 "src/libre/dialect/pcre/parser.c"
+#line 3270 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 313 "src/libre/parser.act"
+#line 319 "src/libre/parser.act"
 
-		ZI206 = '-';
-		ZI207 = lex_state->lx.start;
-		ZI208   = lex_state->lx.end;
+		ZI208 = '-';
+		ZI209 = lex_state->lx.start;
+		ZI210   = lex_state->lx.end;
 	
-#line 3226 "src/libre/dialect/pcre/parser.c"
+#line 3281 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
@@ -3233,17 +3288,17 @@ p_205(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 			}
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 796 "src/libre/parser.act"
+#line 802 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_LITERAL;
 		(ZIlower).u.literal.c = (*ZIcbrak);
 	
-#line 3242 "src/libre/dialect/pcre/parser.c"
+#line 3297 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 950 "src/libre/parser.act"
+#line 960 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -3276,7 +3331,7 @@ p_205(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 			goto ZL1;
 		}
 	
-#line 3280 "src/libre/dialect/pcre/parser.c"
+#line 3335 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -3290,55 +3345,6 @@ ZL1:;
 	return;
 ZL0:;
 	*ZOnode1 = ZInode1;
-}
-
-static void
-p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint(flags flags, lex_state lex_state, act_state act_state, err err, t_endpoint *ZOr, t_pos *ZOstart, t_pos *ZOend)
-{
-	t_endpoint ZIr;
-	t_pos ZIstart;
-	t_pos ZIend;
-
-	if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-		return;
-	}
-	{
-		/* BEGINNING OF INLINE: 154 */
-		{
-			switch (CURRENT_TERMINAL) {
-			case (TOK_NAMED__CLASS):
-				{
-					p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hclass (flags, lex_state, act_state, err, &ZIr, &ZIstart, &ZIend);
-					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-						RESTORE_LEXER;
-						goto ZL1;
-					}
-				}
-				break;
-			case (TOK_ESC): case (TOK_CONTROL): case (TOK_OCT): case (TOK_HEX):
-			case (TOK_CHAR):
-				{
-					p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral (flags, lex_state, act_state, err, &ZIr, &ZIstart, &ZIend);
-					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-						RESTORE_LEXER;
-						goto ZL1;
-					}
-				}
-				break;
-			default:
-				goto ZL1;
-			}
-		}
-		/* END OF INLINE: 154 */
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOr = ZIr;
-	*ZOstart = ZIstart;
-	*ZOend = ZIend;
 }
 
 static void
@@ -3358,7 +3364,7 @@ p_class_Hnamed(flags flags, lex_state lex_state, act_state act_state, err err, t
 		case (TOK_NAMED__CLASS):
 			/* BEGINNING OF EXTRACT: NAMED_CLASS */
 			{
-#line 587 "src/libre/parser.act"
+#line 593 "src/libre/parser.act"
 
 		ZIid = DIALECT_CLASS(lex_state->buf.a);
 		if (ZIid == NULL) {
@@ -3369,7 +3375,7 @@ p_class_Hnamed(flags flags, lex_state lex_state, act_state act_state, err err, t
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 3373 "src/libre/dialect/pcre/parser.c"
+#line 3379 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			break;
@@ -3379,14 +3385,14 @@ p_class_Hnamed(flags flags, lex_state lex_state, act_state act_state, err err, t
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-make-named */
 		{
-#line 980 "src/libre/parser.act"
+#line 990 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_named(act_state->poolp, *flags, (ZIid));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3390 "src/libre/dialect/pcre/parser.c"
+#line 3396 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-named */
 	}
@@ -3417,16 +3423,16 @@ ZL2_expr_C_Clist_Hof_Halts:;
 		}
 		/* BEGINNING OF ACTION: ast-add-alt */
 		{
-#line 993 "src/libre/parser.act"
+#line 1003 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIalts), (ZIa))) {
 			goto ZL1;
 		}
 	
-#line 3427 "src/libre/dialect/pcre/parser.c"
+#line 3433 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-add-alt */
-		/* BEGINNING OF INLINE: 276 */
+		/* BEGINNING OF INLINE: 278 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ALT):
@@ -3441,21 +3447,21 @@ ZL2_expr_C_Clist_Hof_Halts:;
 				break;
 			}
 		}
-		/* END OF INLINE: 276 */
+		/* END OF INLINE: 278 */
 	}
 	return;
 ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-alts */
 		{
-#line 651 "src/libre/parser.act"
+#line 657 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXALTS;
 		}
 		goto ZL4;
 	
-#line 3459 "src/libre/dialect/pcre/parser.c"
+#line 3465 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
 	}
@@ -3474,18 +3480,18 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 	switch (CURRENT_TERMINAL) {
 	case (TOK_OPENCOUNT):
 		{
-			t_pos ZI313;
-			t_pos ZI314;
+			t_pos ZI315;
+			t_pos ZI316;
 			t_unsigned ZIm;
 
 			/* BEGINNING OF EXTRACT: OPENCOUNT */
 			{
-#line 351 "src/libre/parser.act"
+#line 357 "src/libre/parser.act"
 
-		ZI313 = lex_state->lx.start;
-		ZI314   = lex_state->lx.end;
+		ZI315 = lex_state->lx.start;
+		ZI316   = lex_state->lx.end;
 	
-#line 3489 "src/libre/dialect/pcre/parser.c"
+#line 3495 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: OPENCOUNT */
 			ADVANCE_LEXER;
@@ -3493,7 +3499,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			case (TOK_COUNT):
 				/* BEGINNING OF EXTRACT: COUNT */
 				{
-#line 575 "src/libre/parser.act"
+#line 581 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -3513,7 +3519,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		ZIm = (unsigned int) u;
 	
-#line 3517 "src/libre/dialect/pcre/parser.c"
+#line 3523 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -3521,7 +3527,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 				goto ZL1;
 			}
 			ADVANCE_LEXER;
-			p_315 (flags, lex_state, act_state, err, &ZI313, &ZIm, &ZIc);
+			p_317 (flags, lex_state, act_state, err, &ZI315, &ZIm, &ZIc);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -3533,11 +3539,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-zero-or-one */
 			{
-#line 768 "src/libre/parser.act"
+#line 774 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, 1, NULL);
 	
-#line 3541 "src/libre/dialect/pcre/parser.c"
+#line 3547 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-one */
 		}
@@ -3547,11 +3553,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-one-or-more */
 			{
-#line 764 "src/libre/parser.act"
+#line 770 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 3555 "src/libre/dialect/pcre/parser.c"
+#line 3561 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-one-or-more */
 		}
@@ -3561,11 +3567,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-zero-or-more */
 			{
-#line 760 "src/libre/parser.act"
+#line 766 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 3569 "src/libre/dialect/pcre/parser.c"
+#line 3575 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 		}
@@ -3580,23 +3586,23 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-count */
 		{
-#line 637 "src/libre/parser.act"
+#line 643 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCOUNT;
 		}
 		goto ZL2;
 	
-#line 3591 "src/libre/dialect/pcre/parser.c"
+#line 3597 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-expected-count */
 		/* BEGINNING OF ACTION: count-one */
 		{
-#line 772 "src/libre/parser.act"
+#line 778 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 3600 "src/libre/dialect/pcre/parser.c"
+#line 3606 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: count-one */
 	}
@@ -3617,7 +3623,7 @@ p_re__pcre(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 278 */
+		/* BEGINNING OF INLINE: 280 */
 		{
 			{
 				p_expr (flags, lex_state, act_state, err, &ZInode);
@@ -3627,8 +3633,8 @@ p_re__pcre(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 				}
 			}
 		}
-		/* END OF INLINE: 278 */
-		/* BEGINNING OF INLINE: 279 */
+		/* END OF INLINE: 280 */
+		/* BEGINNING OF INLINE: 281 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -3644,20 +3650,20 @@ p_re__pcre(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 693 "src/libre/parser.act"
+#line 699 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
 		}
 		goto ZL1;
 	
-#line 3655 "src/libre/dialect/pcre/parser.c"
+#line 3661 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 279 */
+		/* END OF INLINE: 281 */
 	}
 	goto ZL0;
 ZL1:;
@@ -3680,24 +3686,24 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: class-any */
 			{
-#line 735 "src/libre/parser.act"
+#line 741 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
 		(ZIa) = (*flags & RE_SINGLE) ? &class_any : &class_notnl;
 	
-#line 3689 "src/libre/dialect/pcre/parser.c"
+#line 3695 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 980 "src/libre/parser.act"
+#line 990 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_named(act_state->poolp, *flags, (ZIa));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3701 "src/libre/dialect/pcre/parser.c"
+#line 3707 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 		}
@@ -3707,14 +3713,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-anchor-end */
 			{
-#line 895 "src/libre/parser.act"
+#line 905 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_anchor(act_state->poolp, *flags, AST_ANCHOR_END);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3718 "src/libre/dialect/pcre/parser.c"
+#line 3724 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-end */
 		}
@@ -3730,37 +3736,37 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-literal-nl */
 			{
-#line 846 "src/libre/parser.act"
+#line 856 "src/libre/parser.act"
 
 		(ZInl) = '\n';
 	
-#line 3738 "src/libre/dialect/pcre/parser.c"
+#line 3744 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: make-literal-nl */
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 831 "src/libre/parser.act"
+#line 837 "src/libre/parser.act"
 
 		(ZIenl) = ast_make_expr_literal(act_state->poolp, *flags, (ZInl));
 		if ((ZIenl) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3750 "src/libre/dialect/pcre/parser.c"
+#line 3756 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 			/* BEGINNING OF ACTION: count-zero-or-one */
 			{
-#line 768 "src/libre/parser.act"
+#line 774 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, 1, NULL);
 	
-#line 3759 "src/libre/dialect/pcre/parser.c"
+#line 3765 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-one */
 			/* BEGINNING OF ACTION: ast-make-piece */
 			{
-#line 850 "src/libre/parser.act"
+#line 860 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZIoptnl) = ast_make_expr_empty(act_state->poolp, *flags);
@@ -3774,53 +3780,53 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 3778 "src/libre/dialect/pcre/parser.c"
+#line 3784 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-piece */
 			/* BEGINNING OF ACTION: ast-make-anchor-end */
 			{
-#line 895 "src/libre/parser.act"
+#line 905 "src/libre/parser.act"
 
 		(ZIa) = ast_make_expr_anchor(act_state->poolp, *flags, AST_ANCHOR_END);
 		if ((ZIa) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3790 "src/libre/dialect/pcre/parser.c"
+#line 3796 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-end */
 			/* BEGINNING OF ACTION: ast-make-concat */
 			{
-#line 817 "src/libre/parser.act"
+#line 823 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_concat(act_state->poolp, *flags);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3802 "src/libre/dialect/pcre/parser.c"
+#line 3808 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-concat */
 			/* BEGINNING OF ACTION: ast-add-concat */
 			{
-#line 987 "src/libre/parser.act"
+#line 997 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIe), (ZIoptnl))) {
 			goto ZL1;
 		}
 	
-#line 3813 "src/libre/dialect/pcre/parser.c"
+#line 3819 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-concat */
 			/* BEGINNING OF ACTION: ast-add-concat */
 			{
-#line 987 "src/libre/parser.act"
+#line 997 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIe), (ZIa))) {
 			goto ZL1;
 		}
 	
-#line 3824 "src/libre/dialect/pcre/parser.c"
+#line 3830 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-concat */
 		}
@@ -3838,134 +3844,134 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: class-bsr */
 			{
-#line 740 "src/libre/parser.act"
+#line 746 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
 		(ZIclass__bsr) = &class_bsr;
 	
-#line 3847 "src/libre/dialect/pcre/parser.c"
+#line 3853 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: class-bsr */
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 980 "src/libre/parser.act"
+#line 990 "src/libre/parser.act"
 
 		(ZIbsr) = ast_make_expr_named(act_state->poolp, *flags, (ZIclass__bsr));
 		if ((ZIbsr) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3859 "src/libre/dialect/pcre/parser.c"
+#line 3865 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 			/* BEGINNING OF ACTION: ast-make-concat */
 			{
-#line 817 "src/libre/parser.act"
+#line 823 "src/libre/parser.act"
 
 		(ZIcrlf) = ast_make_expr_concat(act_state->poolp, *flags);
 		if ((ZIcrlf) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3871 "src/libre/dialect/pcre/parser.c"
+#line 3877 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-concat */
 			/* BEGINNING OF ACTION: make-literal-cr */
 			{
-#line 842 "src/libre/parser.act"
+#line 852 "src/libre/parser.act"
 
 		(ZIcr) = '\r';
 	
-#line 3880 "src/libre/dialect/pcre/parser.c"
+#line 3886 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: make-literal-cr */
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 831 "src/libre/parser.act"
+#line 837 "src/libre/parser.act"
 
 		(ZIecr) = ast_make_expr_literal(act_state->poolp, *flags, (ZIcr));
 		if ((ZIecr) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3892 "src/libre/dialect/pcre/parser.c"
+#line 3898 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 			/* BEGINNING OF ACTION: make-literal-nl */
 			{
-#line 846 "src/libre/parser.act"
+#line 856 "src/libre/parser.act"
 
 		(ZInl) = '\n';
 	
-#line 3901 "src/libre/dialect/pcre/parser.c"
+#line 3907 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: make-literal-nl */
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 831 "src/libre/parser.act"
+#line 837 "src/libre/parser.act"
 
 		(ZIenl) = ast_make_expr_literal(act_state->poolp, *flags, (ZInl));
 		if ((ZIenl) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3913 "src/libre/dialect/pcre/parser.c"
+#line 3919 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 			/* BEGINNING OF ACTION: ast-add-concat */
 			{
-#line 987 "src/libre/parser.act"
+#line 997 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcrlf), (ZIecr))) {
 			goto ZL1;
 		}
 	
-#line 3924 "src/libre/dialect/pcre/parser.c"
+#line 3930 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-concat */
 			/* BEGINNING OF ACTION: ast-add-concat */
 			{
-#line 987 "src/libre/parser.act"
+#line 997 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcrlf), (ZIenl))) {
 			goto ZL1;
 		}
 	
-#line 3935 "src/libre/dialect/pcre/parser.c"
+#line 3941 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-concat */
 			/* BEGINNING OF ACTION: ast-make-alt */
 			{
-#line 824 "src/libre/parser.act"
+#line 830 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3947 "src/libre/dialect/pcre/parser.c"
+#line 3953 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-alt */
 			/* BEGINNING OF ACTION: ast-add-alt */
 			{
-#line 993 "src/libre/parser.act"
+#line 1003 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIe), (ZIcrlf))) {
 			goto ZL1;
 		}
 	
-#line 3958 "src/libre/dialect/pcre/parser.c"
+#line 3964 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 			/* BEGINNING OF ACTION: ast-add-alt */
 			{
-#line 993 "src/libre/parser.act"
+#line 1003 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIe), (ZIbsr))) {
 			goto ZL1;
 		}
 	
-#line 3969 "src/libre/dialect/pcre/parser.c"
+#line 3975 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 		}
@@ -3973,18 +3979,28 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 	case (TOK_OPEN):
 		{
 			t_re__flags ZIflags;
+			t_group__id ZIid;
 			t_ast__expr ZIg;
 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-get-re-flags */
 			{
-#line 871 "src/libre/parser.act"
+#line 881 "src/libre/parser.act"
 
 		(ZIflags) = *flags;
 	
-#line 3986 "src/libre/dialect/pcre/parser.c"
+#line 3993 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-get-re-flags */
+			/* BEGINNING OF ACTION: make-group-id */
+			{
+#line 844 "src/libre/parser.act"
+
+		(ZIid) = act_state->group_id++;
+	
+#line 4002 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: make-group-id */
 			p_expr (flags, lex_state, act_state, err, &ZIg);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
@@ -3992,23 +4008,23 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			}
 			/* BEGINNING OF ACTION: ast-set-re-flags */
 			{
-#line 875 "src/libre/parser.act"
+#line 885 "src/libre/parser.act"
 
 		*flags = (ZIflags);
 	
-#line 4000 "src/libre/dialect/pcre/parser.c"
+#line 4016 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-set-re-flags */
 			/* BEGINNING OF ACTION: ast-make-group */
 			{
-#line 864 "src/libre/parser.act"
+#line 874 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_group(act_state->poolp, *flags, (ZIg));
+		(ZIe) = ast_make_expr_group(act_state->poolp, *flags, (ZIg), (ZIid));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 4012 "src/libre/dialect/pcre/parser.c"
+#line 4028 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-group */
 			switch (CURRENT_TERMINAL) {
@@ -4025,14 +4041,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-anchor-start */
 			{
-#line 888 "src/libre/parser.act"
+#line 898 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_anchor(act_state->poolp, *flags, AST_ANCHOR_START);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 4036 "src/libre/dialect/pcre/parser.c"
+#line 4052 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-start */
 		}
@@ -4084,26 +4100,26 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-atom */
 		{
-#line 644 "src/libre/parser.act"
+#line 650 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXATOM;
 		}
 		goto ZL2;
 	
-#line 4095 "src/libre/dialect/pcre/parser.c"
+#line 4111 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 810 "src/libre/parser.act"
+#line 816 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZIe) == NULL) {
 			goto ZL2;
 		}
 	
-#line 4107 "src/libre/dialect/pcre/parser.c"
+#line 4123 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -4129,14 +4145,14 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 		{
 			/* BEGINNING OF ACTION: ast-make-concat */
 			{
-#line 817 "src/libre/parser.act"
+#line 823 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_concat(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 4140 "src/libre/dialect/pcre/parser.c"
+#line 4156 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-concat */
 			p_expr_C_Clist_Hof_Hpieces (flags, lex_state, act_state, err, ZInode);
@@ -4150,14 +4166,14 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 		{
 			/* BEGINNING OF ACTION: ast-make-empty */
 			{
-#line 810 "src/libre/parser.act"
+#line 816 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 4161 "src/libre/dialect/pcre/parser.c"
+#line 4177 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-empty */
 		}
@@ -4193,30 +4209,30 @@ p_expr_C_Ctype(flags flags, lex_state lex_state, act_state act_state, err err, t
 		}
 		/* BEGINNING OF ACTION: ast-make-alt */
 		{
-#line 824 "src/libre/parser.act"
+#line 830 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 4204 "src/libre/dialect/pcre/parser.c"
+#line 4220 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-alt */
 		/* BEGINNING OF ACTION: ast-add-alt */
 		{
-#line 993 "src/libre/parser.act"
+#line 1003 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZInode), (ZIclass))) {
 			goto ZL1;
 		}
 	
-#line 4215 "src/libre/dialect/pcre/parser.c"
+#line 4231 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-add-alt */
 		/* BEGINNING OF ACTION: mark-expr */
 		{
-#line 721 "src/libre/parser.act"
+#line 727 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -4231,7 +4247,7 @@ p_expr_C_Ctype(flags flags, lex_state lex_state, act_state act_state, err err, t
 		(ZInode)->u.class.end   = ast_end;
 */
 	
-#line 4235 "src/libre/dialect/pcre/parser.c"
+#line 4251 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: mark-expr */
 	}
@@ -4245,7 +4261,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 1143 "src/libre/parser.act"
+#line 1155 "src/libre/parser.act"
 
 
 	static int
@@ -4321,6 +4337,8 @@ ZL0:;
 		act_state->overlap = overlap;
 		act_state->poolp   = &ast->pool;
 
+		act_state->group_id = 1;
+
 		err->e = RE_ESUCCESS;
 
 		ADVANCE_LEXER;
@@ -4391,6 +4409,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 4395 "src/libre/dialect/pcre/parser.c"
+#line 4413 "src/libre/dialect/pcre/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/pcre/parser.h
+++ b/src/libre/dialect/pcre/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 304 "src/libre/parser.act"
+#line 310 "src/libre/parser.act"
 
 
 	#include <re/re.h>
@@ -28,7 +28,7 @@
 extern void p_re__pcre(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 1145 "src/libre/parser.act"
+#line 1157 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/pcre/parser.h"

--- a/src/libre/dialect/pcre/parser.sid
+++ b/src/libre/dialect/pcre/parser.sid
@@ -183,6 +183,9 @@
 					/* TODO: just construct the AST here;
 					 * complain about unsupported things at a later stage */
 					<err-unsupported>;
+				||
+					(c, !, !) = UNSUPPORTED;
+					<err-unsupported>;
 				};
 
 				node = <ast-make-literal>(c);
@@ -205,6 +208,9 @@
 						(c, start, end) = CHAR;
 					||
 						(c, start, end) = CONTROL;
+						<err-unsupported>;
+					||
+						(c, start, end) = UNSUPPORTED;
 						<err-unsupported>;
 					};
 					r = <ast-range-endpoint-literal>(c);

--- a/src/libre/dialect/pcre/parser.sid
+++ b/src/libre/dialect/pcre/parser.sid
@@ -27,6 +27,7 @@
 	ast_class_id;
 	ast_count;
 	endpoint;
+	group_id;
 
 %terminals%
 
@@ -95,6 +96,7 @@
 	<count-one>:          () -> (:ast_count);
 	<count-range>: (:unsigned, :pos, :unsigned, :pos) -> (:ast_count);
 
+	<make-group-id>:      () -> (:group_id);
 	<make-literal-cbrak>: () -> (:char);
 	<make-literal-cr>:    () -> (:char);
 	<make-literal-nl>:    () -> (:char);
@@ -107,7 +109,7 @@
 	<ast-make-concat>:       ()                       -> (:ast_expr);
 	<ast-make-alt>:          ()                       -> (:ast_expr);
 	<ast-make-piece>:        (:ast_expr, :ast_count)  -> (:ast_expr);
-	<ast-make-group>:        (:ast_expr)              -> (:ast_expr);
+	<ast-make-group>:        (:ast_expr, :group_id)   -> (:ast_expr);
 	<ast-get-re-flags>:      ()                       -> (:re_flags);
 	<ast-set-re-flags>:      (:re_flags)              -> ();
 	<ast-mask-re-flags>:     (:re_flags, :re_flags)   -> ();
@@ -524,9 +526,10 @@
 			||
 				OPEN;
 				flags = <ast-get-re-flags>();
+				id = <make-group-id>;
 				g = expr;
 				<ast-set-re-flags>(flags);
-				e = <ast-make-group>(g);
+				e = <ast-make-group>(g, id);
 				CLOSE;
 			##
 				<err-expected-atom>;

--- a/src/libre/dialect/sql/parser.c
+++ b/src/libre/dialect/sql/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 142 "src/libre/parser.act"
+#line 149 "src/libre/parser.act"
 
 
 	#include <assert.h>
@@ -90,6 +90,7 @@
 	typedef const struct class * t_ast__class__id;
 	typedef struct ast_count t_ast__count;
 	typedef struct ast_endpoint t_endpoint;
+	typedef unsigned t_group__id;
 
 	struct act_state {
 		struct ast_expr_pool **poolp;
@@ -112,6 +113,12 @@
 		struct re_pos groupstart; struct re_pos groupend;
 		struct re_pos rangestart; struct re_pos rangeend;
 		struct re_pos countstart; struct re_pos countend;
+
+		/*
+		 * Numbering for capturing groups. By convention these start from 1,
+		 * and 0 represents the entire matching text.
+		 */
+		unsigned group_id;
 	};
 
 	struct lex_state {
@@ -148,7 +155,6 @@
 	{
 		enum re_flags fl = (lex_state->flags_ptr != NULL) ? lex_state->flags_ptr[0] : 0;
 		enum LX_TOKEN tok;
-
 
 		if ((fl & RE_EXTENDED) == 0) {
 			tok = act_state->lex_tok;
@@ -281,7 +287,7 @@
 		return s;
 	}
 
-#line 285 "src/libre/dialect/sql/parser.c"
+#line 291 "src/libre/dialect/sql/parser.c"
 
 
 #ifndef ERROR_TERMINAL
@@ -299,9 +305,9 @@ static void p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags, lex_state, act_stat
 static void p_expr_C_Ccharacter_Hclass(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Cpiece(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_205(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_209(flags, lex_state, act_state, err, t_char *, t_pos *, t_ast__expr *);
-static void p_212(flags, lex_state, act_state, err, t_pos *, t_unsigned *, t_ast__count *);
+static void p_207(flags, lex_state, act_state, err, t_ast__expr *);
+static void p_211(flags, lex_state, act_state, err, t_char *, t_pos *, t_ast__expr *);
+static void p_214(flags, lex_state, act_state, err, t_pos *, t_unsigned *, t_ast__count *);
 static void p_expr_C_Clist_Hof_Halts(flags, lex_state, act_state, err, t_ast__expr);
 static void p_expr_C_Cpiece_C_Ccount(flags, lex_state, act_state, err, t_ast__count *);
 static void p_expr_C_Cpiece_C_Catom(flags, lex_state, act_state, err, t_ast__expr *);
@@ -319,19 +325,19 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead(flags flags, lex_state lex_state, act_
 	switch (CURRENT_TERMINAL) {
 	case (TOK_INVERT):
 		{
-			t_char ZI204;
+			t_char ZI206;
 
 			/* BEGINNING OF EXTRACT: INVERT */
 			{
-#line 309 "src/libre/parser.act"
+#line 315 "src/libre/parser.act"
 
-		ZI204 = '^';
+		ZI206 = '^';
 	
-#line 331 "src/libre/dialect/sql/parser.c"
+#line 337 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: INVERT */
 			ADVANCE_LEXER;
-			p_205 (flags, lex_state, act_state, err, ZIclass);
+			p_207 (flags, lex_state, act_state, err, ZIclass);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -341,43 +347,43 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead(flags flags, lex_state lex_state, act_
 	case (TOK_RANGE):
 		{
 			t_char ZIc;
-			t_pos ZI112;
-			t_pos ZI113;
+			t_pos ZI114;
+			t_pos ZI115;
 			t_ast__expr ZInode;
 
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 313 "src/libre/parser.act"
+#line 319 "src/libre/parser.act"
 
 		ZIc = '-';
-		ZI112 = lex_state->lx.start;
-		ZI113   = lex_state->lx.end;
+		ZI114 = lex_state->lx.start;
+		ZI115   = lex_state->lx.end;
 	
-#line 357 "src/libre/dialect/sql/parser.c"
+#line 363 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 831 "src/libre/parser.act"
+#line 837 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 370 "src/libre/dialect/sql/parser.c"
+#line 376 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 			/* BEGINNING OF ACTION: ast-add-alt */
 			{
-#line 993 "src/libre/parser.act"
+#line 1003 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((*ZIclass), (ZInode))) {
 			goto ZL1;
 		}
 	
-#line 381 "src/libre/dialect/sql/parser.c"
+#line 387 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 		}
@@ -402,7 +408,7 @@ p_re__sql(flags flags, lex_state lex_state, act_state act_state, err err, t_ast_
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 191 */
+		/* BEGINNING OF INLINE: 193 */
 		{
 			{
 				p_expr (flags, lex_state, act_state, err, &ZInode);
@@ -412,8 +418,8 @@ p_re__sql(flags flags, lex_state lex_state, act_state act_state, err err, t_ast_
 				}
 			}
 		}
-		/* END OF INLINE: 191 */
-		/* BEGINNING OF INLINE: 192 */
+		/* END OF INLINE: 193 */
+		/* BEGINNING OF INLINE: 194 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -429,20 +435,20 @@ p_re__sql(flags flags, lex_state lex_state, act_state act_state, err err, t_ast_
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 693 "src/libre/parser.act"
+#line 699 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
 		}
 		goto ZL1;
 	
-#line 440 "src/libre/dialect/sql/parser.c"
+#line 446 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 192 */
+		/* END OF INLINE: 194 */
 	}
 	goto ZL0;
 ZL1:;
@@ -460,7 +466,7 @@ p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms(flags flags, lex_state lex_
 	}
 ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 	{
-		/* BEGINNING OF INLINE: 145 */
+		/* BEGINNING OF INLINE: 147 */
 		{
 			{
 				t_ast__expr ZInode;
@@ -472,13 +478,13 @@ ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 				}
 				/* BEGINNING OF ACTION: ast-add-alt */
 				{
-#line 993 "src/libre/parser.act"
+#line 1003 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIclass), (ZInode))) {
 			goto ZL4;
 		}
 	
-#line 482 "src/libre/dialect/sql/parser.c"
+#line 488 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: ast-add-alt */
 			}
@@ -487,21 +493,21 @@ ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 			{
 				/* BEGINNING OF ACTION: err-expected-term */
 				{
-#line 630 "src/libre/parser.act"
+#line 636 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXTERM;
 		}
 		goto ZL1;
 	
-#line 498 "src/libre/dialect/sql/parser.c"
+#line 504 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: err-expected-term */
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 145 */
-		/* BEGINNING OF INLINE: 146 */
+		/* END OF INLINE: 147 */
+		/* BEGINNING OF INLINE: 148 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_NAMED__CLASS): case (TOK_CHAR):
@@ -515,7 +521,7 @@ ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 				break;
 			}
 		}
-		/* END OF INLINE: 146 */
+		/* END OF INLINE: 148 */
 	}
 	return;
 ZL1:;
@@ -548,16 +554,16 @@ ZL2_expr_C_Clist_Hof_Hpieces:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 987 "src/libre/parser.act"
+#line 997 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
 		}
 	
-#line 558 "src/libre/dialect/sql/parser.c"
+#line 564 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-add-concat */
-		/* BEGINNING OF INLINE: 183 */
+		/* BEGINNING OF INLINE: 185 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_MANY): case (TOK_OPENSUB): case (TOK_OPENGROUP):
@@ -572,7 +578,7 @@ ZL2_expr_C_Clist_Hof_Hpieces:;
 				break;
 			}
 		}
-		/* END OF INLINE: 183 */
+		/* END OF INLINE: 185 */
 	}
 	return;
 ZL1:;
@@ -588,27 +594,27 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CHAR):
 		{
-			t_char ZI206;
-			t_pos ZI207;
-			t_pos ZI208;
+			t_char ZI208;
+			t_pos ZI209;
+			t_pos ZI210;
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
-#line 530 "src/libre/parser.act"
+#line 536 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI207 = lex_state->lx.start;
-		ZI208   = lex_state->lx.end;
+		ZI209 = lex_state->lx.start;
+		ZI210   = lex_state->lx.end;
 
-		ZI206 = lex_state->buf.a[0];
+		ZI208 = lex_state->buf.a[0];
 	
-#line 608 "src/libre/dialect/sql/parser.c"
+#line 614 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
-			p_209 (flags, lex_state, act_state, err, &ZI206, &ZI207, &ZInode);
+			p_211 (flags, lex_state, act_state, err, &ZI208, &ZI209, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -655,12 +661,12 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		case (TOK_OPENGROUP):
 			/* BEGINNING OF EXTRACT: OPENGROUP */
 			{
-#line 319 "src/libre/parser.act"
+#line 325 "src/libre/parser.act"
 
 		ZIopen__start = lex_state->lx.start;
 		ZIopen__end   = lex_state->lx.end;
 	
-#line 664 "src/libre/dialect/sql/parser.c"
+#line 670 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: OPENGROUP */
 			break;
@@ -670,54 +676,54 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-make-alt */
 		{
-#line 824 "src/libre/parser.act"
+#line 830 "src/libre/parser.act"
 
 		(ZIclass) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZIclass) == NULL) {
 			goto ZL1;
 		}
 	
-#line 681 "src/libre/dialect/sql/parser.c"
+#line 687 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-alt */
 		ZItmp = ZIclass;
 		p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead (flags, lex_state, act_state, err, &ZIclass);
 		p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, ZItmp);
 		p_expr_C_Ccharacter_Hclass_C_Cclass_Htail (flags, lex_state, act_state, err, ZItmp);
-		/* BEGINNING OF INLINE: 151 */
+		/* BEGINNING OF INLINE: 153 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CLOSEGROUP):
 				{
-					t_char ZI152;
+					t_char ZI154;
 					t_pos ZIclose__start;
 					t_pos ZIclose__end;
 
 					/* BEGINNING OF EXTRACT: CLOSEGROUP */
 					{
-#line 339 "src/libre/parser.act"
+#line 345 "src/libre/parser.act"
 
-		ZI152 = ']';
+		ZI154 = ']';
 		ZIclose__start = lex_state->lx.start;
 		ZIclose__end   = lex_state->lx.end;
 	
-#line 705 "src/libre/dialect/sql/parser.c"
+#line 711 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF EXTRACT: CLOSEGROUP */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: mark-group */
 					{
-#line 704 "src/libre/parser.act"
+#line 710 "src/libre/parser.act"
 
 		mark(&act_state->groupstart, &(ZIopen__start));
 		mark(&act_state->groupend,   &(ZIopen__end));
 	
-#line 716 "src/libre/dialect/sql/parser.c"
+#line 722 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: mark-group */
 					/* BEGINNING OF ACTION: mark-expr */
 					{
-#line 721 "src/libre/parser.act"
+#line 727 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -732,7 +738,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		(ZItmp)->u.class.end   = ast_end;
 */
 	
-#line 736 "src/libre/dialect/sql/parser.c"
+#line 742 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: mark-expr */
 					ZInode = ZIclass;
@@ -740,58 +746,58 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 				break;
 			case (TOK_INVERT):
 				{
-					t_char ZI156;
+					t_char ZI158;
 					t_ast__expr ZImask;
 					t_ast__expr ZImask__tmp;
 					t_pos ZIclose__end;
 
 					/* BEGINNING OF EXTRACT: INVERT */
 					{
-#line 309 "src/libre/parser.act"
+#line 315 "src/libre/parser.act"
 
-		ZI156 = '^';
+		ZI158 = '^';
 	
-#line 755 "src/libre/dialect/sql/parser.c"
+#line 761 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF EXTRACT: INVERT */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-alt */
 					{
-#line 824 "src/libre/parser.act"
+#line 830 "src/libre/parser.act"
 
 		(ZImask) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZImask) == NULL) {
 			goto ZL3;
 		}
 	
-#line 768 "src/libre/dialect/sql/parser.c"
+#line 774 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: ast-make-alt */
 					ZImask__tmp = ZImask;
 					p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead (flags, lex_state, act_state, err, &ZImask);
 					p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, ZImask__tmp);
 					p_expr_C_Ccharacter_Hclass_C_Cclass_Htail (flags, lex_state, act_state, err, ZImask__tmp);
-					/* BEGINNING OF INLINE: 160 */
+					/* BEGINNING OF INLINE: 162 */
 					{
 						if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 							RESTORE_LEXER;
 							goto ZL3;
 						}
 						{
-							t_char ZI161;
+							t_char ZI163;
 							t_pos ZIclose__start;
 
 							switch (CURRENT_TERMINAL) {
 							case (TOK_CLOSEGROUP):
 								/* BEGINNING OF EXTRACT: CLOSEGROUP */
 								{
-#line 339 "src/libre/parser.act"
+#line 345 "src/libre/parser.act"
 
-		ZI161 = ']';
+		ZI163 = ']';
 		ZIclose__start = lex_state->lx.start;
 		ZIclose__end   = lex_state->lx.end;
 	
-#line 795 "src/libre/dialect/sql/parser.c"
+#line 801 "src/libre/dialect/sql/parser.c"
 								}
 								/* END OF EXTRACT: CLOSEGROUP */
 								break;
@@ -801,12 +807,12 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 							ADVANCE_LEXER;
 							/* BEGINNING OF ACTION: mark-group */
 							{
-#line 704 "src/libre/parser.act"
+#line 710 "src/libre/parser.act"
 
 		mark(&act_state->groupstart, &(ZIclose__start));
 		mark(&act_state->groupend,   &(ZIclose__end));
 	
-#line 810 "src/libre/dialect/sql/parser.c"
+#line 816 "src/libre/dialect/sql/parser.c"
 							}
 							/* END OF ACTION: mark-group */
 						}
@@ -817,14 +823,14 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 							/* BEGINNING OF ACTION: err-expected-closegroup */
 							{
-#line 665 "src/libre/parser.act"
+#line 671 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCLOSEGROUP;
 		}
 		goto ZL3;
 	
-#line 828 "src/libre/dialect/sql/parser.c"
+#line 834 "src/libre/dialect/sql/parser.c"
 							}
 							/* END OF ACTION: err-expected-closegroup */
 							ZIclose__start = ZIopen__end;
@@ -832,10 +838,10 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 						}
 					ZL4:;
 					}
-					/* END OF INLINE: 160 */
+					/* END OF INLINE: 162 */
 					/* BEGINNING OF ACTION: mark-expr */
 					{
-#line 721 "src/libre/parser.act"
+#line 727 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -850,12 +856,12 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		(ZItmp)->u.class.end   = ast_end;
 */
 	
-#line 854 "src/libre/dialect/sql/parser.c"
+#line 860 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: mark-expr */
 					/* BEGINNING OF ACTION: mark-expr */
 					{
-#line 721 "src/libre/parser.act"
+#line 727 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -870,19 +876,19 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		(ZImask__tmp)->u.class.end   = ast_end;
 */
 	
-#line 874 "src/libre/dialect/sql/parser.c"
+#line 880 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: mark-expr */
 					/* BEGINNING OF ACTION: ast-make-subtract */
 					{
-#line 902 "src/libre/parser.act"
+#line 912 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_subtract(act_state->poolp, *flags, (ZIclass), (ZImask));
 		if ((ZInode) == NULL) {
 			goto ZL3;
 		}
 	
-#line 886 "src/libre/dialect/sql/parser.c"
+#line 892 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: ast-make-subtract */
 				}
@@ -898,32 +904,32 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			{
 				/* BEGINNING OF ACTION: err-expected-closegroup */
 				{
-#line 665 "src/libre/parser.act"
+#line 671 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCLOSEGROUP;
 		}
 		goto ZL1;
 	
-#line 909 "src/libre/dialect/sql/parser.c"
+#line 915 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: err-expected-closegroup */
 				/* BEGINNING OF ACTION: ast-make-empty */
 				{
-#line 810 "src/libre/parser.act"
+#line 816 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 921 "src/libre/dialect/sql/parser.c"
+#line 927 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: ast-make-empty */
 			}
 		ZL2:;
 		}
-		/* END OF INLINE: 151 */
+		/* END OF INLINE: 153 */
 	}
 	goto ZL0;
 ZL1:;
@@ -953,7 +959,7 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 		}
 		/* BEGINNING OF ACTION: ast-make-piece */
 		{
-#line 850 "src/libre/parser.act"
+#line 860 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
@@ -967,7 +973,7 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 			goto ZL1;
 		}
 	
-#line 971 "src/libre/dialect/sql/parser.c"
+#line 977 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-piece */
 	}
@@ -990,14 +996,14 @@ p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__ex
 	{
 		/* BEGINNING OF ACTION: ast-make-alt */
 		{
-#line 824 "src/libre/parser.act"
+#line 830 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1001 "src/libre/dialect/sql/parser.c"
+#line 1007 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-alt */
 		p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, ZInode);
@@ -1011,26 +1017,26 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-alts */
 		{
-#line 651 "src/libre/parser.act"
+#line 657 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXALTS;
 		}
 		goto ZL2;
 	
-#line 1022 "src/libre/dialect/sql/parser.c"
+#line 1028 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 810 "src/libre/parser.act"
+#line 816 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL2;
 		}
 	
-#line 1034 "src/libre/dialect/sql/parser.c"
+#line 1040 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -1043,54 +1049,54 @@ ZL0:;
 }
 
 static void
-p_205(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZIclass)
+p_207(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZIclass)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_RANGE):
 		{
 			t_char ZIc;
-			t_pos ZI115;
-			t_pos ZI116;
+			t_pos ZI117;
+			t_pos ZI118;
 			t_ast__expr ZInode;
 
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 313 "src/libre/parser.act"
+#line 319 "src/libre/parser.act"
 
 		ZIc = '-';
-		ZI115 = lex_state->lx.start;
-		ZI116   = lex_state->lx.end;
+		ZI117 = lex_state->lx.start;
+		ZI118   = lex_state->lx.end;
 	
-#line 1065 "src/libre/dialect/sql/parser.c"
+#line 1071 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 831 "src/libre/parser.act"
+#line 837 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1078 "src/libre/dialect/sql/parser.c"
+#line 1084 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 			/* BEGINNING OF ACTION: ast-add-alt */
 			{
-#line 993 "src/libre/parser.act"
+#line 1003 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((*ZIclass), (ZInode))) {
 			goto ZL1;
 		}
 	
-#line 1089 "src/libre/dialect/sql/parser.c"
+#line 1095 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 			/* BEGINNING OF ACTION: ast-make-invert */
 			{
-#line 937 "src/libre/parser.act"
+#line 947 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -1128,7 +1134,7 @@ p_205(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			goto ZL1;
 		}
 	
-#line 1132 "src/libre/dialect/sql/parser.c"
+#line 1138 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-invert */
 		}
@@ -1137,7 +1143,7 @@ p_205(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 		{
 			/* BEGINNING OF ACTION: ast-make-invert */
 			{
-#line 937 "src/libre/parser.act"
+#line 947 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -1175,7 +1181,7 @@ p_205(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			goto ZL1;
 		}
 	
-#line 1179 "src/libre/dialect/sql/parser.c"
+#line 1185 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-invert */
 		}
@@ -1190,7 +1196,7 @@ ZL1:;
 }
 
 static void
-p_209(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI206, t_pos *ZI207, t_ast__expr *ZOnode)
+p_211(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI208, t_pos *ZI209, t_ast__expr *ZOnode)
 {
 	t_ast__expr ZInode;
 
@@ -1199,14 +1205,14 @@ p_209(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		{
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 831 "src/libre/parser.act"
+#line 837 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (*ZI206));
+		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (*ZI208));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1210 "src/libre/dialect/sql/parser.c"
+#line 1216 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -1214,33 +1220,33 @@ p_209(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 	case (TOK_RANGE):
 		{
 			t_endpoint ZIa;
-			t_char ZI134;
-			t_pos ZI135;
-			t_pos ZI136;
-			t_char ZIcz;
+			t_char ZI136;
+			t_pos ZI137;
 			t_pos ZI138;
+			t_char ZIcz;
+			t_pos ZI140;
 			t_pos ZIend;
 			t_endpoint ZIz;
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 796 "src/libre/parser.act"
+#line 802 "src/libre/parser.act"
 
 		(ZIa).type = AST_ENDPOINT_LITERAL;
-		(ZIa).u.literal.c = (*ZI206);
+		(ZIa).u.literal.c = (*ZI208);
 	
-#line 1233 "src/libre/dialect/sql/parser.c"
+#line 1239 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 313 "src/libre/parser.act"
+#line 319 "src/libre/parser.act"
 
-		ZI134 = '-';
-		ZI135 = lex_state->lx.start;
-		ZI136   = lex_state->lx.end;
+		ZI136 = '-';
+		ZI137 = lex_state->lx.start;
+		ZI138   = lex_state->lx.end;
 	
-#line 1244 "src/libre/dialect/sql/parser.c"
+#line 1250 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
@@ -1248,17 +1254,17 @@ p_209(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			case (TOK_CHAR):
 				/* BEGINNING OF EXTRACT: CHAR */
 				{
-#line 530 "src/libre/parser.act"
+#line 536 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI138 = lex_state->lx.start;
+		ZI140 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 
 		ZIcz = lex_state->buf.a[0];
 	
-#line 1262 "src/libre/dialect/sql/parser.c"
+#line 1268 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: CHAR */
 				break;
@@ -1268,32 +1274,32 @@ p_209(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 796 "src/libre/parser.act"
+#line 802 "src/libre/parser.act"
 
 		(ZIz).type = AST_ENDPOINT_LITERAL;
 		(ZIz).u.literal.c = (ZIcz);
 	
-#line 1277 "src/libre/dialect/sql/parser.c"
+#line 1283 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF ACTION: mark-range */
 			{
-#line 709 "src/libre/parser.act"
+#line 715 "src/libre/parser.act"
 
-		mark(&act_state->rangestart, &(*ZI207));
+		mark(&act_state->rangestart, &(*ZI209));
 		mark(&act_state->rangeend,   &(ZIend));
 	
-#line 1287 "src/libre/dialect/sql/parser.c"
+#line 1293 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 950 "src/libre/parser.act"
+#line 960 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI207));
+		AST_POS_OF_LX_POS(ast_start, (*ZI209));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		if ((ZIa).type != AST_ENDPOINT_LITERAL ||
@@ -1321,7 +1327,7 @@ p_209(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			goto ZL1;
 		}
 	
-#line 1325 "src/libre/dialect/sql/parser.c"
+#line 1331 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -1338,40 +1344,40 @@ ZL0:;
 }
 
 static void
-p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI210, t_unsigned *ZIm, t_ast__count *ZOc)
+p_214(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI212, t_unsigned *ZIm, t_ast__count *ZOc)
 {
 	t_ast__count ZIc;
 
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CLOSECOUNT):
 		{
-			t_pos ZI176;
+			t_pos ZI178;
 			t_pos ZIend;
 
 			/* BEGINNING OF EXTRACT: CLOSECOUNT */
 			{
-#line 356 "src/libre/parser.act"
+#line 362 "src/libre/parser.act"
 
-		ZI176 = lex_state->lx.start;
+		ZI178 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1359 "src/libre/dialect/sql/parser.c"
+#line 1365 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: CLOSECOUNT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 714 "src/libre/parser.act"
+#line 720 "src/libre/parser.act"
 
-		mark(&act_state->countstart, &(*ZI210));
+		mark(&act_state->countstart, &(*ZI212));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 1370 "src/libre/dialect/sql/parser.c"
+#line 1376 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 778 "src/libre/parser.act"
+#line 784 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -1380,18 +1386,18 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			err->m = (*ZIm);
 			err->n = (*ZIm);
 
-			mark(&act_state->countstart, &(*ZI210));
+			mark(&act_state->countstart, &(*ZI212));
 			mark(&act_state->countend,   &(ZIend));
 
 			goto ZL1;
 		}
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI210));
+		AST_POS_OF_LX_POS(ast_start, (*ZI212));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (*ZIm), &ast_end);
 	
-#line 1395 "src/libre/dialect/sql/parser.c"
+#line 1401 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-range */
 		}
@@ -1399,7 +1405,7 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 	case (TOK_SEP):
 		{
 			t_unsigned ZIn;
-			t_pos ZI179;
+			t_pos ZI181;
 			t_pos ZIend;
 
 			ADVANCE_LEXER;
@@ -1407,7 +1413,7 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			case (TOK_COUNT):
 				/* BEGINNING OF EXTRACT: COUNT */
 				{
-#line 575 "src/libre/parser.act"
+#line 581 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -1427,7 +1433,7 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 
 		ZIn = (unsigned int) u;
 	
-#line 1431 "src/libre/dialect/sql/parser.c"
+#line 1437 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -1439,12 +1445,12 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			case (TOK_CLOSECOUNT):
 				/* BEGINNING OF EXTRACT: CLOSECOUNT */
 				{
-#line 356 "src/libre/parser.act"
+#line 362 "src/libre/parser.act"
 
-		ZI179 = lex_state->lx.start;
+		ZI181 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 	
-#line 1448 "src/libre/dialect/sql/parser.c"
+#line 1454 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: CLOSECOUNT */
 				break;
@@ -1454,17 +1460,17 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 714 "src/libre/parser.act"
+#line 720 "src/libre/parser.act"
 
-		mark(&act_state->countstart, &(*ZI210));
+		mark(&act_state->countstart, &(*ZI212));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 1463 "src/libre/dialect/sql/parser.c"
+#line 1469 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 778 "src/libre/parser.act"
+#line 784 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -1473,18 +1479,18 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			err->m = (*ZIm);
 			err->n = (ZIn);
 
-			mark(&act_state->countstart, &(*ZI210));
+			mark(&act_state->countstart, &(*ZI212));
 			mark(&act_state->countend,   &(ZIend));
 
 			goto ZL1;
 		}
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI210));
+		AST_POS_OF_LX_POS(ast_start, (*ZI212));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (ZIn), &ast_end);
 	
-#line 1488 "src/libre/dialect/sql/parser.c"
+#line 1494 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-range */
 		}
@@ -1519,16 +1525,16 @@ ZL2_expr_C_Clist_Hof_Halts:;
 		}
 		/* BEGINNING OF ACTION: ast-add-alt */
 		{
-#line 993 "src/libre/parser.act"
+#line 1003 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIalts), (ZIa))) {
 			goto ZL1;
 		}
 	
-#line 1529 "src/libre/dialect/sql/parser.c"
+#line 1535 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-add-alt */
-		/* BEGINNING OF INLINE: 189 */
+		/* BEGINNING OF INLINE: 191 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ALT):
@@ -1543,21 +1549,21 @@ ZL2_expr_C_Clist_Hof_Halts:;
 				break;
 			}
 		}
-		/* END OF INLINE: 189 */
+		/* END OF INLINE: 191 */
 	}
 	return;
 ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-alts */
 		{
-#line 651 "src/libre/parser.act"
+#line 657 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXALTS;
 		}
 		goto ZL4;
 	
-#line 1561 "src/libre/dialect/sql/parser.c"
+#line 1567 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
 	}
@@ -1576,18 +1582,18 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 	switch (CURRENT_TERMINAL) {
 	case (TOK_OPENCOUNT):
 		{
-			t_pos ZI210;
-			t_pos ZI211;
+			t_pos ZI212;
+			t_pos ZI213;
 			t_unsigned ZIm;
 
 			/* BEGINNING OF EXTRACT: OPENCOUNT */
 			{
-#line 351 "src/libre/parser.act"
+#line 357 "src/libre/parser.act"
 
-		ZI210 = lex_state->lx.start;
-		ZI211   = lex_state->lx.end;
+		ZI212 = lex_state->lx.start;
+		ZI213   = lex_state->lx.end;
 	
-#line 1591 "src/libre/dialect/sql/parser.c"
+#line 1597 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: OPENCOUNT */
 			ADVANCE_LEXER;
@@ -1595,7 +1601,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			case (TOK_COUNT):
 				/* BEGINNING OF EXTRACT: COUNT */
 				{
-#line 575 "src/libre/parser.act"
+#line 581 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -1615,7 +1621,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		ZIm = (unsigned int) u;
 	
-#line 1619 "src/libre/dialect/sql/parser.c"
+#line 1625 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -1623,7 +1629,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 				goto ZL1;
 			}
 			ADVANCE_LEXER;
-			p_212 (flags, lex_state, act_state, err, &ZI210, &ZIm, &ZIc);
+			p_214 (flags, lex_state, act_state, err, &ZI212, &ZIm, &ZIc);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1635,11 +1641,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-zero-or-one */
 			{
-#line 768 "src/libre/parser.act"
+#line 774 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, 1, NULL);
 	
-#line 1643 "src/libre/dialect/sql/parser.c"
+#line 1649 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-one */
 		}
@@ -1649,11 +1655,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-one-or-more */
 			{
-#line 764 "src/libre/parser.act"
+#line 770 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 1657 "src/libre/dialect/sql/parser.c"
+#line 1663 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-one-or-more */
 		}
@@ -1663,11 +1669,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-zero-or-more */
 			{
-#line 760 "src/libre/parser.act"
+#line 766 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 1671 "src/libre/dialect/sql/parser.c"
+#line 1677 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 		}
@@ -1676,11 +1682,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 		{
 			/* BEGINNING OF ACTION: count-one */
 			{
-#line 772 "src/libre/parser.act"
+#line 778 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 1684 "src/libre/dialect/sql/parser.c"
+#line 1690 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-one */
 		}
@@ -1693,23 +1699,23 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-count */
 		{
-#line 637 "src/libre/parser.act"
+#line 643 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCOUNT;
 		}
 		goto ZL2;
 	
-#line 1704 "src/libre/dialect/sql/parser.c"
+#line 1710 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: err-expected-count */
 		/* BEGINNING OF ACTION: count-one */
 		{
-#line 772 "src/libre/parser.act"
+#line 778 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 1713 "src/libre/dialect/sql/parser.c"
+#line 1719 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: count-one */
 	}
@@ -1734,24 +1740,24 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: class-any */
 			{
-#line 735 "src/libre/parser.act"
+#line 741 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
 		(ZIa) = (*flags & RE_SINGLE) ? &class_any : &class_notnl;
 	
-#line 1743 "src/libre/dialect/sql/parser.c"
+#line 1749 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 980 "src/libre/parser.act"
+#line 990 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_named(act_state->poolp, *flags, (ZIa));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1755 "src/libre/dialect/sql/parser.c"
+#line 1761 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 		}
@@ -1759,35 +1765,35 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 	case (TOK_CHAR):
 		{
 			t_char ZIa;
-			t_pos ZI170;
-			t_pos ZI171;
+			t_pos ZI172;
+			t_pos ZI173;
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
-#line 530 "src/libre/parser.act"
+#line 536 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI170 = lex_state->lx.start;
-		ZI171   = lex_state->lx.end;
+		ZI172 = lex_state->lx.start;
+		ZI173   = lex_state->lx.end;
 
 		ZIa = lex_state->buf.a[0];
 	
-#line 1778 "src/libre/dialect/sql/parser.c"
+#line 1784 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 831 "src/libre/parser.act"
+#line 837 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_literal(act_state->poolp, *flags, (ZIa));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1791 "src/libre/dialect/sql/parser.c"
+#line 1797 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -1801,38 +1807,38 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: class-any */
 			{
-#line 735 "src/libre/parser.act"
+#line 741 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
 		(ZIa) = (*flags & RE_SINGLE) ? &class_any : &class_notnl;
 	
-#line 1810 "src/libre/dialect/sql/parser.c"
+#line 1816 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 980 "src/libre/parser.act"
+#line 990 "src/libre/parser.act"
 
 		(ZIg) = ast_make_expr_named(act_state->poolp, *flags, (ZIa));
 		if ((ZIg) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1822 "src/libre/dialect/sql/parser.c"
+#line 1828 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 			/* BEGINNING OF ACTION: count-zero-or-more */
 			{
-#line 760 "src/libre/parser.act"
+#line 766 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 1831 "src/libre/dialect/sql/parser.c"
+#line 1837 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 			/* BEGINNING OF ACTION: ast-make-piece */
 			{
-#line 850 "src/libre/parser.act"
+#line 860 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
@@ -1846,16 +1852,26 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 1850 "src/libre/dialect/sql/parser.c"
+#line 1856 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-piece */
 		}
 		break;
 	case (TOK_OPENSUB):
 		{
+			t_group__id ZIid;
 			t_ast__expr ZIg;
 
 			ADVANCE_LEXER;
+			/* BEGINNING OF ACTION: make-group-id */
+			{
+#line 844 "src/libre/parser.act"
+
+		(ZIid) = act_state->group_id++;
+	
+#line 1873 "src/libre/dialect/sql/parser.c"
+			}
+			/* END OF ACTION: make-group-id */
 			p_expr (flags, lex_state, act_state, err, &ZIg);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
@@ -1863,14 +1879,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			}
 			/* BEGINNING OF ACTION: ast-make-group */
 			{
-#line 864 "src/libre/parser.act"
+#line 874 "src/libre/parser.act"
 
-		(ZIe) = ast_make_expr_group(act_state->poolp, *flags, (ZIg));
+		(ZIe) = ast_make_expr_group(act_state->poolp, *flags, (ZIg), (ZIid));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1874 "src/libre/dialect/sql/parser.c"
+#line 1890 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-group */
 			switch (CURRENT_TERMINAL) {
@@ -1901,26 +1917,26 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-atom */
 		{
-#line 644 "src/libre/parser.act"
+#line 650 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXATOM;
 		}
 		goto ZL2;
 	
-#line 1912 "src/libre/dialect/sql/parser.c"
+#line 1928 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 810 "src/libre/parser.act"
+#line 816 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZIe) == NULL) {
 			goto ZL2;
 		}
 	
-#line 1924 "src/libre/dialect/sql/parser.c"
+#line 1940 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -1942,14 +1958,14 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed(flags flags, lex_state lex_state, act
 	}
 	{
 		t_ast__class__id ZIid;
-		t_pos ZI126;
-		t_pos ZI127;
+		t_pos ZI128;
+		t_pos ZI129;
 
 		switch (CURRENT_TERMINAL) {
 		case (TOK_NAMED__CLASS):
 			/* BEGINNING OF EXTRACT: NAMED_CLASS */
 			{
-#line 587 "src/libre/parser.act"
+#line 593 "src/libre/parser.act"
 
 		ZIid = DIALECT_CLASS(lex_state->buf.a);
 		if (ZIid == NULL) {
@@ -1957,10 +1973,10 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed(flags flags, lex_state lex_state, act
 			goto ZL1;
 		}
 
-		ZI126 = lex_state->lx.start;
-		ZI127   = lex_state->lx.end;
+		ZI128 = lex_state->lx.start;
+		ZI129   = lex_state->lx.end;
 	
-#line 1964 "src/libre/dialect/sql/parser.c"
+#line 1980 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			break;
@@ -1970,14 +1986,14 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed(flags flags, lex_state lex_state, act
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-make-named */
 		{
-#line 980 "src/libre/parser.act"
+#line 990 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_named(act_state->poolp, *flags, (ZIid));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1981 "src/libre/dialect/sql/parser.c"
+#line 1997 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-named */
 	}
@@ -2000,14 +2016,14 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 		{
 			/* BEGINNING OF ACTION: ast-make-concat */
 			{
-#line 817 "src/libre/parser.act"
+#line 823 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_concat(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2011 "src/libre/dialect/sql/parser.c"
+#line 2027 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-concat */
 			p_expr_C_Clist_Hof_Hpieces (flags, lex_state, act_state, err, ZInode);
@@ -2021,14 +2037,14 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 		{
 			/* BEGINNING OF ACTION: ast-make-empty */
 			{
-#line 810 "src/libre/parser.act"
+#line 816 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2032 "src/libre/dialect/sql/parser.c"
+#line 2048 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-empty */
 		}
@@ -2046,7 +2062,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 1143 "src/libre/parser.act"
+#line 1155 "src/libre/parser.act"
 
 
 	static int
@@ -2122,6 +2138,8 @@ ZL0:;
 		act_state->overlap = overlap;
 		act_state->poolp   = &ast->pool;
 
+		act_state->group_id = 1;
+
 		err->e = RE_ESUCCESS;
 
 		ADVANCE_LEXER;
@@ -2192,6 +2210,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 2196 "src/libre/dialect/sql/parser.c"
+#line 2214 "src/libre/dialect/sql/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/sql/parser.h
+++ b/src/libre/dialect/sql/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 304 "src/libre/parser.act"
+#line 310 "src/libre/parser.act"
 
 
 	#include <re/re.h>
@@ -28,7 +28,7 @@
 extern void p_re__sql(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 1145 "src/libre/parser.act"
+#line 1157 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/sql/parser.h"

--- a/src/libre/dialect/sql/parser.sid
+++ b/src/libre/dialect/sql/parser.sid
@@ -24,6 +24,7 @@
 	ast_count;
 	ast_class_id;
 	endpoint;
+	group_id;
 
 %terminals%
 
@@ -94,6 +95,7 @@
 	<count-one>:          () -> (:ast_count);
 	<count-range>: (:unsigned, :pos, :unsigned, :pos) -> (:ast_count);
 
+	<make-group-id>:       () -> (:group_id);
 	!<make-literal-cbrak>: () -> (:char);
 	!<make-literal-cr>:    () -> (:char);
 	!<make-literal-nl>:    () -> (:char);
@@ -106,7 +108,7 @@
 	<ast-make-concat>:        ()                       -> (:ast_expr);
 	<ast-make-alt>:           ()                       -> (:ast_expr);
 	<ast-make-piece>:         (:ast_expr, :ast_count)  -> (:ast_expr);
-	<ast-make-group>:         (:ast_expr)              -> (:ast_expr);
+	<ast-make-group>:         (:ast_expr, :group_id)   -> (:ast_expr);
 	!<ast-get-re-flags>:      ()                       -> (:re_flags);
 	!<ast-set-re-flags>:      (:re_flags)              -> ();
 	!<ast-mask-re-flags>:     (:re_flags, :re_flags)   -> ();
@@ -324,8 +326,9 @@
 				e = character-class;
 			||
 				OPENSUB;
+				id = <make-group-id>;
 				g = expr;
-				e = <ast-make-group>(g);
+				e = <ast-make-group>(g, id);
 				CLOSESUB;
 			##
 				<err-expected-atom>;

--- a/src/libre/parser.act
+++ b/src/libre/parser.act
@@ -99,6 +99,7 @@
 	typedef const struct class * t_ast__class__id;
 	typedef struct ast_count t_ast__count;
 	typedef struct ast_endpoint t_endpoint;
+	typedef unsigned t_group__id;
 
 	struct act_state {
 		struct ast_expr_pool **poolp;
@@ -121,6 +122,12 @@
 		struct re_pos groupstart; struct re_pos groupend;
 		struct re_pos rangestart; struct re_pos rangeend;
 		struct re_pos countstart; struct re_pos countend;
+
+		/*
+		 * Numbering for capturing groups. By convention these start from 1,
+		 * and 0 represents the entire matching text.
+		 */
+		unsigned group_id;
 	};
 
 	struct lex_state {
@@ -157,7 +164,6 @@
 	{
 		enum re_flags fl = (lex_state->flags_ptr != NULL) ? lex_state->flags_ptr[0] : 0;
 		enum LX_TOKEN tok;
-
 
 		if ((fl & RE_EXTENDED) == 0) {
 			tok = act_state->lex_tok;
@@ -834,6 +840,10 @@
 		}
 	@};
 
+	<make-group-id>: () -> (id :group_id) = @{
+		@id = act_state->group_id++;
+	@};
+
 	<make-literal-cbrak>: () -> (c :char) = @{
 		@c = ']';
 	@};
@@ -860,8 +870,8 @@
 		}
 	@};
 
-	<ast-make-group>: (e :ast_expr) -> (node :ast_expr) = @{
-		@node = ast_make_expr_group(act_state->poolp, *flags, @e);
+	<ast-make-group>: (e :ast_expr, id :group_id) -> (node :ast_expr) = @{
+		@node = ast_make_expr_group(act_state->poolp, *flags, @e, @id);
 		if (@node == NULL) {
 			@!;
 		}
@@ -1069,6 +1079,8 @@
 
 		act_state->overlap = overlap;
 		act_state->poolp   = &ast->pool;
+
+		act_state->group_id = 1;
 
 		err->e = RE_ESUCCESS;
 


### PR DESCRIPTION
With this PR I set out to knowledge of group numbering to the parser actions thinking I could resolve #335 by parsing these cases correctly. I might be misunderstanding the PCRE spec, but I don't currently think this is possible for decimal literals inside character classes:
>   \81    is either a back reference, or the two characters "8" and "1"

because here we would need to lex either one or two tokens, and the lexer isn't designed to be conditional.

I think those could be buffered in the parser's fetch-the-next-token interface, and have that fabricate tokens. But for the moment my goal is about getting the PCRE suite running, so I don't want to take on that work at the moment.

So instead, I've elected to handle the unambiguous octal literals (starting with 0), and to reject all decimal sequences (starting with non-zero), whether they're backreferences or literals.