### PR TITLE
Fix the build for FreeBSD, and switch to -std=c99

### DIFF
--- a/examples/bm/Makefile
+++ b/examples/bm/Makefile
@@ -5,8 +5,8 @@ BM_MAX ?= 100
 BM_CFLAGS += -DBM_MAX=${BM_MAX}
 
 pcre: pcre.c
-	gcc -o pcre -O3 -Wall -std=c89 ${BM_CFLAGS} pcre.c -lpcre
+	gcc -o pcre -O3 -Wall -std=c99 ${BM_CFLAGS} pcre.c -lpcre
 
 libfsm: libfsm.c
-	gcc -o libfsm -O3 -Wall -std=c89 ${BM_CFLAGS} libfsm.c -I ../../include ../../build/lib/libre.a ../../build/lib/libfsm.a
+	gcc -o libfsm -O3 -Wall -std=c99 ${BM_CFLAGS} libfsm.c -I ../../include ../../build/lib/libre.a ../../build/lib/libfsm.a
 

--- a/examples/glob/Makefile
+++ b/examples/glob/Makefile
@@ -1,4 +1,4 @@
-CFLAGS = -O2 -g -pedantic -std=c89 -Wall -W
+CFLAGS = -O2 -g -pedantic -std=c99 -Wall -W
 CC = gcc
 
 #CFLAGS = -Yposix2 -Xp

--- a/examples/rpn/Makefile
+++ b/examples/rpn/Makefile
@@ -1,7 +1,7 @@
 LX?= ../../build/bin/lx
 CC?= gcc
 
-CFLAGS+= -ansi -pedantic -Wall -Werror
+CFLAGS+= -std=c99 -pedantic -Wall -Werror
 
 
 all: rpn

--- a/examples/uncomment/Makefile
+++ b/examples/uncomment/Makefile
@@ -1,7 +1,7 @@
 LX?= ../../build/bin/lx
 CC?= gcc
 
-CFLAGS+= -ansi -pedantic -Wall -Werror
+CFLAGS+= -std=c99 -pedantic -Wall -Werror
 
 
 all: uncomment

--- a/examples/words/Makefile
+++ b/examples/words/Makefile
@@ -1,4 +1,4 @@
-CFLAGS = -O2 -g -pedantic -std=c89 -Wall -W
+CFLAGS = -O2 -g -pedantic -std=c99 -Wall -W
 CC = gcc
 
 #CFLAGS = -Yposix2 -Xp

--- a/src/adt/Makefile
+++ b/src/adt/Makefile
@@ -24,11 +24,6 @@ CFLAGS.${src} += -I src # XXX: for internal.h
 DFLAGS.${src} += -I src # XXX: for internal.h
 .endfor
 
-.for src in ${SRC:Msrc/adt/siphash.c} ${SRC:Msrc/adt/edgeset.c} ${SRC:Msrc/adt/idmap.c} ${SRC:Msrc/adt/internedstateset.c} ${SRC:Msrc/adt/ipriq.c}
-CFLAGS.${src} += -std=c99 # XXX: for internal.h
-DFLAGS.${src} += -std=c99 # XXX: for internal.h
-.endfor
-
 # not all concrete set interfaces use all static functions from set.inc
 .if ${CC:T:Mgcc*} || ${CC:T:Mclang*}
 .for src in ${SRC:Msrc/adt/stateset.c} ${SRC:Msrc/adt/tupleset.c} ${SRC:Msrc/adt/edgeset.c}

--- a/src/adt/edgeset.c
+++ b/src/adt/edgeset.c
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <string.h>
 #include <stdio.h>
+#include <inttypes.h>
 
 /* If non-zero, use an experimental edge_set implementation
  * that collects edges leading to the same set in a group
@@ -1016,7 +1017,7 @@ dump_edge_set(const struct edge_set *set)
 
 	for (i = 0; i < set->count; i++) {
 		eg = &set->groups[i];
-		fprintf(stderr, " -- %ld: [0x%lx, 0x%lx, 0x%lx, 0x%lx] -> %u\n",
+		fprintf(stderr, " -- %zu: [0x%" PRIx64 ", 0x%" PRIx64 ", 0x%" PRIx64 ", 0x%" PRIx64 "] -> %u\n",
 		    i,
 		    eg->symbols[0], eg->symbols[1],
 		    eg->symbols[2], eg->symbols[3], eg->to);

--- a/src/fsm/Makefile
+++ b/src/fsm/Makefile
@@ -4,12 +4,12 @@ SRC += src/fsm/main.c
 # SRC += src/fsm/wordgen.c
 # SRC += src/fsm/xoroshiro256starstar.c
 
-.for src in ${SRC:Msrc/fsm/main.c}
-CFLAGS.${src} += -I src -std=c99 # XXX: for internal.h
-DFLAGS.${src} += -I src -std=c99 # XXX: for internal.h
-.endfor
-
 PROG += fsm
+
+.for src in ${SRC:Msrc/fsm/main.c}
+CFLAGS.${src} += -I src # XXX: for internal.h
+DFLAGS.${src} += -I src # XXX: for internal.h
+.endfor
 
 .for lib in ${LIB:Mlibfsm}
 ${BUILD}/bin/fsm: ${BUILD}/lib/${lib:R}.a

--- a/src/libfsm/Makefile
+++ b/src/libfsm/Makefile
@@ -66,11 +66,6 @@ CFLAGS.src/libfsm/parser.c += -Wno-unused-parameter
 ${src}: src/libfsm/lexer.h
 .endfor
 
-.for src in ${SRC:Msrc/libfsm/closure.c} ${SRC:Msrc/libfsm/determinise.c} ${SRC:Msrc/libfsm/minimise.c} ${SRC:Msrc/libfsm/vm.c} ${SRC:Msrc/libfsm/example.c}
-CFLAGS.${src} += -std=c99
-DFLAGS.${src} += -std=c99
-.endfor
-
 LIB         += libfsm
 SYMS.libfsm += src/libfsm/libfsm.syms
 

--- a/src/libfsm/print/Makefile
+++ b/src/libfsm/print/Makefile
@@ -16,11 +16,6 @@ SRC += src/libfsm/print/vmc.c
 SRC += src/libfsm/print/vmdot.c
 SRC += src/libfsm/print/vmasm.c
 
-.for src in ${SRC:Msrc/libfsm/print/awk.c} ${SRC:Msrc/libfsm/print/vmc.c} ${SRC:Msrc/libfsm/print/rust.c} ${SRC:Msrc/libfsm/print/sh.c} ${SRC:Msrc/libfsm/print/go.c} ${SRC:Msrc/libfsm/print/vmasm.c} ${SRC:Msrc/libfsm/print/vmdot.c}
-CFLAGS.${src} += -std=c99 # XXX: for ir.h
-DFLAGS.${src} += -std=c99 # XXX: for ir.h
-.endfor
-
 .for src in ${SRC:Msrc/libfsm/print/*.c}
 CFLAGS.${src} += -I src # XXX: for internal.h
 DFLAGS.${src} += -I src # XXX: for internal.h

--- a/src/libfsm/print/api.c
+++ b/src/libfsm/print/api.c
@@ -98,20 +98,20 @@ fsm_print_api(FILE *f, const struct fsm *fsm_orig)
 		fprintf(f, "{\n");
 	}
 
-	fprintf(f, "\tfsm_state_t s[%lu];\n", (unsigned long) fsm->statecount);
+	fprintf(f, "\tfsm_state_t s[%zu];\n", fsm->statecount);
 	fprintf(f, "\tsize_t i;\n");
 	fprintf(f, "\n");
 
-	fprintf(f, "\tfor (i = 0; i < %lu; i++) {\n", (unsigned long) fsm->statecount);
+	fprintf(f, "\tfor (i = 0; i < %zu; i++) {\n", fsm->statecount);
 
-	fprintf(f, "\t\tif (i == %lu) {\n", (unsigned long) start);
-	fprintf(f, "\t\t\ts[%lu] = x;\n", (unsigned long) start);
+	fprintf(f, "\t\tif (i == %u) {\n", start);
+	fprintf(f, "\t\t\ts[%u] = x;\n", start);
 	fprintf(f, "\t\t\tcontinue;\n");
 	fprintf(f, "\t\t}\n");
 	fprintf(f, "\n");
 
-	fprintf(f, "\t\tif (i == %lu) {\n", (unsigned long) end);
-	fprintf(f, "\t\t\ts[%lu] = y;\n", (unsigned long) end);
+	fprintf(f, "\t\tif (i == %u) {\n", end);
+	fprintf(f, "\t\t\ts[%u] = y;\n", end);
 	fprintf(f, "\t\t\tcontinue;\n");
 	fprintf(f, "\t\t}\n");
 	fprintf(f, "\n");

--- a/src/libfsm/print/awk.c
+++ b/src/libfsm/print/awk.c
@@ -10,6 +10,7 @@
 #include <stdint.h>
 #include <errno.h>
 #include <stdio.h>
+#include <inttypes.h>
 
 #include <print/esc.h>
 
@@ -70,7 +71,7 @@ print_label(FILE *f, const struct dfavm_op_ir *op)
 	if (op->index == START) {
 		fprintf(f, "\"\"");
 	} else {
-		fprintf(f, "%lu", (unsigned long) op->index);
+		fprintf(f, "%" PRIu32, op->index);
 	}
 }
 
@@ -98,7 +99,7 @@ print_end(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt,
 	if (opt->endleaf != NULL) {
 		opt->endleaf(f, op->ir_state->end_ids, opt->endleaf_opaque);
 	} else {
-		fprintf(f, "return %lu", (unsigned long) (op->ir_state - ir->states));
+		fprintf(f, "return %td", op->ir_state - ir->states);
 	}
 }
 

--- a/src/libfsm/print/go.c
+++ b/src/libfsm/print/go.c
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <errno.h>
 #include <stdio.h>
+#include <inttypes.h>
 
 #include <print/esc.h>
 
@@ -64,7 +65,7 @@ cmp_operator(int cmp)
 static void
 print_label(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt)
 {
-	fprintf(f, "l%lu:", (unsigned long) op->index);
+	fprintf(f, "l%" PRIu32 ":", op->index);
 
 	if (op->ir_state->example != NULL) {
 		fprintf(f, " // e.g. \"");
@@ -99,14 +100,14 @@ print_end(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt,
 	if (opt->endleaf != NULL) {
 		opt->endleaf(f, op->ir_state->end_ids, opt->endleaf_opaque);
 	} else {
-		fprintf(f, "{\n\t\treturn %lu\n\t}\n", (unsigned long) (op->ir_state - ir->states));
+		fprintf(f, "{\n\t\treturn %td\n\t}\n", op->ir_state - ir->states);
 	}
 }
 
 static void
 print_branch(FILE *f, const struct dfavm_op_ir *op)
 {
-	fprintf(f, "{\n\t\tgoto l%lu\n\t}\n", (unsigned long) op->u.br.dest_arg->index);
+	fprintf(f, "{\n\t\tgoto l%" PRIu32 "\n\t}\n", op->u.br.dest_arg->index);
 }
 
 static void

--- a/src/libfsm/print/rust.c
+++ b/src/libfsm/print/rust.c
@@ -10,6 +10,7 @@
 #include <stdint.h>
 #include <errno.h>
 #include <stdio.h>
+#include <inttypes.h>
 
 #include <print/esc.h>
 
@@ -70,7 +71,7 @@ print_label(FILE *f, const struct dfavm_op_ir *op)
 	if (op->index == START) {
 		fprintf(f, "Ls");
 	} else {
-		fprintf(f, "L%lu", (unsigned long) op->index);
+		fprintf(f, "L%" PRIu32, op->index);
 	}
 }
 
@@ -98,7 +99,7 @@ print_end(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt,
 	if (opt->endleaf != NULL) {
 		opt->endleaf(f, op->ir_state->end_ids, opt->endleaf_opaque);
 	} else {
-		fprintf(f, "return Some(%lu)", (unsigned long) (op->ir_state - ir->states));
+		fprintf(f, "return Some(%td)", op->ir_state - ir->states);
 	}
 }
 

--- a/src/libfsm/print/sh.c
+++ b/src/libfsm/print/sh.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 #include <stdio.h>
 #include <ctype.h>
+#include <inttypes.h>
 
 #include <print/esc.h>
 
@@ -67,7 +68,7 @@ ord_operator(int cmp)
 static void
 print_label(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt)
 {
-	fprintf(f, "l%lu)", (unsigned long) op->index);
+	fprintf(f, "l%" PRIu32 ")", op->index);
 
 	/*
 	 * The example strings here are just for human-readable comments;
@@ -113,7 +114,7 @@ print_cond(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt)
 			fprintf(f, " || $c %s '%c'", str_operator(VM_CMP_EQ), c);
 		}
 	} else {
-		fprintf(f, "$(ord \"$c\") %s %3hhu", ord_operator(op->cmp), (unsigned char) c);
+		fprintf(f, "$(ord \"$c\") %s %3u", ord_operator(op->cmp), (unsigned char) c);
 	}
 	fprintf(f, " ]] && ");
 }
@@ -130,14 +131,14 @@ print_end(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt,
 	if (opt->endleaf != NULL) {
 		opt->endleaf(f, op->ir_state->end_ids, opt->endleaf_opaque);
 	} else {
-		fprintf(f, "matched %lu", (unsigned long) (op->ir_state - ir->states));
+		fprintf(f, "matched %td", op->ir_state - ir->states);
 	}
 }
 
 static void
 print_branch(FILE *f, const struct dfavm_op_ir *op)
 {
-	fprintf(f, "{ l=l%lu; continue; }", (unsigned long) op->u.br.dest_arg->index);
+	fprintf(f, "{ l=l%" PRIu32 "; continue; }", op->u.br.dest_arg->index);
 }
 
 static void

--- a/src/libfsm/print/vmc.c
+++ b/src/libfsm/print/vmc.c
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <errno.h>
 #include <stdio.h>
+#include <inttypes.h>
 
 #include <print/esc.h>
 
@@ -64,7 +65,7 @@ cmp_operator(int cmp)
 static void
 print_label(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt)
 {
-	fprintf(f, "l%lu:", (unsigned long) op->index);
+	fprintf(f, "l%" PRIu32 ":", op->index);
 
 	if (op->ir_state->example != NULL) {
 		fprintf(f, " /* e.g. \"");
@@ -97,14 +98,14 @@ print_end(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt,
 	if (opt->endleaf != NULL) {
 		opt->endleaf(f, op->ir_state->end_ids, opt->endleaf_opaque);
 	} else {
-		fprintf(f, "return %lu;", (unsigned long) (op->ir_state - ir->states));
+		fprintf(f, "return %td;", op->ir_state - ir->states);
 	}
 }
 
 static void
 print_branch(FILE *f, const struct dfavm_op_ir *op)
 {
-	fprintf(f, "goto l%lu;", (unsigned long) op->u.br.dest_arg->index);
+	fprintf(f, "goto l%" PRIu32 ";", op->u.br.dest_arg->index);
 }
 
 static void

--- a/src/libfsm/print/vmdot.c
+++ b/src/libfsm/print/vmdot.c
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <errno.h>
 #include <stdio.h>
+#include <inttypes.h>
 
 #include <print/esc.h>
 
@@ -93,14 +94,14 @@ print_end(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt,
 	if (opt->endleaf != NULL) {
 		opt->endleaf(f, op->ir_state->end_ids, opt->endleaf_opaque);
 	} else {
-		fprintf(f, "ret %lu", (unsigned long) (op->ir_state - ir->states));
+		fprintf(f, "ret %td", op->ir_state - ir->states);
 	}
 }
 
 static void
 print_branch(FILE *f, const struct dfavm_op_ir *op)
 {
-	fprintf(f, "branch #%lu", (unsigned long) op->u.br.dest_arg->index);
+	fprintf(f, "branch #%" PRIu32, op->u.br.dest_arg->index);
 }
 
 static void
@@ -124,7 +125,7 @@ fsm_print_nodes(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 
 			fprintf(f, "\n");
 
-			fprintf(f, "\tS%lu [ label=<\n", (unsigned long) op->index);
+			fprintf(f, "\tS%" PRIu32 " [ label=<\n", op->index);
 			fprintf(f, "\t\t<table border='0' cellborder='1' cellpadding='6' cellspacing='0'>\n");
 
 			fprintf(f, "\t\t<tr>\n");
@@ -155,8 +156,8 @@ fsm_print_nodes(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 
 		fprintf(f, "\t\t<tr>\n");
 
-		fprintf(f, "\t\t\t<td align='right' port='i%lu'>", (unsigned long) op->index);
-		fprintf(f, "#%lu", (unsigned long) op->index);
+		fprintf(f, "\t\t\t<td align='right' port='i%" PRIu32 "'>", op->index);
+		fprintf(f, "#%" PRIu32, op->index);
 		fprintf(f, "</td>\n");
 
 		fprintf(f, "\t\t\t<td>");
@@ -222,9 +223,9 @@ fsm_print_edges(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 		if (op->num_incoming > 0 || op == a->linked) {
 			if (op != a->linked && can_fallthrough) {
 				fprintf(f, "\t");
-				fprintf(f, "S%lu:s -> S%lu:n [ style = bold ]; /* fallthrough */",
-					(unsigned long) block,
-					(unsigned long) op->index);
+				fprintf(f, "S%lu:s -> S%" PRIu32 ":n [ style = bold ]; /* fallthrough */",
+					block,
+					op->index);
 				fprintf(f, "\n");
 			}
 
@@ -247,24 +248,24 @@ fsm_print_edges(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 		 */
 		if (op->u.br.dest_arg->index > block) {
 			/* branch to a later block */
-			fprintf(f, "S%lu:b%lu:e -> S%lu;",
-				(unsigned long) block,
-				(unsigned long) op->index,
-				(unsigned long) op->u.br.dest_arg->index);
+			fprintf(f, "S%lu:b%" PRIu32 ":e -> S%" PRIu32 ";",
+				block,
+				op->index,
+				op->u.br.dest_arg->index);
 		} else if (op->u.br.dest_arg->index < block) {
 			/* branch to an earlier block */
-			fprintf(f, "S%lu:i%lu:w -> S%lu;",
-				(unsigned long) block,
-				(unsigned long) op->index,
-				(unsigned long) op->u.br.dest_arg->index);
+			fprintf(f, "S%lu:i%" PRIu32 ":w -> S%" PRIu32 ";",
+				block,
+				op->index,
+				op->u.br.dest_arg->index);
 		} else {
 			/* relative branch within the same block, entry on the east */
 			/* XXX: would like to make these edges shorter, but I don't know how */
-			fprintf(f, "S%lu:b%lu:e -> S%lu:b%lu:e [ constraint = false ]; /* relative */",
-				(unsigned long) block,
-				(unsigned long) op->index,
-				(unsigned long) block,
-				(unsigned long) op->u.br.dest_arg->index);
+			fprintf(f, "S%lu:b%" PRIu32 ":e -> S%lu:b%" PRIu32 ":e [ constraint = false ]; /* relative */",
+				block,
+				op->index,
+				block,
+				op->u.br.dest_arg->index);
 		}
 
 		fprintf(f, "\n");

--- a/src/libfsm/trim.c
+++ b/src/libfsm/trim.c
@@ -144,7 +144,7 @@ mark_states(struct fsm *fsm, enum fsm_trim_mode mode,
 				}
 			}
 			if (LOG_TRIM > 0) {
-				fprintf(stderr, "mark_states: ends[%ld] = %d\n",
+				fprintf(stderr, "mark_states: ends[%zu] = %d\n",
 				    end_count, s_id);
 			}
 			ends[end_count] = s_id;
@@ -301,7 +301,7 @@ mark_states(struct fsm *fsm, enum fsm_trim_mode mode,
 			}
 
 			if (LOG_TRIM > 1) {
-				fprintf(stderr, "mark_states: offsets[%ld]: %ld\n",
+				fprintf(stderr, "mark_states: offsets[%zu]: %zu\n",
 				    i, offsets[i]);
 			}
 		}
@@ -311,7 +311,7 @@ mark_states(struct fsm *fsm, enum fsm_trim_mode mode,
 	if (LOG_TRIM > 1) {
 		size_t i;
 		for (i = 0; i < edge_count; i++) {
-		fprintf(stderr, "mark_states: edges[%ld]: %d -> %d\n",
+		fprintf(stderr, "mark_states: edges[%zu]: %d -> %d\n",
 		    i, edges[i].from, edges[i].to);
 		}
 	}
@@ -325,7 +325,7 @@ mark_states(struct fsm *fsm, enum fsm_trim_mode mode,
 		limit = offsets[s_id];
 
 		if (LOG_TRIM > 0) {
-			fprintf(stderr, "mark_states: popped %d, offsets [%ld, %ld]\n",
+			fprintf(stderr, "mark_states: popped %d, offsets [%zu, %zu]\n",
 			    s_id, base, limit);
 		}
 
@@ -336,7 +336,7 @@ mark_states(struct fsm *fsm, enum fsm_trim_mode mode,
 			assert(from < state_count);
 
 			if (LOG_TRIM > 0) {
-				fprintf(stderr, "mark_states: edges[%ld]: from: %d, visited? %d\n",
+				fprintf(stderr, "mark_states: edges[%zu]: from: %d, visited? %d\n",
 				    e_i, from, fsm->states[from].visited);
 			}
 
@@ -434,7 +434,7 @@ sweep_states(struct fsm *fsm)
 	if (LOG_TRIM > 1) {
 		size_t i;
 		for (i = 0; i < fsm->statecount; i++) {
-			fprintf(stderr, "sweep_states: state[%ld]: visited? %d\n",
+			fprintf(stderr, "sweep_states: state[%zu]: visited? %d\n",
 			    i, fsm->states[i].visited);
 		}
 	}
@@ -468,7 +468,7 @@ integrity_check(const char *descr, const struct fsm *fsm)
 		for (state_set_reset(fsm->states[s_id].epsilons, &state_iter);
 		     state_set_next(&state_iter, &to); ) {
 			if (to >= count) {
-				fprintf(stderr, "FAILURE (state_set): s_id %lu, to %u, count %lu\n", s_id, to, count);
+				fprintf(stderr, "FAILURE (state_set): s_id %zu, to %u, count %zu\n", s_id, to, count);
 				assert(to < count);
 			}
 		}
@@ -477,7 +477,7 @@ integrity_check(const char *descr, const struct fsm *fsm)
 		     edge_set_next(&edge_iter, &e); ) {
 			const fsm_state_t to = e.state;
 			if (to >= count) {
-				fprintf(stderr, "FAILURE (edge_set): s_id %lu, to %u, count %lu\n", s_id, to, count);
+				fprintf(stderr, "FAILURE (edge_set): s_id %zu, to %u, count %zu\n", s_id, to, count);
 				assert(to < count);
 			}
 		}

--- a/src/libfsm/vm/Makefile
+++ b/src/libfsm/vm/Makefile
@@ -5,11 +5,6 @@ SRC += src/libfsm/vm/vm.c
 SRC += src/libfsm/vm/v1.c
 SRC += src/libfsm/vm/v2.c
 
-.for src in ${SRC:Msrc/libfsm/vm/*.c} 
-CFLAGS.${src} += -std=c99
-DFLAGS.${src} += -std=c99
-.endfor 
-
 .for src in ${SRC:Msrc/libfsm/vm/*.c}
 CFLAGS.${src} += -I src # XXX: for internal.h
 DFLAGS.${src} += -I src # XXX: for internal.h

--- a/src/libfsm/vm/ir.c
+++ b/src/libfsm/vm/ir.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <ctype.h>
+#include <inttypes.h>
 
 #include <fsm/fsm.h>
 #include <fsm/vm.h>
@@ -172,7 +173,7 @@ print_op_ir(FILE *f, struct dfavm_op_ir *op)
 
 	cmp = cmp_name(op->cmp);
 
-	// fprintf(f, "[%4lu] %1lu\t", (unsigned long)op->offset, (unsigned long)op->num_encoded_bytes);
+	// fprintf(f, "[%4" PRIu32 "] %1u\t", op->offset, op->num_encoded_bytes);
 
 	char opstr_buf[128];
 	size_t nop = sizeof opstr_buf;
@@ -219,8 +220,8 @@ print_op_ir(FILE *f, struct dfavm_op_ir *op)
 	}
 
 	if (op->instr == VM_OP_BRANCH) {
-		n = snprintf(opstr, nop, "%s [st=%lu]", ((nargs>0) ? "," : " "),
-			(unsigned long)op->u.br.dest_state);
+		n = snprintf(opstr, nop, "%s [st=%u]", ((nargs>0) ? "," : " "),
+			op->u.br.dest_state);
 
 		opstr += n;
 		nop   -= n;
@@ -1033,12 +1034,12 @@ dump_states(FILE *f, struct dfavm_assembler_ir *a)
 	for (op = a->linked; op != NULL; op = op->next) {
 		if (op->instr == VM_OP_FETCH) {
 			unsigned state = op->u.fetch.state;
-			fprintf(f, "\n%p ;;; state %u (index: %lu, asm_index: %lu) %s\n",
-				(void *)op, state, (unsigned long)op->index, (unsigned long)op->asm_index,
+			fprintf(f, "\n%p ;;; state %u (index: %" PRIu32 ", asm_index: %" PRIu32 ") %s\n",
+				(void *) op, state, op->index, op->asm_index,
 				(state == a->start) ? "(start)" : "");
 		}
 
-		fprintf(f, "%p | %6zu | %6lu |  ", (void *)op, (unsigned long)op->index, (unsigned long)op->asm_index);
+		fprintf(f, "%p | %6" PRIu32 " | %6" PRIu32 " |  ", (void *)op, op->index, op->asm_index);
 		print_op_ir(f, op);
 	}
 }

--- a/src/libfsm/vm/v1.c
+++ b/src/libfsm/vm/v1.c
@@ -10,6 +10,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <ctype.h>
+#include <inttypes.h>
 
 #include "vm.h"
 
@@ -222,8 +223,8 @@ running_print_op_v1(const unsigned char *ops, uint32_t pc, const char *sp, const
 	dest = b & 0x03;
 	end  = b & 0x01;
 
-	fprintf(f, "[%4lu sp=%zd n=%zu ch=%3u '%c' end=%d] ",
-		(unsigned long)pc, sp-buf, n, (unsigned char)ch, isprint(ch) ? ch : ' ', end);
+	fprintf(f, "[%4" PRIu32 " sp=%zd n=%zu ch=%3u '%c' end=%d] ",
+		pc, sp-buf, n, (unsigned char)ch, isprint(ch) ? ch : ' ', end);
 
 	switch (op) {
 	case VM_OP_FETCH:

--- a/src/libfsm/vm/v2.c
+++ b/src/libfsm/vm/v2.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <ctype.h>
+#include <inttypes.h>
 
 #include "vm.h"
 
@@ -136,9 +137,9 @@ encode_opasm_v2(const struct dfavm_vm_op *instr, size_t ninstr)
 			(((uint32_t)cmp_arg)<<16) | dest_arg;
 
 #if DEBUG_ENCODING
-		fprintf(stderr, "enc[%4zu] instr=0x%02x cmp=0x%02x result=0x%02x cmp_arg=0x%02x dest_arg=0x%04x (%d | %u) instr=0x%08lx\n",
-			off, instr_bits, cmp_bits, result_bit, (unsigned)cmp_arg, (unsigned)dest_arg, (int16_t)dest_arg, (unsigned)dest_arg,
-			(unsigned long)instr);
+		fprintf(stderr, "enc[%4zu] instr=0x%02x cmp=0x%02x result=0x%02x cmp_arg=0x%02x dest_arg=0x%04" PRIx16 " (%" PRId16 " | %" PRId16 ") instr=0x%08" PRIx32 "\n",
+			off, instr_bits, cmp_bits, result_bit, cmp_arg, dest_arg, dest_arg, dest_arg,
+			instr);
 #endif /* DEBUG_ENCODING */
 
 		enc[i] = instr;
@@ -167,8 +168,8 @@ running_print_op_v2(const struct dfavm_v2 *vm, uint32_t pc, const char *sp, cons
 
 	V2DEC(vm->ops[pc], op,cmp,end, arg, dest);
 
-	fprintf(f, "[%4lu sp=%zd n=%zu ch=%3u '%c' end=%d] ",
-		(unsigned long)pc, sp-buf, n, (unsigned char)ch, isprint(ch) ? ch : ' ', end);
+	fprintf(f, "[%4" PRIu32 " sp=%zd n=%zu ch=%3u '%c' end=%d] ",
+		pc, sp-buf, n, (unsigned char)ch, isprint(ch) ? ch : ' ', end);
 
 	switch (op) {
 	case VM_V2_OP_FETCH:
@@ -222,7 +223,7 @@ running_print_op_v2(const struct dfavm_v2 *vm, uint32_t pc, const char *sp, cons
 		{
 			assert(dest >= 0 && (uint32_t)dest < vm->alen);
 			uint32_t dest_addr = vm->abuf[dest];
-			fprintf(f, " dest=%lu index=%d\n", (unsigned long)dest_addr, dest);
+			fprintf(f, " dest=%" PRIu32 " index=%d\n", dest_addr, dest);
 		}
 		break;
 

--- a/src/libfsm/vm/vm.c
+++ b/src/libfsm/vm/vm.c
@@ -12,6 +12,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include <ctype.h>
+#include <inttypes.h>
 
 #include <fsm/fsm.h>
 #include <fsm/vm.h>
@@ -146,7 +147,7 @@ print_vm_op(FILE *f, struct dfavm_vm_op *op)
 
 	cmp = cmp_name(op->cmp);
 
-	fprintf(f, "[%4lu] %1lu\t", (unsigned long)op->offset, (unsigned long)op->num_encoded_bytes);
+	fprintf(f, "[%4" PRIu32 "] %1u\t", op->offset, op->num_encoded_bytes);
 
 	switch (op->instr) {
 	case VM_OP_FETCH:
@@ -191,13 +192,13 @@ print_vm_op(FILE *f, struct dfavm_vm_op *op)
 	}
 
 	if (op->instr == VM_OP_BRANCH) {
-		fprintf(f, "%s%ld [dst_ind=%lu]", ((nargs>0) ? ", " : " "),
-			(long)op->u.br.rel_dest, (unsigned long)op->u.br.dest_index);
+		fprintf(f, "%s%ld [dst_ind=%" PRIu32 "]", ((nargs>0) ? ", " : " "),
+			(long)op->u.br.rel_dest, op->u.br.dest_index);
 		nargs++;
 	}
 
-	fprintf(f, "\t; %6lu bytes",
-		(unsigned long)op->num_encoded_bytes);
+	fprintf(f, "\t; %6u bytes",
+		op->num_encoded_bytes);
 	switch (op->instr) {
 	case VM_OP_FETCH:
 		fprintf(f, "  [state %u]", op->u.fetch.state);
@@ -434,7 +435,7 @@ dfavm_compile_vm(const struct dfavm_assembler_ir *a, struct fsm_vm_compile_opts 
 
 #if DEBUG_VM_OPCODES
 	dump_states(stdout, a);
-	fprintf(f, "%6lu total bytes\n", (unsigned long)b.nbytes);
+	fprintf(f, "%6" PRIu32 " total bytes\n", b.nbytes);
 #endif /* DEBUG_VM_OPCODES */
 
 	if (opts.flags & FSM_VM_COMPILE_PRINT_ENC) {

--- a/src/libre/Makefile
+++ b/src/libre/Makefile
@@ -19,11 +19,6 @@ CFLAGS.${src} += -I src # XXX: for internal.h
 DFLAGS.${src} += -I src # XXX: for internal.h
 .endfor
 
-.for src in ${SRC:Msrc/libre/ast.c} ${SRC:Msrc/libre/ast_analysis.c} ${SRC:Msrc/libre/ast_compile.c} ${SRC:Msrc/libre/re.c}
-CFLAGS.${src} += -std=c99 # XXX: for ast.h
-DFLAGS.${src} += -std=c99 # XXX: for ast.h
-.endfor
-
 LIB        += libre
 SYMS.libre += src/libre/libre.syms
 

--- a/src/libre/dialect/Makefile
+++ b/src/libre/dialect/Makefile
@@ -42,11 +42,6 @@ CFLAGS.${src} += -I src # XXX: for internal.h
 DFLAGS.${src} += -I src # XXX: for internal.h
 .endfor
 
-.for src in ${SRC:Msrc/libre/dialect/${dialect}/parser.c}
-CFLAGS.${src} += -std=c99 # XXX: for ast.h
-DFLAGS.${src} += -std=c99 # XXX: for ast.h
-.endfor
-
 .for parser in ${PARSER:Msrc/libre/dialect/${dialect}/parser.sid}
 ACT.${parser} = src/libre/parser.act
 .endfor

--- a/src/libre/dialect/Makefile
+++ b/src/libre/dialect/Makefile
@@ -31,7 +31,12 @@ DFLAGS.${src} += -D LX_HEADER='"lexer.h"'
 CFLAGS.${src} += -D DIALECT='${dialect}'
 DFLAGS.${src} += -D DIALECT='${dialect}'
 
-.if ${dialect:T:Mpcre}
+# This workaround is for OpenBSD's make(1), where despite being claimed
+# to be legal in the documentation, .if ${dialect} == pcre gives a syntax error.
+# I think this might be because ${dialect} isn't evaulated because it's a loop
+# variable, so my workaround here is to force evaulation.
+tmp := ${dialect}
+.if ${tmp} == pcre
 CFLAGS.${src} += -D PCRE_DIALECT=1
 DFLAGS.${src} += -D PCRE_DIALECT=1
 .endif

--- a/src/libre/print/Makefile
+++ b/src/libre/print/Makefile
@@ -10,11 +10,6 @@ CFLAGS.${src} += -I src # XXX: for internal.h
 DFLAGS.${src} += -I src # XXX: for internal.h
 .endfor
 
-.for src in ${SRC:Msrc/libre/print/dot.c} ${SRC:Msrc/libre/print/abnf.c} ${SRC:Msrc/libre/print/pcre.c} ${SRC:Msrc/libre/print/tree.c}
-CFLAGS.${src} += -std=c99 # XXX: for ast.h
-DFLAGS.${src} += -std=c99 # XXX: for ast.h
-.endfor
-
 .for src in ${SRC:Msrc/libre/print/*.c}
 ${BUILD}/lib/libre.o:    ${BUILD}/${src:R}.o
 ${BUILD}/lib/libre.opic: ${BUILD}/${src:R}.opic

--- a/src/libre/print/abnf.c
+++ b/src/libre/print/abnf.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <ctype.h>
+#include <inttypes.h>
 
 #include <re/re.h>
 
@@ -159,7 +160,7 @@ pp_iter(FILE *f, const struct fsm_options *opt, enum re_flags *re_flags, struct 
 
 	case AST_EXPR_CODEPOINT:
 		assert(!"unimplemented");
-		fprintf(f, "%%x\"%lX\"", (unsigned long) n->u.codepoint.u);
+		fprintf(f, "%%x\"%" PRIX32 "\"", n->u.codepoint.u);
 		break;
 
 	case AST_EXPR_REPEAT: {

--- a/src/libre/print/dot.c
+++ b/src/libre/print/dot.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <ctype.h>
+#include <inttypes.h>
 
 #include <re/re.h>
 
@@ -49,7 +50,7 @@ print_endpoint(FILE *f, const struct fsm_options *opt, const struct ast_endpoint
 		break;
 
 	case AST_ENDPOINT_CODEPOINT:
-		fprintf(f, "U+%lX", (unsigned long) e->u.codepoint.u);
+		fprintf(f, "U+%" PRIX32, e->u.codepoint.u);
 		break; 
 
 	default:
@@ -144,11 +145,11 @@ pp_iter(FILE *f, const struct fsm_options *opt,
 		break;
 
 	case AST_EXPR_CONCAT:
-		fprintf(f, "}|{%lu", n->u.concat.count);
+		fprintf(f, "}|{%zu", n->u.concat.count);
 		break;
 
 	case AST_EXPR_ALT:
-		fprintf(f, "}|{%lu", n->u.alt.count);
+		fprintf(f, "}|{%zu", n->u.alt.count);
 		break;
 
 	case AST_EXPR_LITERAL:
@@ -157,7 +158,7 @@ pp_iter(FILE *f, const struct fsm_options *opt,
 		break;
 
 	case AST_EXPR_CODEPOINT:
-		fprintf(f, "}|{U+%lX", (unsigned long) n->u.codepoint.u);
+		fprintf(f, "}|{U+%" PRIX32, n->u.codepoint.u);
 		break;
 
 	case AST_EXPR_REPEAT:

--- a/src/libre/print/pcre.c
+++ b/src/libre/print/pcre.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <stdlib.h>
+#include <inttypes.h>
 
 #include <re/re.h>
 
@@ -83,7 +84,7 @@ print_endpoint(FILE *f, const struct fsm_options *opt, const struct ast_endpoint
 		break;
 
 	case AST_ENDPOINT_CODEPOINT:
-		fprintf(f, "\\x{%lX}", (unsigned long) e->u.codepoint.u);
+		fprintf(f, "\\x{%" PRIX32 "}", e->u.codepoint.u);
 		break;
 
 	default:
@@ -162,7 +163,7 @@ pp_iter(FILE *f, const struct fsm_options *opt, enum re_flags *re_flags, struct 
 		break;
 
 	case AST_EXPR_CODEPOINT:
-		fprintf(f, "\\x{%lX}", (unsigned long) n->u.codepoint.u);
+		fprintf(f, "\\x{%" PRIX32 "}", n->u.codepoint.u);
 		break;
 
 	case AST_EXPR_REPEAT: {

--- a/src/libre/print/tree.c
+++ b/src/libre/print/tree.c
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <ctype.h>
+#include <inttypes.h>
 
 #include <re/re.h>
 
@@ -86,7 +87,7 @@ print_endpoint(FILE *f, const struct ast_endpoint *e)
 		break;
 
 	case AST_ENDPOINT_CODEPOINT:
-		fprintf(f, "U+%lX\n", (unsigned long) e->u.codepoint.u);
+		fprintf(f, "U+%" PRIX32 "\n", e->u.codepoint.u);
 		break;
 
 	default:
@@ -153,7 +154,7 @@ pp_iter(FILE *f, const struct fsm_options *opt, size_t indent, enum re_flags re_
 		break;
 
 	case AST_EXPR_CODEPOINT:
-		fprintf(f, "CODEPOINT U+%lX\n", (unsigned long) n->u.codepoint.u);
+		fprintf(f, "CODEPOINT U+%" PRIX32 "\n", n->u.codepoint.u);
 		break;
 
 	case AST_EXPR_REPEAT:

--- a/src/retest/Makefile
+++ b/src/retest/Makefile
@@ -10,11 +10,6 @@ CFLAGS.${src} += -I src # XXX: for internal.h
 DFLAGS.${src} += -I src # XXX: for internal.h
 .endfor
 
-.for src in ${SRC:Msrc/retest/main.c} ${SRC:Msrc/retest/reperf.c} ${SRC:Msrc/retest/cvtpcre.c} ${SRC:Msrc/retest/runner.c}
-CFLAGS.${src} += -std=c99
-DFLAGS.${src} += -std=c99
-.endfor
-
 .if ${SYSTEM} == Linux
 LFLAGS.reperf += -ldl
 LFLAGS.retest += -ldl

--- a/src/retest/cvtpcre.c
+++ b/src/retest/cvtpcre.c
@@ -1,3 +1,8 @@
+
+#if !defined(__APPLE__) && !defined(__MACH__)
+#define _POSIX_C_SOURCE 200809L
+#endif
+
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>

--- a/src/retest/main.c
+++ b/src/retest/main.c
@@ -4,9 +4,8 @@
  * See LICENCE for the full copyright terms.
  */
 
-#if __linux__
-/* apparently you need this for Linux, and it breaks macOS */
-#  define _POSIX_C_SOURCE 200809L
+#if !defined(__APPLE__) && !defined(__MACH__)
+#define _POSIX_C_SOURCE 200809L
 #endif
 
 #include <unistd.h>
@@ -77,7 +76,9 @@ static void watchdog_handler(int arg) {
 
 static struct sigaction watchdog_action_enabled = {
 	.sa_handler = &watchdog_handler,
+#if defined(SA_RESETHAND)
 	.sa_flags = SA_RESETHAND,
+#endif
 };
 static struct sigaction watchdog_action_disabled = {
 	.sa_handler = SIG_DFL

--- a/src/retest/reperf.c
+++ b/src/retest/reperf.c
@@ -4,9 +4,8 @@
  * See LICENCE for the full copyright terms.
  */
 
-#if __linux__
-/* apparently you need this for Linux, and it breaks macOS */
-#  define _POSIX_C_SOURCE 200809L
+#if !defined(__APPLE__) && !defined(__MACH__)
+#define _POSIX_C_SOURCE 200809L
 #endif
 
 #include <unistd.h>

--- a/theft/Makefile
+++ b/theft/Makefile
@@ -43,14 +43,7 @@ PROPNAME.theft += union_literals
 
 .for src in ${SRC:Mtheft/*.c}
 CFLAGS.${src} += -D_POSIX_C_SOURCE=200809L
-CFLAGS.${src} += -std=c99
-.if ${CC:T:Mgcc*} || ${CC:T:Mclang*}
-.endif
-.endfor
-
-.for src in ${SRC:Mtheft/*.c}
 DFLAGS.${src} += -D_POSIX_C_SOURCE=200809L
-DFLAGS.${src} += -std=c99
 .endfor
 
 .for src in ${SRC:Mtheft/*.c}


### PR DESCRIPTION
Here I've made things work for freebsd's headers, mostly by doing:
```
#if !defined(__APPLE__) && !defined(__MACH__)
#define _POSIX_C_SOURCE 200809L
#endif
```
to avoid bringing in the system prototype for `re_comp(3)` (which is present under `_BSD_VISIBLE`), which of course conflicts with our own.

To do that, I also made the makefiles work (again) for FreeBSD's make(1), and while I was there, to some extent also with OpenBSD's make(1).

I also switched the makefiles to `-std=c99` because we're doing that in a bunch of places already, so I'd prefer we do it for everything, just for consistency. I'm not introducing `bool` and such in this PR, but that should come at some point.

This resolves #362.