### PR TITLE
Install the `include/fsm/capture.h` header.

### DIFF
--- a/include/fsm/Makefile
+++ b/include/fsm/Makefile
@@ -2,6 +2,7 @@
 
 STAGE_COPY += include/fsm/alloc.h
 STAGE_COPY += include/fsm/bool.h
+STAGE_COPY += include/fsm/capture.h
 STAGE_COPY += include/fsm/cost.h
 STAGE_COPY += include/fsm/fsm.h
 STAGE_COPY += include/fsm/options.h


### PR DESCRIPTION
This wasn't added to the makefile, and now `fsm_exec` depends on it.

Closes #346.