### PR TITLE
fsm_print_fsm: add option for printing grouped edges, add CLI flag.

### DIFF
--- a/include/fsm/options.h
+++ b/include/fsm/options.h
@@ -47,6 +47,11 @@ struct fsm_options {
 	 */
 	unsigned int always_hex:1;
 
+	/* boolean: true indicates to group edges with a common destination in output,
+	 * when possible, rather than printing them all individually.
+	 */
+	unsigned int group_edges:1;
+
 	/* for generated code, what kind of I/O API to generate */
 	enum fsm_io io;
 

--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -106,7 +106,7 @@ static void
 usage(void)
 {
 	printf("usage: fsm [-x] {<text> ...}\n");
-	printf("       fsm {-p} [-l <language>] [-aCcwX] [-k <io>] [-e <prefix>]\n");
+	printf("       fsm {-p} [-l <language>] [-aCcgwX] [-k <io>] [-e <prefix>]\n");
 	printf("       fsm {-dmr | -t <transformation>} [-i <iterations>] [<file.fsm> | <file-a> <file-b>]\n");
 	printf("       fsm {-q <query>} [<file>]\n");
 	printf("       fsm {-W <maxlen>} <file.fsm>\n");
@@ -394,11 +394,12 @@ main(int argc, char *argv[])
 	{
 		int c;
 
-		while (c = getopt(argc, argv, "h" "aCcwXe:k:i:" "xpq:l:dGmrt:W:"), c != -1) {
+		while (c = getopt(argc, argv, "h" "aCcgwXe:k:i:" "xpq:l:dGmrt:W:"), c != -1) {
 			switch (c) {
 			case 'a': opt.anonymous_states  = 1;          break;
 			case 'c': opt.consolidate_edges = 1;          break;
 			case 'C': opt.comments		= 0;          break;
+			case 'g': opt.group_edges       = 1;          break;
 			case 'w': opt.fragment          = 1;          break;
 			case 'X': opt.always_hex        = 1;          break;
 			case 'e': opt.prefix            = optarg;     break;


### PR DESCRIPTION
Add a flag to `struct fsm_options`, `group_edges`, which tells fsm to print edges in a group whenever the output method supports it.

This can make fsm output much easier to read with FSMs from unanchored regexes, which often have hundreds of "...and everything else 0x00 - 0xFF goes back to state X" edges.

Without the `-g` flag, this output would be 1798 lines long:

    0; 1; 2; 3; 4; 5; 6; 7;

    0  ->  0 "\x00" .. "a", "c" .. "\xff";
    0  ->  1 "b";
    1  ->  0 "\x00" .. "`", "c" .. "\xff";
    1  ->  1 "b";
    1  ->  2 "a";
    2  ->  0 "\x00" .. "a", "c" .. "m", "o" .. "\xff";
    2  ->  1 "b";
    2  ->  3 "n";
    3  ->  0 "\x00" .. "`", "c" .. "\xff";
    3  ->  1 "b";
    3  ->  4 "a";
    4  ->  0 "\x00" .. "a", "c" .. "m", "o" .. "\xff";
    4  ->  1 "b";
    4  ->  5 "n";
    5  ->  0 "\x00" .. "`", "c" .. "\xff";
    5  ->  1 "b";
    5  ->  6 "a";
    6  ->  0 "\x00" .. "a", "c" .. "r", "t" .. "\xff";
    6  ->  1 "b";
    6  ->  7 "s";
    7  ->  7 ?;

    start: 0;
    end:   7;

Note that this change does not update the man page, any other output modes (it would be nice to support this in `dot` later), or make fsm able to read that input back in yet.