### PR TITLE
Address a couple more UBSan warnings

### DIFF
--- a/src/libfsm/complete.c
+++ b/src/libfsm/complete.c
@@ -76,7 +76,7 @@ fsm_complete(struct fsm *fsm,
 		/* TODO: bulk add symbols as the inverse of this bitmap */
 		i = -1;
 		while (i = bm_next(&bm, i, 0), i <= UCHAR_MAX) {
-			if (!fsm_addedge_literal(fsm, s, new, i)) {
+			if (!fsm_addedge_literal(fsm, s, new, (char)i)) {
 				/* TODO: free stuff */
 				return 0;
 			}

--- a/src/libfsm/cost/legible.c
+++ b/src/libfsm/cost/legible.c
@@ -59,7 +59,7 @@ fsm_cost_legible(fsm_state_t from, fsm_state_t to, char c)
 	for (i = 0; i < sizeof a / sizeof *a; i++) {
 		if (a[i].is(c)) {
 			const unsigned char_class_cost = 1000 * a[i].cost;
-			return char_class_cost + (unsigned)c;
+			return char_class_cost + (unsigned char)c;
 		}
 	}
 

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -371,6 +371,7 @@ det_copy_capture_actions(struct reverse_mapping *reverse_mappings,
 	return env.ok;
 }
 
+SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
 static unsigned long
 hash_iss(const struct interned_state_set *iss)
 {

--- a/src/libfsm/parser.act
+++ b/src/libfsm/parser.act
@@ -104,6 +104,7 @@
 	#define FNV1a_32_OFFSET_BASIS 	2166136261UL
 	#define FNV1a_32_PRIME		16777619UL
 
+	SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
 	static unsigned
 	hash_of_id(const char *id)
 	{

--- a/src/libfsm/parser.c
+++ b/src/libfsm/parser.c
@@ -91,6 +91,7 @@
 	#define FNV1a_32_OFFSET_BASIS 	2166136261UL
 	#define FNV1a_32_PRIME		16777619UL
 
+	SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
 	static unsigned
 	hash_of_id(const char *id)
 	{

--- a/src/libfsm/print/ir.c
+++ b/src/libfsm/print/ir.c
@@ -476,7 +476,7 @@ make_ir(const struct fsm *fsm)
 			size_t written;
 			const size_t count = fsm_getendidcount(fsm, i);
 			struct fsm_end_ids *ids = f_malloc(fsm->opt->alloc,
-			    sizeof(*ids) + ((count - 1) * sizeof(ids->ids[0])));
+			    sizeof(*ids) + (count == 0 ? 0 : (count - 1) * sizeof(ids->ids[0])));
 			if (ids == NULL) {
 				goto error;
 			}

--- a/src/libfsm/shortest.c
+++ b/src/libfsm/shortest.c
@@ -122,7 +122,7 @@ fsm_shortest(const struct fsm *fsm,
 			if (v->cost > u->cost + c) {
 				v->cost = u->cost + c;
 				v->prev = u;
-				v->c    = e.symbol;
+				v->c    = (char)e.symbol;
 
 				priq_update(&todo, v, v->cost);
 			}

--- a/src/libfsm/subgraph.c
+++ b/src/libfsm/subgraph.c
@@ -128,7 +128,7 @@ fsm_subgraph_duplicate(struct fsm *fsm,
 
 			new_dst = new_start + (old_dst - old_start);
 
-			if (!fsm_addedge_literal(fsm, ind, new_dst, e.symbol)) {
+			if (!fsm_addedge_literal(fsm, ind, new_dst, (char)e.symbol)) {
 				return 0;
 			}
 		}

--- a/src/libre/ac.c
+++ b/src/libre/ac.c
@@ -307,7 +307,7 @@ trie_to_fsm_state(struct trie_state *ts, struct fsm *fsm,
 				return 0;
 			}
 
-			if (!fsm_addedge_literal(fsm, st, dst, sym)) {
+			if (!fsm_addedge_literal(fsm, st, dst, (char)sym)) {
 				return 0;
 			}
 		}

--- a/src/libre/ast.c
+++ b/src/libre/ast.c
@@ -842,7 +842,7 @@ ast_make_expr_named(struct ast_expr_pool **poolp, enum re_flags re_flags, const 
 	for (i = 0; i < class->count; i++) {
 		if (class->ranges[i].a == class->ranges[i].b) {
 			if (class->ranges[i].a <= UCHAR_MAX) {
-				res->u.alt.n[i] = ast_make_expr_literal(poolp, re_flags, (unsigned char) class->ranges[i].a);
+				res->u.alt.n[i] = ast_make_expr_literal(poolp, re_flags, (char) class->ranges[i].a);
 			} else {
 				res->u.alt.n[i] = ast_make_expr_codepoint(poolp, re_flags, class->ranges[i].a);
 			}

--- a/src/libre/ast_compile.c
+++ b/src/libre/ast_compile.c
@@ -497,7 +497,7 @@ print_linkage(enum link_types t)
     if (!fsm_addedge_any(env->fsm, (FROM), (TO))) { return 0; }
 
 #define LITERAL(FROM, TO, C)        \
-    if (!addedge_literal(env, n->re_flags, (FROM), (TO), (C))) { return 0; }
+    if (!addedge_literal(env, n->re_flags, (FROM), (TO), ((char)C))) { return 0; }
 
 #define RECURSE(FROM, TO, NODE)     \
     if (!comp_iter(env, (FROM), (TO), (NODE))) { return 0; }

--- a/src/libre/re.c
+++ b/src/libre/re.c
@@ -68,7 +68,7 @@ re_flags(const char *s, enum re_flags *f)
 
 	for (p = s; *p != '\0'; p++) {
 		if (*p & RE_ANCHOR) {
-			*f &= ~RE_ANCHOR;
+			*f &= (unsigned)~RE_ANCHOR;
 		}
 
 		switch (*p) {

--- a/src/lx/print/c.c
+++ b/src/lx/print/c.c
@@ -754,7 +754,7 @@ print_zone(FILE *f, const struct ast *ast, const struct ast_zone *z)
 
 			fprintf(f, "\t\tdefault:\n");
 			fprintf(f, "\t\t\tif (lx->push != NULL) {\n");
-			fprintf(f, "\t\t\t\tif (-1 == lx->push(lx->buf_opaque, %s)) {\n", opt.cp);
+			fprintf(f, "\t\t\t\tif (-1 == lx->push(lx->buf_opaque, (char)%s)) {\n", opt.cp);
 			fprintf(f, "\t\t\t\t\treturn %sERROR;\n", prefix.tok);
 			fprintf(f, "\t\t\t\t}\n");
 			fprintf(f, "\t\t\t}\n");
@@ -765,7 +765,7 @@ print_zone(FILE *f, const struct ast *ast, const struct ast_zone *z)
 		} else {
 			fprintf(f, "\n");
 			fprintf(f, "\t\tif (lx->push != NULL) {\n");
-			fprintf(f, "\t\t\tif (-1 == lx->push(lx->buf_opaque, %s)) {\n", opt.cp);
+			fprintf(f, "\t\t\tif (-1 == lx->push(lx->buf_opaque, (char)%s)) {\n", opt.cp);
 			fprintf(f, "\t\t\t\treturn %sERROR;\n", prefix.tok);
 			fprintf(f, "\t\t\t}\n");
 			fprintf(f, "\t\t}\n");

--- a/src/retest/main.c
+++ b/src/retest/main.c
@@ -421,7 +421,7 @@ hexdigit:
 			return PARSE_INCOMPLETE_ESCAPE;
 		}
 
-		s[j++] = ccode;
+		s[j++] = (char)ccode;
 		break;
 	}
 


### PR DESCRIPTION
- Some of the hash functions weren't using `SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()`.
- Address more implicit conversions between signed / unsigned char.
- Fix a possible underflow in ir.c.
- Explicitly cast a negated flag.
- Cast int to char in lx's generated code.

These don't address ALL the remaining warnings, but it eliminates quite a few of them.