### PR TITLE
Remove CI builds for MacOS

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu, macos ]
+        os: [ ubuntu ]
         cc: [ clang ]
         make: [ bmake, pmake ]
         debug: [ DEBUG, RELEASE ] # RELEASE=1 is a no-op

--- a/.github/workflows/san.yml
+++ b/.github/workflows/san.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         san: [ ASAN, UBSAN, MSAN, EFENCE ]
-        os: [ ubuntu, macos ]
+        os: [ ubuntu ]
         cc: [ clang, gcc ]
         debug: [ DEBUG, RELEASE ] # RELEASE=1 is a no-op
         exclude:


### PR DESCRIPTION
This occasionally needs updates, and I don't have the resources to support it. It'd be easier if I owned a mac, but I don't.

This is a shame, because there's no reason this can't be supported. I'm just not able to do it myself.