### PR TITLE
DFA group captures -- foundational changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,10 @@ SUBDIR += src/retest
 SUBDIR += src/lx/print
 SUBDIR += src/lx
 SUBDIR += src
-SUBDIR += tests/capture
+
+# Temporarily disabled -- not currently expected to pass.
+#SUBDIR += tests/capture
+
 SUBDIR += tests/complement
 SUBDIR += tests/idmap
 SUBDIR += tests/intersect

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ SUBDIR += src/lx
 SUBDIR += src
 SUBDIR += tests/capture
 SUBDIR += tests/complement
+SUBDIR += tests/idmap
 SUBDIR += tests/intersect
 SUBDIR += tests/ir
 SUBDIR += tests/eclosure

--- a/include/adt/hash.h
+++ b/include/adt/hash.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#ifndef FSM_HASH_H
+#define FSM_HASH_H
+
+#include <stdint.h>
+
+#include "common/check.h"
+
+/* 32 and 64-bit approximations of the golden ratio. */
+#define FSM_PHI_32 0x9e3779b9UL
+#define FSM_PHI_64 0x9e3779b97f4a7c15UL
+
+/* A suitable hash function for individual sequentially allocated
+ * identifiers. See Knuth 6.4, Fibonacci hashing. */
+
+SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
+static __inline__ uint64_t
+fsm_hash_id(unsigned id)
+{
+	return FSM_PHI_64 * (id + 1);
+}
+
+/* FNV-1a hash function, 32 and 64 bit versions. This is in the public
+ * domain. For details, see:
+ *
+ *     http://www.isthe.com/chongo/tech/comp/fnv/index.html
+ */
+
+SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
+static __inline__ uint32_t
+fsm_hash_fnv1a_32(const uint8_t *buf, size_t length)
+{
+#define FNV1a_32_OFFSET_BASIS 	0x811c9dc5UL
+#define FNV1a_32_PRIME		0x01000193UL
+	uint32_t h = FNV1a_32_OFFSET_BASIS;
+	size_t i;
+	for (i = 0; i < length; i++) {
+		h ^= buf[i];
+		h *= FNV1a_32_PRIME;
+	}
+	return h;
+}
+
+SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
+static __inline__ uint64_t
+fsm_hash_fnv1a_64(const uint8_t *buf, size_t length)
+{
+#define FNV1a_64_OFFSET_BASIS   0xcbf29ce484222325UL
+#define FNV1a_64_PRIME		0x100000001b3UL
+	uint64_t h = FNV1a_64_OFFSET_BASIS;
+	size_t i;
+	for (i = 0; i < length; i++) {
+		h ^= buf[i];
+		h *= FNV1a_64_PRIME;
+	}
+	return h;
+}
+
+#endif

--- a/include/adt/idmap.h
+++ b/include/adt/idmap.h
@@ -1,0 +1,58 @@
+#ifndef IDMAP_H
+#define IDMAP_H
+
+/* Mapping between one fsm_state_t and a set of
+ * unsigned IDs. The implementation assumes that both
+ * IDs are sequentially assigned and don't need a sparse
+ * mapping -- it will handle 10 -> [1, 3, 47] well, but
+ * not 1000000 -> [14, 524288, 1073741823]. */
+
+#include <stdlib.h>
+
+#include "fsm/fsm.h"
+#include "fsm/alloc.h"
+
+struct idmap;			/* Opaque handle. */
+
+struct idmap *
+idmap_new(const struct fsm_alloc *alloc);
+
+void
+idmap_free(struct idmap *m);
+
+/* Associate a value with a state (if not already present.)
+ * Returns 1 on success, or 0 on allocation failure. */
+int
+idmap_set(struct idmap *m, fsm_state_t state_id, unsigned value);
+
+/* How many values are associated with an ID? */
+size_t
+idmap_get_value_count(const struct idmap *m, fsm_state_t state_id);
+
+/* Get the values associated with an ID.
+ *
+ * Returns 1 on success and writes them into the buffer, in ascending
+ * order, with the count in *written (if non-NULL).
+ *
+ * Returns 0 on error (insufficient buffer space). */
+int
+idmap_get(const struct idmap *m, fsm_state_t state_id,
+	size_t buf_size, unsigned *buf, size_t *written);
+
+/* Iterator callback. */
+typedef void
+idmap_iter_fun(fsm_state_t state_id, unsigned value, void *opaque);
+
+/* Iterate over the ID map. State IDs may be yielded out of order,
+ * values will be in ascending order. */
+void
+idmap_iter(const struct idmap *m,
+	idmap_iter_fun *cb, void *opaque);
+
+/* Iterate over the values associated with a single state
+ * (in ascending order). */
+void
+idmap_iter_for_state(const struct idmap *m, fsm_state_t state_id,
+	idmap_iter_fun *cb, void *opaque);
+
+#endif

--- a/include/adt/u64bitset.h
+++ b/include/adt/u64bitset.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#ifndef U64BITSET_H
+#define U64BITSET_H
+
+/* Various inline functions for using a bare uint64_t array
+ * as a bitset. The size should be managed by the caller. */
+
+#include <stdint.h>
+
+static __inline__ uint64_t
+u64bitset_get(const uint64_t *s, size_t id)
+{
+	return s[id/64] & ((uint64_t)1 << (id & 63));
+}
+
+static __inline__ void
+u64bitset_set(uint64_t *s, size_t id)
+{
+	s[id/64] |= ((uint64_t)1 << (id & 63));
+}
+
+static __inline__ void
+u64bitset_clear(uint64_t *s, size_t id)
+{
+	s[id/64] &=~ ((uint64_t)1 << (id & 63));
+}
+
+static __inline__ size_t
+u64bitset_words(size_t count)
+{
+	return count/64 + ((count & 63) ? 1 : 0);
+}
+
+#endif

--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -203,6 +203,10 @@ fsm_setend(struct fsm *fsm, fsm_state_t state, int end);
 int
 fsm_setendid(struct fsm *fsm, fsm_end_id_t id);
 
+/* Associate a numeric ID with a single end state in an FSM. */
+int
+fsm_setendid_state(struct fsm *fsm, fsm_state_t s, fsm_end_id_t id);
+
 /* Get the end IDs associated with an end state, if any.
  * If id_buf has enough cells to store all the end IDs (according
  * to id_buf_count) then they are written into id_buf[] and
@@ -224,6 +228,17 @@ fsm_getendids(const struct fsm *fsm, fsm_state_t end_state,
 /* Get the number of end IDs associated with an end state. */
 size_t
 fsm_getendidcount(const struct fsm *fsm, fsm_state_t end_state);
+
+/* Callback for iterating over end IDs.
+ * Returns whether iteration should continue. */
+typedef int
+fsm_iterendids_cb(const struct fsm *fsm, fsm_state_t end_state,
+    size_t nth, fsm_end_id_t id, void *opaque);
+
+/* Iterate over the end IDs associated with a state, if any. */
+void
+fsm_iterendids(const struct fsm *fsm, fsm_state_t state,
+	fsm_iterendids_cb *cb, void *opaque);
 
 /*
  * Find the state (if there is just one), or add epsilon edges from all states,

--- a/src/adt/Makefile
+++ b/src/adt/Makefile
@@ -3,6 +3,7 @@
 SRC += src/adt/alloc.c
 SRC += src/adt/bitmap.c
 SRC += src/adt/dlist.c
+SRC += src/adt/idmap.c
 SRC += src/adt/internedstateset.c
 SRC += src/adt/ipriq.c
 SRC += src/adt/priq.c
@@ -24,7 +25,7 @@ CFLAGS.${src} += -I src # XXX: for internal.h
 DFLAGS.${src} += -I src # XXX: for internal.h
 .endfor
 
-.for src in ${SRC:Msrc/adt/siphash.c} ${SRC:Msrc/adt/edgeset.c} ${SRC:Msrc/adt/ipriq.c}
+.for src in ${SRC:Msrc/adt/siphash.c} ${SRC:Msrc/adt/edgeset.c} ${SRC:Msrc/adt/idmap.c} ${SRC:Msrc/adt/ipriq.c}
 CFLAGS.${src} += -std=c99 # XXX: for internal.h
 DFLAGS.${src} += -std=c99 # XXX: for internal.h
 .endfor

--- a/src/adt/idmap.c
+++ b/src/adt/idmap.c
@@ -1,0 +1,354 @@
+/*
+ * Copyright 2021 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include "adt/idmap.h"
+
+#include "adt/alloc.h"
+#include "adt/hash.h"
+#include "adt/u64bitset.h"
+
+#include <stdint.h>
+#include <assert.h>
+#include <stdio.h>
+
+#define NO_STATE ((fsm_state_t)-1)
+
+#define DEF_BUCKET_COUNT 4
+
+struct idmap {
+	const struct fsm_alloc *alloc;
+	unsigned bucket_count;
+	unsigned buckets_used;
+
+	/* All buckets' values are assumed to be large
+	 * enough to store this value, and they will all
+	 * grow as necessary. */
+	unsigned max_value;
+
+	/* Basic linear-probing, add-only hash table. */
+	struct idmap_bucket {
+		fsm_state_t state; /* Key. NO_STATE when empty. */
+
+		/* values[] is always either NULL or has at least
+		 * max_value + 1 bits; all grow on demand. */
+		uint64_t *values;
+	} *buckets;
+};
+
+struct idmap *
+idmap_new(const struct fsm_alloc *alloc)
+{
+	struct idmap *res = NULL;
+	struct idmap_bucket *buckets = NULL;
+
+	res = f_malloc(alloc, sizeof(*res));
+	if (res == NULL) {
+		goto cleanup;
+	}
+
+	buckets = f_calloc(alloc,
+	    DEF_BUCKET_COUNT, sizeof(buckets[0]));
+	if (buckets == NULL) {
+		goto cleanup;
+	}
+
+	for (size_t i = 0; i < DEF_BUCKET_COUNT; i++) {
+		buckets[i].state = NO_STATE;
+	}
+
+	res->alloc = alloc;
+	res->buckets_used = 0;
+        res->bucket_count = DEF_BUCKET_COUNT;
+	res->max_value = 0;
+	res->buckets = buckets;
+
+	return res;
+
+cleanup:
+	f_free(alloc, res);
+	f_free(alloc, buckets);
+	return NULL;
+}
+
+void
+idmap_free(struct idmap *m)
+{
+	if (m == NULL) {
+		return;
+	}
+
+	for (size_t i = 0; i < m->bucket_count; i++) {
+		if (m->buckets[i].state == NO_STATE) {
+			continue;
+		}
+		f_free(m->alloc, m->buckets[i].values);
+	}
+
+	f_free(m->alloc, m->buckets);
+	f_free(m->alloc, m);
+}
+
+static int
+grow_bucket_values(struct idmap *m, unsigned old_words, unsigned new_words)
+{
+	assert(new_words > old_words);
+
+	for (size_t b_i = 0; b_i < m->bucket_count; b_i++) {
+		struct idmap_bucket *b = &m->buckets[b_i];
+		if (b->state == NO_STATE) {
+			assert(b->values == NULL);
+			continue;
+		}
+
+		uint64_t *nv = f_calloc(m->alloc,
+		    new_words, sizeof(nv[0]));
+		if (nv == NULL) {
+			return 0;
+		}
+
+		for (size_t w_i = 0; w_i < old_words; w_i++) {
+			nv[w_i] = b->values[w_i];
+		}
+		f_free(m->alloc, b->values);
+		b->values = nv;
+	}
+	return 1;
+}
+
+static int
+grow_buckets(struct idmap *m)
+{
+	const size_t ocount = m->bucket_count;
+	const size_t ncount = 2*ocount;
+	assert(ncount > m->bucket_count);
+
+	struct idmap_bucket *nbuckets = f_calloc(m->alloc,
+	    ncount, sizeof(nbuckets[0]));
+	if (nbuckets == NULL) {
+		return 0;
+	}
+	for (size_t nb_i = 0; nb_i < ncount; nb_i++) {
+		nbuckets[nb_i].state = NO_STATE;
+	}
+
+	const size_t nmask = ncount - 1;
+
+	for (size_t ob_i = 0; ob_i < ocount; ob_i++) {
+		const struct idmap_bucket *ob = &m->buckets[ob_i];
+		if (ob->state == NO_STATE) {
+			continue;
+		}
+
+		const uint64_t h = fsm_hash_id(ob->state);
+		for (size_t nb_i = 0; nb_i < ncount; nb_i++) {
+			struct idmap_bucket *nb = &nbuckets[(h + nb_i) & nmask];
+			if (nb->state == NO_STATE) {
+				nb->state = ob->state;
+				nb->values = ob->values;
+				break;
+			} else {
+				assert(nb->state != ob->state);
+				/* collision */
+				continue;
+			}
+		}
+	}
+
+	f_free(m->alloc, m->buckets);
+
+	m->buckets = nbuckets;
+	m->bucket_count = ncount;
+
+	return 1;
+}
+
+int
+idmap_set(struct idmap *m, fsm_state_t state_id,
+    unsigned value)
+{
+	const uint64_t h = fsm_hash_id(state_id);
+	if (value > m->max_value) {
+		const unsigned ovw = u64bitset_words(m->max_value);
+		const unsigned nvw = u64bitset_words(value);
+		/* If this value won't fit in the existing value
+		 * arrays, then grow them all. We do not track the
+		 * number of bits in each individual array. */
+		if (nvw > ovw && !grow_bucket_values(m, ovw, nvw)) {
+			return 0;
+		}
+		m->max_value = value;
+	}
+
+	assert(m->max_value >= value);
+
+	if (m->buckets_used >= m->bucket_count/2) {
+		if (!grow_buckets(m)) {
+			return 0;
+		}
+	}
+
+	const uint64_t mask = m->bucket_count - 1;
+	for (size_t b_i = 0; b_i < m->bucket_count; b_i++) {
+		struct idmap_bucket *b = &m->buckets[(h + b_i) & mask];
+		if (b->state == state_id) {
+			assert(b->values != NULL);
+			u64bitset_set(b->values, value);
+			return 1;
+		} else if (b->state == NO_STATE) {
+			b->state = state_id;
+			assert(b->values == NULL);
+
+			const unsigned vw = u64bitset_words(m->max_value);
+			b->values = f_calloc(m->alloc,
+			    vw, sizeof(b->values[0]));
+			if (b->values == NULL) {
+				return 0;
+			}
+			m->buckets_used++;
+
+			u64bitset_set(b->values, value);
+			return 1;
+		} else {
+			continue; /* collision */
+		}
+
+	}
+
+	assert(!"unreachable");
+	return 0;
+}
+
+static const struct idmap_bucket *
+get_bucket(const struct idmap *m, fsm_state_t state_id)
+{
+	const uint64_t h = fsm_hash_id(state_id);
+	const uint64_t mask = m->bucket_count - 1;
+	for (size_t b_i = 0; b_i < m->bucket_count; b_i++) {
+		const struct idmap_bucket *b = &m->buckets[(h + b_i) & mask];
+		if (b->state == NO_STATE) {
+			return NULL;
+		} else if (b->state == state_id) {
+			return b;
+		}
+	}
+
+	return NULL;
+}
+
+size_t
+idmap_get_value_count(const struct idmap *m, fsm_state_t state_id)
+{
+	const struct idmap_bucket *b = get_bucket(m, state_id);
+	if (b == NULL) {
+		return 0;
+	}
+	assert(b->values != NULL);
+
+	size_t res = 0;
+	const size_t words = u64bitset_words(m->max_value);
+	for (size_t w_i = 0; w_i < words; w_i++) {
+		const uint64_t w = b->values[w_i];
+		/* This could use popcount64(w). */
+		if (w == 0) {
+			continue;
+		}
+		for (uint64_t bit = 1; bit; bit <<= 1) {
+			if (w & bit) {
+				res++;
+			}
+		}
+	}
+
+	return res;
+}
+
+int
+idmap_get(const struct idmap *m, fsm_state_t state_id,
+    size_t buf_size, unsigned *buf, size_t *written)
+{
+	const struct idmap_bucket *b = get_bucket(m, state_id);
+	if (b == NULL) {
+		if (written != NULL) {
+			*written = 0;
+		}
+		return 1;
+	}
+
+	size_t buf_offset = 0;
+	const size_t words = u64bitset_words(m->max_value);
+	for (size_t w_i = 0; w_i < words; w_i++) {
+		const uint64_t w = b->values[w_i];
+		if (w == 0) {
+			continue;
+		}
+
+		for (uint64_t b_i = 0; b_i < 64; b_i++) {
+			if (w & ((uint64_t)1 << b_i)) {
+				if (buf_offset * sizeof(buf[0]) >= buf_size) {
+					return 0;
+				}
+				buf[buf_offset] = 64*w_i + b_i;
+				buf_offset++;
+			}
+		}
+	}
+
+	if (written != NULL) {
+		*written = buf_offset;
+	}
+	return 1;
+}
+
+void
+idmap_iter(const struct idmap *m,
+    idmap_iter_fun *cb, void *opaque)
+{
+	const size_t words = u64bitset_words(m->max_value);
+
+	for (size_t b_i = 0; b_i < m->bucket_count; b_i++) {
+		const struct idmap_bucket *b = &m->buckets[b_i];
+		if (b->state == NO_STATE) {
+			continue;
+		}
+
+		for (size_t w_i = 0; w_i < words; w_i++) {
+			const uint64_t w = b->values[w_i];
+			if (w == 0) {
+				continue;
+			}
+			for (uint64_t b_i = 0; b_i < 64; b_i++) {
+				if (w & ((uint64_t)1 << b_i)) {
+					const unsigned v = 64*w_i + b_i;
+					cb(b->state, v, opaque);
+				}
+			}
+		}
+	}
+}
+
+void
+idmap_iter_for_state(const struct idmap *m, fsm_state_t state_id,
+    idmap_iter_fun *cb, void *opaque)
+{
+	const size_t words = u64bitset_words(m->max_value);
+	const struct idmap_bucket *b = get_bucket(m, state_id);
+	if (b == NULL) {
+		return;
+	}
+
+	for (size_t w_i = 0; w_i < words; w_i++) {
+		const uint64_t w = b->values[w_i];
+		if (w == 0) {
+			continue;
+		}
+		for (uint64_t b_i = 0; b_i < 64; b_i++) {
+			if (w & ((uint64_t)1 << b_i)) {
+				const unsigned v = 64*w_i + b_i;
+				cb(b->state, v, opaque);
+			}
+		}
+	}
+}

--- a/src/adt/internedstateset.c
+++ b/src/adt/internedstateset.c
@@ -10,6 +10,7 @@
 #include <fsm/fsm.h>
 
 #include <adt/alloc.h>
+#include <adt/hash.h>
 #include <adt/stateset.h>
 #include <adt/internedstateset.h>
 
@@ -22,9 +23,6 @@
 #if LOG_INTERNEDSTATESET
 #include <stdio.h>
 #endif
-
-/* 32-bit approximation of golden ratio, used for hashing */
-#define PHI32 0x9e3779b9
 
 #define NO_ISS ((struct interned_state_set *)-1)
 #define BUCKET_STATE_NONE ((fsm_state_t)-1)
@@ -170,11 +168,10 @@ interned_state_set_empty(struct interned_state_set_pool *pool)
 	return pool->empty;
 }
 
-SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
 static unsigned long
 hash_state(fsm_state_t state)
 {
-	return PHI32 * (state + 1);
+	return fsm_hash_id(state);
 }
 
 struct interned_state_set *

--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -593,7 +593,7 @@ main(int argc, char *argv[])
 			size_t n;
 			struct state_iter it;
 
-			closures = epsilon_closure(fsm);
+			closures = fsm_epsilon_closure(fsm);
 			if (closures == NULL) {
 				return -1;
 			}
@@ -614,7 +614,7 @@ main(int argc, char *argv[])
 				printf("\n");
 			}
 
-			closure_free(closures, fsm->statecount);
+			fsm_closure_free(closures, fsm->statecount);
 
 			return 0;
 		} else {

--- a/src/libfsm/capture.c
+++ b/src/libfsm/capture.c
@@ -281,11 +281,10 @@ fsm_capture_add_action(struct fsm *fsm,
 	    state, &action);
 }
 
-SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
 static unsigned
 hash_state(fsm_state_t state)
 {
-	return PHI32 * (state + 1);
+	return fsm_hash_id(state);
 }
 
 static int

--- a/src/libfsm/capture_internal.h
+++ b/src/libfsm/capture_internal.h
@@ -9,6 +9,7 @@
 #include <fsm/fsm.h>
 
 #include <adt/edgeset.h>
+#include <adt/hash.h>
 
 #include <string.h>
 #include <assert.h>

--- a/src/libfsm/clone.c
+++ b/src/libfsm/clone.c
@@ -119,16 +119,18 @@ copy_capture_actions(struct fsm *dst, const struct fsm *src)
 struct copy_end_ids_env {
 	char tag;
 	struct fsm *dst;
-	const struct fsm *src;
 	int ok;
 };
 
 static int
-copy_end_ids_cb(fsm_state_t state, const fsm_end_id_t id, void *opaque)
+copy_end_ids_cb(const struct fsm *fsm, fsm_state_t state,
+	size_t nth, const fsm_end_id_t id, void *opaque)
 {
 	struct copy_end_ids_env *env = opaque;
 	enum fsm_endid_set_res sres;
 	assert(env->tag == 'c');
+	(void)fsm;
+	(void)nth;
 
 #if LOG_CLONE_ENDIDS
 	fprintf(stderr, "clone[%d] <- %d\n", state, id);
@@ -149,7 +151,6 @@ copy_end_ids(struct fsm *dst, const struct fsm *src)
 	struct copy_end_ids_env env;
 	env.tag = 'c';		/* for clone */
 	env.dst = dst;
-	env.src = src;
 	env.ok = 1;
 
 	fsm_endid_iter(src, copy_end_ids_cb, &env);

--- a/src/libfsm/closure.c
+++ b/src/libfsm/closure.c
@@ -128,7 +128,7 @@ error:
 }
 
 struct state_set **
-epsilon_closure(struct fsm *fsm)
+fsm_epsilon_closure(struct fsm *fsm)
 {
 	struct state_set **closures;
 	fsm_state_t s;
@@ -253,7 +253,7 @@ symbol_closure(const struct fsm *fsm, fsm_state_t s,
 }
 
 void
-closure_free(struct state_set **closures, size_t n)
+fsm_closure_free(struct state_set **closures, size_t n)
 {
 	fsm_state_t s;
 

--- a/src/libfsm/consolidate.c
+++ b/src/libfsm/consolidate.c
@@ -21,6 +21,7 @@
 #include <adt/stateset.h>
 #include <adt/hashset.h>
 #include <adt/mappinghashset.h>
+#include <adt/u64bitset.h>
 
 #include "internal.h"
 #include "capture.h"
@@ -98,8 +99,8 @@ fsm_consolidate(struct fsm *src,
 		goto cleanup;
 	}
 
-#define DST_SEEN(I) (seen[I/64] & ((uint64_t)1 << (I&63)))
-#define SET_DST_SEEN(I) (seen[I/64] |= ((uint64_t)1 << (I&63)))
+#define DST_SEEN(I) u64bitset_get(seen, I)
+#define SET_DST_SEEN(I) u64bitset_set(seen, I)
 
 	/* map N states to M states, where N >= M.
 	 * if it's the first time state[M] is seen,

--- a/src/libfsm/consolidate.c
+++ b/src/libfsm/consolidate.c
@@ -232,24 +232,24 @@ struct consolidate_end_ids_env {
 };
 
 static int
-consolidate_end_ids_cb(fsm_state_t state, const fsm_end_id_t id,
-    void *opaque)
+consolidate_end_ids_cb(const struct fsm *fsm, fsm_state_t state,
+    size_t nth, const fsm_end_id_t id, void *opaque)
 {
 	struct consolidate_end_ids_env *env = opaque;
 	enum fsm_endid_set_res sres;
 	fsm_state_t s;
 	assert(env->tag == 'C');
 
+	(void)fsm;
+	(void)nth;
+
 #if LOG_CONSOLIDATE_ENDIDS > 1
-	fprintf(stderr, "consolidate_end_ids_cb: state %u, count %lu, ID %d:",
+	fprintf(stderr, "consolidate_end_ids_cb: state %u, ID: %d\n",
 	    state, id);
-	for (i = 0; i < count; i++) {
-		fprintf(stderr, " %u", ids[i]);
-	}
-	fprintf(stderr, "\n");
+	fprintf(stderr, "  -- mapping_count %zu\n",
+	    env->mapping_count);
 #endif
 
-	assert(state < env->mapping_count);
 	s = env->mapping[state];
 
 #if LOG_CONSOLIDATE_ENDIDS > 1

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -377,7 +377,7 @@ hash_iss(const struct interned_state_set *iss)
 {
 	/* Just hashing the address directly is fine here -- since they're
 	 * interned, they're identified by pointer equality. */
-	return PHI32 * (uintptr_t)iss;
+	return FSM_PHI_32 * (uintptr_t)iss;
 }
 
 static struct mapping *

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -11,7 +11,7 @@ dump_labels(FILE *f, const uint64_t labels[4])
 {
 	size_t i;
 	for (i = 0; i < 256; i++) {
-		if (labels[i/64] & ((uint64_t)1 << (i&63))) {
+		if (u64bitset_get(labels, i)) {
 			fprintf(f, "%c", (char)(isprint(i) ? i : '.'));
 		}
 	}

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -135,7 +135,7 @@ fsm_determinise(struct fsm *nfa)
 #if LOG_DETERMINISE_CLOSURES
 			fprintf(stderr, "fsm_determinise: cur (dfa %zu) label [", curr->dfastate);
 			dump_labels(stderr, output->labels);
-			fprintf(stderr, "] -> iss:%p: ", output->iss);
+			fprintf(stderr, "] -> iss:%p: ", (void *)output->iss);
 			{
 				struct state_iter it;
 				fsm_state_t s;

--- a/src/libfsm/determinise_internal.h
+++ b/src/libfsm/determinise_internal.h
@@ -17,6 +17,7 @@
 #include <adt/stateset.h>
 #include <adt/internedstateset.h>
 #include <adt/ipriq.h>
+#include <adt/u64bitset.h>
 
 #include "internal.h"
 #include "capture.h"

--- a/src/libfsm/determinise_internal.h
+++ b/src/libfsm/determinise_internal.h
@@ -13,6 +13,7 @@
 
 #include <adt/alloc.h>
 #include <adt/set.h>
+#include <adt/hash.h>
 #include <adt/edgeset.h>
 #include <adt/stateset.h>
 #include <adt/internedstateset.h>

--- a/src/libfsm/endids.c
+++ b/src/libfsm/endids.c
@@ -118,11 +118,10 @@ fsm_endid_free(struct fsm *fsm)
 	f_free(fsm->opt->alloc, fsm->endid_info);
 }
 
-SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
 static unsigned long
 hash_state(fsm_state_t state)
 {
-	return PHI32 * (state + 1);
+	return fsm_hash_id(state);
 }
 
 static int

--- a/src/libfsm/endids.h
+++ b/src/libfsm/endids.h
@@ -3,6 +3,7 @@
 
 #include <stdlib.h>
 #include <fsm/fsm.h>
+#include <adt/stateset.h>
 
 int
 fsm_endid_init(struct fsm *fsm);
@@ -35,7 +36,8 @@ fsm_endid_carry(const struct fsm *src_fsm, const struct state_set *src_set,
 /* Callback when iterating over the endids.
  * Return 0 to halt, or non-zero to continue. */
 typedef int
-fsm_endid_iter_cb(fsm_state_t state, const fsm_end_id_t id, void *opaque);
+fsm_endid_iter_cb(const struct fsm *fsm, fsm_state_t state,
+    size_t nth, const fsm_end_id_t id, void *opaque);
 
 void
 fsm_endid_iter(const struct fsm *fsm,

--- a/src/libfsm/endids_internal.h
+++ b/src/libfsm/endids_internal.h
@@ -9,6 +9,7 @@
 #include <fsm/fsm.h>
 #include <fsm/pred.h>
 
+#include <adt/hash.h>
 #include <adt/stateset.h>
 
 #include <string.h>

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -44,9 +44,6 @@ struct state_array;
 
 #define FSM_CAPTURE_MAX INT_MAX
 
-/* 32-bit approximation of golden ratio, used for hashing */
-#define PHI32 0x9e3779b9
-
 struct fsm_edge {
 	fsm_state_t state; /* destination */
 	unsigned char symbol;

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -98,7 +98,7 @@ state_hasnondeterminism(const struct fsm *fsm, fsm_state_t state, struct bm *bm)
  * for states, with wrapper to populate malloced array of user-facing structs.
  */
 struct state_set **
-epsilon_closure(struct fsm *fsm);
+fsm_epsilon_closure(struct fsm *fsm);
 
 int
 symbol_closure_without_epsilons(const struct fsm *fsm, fsm_state_t s,
@@ -110,7 +110,7 @@ symbol_closure(const struct fsm *fsm, fsm_state_t s,
 	struct state_set *sclosures[]);
 
 void
-closure_free(struct state_set **closures, size_t n);
+fsm_closure_free(struct state_set **closures, size_t n);
 
 /*
  * Internal free function that invokes free(3) by default, or a user-provided

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -108,8 +108,8 @@ fsm_print_cfrag # XXX: workaround for lx
 make_ir # XXX: workaround for lx
 free_ir # XXX: workaround for lx
 
-epsilon_closure # XXX: workaround for fsm
-closure_free # XXX: workaround for fsm
+fsm_epsilon_closure # XXX: workaround for fsm
+fsm_closure_free # XXX: workaround for fsm
 
 fsm_mergeab
 

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -80,6 +80,8 @@ fsm_setend
 fsm_getendidcount
 fsm_getendids
 fsm_setendid
+fsm_setendid_state
+fsm_iterendids
 
 fsm_countedges
 fsm_countstates

--- a/src/libfsm/merge.c
+++ b/src/libfsm/merge.c
@@ -162,11 +162,14 @@ struct copy_end_ids_env {
 };
 
 static int
-copy_end_ids_cb(fsm_state_t state, fsm_end_id_t id, void *opaque)
+copy_end_ids_cb(const struct fsm *fsm, fsm_state_t state,
+	size_t nth, const fsm_end_id_t id, void *opaque)
 {
 	enum fsm_endid_set_res sres;
 	struct copy_end_ids_env *env = opaque;
 	assert(env->tag == 'M');
+	(void)fsm;
+	(void)nth;
 
 #if LOG_MERGE_ENDIDS > 1
 	fprintf(stderr, "merge[%d] <- %d\n",
@@ -188,7 +191,6 @@ copy_end_ids(struct fsm *dst, struct fsm *src, fsm_state_t base_src)
 	struct copy_end_ids_env env;
 	env.tag = 'M';		/* for Merge */
 	env.dst = dst;
-	env.src = src;
 	env.base_src = base_src;
 	env.ok = 1;
 

--- a/src/libfsm/minimise.c
+++ b/src/libfsm/minimise.c
@@ -19,6 +19,7 @@
 
 #include <adt/edgeset.h>
 #include <adt/set.h>
+#include <adt/u64bitset.h>
 
 #include "internal.h"
 
@@ -154,10 +155,10 @@ collect_labels(const struct fsm *fsm,
 			assert(e.state < fsm->statecount);
 			label = e.symbol;
 
-			if (label_set[label/64] & (UINT64_C(1) << (label & 63))) {
+			if (u64bitset_get(label_set, label)) {
 				/* already set, ignore */
 			} else {
-				label_set[label/64] |= (UINT64_C(1) << (label & 63));
+				u64bitset_set(label_set, label);
 				count++;
 			}
 		}
@@ -165,7 +166,7 @@ collect_labels(const struct fsm *fsm,
 
 	*label_count = 0;
 	for (i = 0; i < 256; i++) {
-		if (label_set[i/64] & (UINT64_C(1) << (i & 63))) {
+		if (u64bitset_get(label_set, i)) {
 			labels[*label_count] = i;
 			(*label_count)++;
 		}

--- a/src/libfsm/print/fsm.c
+++ b/src/libfsm/print/fsm.c
@@ -16,6 +16,7 @@
 #include <adt/bitmap.h>
 #include <adt/stateset.h>
 #include <adt/edgeset.h>
+#include <adt/u64bitset.h>
 
 #include <fsm/fsm.h>
 #include <fsm/pred.h>
@@ -197,7 +198,7 @@ fprintf_state(FILE *f, const struct fsm *fsm, fsm_state_t s)
 			fprintf(f, "%-2u -> %2u ", s, info.to);
 
 			for (i = 0; i < 256; i++) {
-				if (info.symbols[i/64] & (1UL << (i & 63))) {
+				if (u64bitset_get(info.symbols, i)) {
 					if (lower > i) {
 						lower = i; /* set lower bound for range */
 					}

--- a/tests/idmap/Makefile
+++ b/tests/idmap/Makefile
@@ -1,0 +1,19 @@
+.include "../../share/mk/top.mk"
+
+TEST.tests/idmap != ls -1 tests/idmap/idmap*.c
+TEST_SRCDIR.tests/idmap = tests/idmap
+TEST_OUTDIR.tests/idmap = ${BUILD}/tests/idmap
+
+.for n in ${TEST.tests/idmap:T:R:C/^idmap//}
+INCDIR.${TEST_SRCDIR.tests/idmap}/idmap${n}.c += src/adt
+.endfor
+
+.for n in ${TEST.tests/idmap:T:R:C/^idmap//}
+test:: ${TEST_OUTDIR.tests/idmap}/res${n}
+SRC += ${TEST_SRCDIR.tests/idmap}/idmap${n}.c
+CFLAGS.${TEST_SRCDIR.tests/idmap}/idmap${n}.c += -UNDEBUG -D_DEFAULT_SOURCE -std=c99
+${TEST_OUTDIR.tests/idmap}/run${n}: ${TEST_OUTDIR.tests/idmap}/idmap${n}.o ${BUILD}/lib/adt.o
+	${CC} ${CFLAGS} ${CFLAGS.${TEST_SRCDIR.tests/idmap}/idmap${n}.c} -o ${TEST_OUTDIR.tests/idmap}/run${n} ${TEST_OUTDIR.tests/idmap}/idmap${n}.o ${BUILD}/lib/adt.o
+${TEST_OUTDIR.tests/idmap}/res${n}: ${TEST_OUTDIR.tests/idmap}/run${n}
+	( ${TEST_OUTDIR.tests/idmap}/run${n} 1>&2 && echo PASS || echo FAIL ) > ${TEST_OUTDIR.tests/idmap}/res${n}
+.endfor

--- a/tests/idmap/idmap_basic.c
+++ b/tests/idmap/idmap_basic.c
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2021 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <adt/idmap.h>
+
+#define DEF_LIMIT 10
+#define DEF_SEED 0
+
+/* Thes numbers were chose to get a reasonable variety,
+ * but also some duplicated values as the input grows. */
+#define MAX_GEN_VALUES 23
+#define ID_MASK ((1 << 9) - 1)
+#define VALUE_MASK ((1 << 10) - 1)
+
+static void
+dump_cb(fsm_state_t state_id, unsigned value, void *opaque)
+{
+	/* fprintf(stderr, " -- state %d, value %u\n", state_id, value); */
+	assert(state_id <= ID_MASK);
+	assert(value <= VALUE_MASK);
+	(void)opaque;
+}
+
+static int
+cmp_u(const void *pa, const void *pb)
+{
+	const unsigned a = *(unsigned *)pa;
+	const unsigned b = *(unsigned *)pb;
+	return a < b ? -1 : a > b ? 1 : 0;
+}
+
+int main(int argc, char **argv) {
+	const size_t limit = (argc > 1 ? atoi(argv[1]) : DEF_LIMIT);
+	const unsigned seed = (argc > 2 ? atoi(argv[2]) : DEF_SEED);
+
+	(void)argc;
+	(void)argv;
+	struct idmap *m = idmap_new(NULL);
+
+	srandom(seed);
+
+	/* Fill the table with random data */
+	for (size_t id_i = 0; id_i < limit; id_i++) {
+		const fsm_state_t id = (fsm_state_t)(random() & ID_MASK);
+		const size_t value_count = random() % MAX_GEN_VALUES;
+
+		for (size_t v_i = 0; v_i < value_count; v_i++) {
+			const unsigned v = random() & VALUE_MASK;
+			if (!idmap_set(m, id, v)) {
+				assert(!"failed to set");
+			}
+		}
+	}
+
+	idmap_iter(m, dump_cb, NULL);
+
+	srandom(seed);
+
+	size_t got_buf_ceil = MAX_GEN_VALUES;
+	unsigned *got_buf = malloc(got_buf_ceil * sizeof(got_buf[0]));
+	assert(got_buf != NULL);
+
+	/* Reset the PRNG and read back the same data. */
+	for (size_t id_i = 0; id_i < limit; id_i++) {
+		const fsm_state_t id = (fsm_state_t)(random() & ID_MASK);
+		const size_t generated_value_count = random() % MAX_GEN_VALUES;
+
+		/* Note: This can occasionally differ from
+		 * generated_value_count, because the same id or values
+		 * may have been generated more than once. As long as
+		 * all the values match, it's fine. */
+		const size_t value_count = idmap_get_value_count(m, id);
+
+		if (value_count > got_buf_ceil) {
+			size_t nceil = got_buf_ceil;
+			while (nceil <= value_count) {
+				nceil *= 2;
+			}
+			free(got_buf);
+			got_buf = malloc(nceil * sizeof(got_buf[0]));
+			assert(got_buf != NULL);
+			got_buf_ceil = nceil;
+		}
+
+		size_t written;
+		if (!idmap_get(m, id,
+			got_buf_ceil * sizeof(got_buf[0]), got_buf,
+			&written)) {
+			assert(!"failed to get");
+		}
+		assert(written == value_count);
+
+		unsigned gen_buf[MAX_GEN_VALUES];
+
+		for (size_t v_i = 0; v_i < generated_value_count; v_i++) {
+			const unsigned v = random() & VALUE_MASK;
+			gen_buf[v_i] = v;
+		}
+		qsort(gen_buf, generated_value_count, sizeof(gen_buf[0]), cmp_u);
+
+		/* Every generated value should appear in the buffer.
+		 * There may be more in the buffer; ignore them. */
+		size_t v_i = 0;
+		for (size_t gen_i = 0; gen_i < generated_value_count; gen_i++) {
+			int found = 0;
+			const unsigned gv = gen_buf[gen_i];
+			assert(value_count <= got_buf_ceil);
+			/* got_buf should be sorted, so we can pick up where we left off */
+			while (v_i < value_count) {
+				if (gv == got_buf[v_i]) {
+					/* Intentionally don't increment v_i on match,
+					 * because gen_buf can repeat values. */
+					found = 1;
+					break;
+				}
+				v_i++;
+			}
+			if (!found) {
+				fprintf(stderr, "NOT FOUND: state %d -- value: %u\n",
+				    id, gv);
+				return EXIT_FAILURE;
+			}
+		}
+	}
+
+	free(got_buf);
+	idmap_free(m);
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
This is the first of a series of PRs for adding group capture support to DFAs. I have it working end-to-end now, from passing a regex to libre, to all the libfsm processing, to dynamic execution or standalone generated code with very little additional overhead at runtime. Because it is a very large, cross-cutting diff (about 27k lines), and because the history has had months of experimentation, exploration, and false starts, it seems better to post as a series of layered PRs against an integration branch rather than squashing everything down.

For example, I can now generate C code from `^(?:(aa)|a*)$` that will match zero or more 'a', but only set the second capture when there are exactly two 'a's. (The first capture is implied, in PCRE, and contains all input except for what was consumed by unanchored start/end loops.)

Note that some of the currently merged tests in `tests/capture/` will not be expected to pass until the later PRs are integrated.

This PR adds a couple things to the ADTs:
- Some generic hash functions used throughout the codebase, including code that will appear in subsequent PRs
- idmap, which tracks which capture(s) are associated with particular end states
- Small `__inline__` functions for using a bare `uint64_t` array as a set

It also rewrites `fsm_remove_epsilons` in terms of grouped edge sets -- this aligns much better with how capture metadata will be rewritten, and working with sets of edges leading to the same destination has less overhead.

Following PRs will have:
- A better developed data model for annotating states and edges with capture actions
- Further changes for epsilon removal, determinisation, minimisation, trimming, etc. to properly re-map capture metadata during those transformations and to preserve distinctions that would otherwise lead to false matches.
- Special handling to explicitly track what is / isn't included in the implied capture 0 for the whole input, because in PCRE it does not include anything matched by an unanchored start or end loop. This required some changes to the parser and AST, and took quite a while to get right.
- Rewriting `ast_compile.c` to not use the C stack, which is necessary to disambiguate special cases with group matches that only appear in a subset of an `AST_EXPR_ALT` node's children.
- `fsm_generate_matches` and `fsm_generate_matches_random`, which generate inputs that match a particular DFA up to a configured buffer size (either depth first or by random walk), which is used for comparison testing against PCRE.
- Lots of test and benchmark code, some of which is still being cleaned up.

The end metadata changes that were necessary to handle otherwise ambiguous captures are also sufficient to address a current limitation of the library -- it will be possible to minimize a determinized and unioned set of DFAs without introducing ambiguous matches.