### PR TITLE
bugfix: Fix typo in anchor mode comparison. (Probably asymptomatic.)

### DIFF
--- a/src/libre/ast.c
+++ b/src/libre/ast.c
@@ -498,7 +498,7 @@ ast_expr_cmp(const struct ast_expr *a, const struct ast_expr *b)
 
 	case AST_EXPR_ANCHOR:
 		if (a->u.anchor.type < b->u.anchor.type) { return -1; }
-		if (a->u.anchor.type < b->u.anchor.type) { return +1; }
+		if (a->u.anchor.type > b->u.anchor.type) { return +1; }
 
 		return 0;
 


### PR DESCRIPTION
This was discovered while fuzzing to check capture behavior, and like a copy-paste issue. I have not been able to find any cases where it leads to incorrect behavior on the current branch, but once capture matching is integrated it can lead to inconsistent capture bounds. There will be a regression test integrated along with the capture behavior.

The minimal case I've found is `$|^|.$` with the input of "x", which should match with the bounds (0,0) for match group zero but instead matches (0,1). The incorrect comparison operator in `ast_expr_cmp`'s case for `AST_EXPR_ANCHOR` causes it to tread the `$` and `^` ALT sub-branches as equal, deduplication during `ast_rewrite.c`'s `deduplicate_alt` incorrectly discards the `^` sub-branch, and this causes the `.$` to match "x" instead of the `^`, so match group zero includes the `.` within its bounds rather than it matching the empty string with an ignored suffix.