### PR TITLE
Disable multithreading in lx for now.

### DIFF
--- a/src/lx/main.c
+++ b/src/lx/main.c
@@ -540,7 +540,7 @@ main(int argc, char *argv[])
 	print = lx_print_c;
 	keep_nfa = 0;
 	print_progress = 0;
-	concurrency = 4;
+	concurrency = 1;
 
 	/* TODO: populate options */
 	opt.anonymous_states  = 1;


### PR DESCRIPTION
Running this in a loop:

    $ while true; do sleep 0.1; ./build/bin/lx -l test < src/lx/lexer.lx \
        && echo ok; done

Produces a stream of intermittent failures. There appears to be
unsynchronized access to a shared/global resource, and races on
either `realloc`ing or `free`ing it can nondeterministically lead
to memory corruption.

For now, change to using only one thread -- issue #351 exists as a
reminder to-enable this once the underlying problem has been fixed.