### PR TITLE
Handle unsatisfiable subexpressions like `^a($b)c$` at the right step.

### DIFF
--- a/src/libre/ast_compile.c
+++ b/src/libre/ast_compile.c
@@ -745,6 +745,15 @@ comp_iter(struct comp_env *env,
 
 		for (i = 0; i < count; i++) {
 			struct ast_expr *curr = n->u.concat.n[i];
+
+			/* If a subtree is unsatisfiable but also nullable, ignore it. */
+			const enum ast_flags nullable_and_unsat = AST_FLAG_NULLABLE
+			    | AST_FLAG_UNSATISFIABLE;
+			if (curr->type == AST_EXPR_REPEAT
+			    && (curr->flags & nullable_and_unsat) == nullable_and_unsat) {
+				continue;
+			}
+
 			struct ast_expr *next = i == count - 1
 				? NULL
 				: n->u.concat.n[i + 1];


### PR DESCRIPTION
We were previously replacing the subtree with an `AST_EXPR_EMPTY` node
when a repeat node had an unsatisfiable subexpression, but that was the
wrong time to do it, because other steps assume that all
`AST_EXPR_EMPTY` nodes have been filtered out by the end of AST
rewriting.

Instead of changing the node type, just set the `AST_FLAG_UNSATISFIABLE`
flag on the AST node and continue. (If the min count is non-zero, it
still reports the whole AST unsatisfiable and halts, but a zero count
can be ignored.) Later on, check for that flag and skip the subtree.

I think this was previously asymptomatic, but changes to address a
different unsatisfiability bug with ALT subexpressions made it possible
for `tests/native/in37.re` to trigger an assert failure.