### PR TITLE
Performance improvenments, mainly for `fsm_determinise`

### DIFF
--- a/include/adt/bitmap.h
+++ b/include/adt/bitmap.h
@@ -23,6 +23,11 @@ bm_get(const struct bm *bm, size_t i);
 void
 bm_set(struct bm *bm, size_t i);
 
+/* Get a writeable pointer to the Nth word of the char set bitmap,
+ * or NULL if out of bounds. */
+uint64_t *
+bm_nth_word(struct bm *bm, size_t n);
+
 size_t
 bm_next(const struct bm *bm, int i, int value);
 

--- a/include/adt/bitmap.h
+++ b/include/adt/bitmap.h
@@ -7,11 +7,14 @@
 #ifndef ADT_BITMAP_H
 #define ADT_BITMAP_H
 
+#include <stdint.h>
+#include "print/esc.h"
+
 struct fsm_state;
 struct fsm_options;
 
 struct bm {
-	unsigned char map[UCHAR_MAX / CHAR_BIT + 1];
+	uint64_t map[(UCHAR_MAX + 1)/sizeof(uint64_t)];
 };
 
 int

--- a/include/adt/u64bitset.h
+++ b/include/adt/u64bitset.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#ifndef U64BITSET_H
+#define U64BITSET_H
+
+/* Various inline functions for using a bare uint64_t array
+ * as a bitset. The size should be managed by the caller. */
+
+#include <stdint.h>
+
+static __inline__ uint64_t
+u64bitset_get(const uint64_t *s, size_t id)
+{
+	return s[id/64] & ((uint64_t)1 << (id & 63));
+}
+
+static __inline__ void
+u64bitset_set(uint64_t *s, size_t id)
+{
+	s[id/64] |= ((uint64_t)1 << (id & 63));
+}
+
+static __inline__ void
+u64bitset_clear(uint64_t *s, size_t id)
+{
+	s[id/64] &=~ ((uint64_t)1 << (id & 63));
+}
+
+/* Calculate how many 64-bit words would be necessary
+ * to store COUNT bits, rounding up. */
+static __inline__ size_t
+u64bitset_words(size_t count)
+{
+	return count/64 + ((count & 63) ? 1 : 0);
+}
+
+/* Count '1' bits in s. */
+static __inline__ uint8_t
+u64bitset_popcount(uint64_t s)
+{
+	return __builtin_popcountl(s);
+}
+
+#endif

--- a/src/adt/bitmap.c
+++ b/src/adt/bitmap.c
@@ -9,10 +9,12 @@
 #include <stdio.h>
 #include <limits.h>
 #include <ctype.h>
-
-#include <print/esc.h>
+#include <stdint.h>
 
 #include <adt/bitmap.h>
+#include <adt/u64bitset.h>
+
+#include <print/esc.h>
 
 int
 bm_get(const struct bm *bm, size_t i)
@@ -20,7 +22,7 @@ bm_get(const struct bm *bm, size_t i)
 	assert(bm != NULL);
 	assert(i <= UCHAR_MAX);
 
-	return bm->map[i / CHAR_BIT] & (1 << i % CHAR_BIT);
+	return 0 != u64bitset_get(bm->map, i);
 }
 
 void
@@ -29,7 +31,7 @@ bm_set(struct bm *bm, size_t i)
 	assert(bm != NULL);
 	assert(i <= UCHAR_MAX);
 
-	bm->map[i / CHAR_BIT] |=  (1 << i % CHAR_BIT);
+	u64bitset_set(bm->map, i);
 }
 
 size_t
@@ -42,8 +44,7 @@ bm_next(const struct bm *bm, int i, int value)
 
 	/* this could be faster by incrementing per element instead of per bit */
 	for (n = i + 1; n <= UCHAR_MAX; n++) {
-		/* ...and this could be faster by using peter wegner's method */
-		if (!(bm->map[n / CHAR_BIT] & (1 << n % CHAR_BIT)) == !value) {
+		if (!u64bitset_get(bm->map, n) == !value) {
 			return n;
 		}
 	}
@@ -54,7 +55,6 @@ bm_next(const struct bm *bm, int i, int value)
 unsigned int
 bm_count(const struct bm *bm)
 {
-	unsigned char c;
 	unsigned int count;
 	size_t n;
 
@@ -62,12 +62,8 @@ bm_count(const struct bm *bm)
 
 	count = 0;
 
-	/* this could be faster using richard hamming's method */
-	for (n = 0; n < sizeof bm->map; n++) {
-		/* counting bits set for an element, peter wegner's method */
-		for (c = bm->map[n]; c != 0; c &= c - 1) {
-			count++;
-		}
+	for (n = 0; n < sizeof(sizeof(bm->map)/sizeof(bm->map[0])); n++) {
+		count += u64bitset_popcount(bm->map[n]);
 	}
 
 	return count;
@@ -76,11 +72,11 @@ bm_count(const struct bm *bm)
 void
 bm_clear(struct bm *bm)
 {
-	static const struct bm bm_empty;
-
 	assert(bm != NULL);
 
-	*bm = bm_empty;
+	for (size_t n = 0; n < sizeof(bm->map)/sizeof(bm->map[0]); n++) {
+		bm->map[n] = 0;
+	}
 }
 
 void
@@ -90,7 +86,7 @@ bm_invert(struct bm *bm)
 
 	assert(bm != NULL);
 
-	for (n = 0; n < sizeof bm->map; n++) {
+	for (n = 0; n < sizeof(bm->map)/sizeof(bm->map[0]); n++) {
 		bm->map[n] = ~bm->map[n];
 	}
 }
@@ -319,4 +315,3 @@ error:
 
 	return -1;
 }
-

--- a/src/adt/bitmap.c
+++ b/src/adt/bitmap.c
@@ -34,6 +34,16 @@ bm_set(struct bm *bm, size_t i)
 	u64bitset_set(bm->map, i);
 }
 
+uint64_t *
+bm_nth_word(struct bm *bm, size_t n)
+{
+	if (n < sizeof(bm->map)/sizeof(bm->map[0])) {
+		return &bm->map[n];
+	}
+
+	return NULL;
+}
+
 size_t
 bm_next(const struct bm *bm, int i, int value)
 {

--- a/src/adt/internedstateset.c
+++ b/src/adt/internedstateset.c
@@ -9,160 +9,194 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
+#include <stdio.h>
 
 #include <fsm/fsm.h>
 
 #include <adt/alloc.h>
 #include <adt/stateset.h>
-#include <adt/internedstateset.h>
 
 #include "common/check.h"
 
-/* Adapted from _Confluently Persistent Sets and Maps_ by Olle Liljenzin.
- *
- * This is a confluent persistent set pool, for interning sets of state
- * IDs. If multiple sets are constructed with the same elements, they
- * will end up with references to the same root node no matter what
- * order the IDs are added, which allows constant-time testing for
- * equality. Partially overlapping sets will be built using shared
- * subtrees when possible, which can save quite a lot of memory.
- *
- * A hash table is used to intern individual nodes, and reference
- * counting tracks when nodes can be returned to the freelist and
- * reused. There can be a lot of short-lived nodes constructed during
- * subtree rebalancing. Reference counting keeps the working set small,
- * but generational tracing collection may also be worth exploring at
- * some point. */
+#include <adt/internedstateset.h>
 
-/* These must both be a power of 2 and > 2. */
-#define ISS_POOL_DEF_CEIL 32
-#define CACHE_BUCKETS_DEF_COUNT 32
+#define LOG_ISS 0
 
-#define LOG_INTERNEDSTATESET (0+0)
-#define LOG_REFERENCE_COUNTING 0
+#define NO_ID ((uint32_t)-1)
+#define DEF_SETS 8
+#define DEF_BUF 64
+#define DEF_BUCKETS 256
 
-/* This should be 0 in production, 1 or 2 for hash table debugging. */
-#define LOG_HTAB 0
-#define EXCESS_MAX_PROBES 32	/* abort when LOG_HTAB > 0 */
-
-#define EXPENSIVE_INTEGRITY_CHECK 0
-
-#if LOG_INTERNEDSTATESET || LOG_HTAB
-#include <stdlib.h>
-#include <stdio.h>
-#endif
-
-#if LOG_REFERENCE_COUNTING
-#define LOG_REF(DESCR, NODE_ID, INC)					\
-	do {								\
-		const iss_node_id id = NODE_ID;				\
-		if (id != NO_ID) {					\
-			fprintf(stderr, "REF %s -- %s: node[%d]: %s\n",	\
-			    __func__, DESCR, NODE_ID, INC);		\
-		}							\
-	} while(0)
-#else
-#define LOG_REF(DESCR, NODE_ID, INC)
-#endif
-
-/* Just an abbreviation. */
-typedef interned_state_set_id iss_node_id;
-
-/* Also used as an ID for the empty set. */
-#define NO_ID ((iss_node_id)-1)
-
-/* Placeholder for deleted nodes in the node cache. */
-#define TOMBSTONE_ID ((iss_node_id)-2)
-
-/* If the refcount gets this high, rather than rolling over, the node
- * just sticks around until the whole pool is freed. */
-#define STUCK_REFCOUNT (UINT32_MAX)
-
+/* Interner for `struct state_set *`s. */
 struct interned_state_set_pool {
 	const struct fsm_alloc *alloc;
 
-	/* The ISS tree nodes are stored in a dynamic array, along with a freelist. */
-	size_t pool_ceil;
-	iss_node_id pool_freelist_head; /* can be NO_ID if the freelist is empty */
-	struct iss_node {
-		/* If .refcount is 0, this node is on the freelist and .r is the
-		 * ID of the next node, or NO_ID for the end of the freelist.
-		 * Otherwise, the refcount is 1 <= refcount <= STUCK_REFCOUNT. */
-		uint32_t refcount;
-		iss_node_id id;
+	/* Buffer for storing lists of state IDs. */
+	struct issp_state_set_buf {
+		size_t ceil;
+		size_t used;
+		fsm_state_t *buf;
+	} buf;
 
-		/* Branch or leaf node's state_id. */
-		fsm_state_t state;
+	/* Unique state sets. */
+	struct issp_state_set_descriptors {
+		size_t ceil;
+		size_t used;
+		struct issp_set {
+			size_t buf_offset;
+			size_t length;
+			struct state_set *ss; /* can be NULL */
+		} *sets;
+	} sets;
 
-		/* Cache of subtree hash, used to find existing nodes whose
-		 * subtrees contain the same state IDs. */
-		uint64_t hash;
-
-		/* This can be NULL. The actual state_set is only instantiated
-		 * when requested with interned_state_set_retain. */
-		struct state_set *set;
-
-		/* IDs for left and right children, can be NO_ID for leaf nodes.
-		 * When on the freelist, .l should be the node's ID (which can
-		 * never happen in the well-formed tree) and .r is the next
-		 * node on the freelist. */
-		iss_node_id l;
-		iss_node_id r;
-	} *pool;
-
-	/* Hash table for finding existing iss_nodes.
-	 *
-	 * This tracks the number of live entries, but also tombstones
-	 * marking entries that have been removed. These need to be
-	 * distinct from empty buckets (NO_ID) so that hash collisions
-	 * placed in buckets after them are not lost when deleting
-	 * nodes. They are also handled differently when the hash table
-	 * becomes too full -- if it's mostly filled with tombstones,
-	 * it may not need to grow, just remove the tombstones and rehash
-	 * the other entries. */
-	struct issp_cache {
-		uint32_t count;	/* bucket count */
-		uint32_t used_entries;
-		uint32_t used_tombstones;
-		struct cache_bucket {
-			iss_node_id id;			/* NO_ID if empty */
-		} *buckets;
-	} cache;
+	/* Hash table, for quickly finding and reusing
+	 * state sets with the same states. */
+	struct issp_htab {
+		size_t bucket_count; /* power of 2 */
+		size_t used;
+		uint32_t *buckets; /* or NO_ID */
+	} htab;
 };
 
-/* Magic values used to make certain things stand out in a debugger. */
-#define NODE_STATE_ON_NEW_FREELIST    77777777
-#define NODE_STATE_ON_GROWN_FREELIST  88888888
-#define NODE_STATE_ON_REUSED_FREELIST 99999999
+/* It's very common to have state sets with only a single state,
+ * particularly when determinising an FSM that is already mostly
+ * deterministic. Rather than interning them, just return a specially
+ * formatted interned_state_set_id boxing the single state. */
+#define SINGLETON_BIT ((uint64_t)1 << 63)
+#define IS_SINGLETON(X) (X & SINGLETON_BIT)
+#define MASK_SINGLETON(X) (X & ~SINGLETON_BIT)
 
-#define NO_DOOMED_ID ((iss_node_id)-2) /* just print */
-static void
-integrity_check(struct interned_state_set_pool *p, iss_node_id doomed_id);
-
-static bool
-is_empty_id(iss_node_id id)
+/* Allocate an interned state set pool. */
+struct interned_state_set_pool *
+interned_state_set_pool_alloc(const struct fsm_alloc *a)
 {
-	return id == NO_ID;
-}
+	struct interned_state_set_pool *res = NULL;
+	struct issp_set *sets = NULL;
+	fsm_state_t *buf = NULL;
+	uint32_t *buckets = NULL;
 
-static struct iss_node *
-get_iss_node(const struct interned_state_set_pool *p, iss_node_id node_id)
-{
-#if LOG_INTERNEDSTATESET > 4
-	fprintf(stderr, "%s: node_id %d\n", __func__, node_id);
-#endif
-	if (node_id == NO_ID) {
-		return NULL;
+	res = f_calloc(a, 1, sizeof(*res));
+	if (res == NULL) { goto cleanup; }
+
+	sets = f_malloc(a, DEF_SETS * sizeof(sets[0]));
+	if (sets == NULL) { goto cleanup; }
+
+	buf = f_malloc(a, DEF_BUF * sizeof(buf[0]));
+	if (sets == NULL) { goto cleanup; }
+
+	buckets = f_malloc(a, DEF_BUCKETS * sizeof(buckets[0]));
+	if (buckets == NULL) { goto cleanup; }
+
+	for (size_t i = 0; i < DEF_BUCKETS; i++) {
+		buckets[i] = NO_ID;
 	}
 
-	assert(node_id < p->pool_ceil);
-	return &p->pool[node_id];
+	struct interned_state_set_pool p = {
+		.alloc = a,
+		.sets = {
+			.ceil = DEF_SETS,
+			.sets = sets,
+		},
+		.buf = {
+			.ceil = DEF_BUF,
+			.buf = buf,
+		},
+		.htab = {
+			.bucket_count = DEF_BUCKETS,
+			.buckets = buckets,
+		},
+	};
+	memcpy(res, &p, sizeof(p));
+	return res;
+
+cleanup:
+	f_free(a, sets);
+	f_free(a, buf);
+	f_free(a, buckets);
+	f_free(a, res);
+	return NULL;
 }
 
-/* This will be in include/adt/hash.h later. */
+/* Free the pool.
+ * Any state_sets on the interned state sets within the pool
+ * will also be freed. */
+void
+interned_state_set_pool_free(struct interned_state_set_pool *pool)
+{
+	if (pool == NULL) { return; }
 
-/* 32 and 64-bit approximations of the golden ratio. */
-#define FSM_PHI_32 0x9e3779b9UL
+#if LOG_ISS
+	fprintf(stderr, "%s: sets: %zu/%zu, buf: %zu/%zu state_ids, htab: %zu/%zu buckets used\n",
+	    __func__, pool->sets.used, pool->sets.ceil,
+	    pool->buf.used, pool->buf.ceil,
+	    pool->htab.used, pool->htab.bucket_count);
+#endif
+
+	for (size_t i = 0; i < pool->sets.used; i++) {
+		if (pool->sets.sets[i].ss != NULL) {
+			state_set_free(pool->sets.sets[i].ss);
+		}
+	}
+
+	f_free(pool->alloc, pool->sets.sets);
+	f_free(pool->alloc, pool->buf.buf);
+	f_free(pool->alloc, pool->htab.buckets);
+	f_free(pool->alloc, pool);
+}
+
+static void
+dump_tables(FILE *f, const struct interned_state_set_pool *pool)
+{
+#if LOG_ISS > 1
+	fprintf(f, "%s: sets:\n", __func__);
+	for (size_t i = 0; i < pool->sets.used; i++) {
+		struct issp_set *s = &pool->sets.sets[i];
+		fprintf(f, "-- sets[%zu]: length %zd, offset %zd =>",
+		    i, s->length, s->buf_offset);
+		for (size_t i = 0; i < s->length; i++) {
+			fprintf(f, " %u", pool->buf.buf[s->buf_offset + i]);
+		}
+		fprintf(f, "\n");
+	}
+
+	fprintf(f, "%s: buf: %zu/%zu used\n", __func__, pool->buf.used, pool->buf.ceil);
+
+	fprintf(f, "%s: htab: %zu/%zu used\n", __func__, pool->htab.used, pool->htab.bucket_count);
+#endif
+
+#if LOG_ISS > 1
+	for (size_t i = 0; i < pool->htab.bucket_count; i++) {
+		const uint32_t b = pool->htab.buckets[i];
+		if (b != NO_ID) {
+			fprintf(f, "%s: htab[%zu]: %u\n", __func__, i, b);
+		}
+	}
+#else
+
+	uint8_t count = 0;
+	size_t row_count = 0;
+	for (size_t i = 0; i < pool->htab.bucket_count; i++) {
+		const uint32_t b = pool->htab.buckets[i];
+		if (b != NO_ID) {
+			count++;
+		}
+		if ((i & 7) == 7) {
+			const char c = (count == 0 ? '.' : '0' + count);
+			fprintf(f, "%c", c);
+			row_count += count;
+			count = 0;
+			if ((i & 511) == 511) { /* 64 chars wide */
+				fprintf(f, " -- %zu\n", row_count);
+				row_count = 0;
+			}
+		}
+	}
+	fprintf(f, "\n");
+#endif
+}
+
+/* This will be moved into include/adt/hash.h later. */
+/* 64-bit approximation of the golden ratio. */
 #define FSM_PHI_64 0x9e3779b97f4a7c15UL
 
 SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
@@ -174,1070 +208,323 @@ fsm_hash_id(unsigned id)
 
 SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
 static uint64_t
-hash_iss_node(const struct interned_state_set_pool *p, const struct iss_node *n, bool transitive)
+hash_state_ids(size_t count, const fsm_state_t *ids)
 {
-	assert(p != NULL);
-	assert(n != NULL);
-
-	uint64_t res;
-
-	/* This hash is derived from the state IDs, rather than the node
-	 * IDs, which will change from one run to another. */
-	res = fsm_hash_id(n->state);
-
-	/* These should be used to quickly locate existing nodes within
-	 * the cache, but the subtree hashes should not be included when
-	 * deciding whether to rebalance the tree inside iss_union
-	 * because that can prevent the tree from converging on the same
-	 * overall shape when keys are added in a different order. */
-	if (transitive) {
-		const struct iss_node *nl = get_iss_node(p, n->l);
-		const struct iss_node *nr = get_iss_node(p, n->r);
-
-		/* Two different primes close to 2**32 */
-		if (nl != NULL) {
-			const uint64_t lprime = ((uint64_t)1 << 32) - 267;
-			res += lprime * nl->hash;
-		}
-		if (nr != NULL) {
-			const uint64_t rprime = ((uint64_t)1 << 32) - 209;
-			res += rprime * nr->hash;
-		}
-
-#if LOG_INTERNEDSTATESET > 3
-		fprintf(stderr, "%s: res 0x%016lx <=== state %d, l: %d (0x%016lx), r: %d (0x%016lx)\n",
-		    __func__, res, n->state,
-		    n->l, n->l == NO_ID ? 0 : nl->hash,
-		    n->r, n->r == NO_ID ? 0 : nr->hash);
-#endif
+	uint64_t h = 0;
+	for (size_t i = 0; i < count; i++) {
+		h = fsm_hash_id(ids[i]) + (FSM_PHI_64 * h);
 	}
-
-	return res;
+	return h;
 }
 
-/* Get a node from the freelist, growing it if necessary.
- * Returns true and sets *node_id, or returns false on alloc error. */
 static bool
-freelist_pop(struct interned_state_set_pool *p,
-    iss_node_id *node_id)
+grow_htab(struct interned_state_set_pool *pool)
 {
-	if (p->pool_freelist_head == NO_ID) {
-		/* TODO: Instead of always doubling, this could double up to
-		 * a certain size and then add a fixed amount. */
-		const size_t nceil = 2*p->pool_ceil;
-
-#if LOG_INTERNEDSTATESET > 1
-	fprintf(stderr, "%s: %zu -> %zu\n", __func__, nceil, p->pool_ceil);
-#endif
-
-		assert(nceil > p->pool_ceil);
-		struct iss_node *npool = f_realloc(p->alloc,
-		    p->pool, nceil * sizeof(npool[0]));
-		if (npool == NULL) {
-			return false;
-		}
-
-		/* update freelist */
-		for (size_t i = p->pool_ceil; i < nceil; i++) {
-			npool[i].refcount = 0;
-			npool[i].state = NODE_STATE_ON_GROWN_FREELIST;
-			npool[i].set = NULL;
-			npool[i].l = i;
-			npool[i].r = (i == nceil - 1 ? NO_ID : i + 1);
-		}
-		p->pool_freelist_head = p->pool_ceil;
-
-		p->pool = npool;
-		p->pool_ceil = nceil;
-	}
-	const iss_node_id head = p->pool_freelist_head;
-#if LOG_INTERNEDSTATESET > 3
-	fprintf(stderr, "%s: current freelist head %u\n", __func__, head);
-#endif
-
-	struct iss_node *n = get_iss_node(p, head);
-
-	assert(n->refcount == 0);
-	assert(n->l == head);
-	assert(n->set == NULL);
-	n->l = NO_ID;
-
-	p->pool_freelist_head = n->r;
-#if LOG_INTERNEDSTATESET > 3
-	fprintf(stderr, "%s: new freelist head %u\n", __func__, n->r);
-#endif
-
-	*node_id = head;
-	return true;
-}
-
-static void
-freelist_push(struct interned_state_set_pool *p, iss_node_id node_id)
-{
-#if LOG_INTERNEDSTATESET > 1
-	fprintf(stderr, "%s: node_id %u\n", __func__, node_id);
-#endif
-	struct iss_node *n = get_iss_node(p, node_id);
-	assert(n->refcount == 0);
-	n->l = node_id;
-	n->r = p->pool_freelist_head;
-	n->state = NODE_STATE_ON_REUSED_FREELIST;
-	p->pool_freelist_head = node_id;
-}
-
-struct interned_state_set_pool *
-interned_state_set_pool_alloc(const struct fsm_alloc *a)
-{
-	struct interned_state_set_pool *res = NULL;
-	struct iss_node *pool = NULL;
-	struct cache_bucket *buckets = NULL;
-
-	size_t i;
-	res = f_calloc(a, 1, sizeof(*res));
-	if (res == NULL) {
-		goto cleanup;
-	}
-
-	/* allocate pool */
-	pool = f_malloc(a, ISS_POOL_DEF_CEIL * sizeof(*pool));
-	if (pool == NULL) {
-		goto cleanup;
-	}
-
-	/* allocate buckets */
-	buckets = f_malloc(a, CACHE_BUCKETS_DEF_COUNT * sizeof(*buckets));
-	if (buckets == NULL) {
-		goto cleanup;
-	}
-
-	/* init buckets */
-	for (i = 0; i < CACHE_BUCKETS_DEF_COUNT; i++) {
-		buckets[i].id = NO_ID;
-	}
-
-	/* init freelist */
-	for (i = 0; i < ISS_POOL_DEF_CEIL; i++) {
-		pool[i].refcount = 0;
-		pool[i].set = NULL;
-		pool[i].state = NODE_STATE_ON_NEW_FREELIST;
-		pool[i].l = i;
-		pool[i].r = (i == ISS_POOL_DEF_CEIL - 1 ? NO_ID : i + 1);
-	}
-
-	res->alloc = a;
-	res->pool_ceil = ISS_POOL_DEF_CEIL;
-	res->pool = pool;
-	res->cache.count = CACHE_BUCKETS_DEF_COUNT;
-	res->cache.buckets = buckets;
-	res->pool_freelist_head = 0;
-
-#if LOG_INTERNEDSTATESET > 1
-	fprintf(stderr, "%s: allocated with pool of %zu, cache with %u buckets\n",
-	    __func__, res->pool_ceil, res->cache.count);
-#endif
-	return res;
-
-cleanup:
-	if (res != NULL) {
-		f_free(a, res);
-	}
-	if (pool != NULL) {
-		f_free(a, pool);
-	}
-	if (buckets != NULL) {
-		f_free(a, buckets);
-	}
-	return NULL;
-}
-
-void
-interned_state_set_pool_free(struct interned_state_set_pool *pool)
-{
-	if (pool == NULL) {
-		return;
-	}
-
-#if LOG_INTERNEDSTATESET > 1
-	fprintf(stderr, "%s: buckets: (e: %u, t: %u, e+t: %u)/%u used (%g%%)\n",
-	    __func__, pool->cache.used_entries, pool->cache.used_tombstones,
-	    pool->cache.used_entries + pool->cache.used_tombstones, pool->cache.count,
-	    (100.0 * (pool->cache.used_entries + pool->cache.used_tombstones))/pool->cache.count);
-	interned_state_set_dump(pool, NULL);
-#endif
-
-	for (size_t i = 0; i < pool->pool_ceil; i++) {
-		if (pool->pool[i].set != NULL) {
-			state_set_free(pool->pool[i].set);
-		}
-	}
-
-	f_free(pool->alloc, pool->pool);
-	f_free(pool->alloc, pool->cache.buckets);
-	f_free(pool->alloc, pool);
-}
-
-interned_state_set_id
-interned_state_set_empty(struct interned_state_set_pool *pool)
-{
-	(void)pool;
-	return NO_ID;
-}
-
-#if LOG_HTAB
-static size_t max_probes = 0;
-
-static void
-dump_max_probes(void)
-{
-	fprintf(stderr, "max_probes: %zu\n", max_probes);
-}
-#endif
-
-static void
-dump_htab(struct interned_state_set_pool *pool)
-{
-#if LOG_HTAB
-	uint8_t bits = 0;
-	size_t used = 0;
-	size_t tombstones = 0;
-	const struct issp_cache *c = &pool->cache;
-	fprintf(stderr, "==== %s: buckets: (e:%u t:%u, e+t:%u)/%u used (%g%%)\n",
-	    __func__, c->used_entries, c->used_tombstones,
-	    c->used_entries + c->used_tombstones, c->count,
-	    (100.0 * (c->used_entries + c->used_tombstones))/c->count);
-
-	for (size_t i = 0; i < c->count; i++) {
-		const iss_node_id id = c->buckets[i].id;
-		if (id != NO_ID) {
-			if (id == TOMBSTONE_ID) {
-				tombstones++;
-				bits++;
-			} else {
-				used++;
-				bits++;
-			}
-		}
-
-		if ((i & 7) == 7) {
-			fprintf(stderr, "%c",
-			    bits == 0 ? '.' : bits + '0');
-			bits = 0;
-		}
-		if ((i & 511) == 511) {
-			fprintf(stderr, "\n");
-		}
-	}
-	if ((c->count & 511) != 511) {
-		fprintf(stderr, "\n");
-	}
-	fprintf(stderr, "==== tombstones: %zu, used %zu, t+u %zu/%u (%g%%)\n",
-	    tombstones, used, tombstones + used, c->count,
-	    (100.0 * (tombstones + used))/c->count);
-#else
-	(void)pool;
-#endif
-}
-
-SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
-static bool
-grow_or_clean_hash_table(struct interned_state_set_pool *pool)
-{
-	const uint32_t ocount = pool->cache.count;
-
-	/* If the table is < 1/4 full when the tombstones aren't counted,
-	 * then just copy the entries to a new htab of the same size,
-	 * discarding all the tombstones. It's not worth growing the hash
-	 * table if it would be nearly empty without tombstones. */
-	const uint32_t ncount = pool->cache.used_entries < ocount/4
-	    ? ocount : 2*ocount;
-
-	assert(ncount >= pool->cache.count);
-	struct cache_bucket *obuckets = pool->cache.buckets;
-	struct cache_bucket *nbuckets = f_malloc(pool->alloc,
-	    ncount * sizeof(nbuckets[0]));
-	size_t nused_entries = 0;
-	size_t old_tombstones = 0;
-
-	if (nbuckets == NULL) {
-		return false;
-	}
-
-#if LOG_HTAB
-	fprintf(stderr, "#### BEFORE grow_or_clean_hash_table\n");
-	dump_htab(pool);
-#endif
-
-#if LOG_INTERNEDSTATESET > 1
-	fprintf(stderr, "%s: %u -> %u\n", __func__, ocount, ncount);
-#endif
-
-	size_t i;
-	for (i = 0; i < ncount; i++) {
-		nbuckets[i].id = NO_ID;
-	}
-
+	const uint64_t ocount = pool->htab.bucket_count;
+	const uint64_t ncount = 2 * ocount;
 	const uint64_t nmask = ncount - 1;
-	for (size_t o_i = 0; o_i < ocount; o_i++) {
-		iss_node_id id = obuckets[o_i].id;
-		if (id == TOMBSTONE_ID) {
-			old_tombstones++;
-			continue;
-		} else if (id == NO_ID) {
-			continue;
-		}
 
-		const struct iss_node *n = get_iss_node(pool, id);
-		for (uint64_t n_i = 0; n_i < (uint64_t)ncount; n_i++) {
-			const uint64_t b = (n->hash + n_i) & nmask;
-			if (nbuckets[b].id == NO_ID) {
-				nbuckets[b].id = id;
-				nused_entries++;
+	uint32_t *obuckets = pool->htab.buckets;
+	uint32_t *nbuckets = f_malloc(pool->alloc,
+	    ncount * sizeof(nbuckets[0]));
+	if (nbuckets == NULL) { return false; }
+
+	for (size_t i = 0; i < ncount; i++) {
+		nbuckets[i] = NO_ID;
+	}
+
+	size_t max_collisions = 0;
+	for (size_t i = 0; i < ocount; i++) {
+		size_t collisions = 0;
+		const uint32_t id = obuckets[i];
+		if (id == NO_ID) { continue; }
+
+		struct issp_set *s = &pool->sets.sets[id];
+		assert(s->buf_offset + s->length <= pool->buf.used);
+		const fsm_state_t *buf = &pool->buf.buf[s->buf_offset];
+
+		const uint64_t h = hash_state_ids(s->length, buf);
+		for (uint64_t b_i = 0; b_i < ncount; b_i++) {
+			uint32_t *nb = &nbuckets[(h + b_i) & nmask];
+			if (*nb == NO_ID) {
+				*nb = id;
 				break;
+			} else {
+				collisions++;
 			}
+		}
+		if (collisions > max_collisions) {
+			max_collisions = collisions;
 		}
 	}
 
 	f_free(pool->alloc, obuckets);
-	pool->cache.count = ncount;
-	pool->cache.buckets = nbuckets;
-	pool->cache.used_tombstones = 0;
-	pool->cache.used_entries = nused_entries;
+	pool->htab.buckets = nbuckets;
+	pool->htab.bucket_count = ncount;
 
-#if LOG_HTAB
-	fprintf(stderr, "#### AFTER grow_or_clean_hash_table\n");
-	dump_htab(pool);
-
-	fprintf(stderr, "nused_entries %zu, old_tombstones %zu\n",
-	    nused_entries, old_tombstones);
-#endif
-
+	if (LOG_ISS) {
+		fprintf(stderr, "%s: %lu -> %lu, max_collisions %zu\n",
+		    __func__, ocount, ncount, max_collisions);
+		dump_tables(stderr, pool);
+	}
 	return true;
 }
 
-static void
-retain_node_id(struct interned_state_set_pool *p, iss_node_id id)
+/* Save a state set and get a unique identifier that can refer
+ * to it later. If there is more than one instance of the same
+ * set of states, reuse the existing identifier. */
+bool
+interned_state_set_intern_set(struct interned_state_set_pool *pool,
+	size_t state_count, const fsm_state_t *states,
+	interned_state_set_id *result)
 {
-	struct iss_node *n = get_iss_node(p, id);
-	if (n == NULL) {
-		return;
-	}
-	if (n->refcount != STUCK_REFCOUNT) {
-#if LOG_INTERNEDSTATESET > 3
-		fprintf(stderr, "%s: node[%d], refcount %d -> %d\n",
-		    __func__, id, n->refcount, n->refcount + 1);
-#endif
-		n->refcount++;
-	}
-}
-
-static void
-release_node_id(struct interned_state_set_pool *p, iss_node_id *p_id)
-{
-	bool freed = false;
-	assert(p_id != NULL);
-	const iss_node_id id = *p_id;
-	if (id == NO_ID) {
-		return;
-	}
-	*p_id = NO_ID;		/* consume caller's reference */
-
-	struct iss_node *n = get_iss_node(p, id);
-	assert(n != NULL);
-	if (n->refcount != STUCK_REFCOUNT) {
-#if LOG_INTERNEDSTATESET > 3
-		fprintf(stderr, "%s: node[%d], refcount %d -> %d\n",
-		    __func__, id, n->refcount,
-		    n->refcount - (n->refcount == STUCK_REFCOUNT ? 0 : 1));
-#endif
-		assert(n->refcount > 0);
-
-		n->refcount--;
-		if (n->refcount == 0) {
-			if (n->set != NULL) {
-				state_set_free(n->set);
-				n->set = NULL;
-			}
-
-			release_node_id(p, &n->l);
-			release_node_id(p, &n->r);
-
-			/* Find the released node in the hash table and replace
-			 * it with a tombstone, so it will be skipped over while
-			 * looking for collisions. The tombstone may be refilled
-			 * by later additions, and all tombstones are discarded
-			 * when growing the hash table. */
-			const uint64_t mask = p->cache.count - 1;
-			for (uint64_t b_i = 0; b_i < p->cache.count; b_i++) {
-				const uint64_t b = (n->hash + b_i) & mask;
-				if (p->cache.buckets[b].id == n->id) {
-					p->cache.buckets[b].id = TOMBSTONE_ID;
-
-					assert(p->cache.used_entries > 0);
-					p->cache.used_entries--;
-					p->cache.used_tombstones++;
-
-#if LOG_HTAB > 1
-					fprintf(stderr, "%s %d: htab delete, used %d -> %d, id %d\n",
-					    __func__, __LINE__,
-					    p->cache.used_entries + 1, p->cache.used_entries, n->id);
-#endif
-					break;
-				}
-			}
-
-			freed = true;
-			freelist_push(p, id);
-		}
-	}
-
-	if (freed) {
-		/* check for dead references */
-		integrity_check(p, id);
-	}
-}
-
-/* Create a node with a given (state, left_id, right_id) tuple,
- * or reuse an existing one if available.
- *
- * This transfers ownership of r_id and l_id from the caller, so it
- * takes pointers and writes NO_ID into them. */
-static bool
-intern_treap_node(struct interned_state_set_pool *pool,
-    fsm_state_t state, iss_node_id *p_l_id, iss_node_id *p_r_id,
-	iss_node_id *res_id)
-{
-	/* Transfer ownership. */
-	assert(p_l_id != NULL);
-	iss_node_id l_id = *p_l_id;
-	*p_l_id = NO_ID;
-
-	assert(p_r_id != NULL);
-	iss_node_id r_id = *p_r_id;
-	*p_r_id = NO_ID;
-
-	/* refcount: If iss is saved as a new node, l_id and r_id's
-	 * ownership is transferred to it, otherwise they will be
-	 * released later. */
-	struct iss_node iss = {
-		.id = NO_ID,	/* to be assigned */
-		.refcount = 1,
-		.state = state,
-		.l = l_id,
-		.r = r_id,
-	};
-
-#if LOG_INTERNEDSTATESET > 1
-	fprintf(stderr, "%s: interning state: %d, l: %d, r: %d\n",
-	    __func__, state, l_id, r_id);
+#if LOG_ISS > 2
+	fprintf(stderr, "%s: state_count %zu\n", __func__, state_count);
 #endif
 
-	const uint64_t hash = hash_iss_node(pool, &iss, true);
-	iss.hash = hash;
+	assert(state_count > 0);
 
-	/* Grow or clean up hash table if excessively full. Only grow
-	 * the table if it would still be too full once tombstones are
-	 * removed. The table should always have at least some empty
-	 * buckets or performance will degrade rapidly. */
-	if (pool->cache.used_entries + pool->cache.used_tombstones/2 >= pool->cache.count/2) {
-		if (!grow_or_clean_hash_table(pool)) {
+	/* If there's only one state, return a singleton. */
+	if (state_count == 1) {
+		*result = states[0] | SINGLETON_BIT;
+		return true;
+	}
+
+	/* otherwise, check the hash table */
+	if (pool->htab.used > pool->htab.bucket_count/2) {
+		if (!grow_htab(pool)) {
 			return false;
 		}
 	}
 
-	/* Count how many probes were neccesary for hash table
-	 * performance tuning. */
+	const uint64_t mask = pool->htab.bucket_count - 1;
+	const uint64_t h = hash_state_ids(state_count, states);
+
+	/*
+	 * TODO: When state_count is > 1 these sets tend to partially
+	 * overlap, so if reducing memory usage becomes more important
+	 * than time, they could be compressed by interning state IDs
+	 * pairwise: for example, [121 261 264 268 273 276 279] might
+	 * become ,4 279 where:
+	 *
+	 * - ,0 -> 121 261
+	 * - ,1 -> 264 268
+	 * - ,2 -> 273 276
+	 * - ,3 -> ,0 ,1
+	 * - ,4 -> ,3 ,2
+	 *
+	 * and each pair is stored as uint32_t[2] and interned,
+	 * where pair IDs have the msb set. fsm_state_t is expected
+	 * to fit in 31 bits.
+	 *
+	 * As long as the pairwise chunking is done bottom-up (group
+	 * all pairs of IDs, then all pairs of pairs, ...) it should
+	 * also converge on the same top level ID, for constant
+	 * comparison, and creating a new pair ID means the set has
+	 * not been seen before. */
+
+	uint32_t *dst_bucket = NULL;
 	size_t probes = 0;
-
-	/* Check hash table for a matching node. If not found,
-	 * insert in an empty bucket. There must be at least one. */
-	const uint64_t mask = pool->cache.count - 1;
-
-#define NO_FIRST_TOMBSTONE_POS ((uint64_t)-1)
-	uint64_t first_tombstone_pos = NO_FIRST_TOMBSTONE_POS;
-
-	for (uint64_t b_i = 0; b_i < pool->cache.count; b_i++) {
-		const uint64_t b = (hash + b_i) & mask;
-		const iss_node_id b_id = pool->cache.buckets[b].id;
-
-#if LOG_INTERNEDSTATESET > 3
-	fprintf(stderr, "%s: htab[b %lu] -> id %d\n", __func__, b, b_id);
+	for (uint64_t b_i = 0; b_i < pool->htab.bucket_count; b_i++) {
+		uint32_t *b = &pool->htab.buckets[(h + b_i) & mask];
+#if LOG_ISS > 1
+		fprintf(stderr, "%s: htab[(0x%lx + %lu) & 0x%lx => %d\n",
+		    __func__, h, b_i, mask, *b);
 #endif
-
-		if (b_id == TOMBSTONE_ID) {
-			if (first_tombstone_pos == NO_FIRST_TOMBSTONE_POS) {
-				first_tombstone_pos = b;
-			}
-			continue;
-		} else if (b_id == NO_ID) {
-			/* not found -- reserve node, save, and return */
-			iss_node_id new_id;
-			if (!freelist_pop(pool, &new_id)) {
-				return false;
-			}
-			iss.id = new_id;
-			pool->pool[new_id] = iss;
-
-			/* Optionally replace a tombstone encountered along the way,
-			 * but only once we've confirmed the node we're looking for
-			 * isn't already present after other collisions and tombstones. */
-			const uint64_t dst = first_tombstone_pos == NO_FIRST_TOMBSTONE_POS
-			    ? b : first_tombstone_pos;
-			pool->cache.buckets[dst].id = new_id;
-
-#if LOG_HTAB > 1
-			fprintf(stderr, "%s %d: htab add in %s, used_entries %d -> %d, used_tombstones %d -> %d, id %d\n",
-			    __func__, __LINE__,
-			    (first_tombstone_pos == NO_FIRST_TOMBSTONE_POS
-				? "empty" : "tombstone"),
-			    pool->cache.used_entries,
-			    pool->cache.used_entries + 1, pool->cache.used_tombstones,
-			    pool->cache.used_tombstones - (dst == b ? 0 : 1), new_id);
+		if (*b == NO_ID) {
+#if LOG_ISS > 3
+			fprintf(stderr, "%s: empty bucket (%zd probes)\n", __func__, probes);
 #endif
-			pool->cache.used_entries++;
-
-			/* Reduce tombstone count if one was replaced. */
-			if (first_tombstone_pos != NO_FIRST_TOMBSTONE_POS) {
-				assert(pool->cache.used_tombstones > 0);
-				pool->cache.used_tombstones--;
-
-				/* Also clear any consecutive run of tombstones immediately
-				 * before the empty bucket. They aren't doing anything
-				 * besides slowing down hash table operations and
-				 * possibly triggering extra hash table resizing. */
-				uint64_t pos = b;
-				for (;;) {
-					if (pos == 0) {
-						pos = pool->cache.count; /* wrap */
-					}
-					pos--;
-					const iss_node_id pos_id = pool->cache.buckets[pos].id;
-					if (pos_id != TOMBSTONE_ID) {
-						break;
-					}
-					pool->cache.buckets[pos].id = NO_ID;
-					assert(pool->cache.used_tombstones > 0);
-					pool->cache.used_tombstones--;
-				}
-			}
-
-			/* Now that we know we're keeping this node,
-			 * keep the refcounts for the left and right
-			 * children as-is, since the new node will hold
-			 * a reference to them that. */
-			*res_id = new_id;
-
-#if LOG_INTERNEDSTATESET > 1
-			fprintf(stderr, "%s: saving as new node[%d], in bucket %lu\n",
-			    __func__, *res_id, b);
-#endif
-#if LOG_INTERNEDSTATESET > 4
-			fprintf(stderr, "%s: hash 0x%16lx, b_i %lu, mask 0x%016lx, bucket %lu (state %d, l %d r %d)\n",
-			    __func__, hash, b_i, mask, dst, iss.state, iss.l, iss.r);
-#endif
-
-#if LOG_HTAB
-			if (probes > max_probes) {
-				if (max_probes == 0) {
-					atexit(dump_max_probes);
-				}
-				max_probes = probes;
-				if (getenv("DUMP_HTAB")) {
-					dump_htab(pool);
-				} else if (LOG_HTAB > 0 && max_probes > EXCESS_MAX_PROBES) {
-					/* LOG_HTAB should be 0 in production! */
-					dump_htab(pool);
-					fprintf(stderr, "!! EXCESS_MAX_PROBES, exiting !!\n");
-					exit(EXIT_FAILURE);
-				}
-			}
-#endif
-
-			LOG_REF("new_node", new_id, "=1");
-			return true;
+			dst_bucket = b;
+			break;
 		}
 
-		const struct iss_node *b_iss = get_iss_node(pool, b_id);
-#if LOG_INTERNEDSTATESET > 1
-			fprintf(stderr, "%s: b_id %d => state: %d, l: %d, r: %d\n",
-			    __func__, b_id, b_iss->state, b_iss->l, b_iss->r);
-#endif
+		const uint32_t id = *b;
+		assert(id < pool->sets.used);
+		struct issp_set *s = &pool->sets.sets[id];
+		if (s->length != state_count) {
+			probes++;
+			continue;
+		}
 
-		/* If a matching (state, left, right) node is found, reuse it,
-		 * and release the references transferred from the caller. */
-		if (b_iss->state == state && b_iss->l == l_id && b_iss->r == r_id) {
-			*res_id = b_iss->id;
-#if LOG_INTERNEDSTATESET > 1
-			fprintf(stderr, "%s: returning existing node[%d], refcount %d -> %d\n",
-			    __func__, *res_id, b_iss->refcount,
-			    b_iss->refcount + (b_iss->refcount == STUCK_REFCOUNT ? 0 : 1));
-#endif
-			/* This is creating a new reference to an
-			 * existing node, so increment its refcount. */
-			LOG_REF("existing_node", *res_id, "+");
-			retain_node_id(pool, b_id);
 
-			/* The left and right node references
-			 * transferred in are released, because the
-			 * reused node already holds a reference to
-			 * them. */
-			LOG_REF("new_node_reused_l", l_id, "-");
-			release_node_id(pool, &l_id);
-			LOG_REF("new_node_reused_r", r_id, "-");
-			release_node_id(pool, &r_id);
+		assert(s->buf_offset + s->length <= pool->buf.used);
+		const fsm_state_t *buf = &pool->buf.buf[s->buf_offset];
 
-#if LOG_HTAB
-			if (probes > max_probes) {
-				max_probes = probes;
-				fprintf(stderr, "max_probes: %zu, hash 0x%016lx, id %d\n", max_probes, hash, state);
-			}
+		if (0 == memcmp(states, buf, s->length * sizeof(buf[0]))) {
+			*result = id;
+#if LOG_ISS > 3
+			fprintf(stderr, "%s: reused %u (%zd probes)\n", __func__, id, probes);
 #endif
 			return true;
 		} else {
 			probes++;
-			continue; /* collision */
-		}
-	}
-
-	/* Should never get here -- the resizing/cleaning criteria for the hash
-	 * table ensures it should have at least one empty node. */
-	dump_htab(pool);
-	assert(!"unreachable");
-	return false;
-}
-
-static bool
-split(struct interned_state_set_pool *pool, iss_node_id *p_n_id, fsm_state_t state,
-    iss_node_id *new_l, iss_node_id *new_r)
-{
-	/* Transfer ownership */
-	assert(p_n_id != NULL);
-	iss_node_id n_id = *p_n_id;
-	*p_n_id = NO_ID;
-
-#if LOG_INTERNEDSTATESET > 2
-	fprintf(stderr, "%s: n_id: %u, state: %d\n",
-	    __func__, n_id, state);
-#endif
-
-	if (is_empty_id(n_id)) {
-		*new_l = NO_ID;
-		*new_r = NO_ID;
-		return true;
-	}
-
-	struct iss_node *n = get_iss_node(pool, n_id);
-
-	/* Don't bother splitting and recreating leaf nodes. */
-	if (n->l == NO_ID && n->r == NO_ID) {
-		if (state < n->state) {
-			*new_l = NO_ID;
-			*new_r = n_id;
-		} else {
-			*new_l = n_id;
-			*new_r = NO_ID;
-		}
-
-#if LOG_INTERNEDSTATESET > 2
-		fprintf(stderr, "%s: not splitting leaf %d, [%d, %d]\n",
-		    __func__, n_id, *new_l, *new_r);
-#endif
-		return true;
-	}
-
-	/* Take new references to the left and right children, which
-	 * will get passed along to split/intern below. */
-	const fsm_state_t n_s = n->state;
-	iss_node_id n_l = n->l;
-	assert(n_l != n_id);
-	retain_node_id(pool, n_l);
-
-	iss_node_id n_r = n->r;
-	assert(n_r != n_id);
-	retain_node_id(pool, n_r);
-
-	if (state < n_s) {
-		iss_node_id l1, l2;
-		if (!split(pool, &n_l, state, &l1, &l2)) {
-			return false;
-		}
-
-		*new_l = l1;
-		if (!intern_treap_node(pool, n_s, &l2, &n_r, new_r)) {
-			return false;
-		}
-	} else {
-		iss_node_id r1, r2;
-		if (!split(pool, &n_r, state, &r1, &r2)) {
-			return false;
-		}
-
-		if (!intern_treap_node(pool, n_s, &n_l, &r1, new_l)) {
-			return false;
-		}
-		*new_r = r2;
-	}
-
-#if 1
-	LOG_REF("after_split", n_id, "-");
-	release_node_id(pool, &n_id);
-#endif
-
-	integrity_check(pool, NO_DOOMED_ID);
-	return true;
-}
-
-/* Return the root node for a version of the old root node's ISS with
- * the state present. Existing subtrees will be reused and have their
- * refcounts updated as necessary, including the entire tree if the
- * state is already present.
- *
- * Returns true and sets *new_root on success, returns false
- * on allocation error.
- *
- * Creates new references to t1_id and t2_id, which may be released or
- * transferred below.
- *
- * This is adapted from `union` in the paper. */
-static bool
-iss_union(struct interned_state_set_pool *pool,
-    iss_node_id *p_t1_id, iss_node_id *p_t2_id, iss_node_id *new_id)
-{
-	/* Transfer ownership */
-	assert(p_t1_id != NULL);
-	iss_node_id t1_id = *p_t1_id;
-	*p_t1_id = NO_ID;
-
-	assert(p_t2_id != NULL);
-	iss_node_id t2_id = *p_t2_id;
-	*p_t2_id = NO_ID;
-
-#if LOG_INTERNEDSTATESET > 2
-	fprintf(stderr, "%s: t1_id: %d, t2_id: %d\n",
-	    __func__, t1_id, t2_id);
-#endif
-
-	/* NOTE: All three of these macros can trigger
-	 * relocation that makes the iss_node pointers become stale. */
-#define SPLIT(ID, STATE, DST_L, DST_R)		\
-	if (!split(pool, ID, STATE, DST_L, DST_R)) { return false; }	\
-
-#define UNION(N1, N2, DST)					\
-	if (!iss_union(pool, N1, N2, DST)) { return false; }
-
-#define TREAP(STATE, L, R, DST)			\
-	intern_treap_node(pool, STATE, L, R, DST)
-
-	/* Handle when one or both are NO_ID. */
-	if (t1_id == t2_id) {
-		/* This should only be possible in a well-formed treap when both
-		 * are NO_ID. If we somehow reach this otherwise, we may need
-		 * updates to the reference counting. */
-		*new_id = t1_id; /* transfer reference */
-		return true;
-	} else if (is_empty_id(t2_id)) {
-		*new_id = t1_id; /* transfer reference */
-		return true;
-	} else if (is_empty_id(t1_id)) {
-		*new_id = t2_id; /* transfer reference */
-		return true;
-	}
-
-	struct iss_node *t1 = get_iss_node(pool, t1_id);
-	struct iss_node *t2 = get_iss_node(pool, t2_id);
-	assert(t1 != NULL);
-	assert(t2 != NULL);
-
-	/* Save copies of these, because the operations below can cause
-	 * the array of nodes to relocate. */
-	iss_node_id t1_l = t1->l;
-	iss_node_id t1_r = t1->r;
-	iss_node_id t2_l = t2->l;
-	iss_node_id t2_r = t2->r;
-	const fsm_state_t t1_s = t1->state;
-	const fsm_state_t t2_s = t2->state;
-
-	/* Temporarily retain the subtrees while other
-	 * tree rebalancing may be in progress. */
-	LOG_REF("union_tmp_t1_l", t1_l, "+");
-	LOG_REF("union_tmp_t1_r", t1_r, "+");
-	LOG_REF("union_tmp_t2_l", t2_l, "+");
-	LOG_REF("union_tmp_t2_r", t2_r, "+");
-	retain_node_id(pool, t1_l);
-	retain_node_id(pool, t1_r);
-	retain_node_id(pool, t2_l);
-	retain_node_id(pool, t2_r);
-
-	if (t1_s == t2_s) {
-		iss_node_id u_l, u_r;
-#if LOG_INTERNEDSTATESET > 2
-		fprintf(stderr, "iss_union: state == branch: ids %d, %d\n", t1_id, t2_id);
-#endif
-		UNION(&t1_l, &t2_l, &u_l);
-		UNION(&t1_r, &t2_r, &u_r);
-		if (!TREAP(t1_s, &u_l, &u_r, new_id)) {
-			return false;
-		}
-
-		LOG_REF("after_union_eq_1", t1_id, "-");
-		release_node_id(pool, &t1_id);
-		LOG_REF("after_union_eq_2", t2_id, "-");
-		release_node_id(pool, &t2_id);
-		goto done;
-	}
-
-	const uint64_t h1 = hash_iss_node(pool, t1, false);
-	const uint64_t h2 = hash_iss_node(pool, t2, false);
-
-	if (h1 < h2) {
-		iss_node_id l1, r1;
-		iss_node_id u1, u2;
-#if LOG_INTERNEDSTATESET > 2
-		fprintf(stderr, "iss_union: < branch: ids %d, %d\n", t1_id, t2_id);
-#endif
-		SPLIT(&t1_id, t2_s, &l1, &r1);
-		UNION(&l1, &t2_l, &u1);
-		UNION(&r1, &t2_r, &u2);
-
-		if (!TREAP(t2_s, &u1, &u2, new_id)) {
-			return false;
-		}
-
-		LOG_REF("after_union_lt_t2", t2_id, "-");
-		release_node_id(pool, &t2_id);
-	} else {
-		iss_node_id l2, r2;
-		iss_node_id u1, u2;
-#if LOG_INTERNEDSTATESET > 2
-		fprintf(stderr, "iss_union: >= branch: ids %d, %d\n", t1_id, t2_id);
-#endif
-		SPLIT(&t2_id, t1_s, &l2, &r2);
-		UNION(&t1_l, &l2, &u1);
-		UNION(&t1_r, &r2, &u2);
-
-		if (!TREAP(t1_s, &u1, &u2, new_id)) {
-			return false;
-		}
-
-		LOG_REF("after_union_gte_t1", t1_id, "-");
-		release_node_id(pool, &t1_id);
-	}
-
-	LOG_REF("union_tmp_t1_l", t1_l, "-");
-	LOG_REF("union_tmp_t1_r", t1_r, "-");
-	LOG_REF("union_tmp_t2_l", t2_l, "-");
-	LOG_REF("union_tmp_t2_r", t2_r, "-");
-	release_node_id(pool, &t1_l);
-	release_node_id(pool, &t1_r);
-	release_node_id(pool, &t2_l);
-	release_node_id(pool, &t2_r);
-
-#undef TREAP
-#undef UNION
-#undef SPLIT
-
-done:
-	return true;
-}
-
-int
-interned_state_set_add(struct interned_state_set_pool *pool,
-    interned_state_set_id *p_set_id, fsm_state_t state,
-    interned_state_set_id *result)
-{
-	/* Transfer ownership */
-	iss_node_id set_id = (iss_node_id)*p_set_id;
-	*p_set_id = NO_ID;
-
-	assert(set_id < pool->pool_ceil || set_id == NO_ID);
-
-	iss_node_id new_node;
-	iss_node_id none_l = NO_ID;
-	iss_node_id none_r = NO_ID;
-	if (!intern_treap_node(pool, state, &none_l, &none_r, &new_node)) {
-		return 0;
-	}
-
-#if LOG_INTERNEDSTATESET > 3
-	fprintf(stderr, "%s: interned node[%u] with [%d]\n",
-	    __func__, new_node, state);
-#endif
-
-	/* Get a node from the freelist. Insert into the
-	 * appropriate side, rebalance on the way up, and return
-	 * the new head, reusing existing nodes (and incrementing refcounts)
-	 * whenever possible. */
-	iss_node_id new_root_id;
-	if (iss_union(pool, &set_id, &new_node, &new_root_id)) {
-#if LOG_INTERNEDSTATESET > 3
-		fprintf(stderr, "%s: new_root_id %u\n", __func__, new_root_id);
-#endif
-		integrity_check(pool, NO_DOOMED_ID);
-		*result = new_root_id;
-		return 1;
-	} else {
-		return 0;
-	}
-}
-
-static bool
-construct_state_set(struct interned_state_set_pool *p,
-    struct state_set **dst, struct iss_node *n)
-{
-	struct iss_node *nl = get_iss_node(p, n->l);
-	struct iss_node *nr = get_iss_node(p, n->r);
-	if (nl != NULL) {
-		if (!construct_state_set(p, dst, nl)) {
-			return false;
-		}
-	}
-
-	if (!state_set_add(dst, p->alloc, n->state)) {
-		return false;
-	}
-
-	if (nr != NULL) {
-		if (!construct_state_set(p, dst, nr)) {
-			return false;
-		}
-	}
-
-	return true;
-}
-
-struct state_set *
-interned_state_set_retain(struct interned_state_set_pool *p, interned_state_set_id set_id)
-{
-	struct iss_node *n = get_iss_node(p, set_id);
-	assert(n != NULL);
-
-	retain_node_id(p, set_id);
-
-	if (n->set != NULL) {
-		return n->set;
-	}
-
-	assert(n->set == NULL);
-	if (!construct_state_set(p, &n->set, n)) {
-		return NULL;
-	}
-	return n->set;
-}
-
-static void
-integrity_check(struct interned_state_set_pool *p, iss_node_id doomed_id)
-{
-	if (!EXPENSIVE_INTEGRITY_CHECK) { return; }
-
-	bool ok = true;
-#if LOG_INTERNEDSTATESET > 1
-	if (doomed_id != NO_DOOMED_ID) {
-		fprintf(stderr, "%s: scanning for %d\n", __func__, doomed_id);
-	}
-#endif
-	for (size_t i = 0; i < p->cache.count; i++) {
-		const iss_node_id id = p->cache.buckets[i].id;
-		if (id == TOMBSTONE_ID || id == NO_ID) {
 			continue;
 		}
-		assert(id != doomed_id);
-		const struct iss_node *n = get_iss_node(p, id);
-		const bool fail = (n->l == doomed_id || n->r == doomed_id) && n->refcount > 0;
-#if LOG_INTERNEDSTATESET
-		if (LOG_INTERNEDSTATESET > 3 || fail) {
-		fprintf(stderr, "%s: %zu: node[%d]: state %d, l %d, r %d, refcount %d %s\n",
-		    __func__, i, id, n->state, n->l, n->r, n->refcount,
-		    fail ? "\t\t<--- live reference to doomed node" : "");
-		}
+	}
+	assert(dst_bucket != NULL);
+
+#if LOG_ISS > 3
+	fprintf(stderr, "%s: miss after %zd probes\n", __func__, probes);
 #endif
-		if (fail) {
-			ok = false;
+
+
+#define VERIFY_HTAB_WITH_LINEAR_SERACH 0
+#if VERIFY_HTAB_WITH_LINEAR_SERACH
+	for (interned_state_set_id i = 0; i < pool->sets.used; i++) {
+		struct issp_set *s = &pool->sets.sets[i];
+		if (s->length == state_count &&
+		    0 == memcmp(states,
+			&pool->buf.buf[s->buf_offset],
+			s->length * sizeof(states[0]))) {
+			dump_tables(stderr, pool);
+			fprintf(stderr, "%s: expected to find set %zu in htab but did not\n",
+			    __func__, i);
+			assert(!"missed in htab but hit in linear search");
 		}
 	}
+#endif
 
-	assert(ok);
+	const interned_state_set_id dst = pool->sets.used;
+
+	/* if not found, add to set list and buffer, growing as necessary */
+	if (pool->sets.used == pool->sets.ceil) {
+		const size_t nceil = 2*pool->sets.ceil;
+		struct issp_set *nsets = f_realloc(pool->alloc,
+		    pool->sets.sets, nceil * sizeof(nsets[0]));
+		if (nsets == NULL) {
+			return false;
+		}
+		pool->sets.ceil = nceil;
+		pool->sets.sets = nsets;
+	}
+	if (pool->buf.used + state_count > pool->buf.ceil) {
+		size_t nceil = 2*pool->buf.ceil;
+		while (nceil < pool->buf.used + state_count) {
+			nceil *= 2;
+		}
+		fsm_state_t *nbuf = f_realloc(pool->alloc,
+		    pool->buf.buf, nceil * sizeof(nbuf[0]));
+		if (nbuf == NULL) {
+			return false;
+		}
+		pool->buf.ceil = nceil;
+		pool->buf.buf = nbuf;
+	}
+
+	struct issp_set *s = &pool->sets.sets[dst];
+	s->ss = NULL;
+	s->buf_offset = pool->buf.used;
+	s->length = state_count;
+
+	memcpy(&pool->buf.buf[s->buf_offset],
+	    states,
+	    s->length * sizeof(states[0]));
+	pool->buf.used += state_count;
+
+	*result = dst;
+	*dst_bucket = dst;
+	pool->htab.used++;
+	pool->sets.used++;
+
+#if LOG_ISS
+	fprintf(stderr, "%s: interned new %ld with %zd states, htab now using %zu/%zu\n",
+	    __func__, *result, state_count, pool->htab.used, pool->htab.bucket_count);
+#endif
+	return true;
 }
 
-void
-interned_state_set_release(struct interned_state_set_pool *p, interned_state_set_id *set_id)
-{
-	release_node_id(p, set_id);
-}
+typedef void
+iter_iss_cb(fsm_state_t s, void *opaque);
 
-#if LOG_INTERNEDSTATESET > 0
 static void
-dump_iter(struct interned_state_set_pool *pool, struct iss_node *n, bool dot)
+iter_interned_state_set(const struct interned_state_set_pool *pool,
+    interned_state_set_id iss_id, iter_iss_cb *cb, void *opaque)
 {
-	struct iss_node *l = get_iss_node(pool, n->l);
-	if (l != NULL) {
-		if (dot) {
-			fprintf(stderr, "\tn%d -> n%d; // L\n",
-			    n->id, n->l);
-		}
-		dump_iter(pool, l, dot);
+	assert(pool != NULL);
+	if (IS_SINGLETON(iss_id)) {
+		cb(MASK_SINGLETON(iss_id), opaque);
+		return;
 	}
 
-	if (dot) {
-		fprintf(stderr, "\tn%d [label=\"n%d: %d\"];\n",
-		    n->id, n->id, n->state);
-	} else {
-		fprintf(stderr, " %d(@ %d)", n->state, n->id);
-	}
+	assert(iss_id < pool->sets.used);
+	const struct issp_set *s = &pool->sets.sets[iss_id];
 
-	assert(n->r != n->id);
-	struct iss_node *r = get_iss_node(pool, n->r);
-	if (r != NULL) {
-		if (dot) {
-			fprintf(stderr, "\tn%d -> n%d [color=\"blue\"]; // R\n",
-			    n->id, n->r);
-		}
-		dump_iter(pool, r, dot);
+#if LOG_ISS
+	fprintf(stderr, "%s: iss_id %ld => s->buf_offset %zu, length %zu\n",
+	    __func__, iss_id, s->buf_offset, s->length);
+#endif
+
+	assert(s->buf_offset + s->length <= pool->buf.used);
+	const fsm_state_t *buf = &pool->buf.buf[s->buf_offset];
+
+	for (size_t i = 0; i < s->length; i++) {
+		cb(buf[i], opaque);
 	}
 }
 
+struct mk_state_set_env {
+	bool ok;
+	const struct fsm_alloc *alloc;
+	struct state_set *dst;
+};
+
+static void
+mk_state_set_cb(fsm_state_t s, void *opaque)
+{
+	struct mk_state_set_env *env = opaque;
+	if (!state_set_add(&env->dst, env->alloc, s)) {
+		env->ok = false;
+	}
+}
+
+/* Get the state_set associated with an interned ID.
+ * If the state_set has already been built, return the saved instance. */
+struct state_set *
+interned_state_set_get_state_set(struct interned_state_set_pool *pool,
+    interned_state_set_id iss_id)
+{
+	if (IS_SINGLETON(iss_id)) {
+		struct state_set *dst = NULL;
+		const fsm_state_t s = MASK_SINGLETON(iss_id);
+		if (!state_set_add(&dst, pool->alloc, s)) {
+			return false;
+		}
+		return dst;	/* also a singleton */
+	}
+
+	assert(iss_id < pool->sets.used);
+	struct issp_set *s = &pool->sets.sets[iss_id];
+
+	if (s->ss == NULL) {
+		struct mk_state_set_env env = {
+			.alloc = pool->alloc,
+			.ok = true,
+			.dst = NULL,
+		};
+		iter_interned_state_set(pool, iss_id, mk_state_set_cb, &env);
+
+		if (!env.ok) {
+			state_set_free(env.dst);
+			env.dst = NULL;
+		}
+		s->ss = env.dst;
+	}
+
+	return s->ss;
+}
+
+static void
+dump_state_set_cb(fsm_state_t s, void *opaque)
+{
+	FILE *f = opaque;
+	fprintf(f, " %d", s);
+}
+
+/* Dump the list of states associated with a set ID. For debugging. */
 void
-interned_state_set_dump(struct interned_state_set_pool *pool, interned_state_set_id set_id)
+interned_state_set_dump(FILE *f, const struct interned_state_set_pool *pool,
+    interned_state_set_id set_id)
 {
-#if LOG_INTERNEDSTATESET > 1
-	for (size_t i = 0; i < pool->pool_ceil; i++) {
-		const struct iss_node *n = &pool->pool[i];
-		if (n->refcount == 0) {
-#if LOG_INTERNEDSTATESET > 3
-			fprintf(stderr, "%zu: freelist, next -> %d (l = %d)\n", i, n->r, n->l);
-#endif
-		} else {
-			fprintf(stderr, "%zu: node[%d], refcount %u, state %d, l %d, r %d\n",
-			    i, n->id, n->refcount, n->state, n->l, n->r);
-		}
-	}
-	if (set == NULL) { return; }
-#endif
-
-	if (is_empty_id(set_id)) {
-		fprintf(stderr, "dump[%u]: <empty>\n", set_id);
-	}
-
-	struct iss_node *n = get_iss_node(pool, set_id);
-	const bool dot = getenv("DOT") != NULL;
-
-	if (dot) {
-		fprintf(stderr, "digraph {\n");
-		fprintf(stderr, "\ts [style=invis];\n");
-		fprintf(stderr, "\ts -> n%d\n", set_id);
-	} else {
-		fprintf(stderr, "dump[%u]:", set_id);
-	}
-	dump_iter(pool, n, dot);
-	if (dot) {
-		fprintf(stderr, "}\n");
-	} else {
-		fprintf(stderr, "\n");
-	}
+	iter_interned_state_set(pool, set_id, dump_state_set_cb, f);
 }
-#else
-void
-interned_state_set_dump(struct interned_state_set_pool *pool, interned_state_set_id set_id)
-{
-	(void)pool;
-	(void)set_id;
-}
-#endif

--- a/src/libfsm/capture_internal.h
+++ b/src/libfsm/capture_internal.h
@@ -28,8 +28,6 @@
 /* Most significant bit of a size_t. */
 #define COMMITTED_CAPTURE_FLAG ((SIZE_MAX) ^ (SIZE_MAX >> 1))
 
-#define EXPENSIVE_CHECKS 1
-
 struct fsm_capture_info {
 	unsigned max_capture_id;
 

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -769,30 +769,6 @@ clear_group_labels(struct ac_group *g, const uint64_t *b)
 	}
 }
 
-#define TRACK_TIMES 0
-
-#if TRACK_TIMES
-#include <sys/time.h>
-#define INIT_TIMERS() struct timeval pre, post
-#define TIME(T) if (gettimeofday(T, NULL) == -1) { assert(!"gettimeofday"); }
-#define DIFF_MSEC(LABEL, PRE, POST, ACCUM)				\
-	do {								\
-		const size_t diff = 1000000*(POST.tv_sec - PRE.tv_sec)	\
-		    + (POST.tv_usec - PRE.tv_usec);			\
-		if (diff > 100) {					\
-			fprintf(stderr, "%s: %zu%s\n", LABEL, diff,	\
-			    diff >= 100 ? " #### OVER 100" : "");	\
-		}							\
-		if (ACCUM != NULL) {					\
-			*ACCUM += diff;					\
-		}							\
-	} while(0)
-#else
-#define INIT_TIMERS()
-#define TIME(T)
-#define DIFF_MSEC(A, B, C, D)
-#endif
-
 static int
 analyze_closures_for_iss(struct analyze_closures_env *env,
     interned_state_set_id cur_iss)

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -11,7 +11,7 @@ dump_labels(FILE *f, const uint64_t labels[4])
 {
 	size_t i;
 	for (i = 0; i < 256; i++) {
-		if (labels[i/64] & ((uint64_t)1 << (i&63))) {
+		if (u64bitset_get(labels, i)) {
 			fprintf(f, "%c", (char)(isprint(i) ? i : '.'));
 		}
 	}

--- a/src/libfsm/determinise_internal.h
+++ b/src/libfsm/determinise_internal.h
@@ -17,6 +17,7 @@
 #include <adt/stateset.h>
 #include <adt/internedstateset.h>
 #include <adt/ipriq.h>
+#include <adt/u64bitset.h>
 
 #include "internal.h"
 #include "capture.h"

--- a/src/libfsm/determinise_internal.h
+++ b/src/libfsm/determinise_internal.h
@@ -39,6 +39,9 @@
  * hash table. Must be a power of 2. */
 #define DEF_MAP_BUCKET_CEIL 4
 
+/* Starting array size for the cleanup vector. */
+#define DEF_CVECT_CEIL 4
+
 /*
  * This maps a DFA state onto its associated NFA symbol closure, such that an
  * existing DFA state may be found given any particular set of NFA states
@@ -133,6 +136,12 @@ struct analyze_closures_env {
 		uint64_t labels[256/64];
 		interned_state_set_id iss;
 	} *outputs;
+
+	struct clearing_vector {
+		size_t ceil;
+		size_t used;
+		fsm_state_t *ids;
+	} cvect;
 
 	size_t dst_ceil;
 	fsm_state_t *dst;

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -51,6 +51,74 @@ struct state_array;
 /* 32-bit approximation of golden ratio, used for hashing */
 #define PHI32 0x9e3779b9
 
+#ifndef TRACK_TIMES
+#define TRACK_TIMES 0
+#endif
+
+#if EXPENSIVE_CHECKS && TRACK_TIMES
+#error benchmarking with EXPENSIVE_CHECKS
+#endif
+
+#if TRACK_TIMES
+#include <sys/time.h>
+#define TIMER_LOG_THRESHOLD 100
+
+#define INIT_TIMERS() struct timeval pre, post
+#define INIT_TIMERS_NAMED(PREFIX) struct timeval PREFIX ## _pre, PREFIX ## _post
+#define TIME(T)								\
+	if (gettimeofday(T, NULL) == -1) { assert(!"gettimeofday"); }
+#define DIFF_MSEC(LABEL, PRE, POST, ACCUM)				\
+	do {								\
+		size_t *accum = ACCUM;					\
+		const size_t diff_usec =				\
+		    (1000000*(POST.tv_sec - PRE.tv_sec)			\
+			+ (POST.tv_usec - PRE.tv_usec));		\
+		const size_t diff_msec = diff_usec/1000;		\
+		if (diff_msec >= TIMER_LOG_THRESHOLD			\
+		    || TRACK_TIMES > 1) {				\
+			fprintf(stderr, "%s: %zu msec%s\n", LABEL,	\
+			    diff_msec,					\
+			    diff_msec >= 100 ? " #### OVER 100" : "");	\
+		}							\
+		if (accum != NULL) {					\
+			(*accum) += diff_usec;				\
+		}							\
+	} while(0)
+#define DIFF_MSEC_ALWAYS(LABEL, PRE, POST, ACCUM)			\
+	do {								\
+		size_t *accum = ACCUM;					\
+		const size_t diff_usec =				\
+		    (1000000*(POST.tv_sec - PRE.tv_sec)			\
+			+ (POST.tv_usec - PRE.tv_usec));		\
+		const size_t diff_msec = diff_usec/1000;		\
+		fprintf(stderr, "%s: %zu msec%s\n", LABEL, diff_msec,	\
+		    diff_msec >= 100 ? " #### OVER 100" : "");		\
+		if (accum != NULL) {					\
+			(*accum) += diff_usec;				\
+		}							\
+	} while(0)
+
+#define DIFF_USEC_ALWAYS(LABEL, PRE, POST, ACCUM)			\
+	do {								\
+		size_t *accum = ACCUM;					\
+		const size_t diff_usec =				\
+		    (1000000*(POST.tv_sec - PRE.tv_sec)			\
+			+ (POST.tv_usec - PRE.tv_usec));		\
+		fprintf(stderr, "%s: %zu usec\n", LABEL, diff_usec);	\
+		if (accum != NULL) {					\
+			(*accum) += diff_usec;				\
+		}							\
+	} while(0)
+
+#else
+#define INIT_TIMERS()
+#define INIT_TIMERS_NAMED(PREFIX)
+#define TIME(T)
+#define DIFF_MSEC(A, B, C, D)
+#define DIFF_MSEC_ALWAYS(A, B, C, D)
+#define DIFF_USEC_ALWAYS(A, B, C, D)
+#endif
+
 struct fsm_edge {
 	fsm_state_t state; /* destination */
 	unsigned char symbol;

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -20,6 +20,10 @@ struct edge_set;
 struct state_set;
 struct state_array;
 
+/* If set to non-zero, do extra intensive integrity checks, often inside
+ * some inner loops, which are far too expensive for production. */
+#define EXPENSIVE_CHECKS 0
+
 /*
  * The alphabet (Sigma) for libfsm's FSM is arbitrary octets.
  * These octets may or may not spell out UTF-8 sequences,

--- a/src/libfsm/minimise.c
+++ b/src/libfsm/minimise.c
@@ -140,37 +140,31 @@ static void
 collect_labels(const struct fsm *fsm,
     unsigned char *labels, size_t *label_count)
 {
-	size_t count = 0;
 	uint64_t label_set[FSM_SIGMA_COUNT/64] = { 0, 0, 0, 0 };
 	int i;
 
 	fsm_state_t id;
 	for (id = 0; id < fsm->statecount; id++) {
-		struct fsm_edge e;
-		struct edge_iter ei;
-		unsigned char label;
-		for (edge_set_reset(fsm->states[id].edges, &ei);
-		     edge_set_next(&ei, &e); ) {
-			assert(e.state < fsm->statecount);
-			label = e.symbol;
-
-			if (label_set[label/64] & (UINT64_C(1) << (label & 63))) {
-				/* already set, ignore */
-			} else {
-				label_set[label/64] |= (UINT64_C(1) << (label & 63));
-				count++;
+		struct edge_group_iter egi;
+		edge_set_group_iter_reset(fsm->states[id].edges,
+		    EDGE_GROUP_ITER_ALL, &egi);
+		struct edge_group_iter_info info;
+		while (edge_set_group_iter_next(&egi, &info)) {
+			for (size_t i = 0; i < 4; i++) {
+				label_set[i] |= info.symbols[i];
 			}
 		}
 	}
 
 	*label_count = 0;
 	for (i = 0; i < 256; i++) {
-		if (label_set[i/64] & (UINT64_C(1) << (i & 63))) {
+		if (label_set[i/64] & ((uint64_t)1 << (i & 63))) {
 			labels[*label_count] = i;
 			(*label_count)++;
+		} else if ((i & 63) == 0 && label_set[i/64] == 0) {
+			i += 63; /* skip whole word */
 		}
 	}
-	assert(*label_count == count);
 }
 
 /* Build a mapping for a minimised version of the DFA, using Moore's
@@ -769,21 +763,21 @@ init_label_iterator(const struct min_env *env,
 	if (should_gather_EC_labels) {
 		fsm_state_t cur;
 		size_t i;
-		uint32_t label_set[FSM_SIGMA_COUNT/32];
-		memset(label_set, 0x00, sizeof(label_set));
+		uint64_t label_set[FSM_SIGMA_COUNT/64 + 1] = { 0 };
 
 		cur = env->ecs[ec_i];
 		assert(cur != NO_ID);
 		cur = MASK_EC_HEAD(cur);
 
 		while (cur != NO_ID) {
-			struct fsm_edge e;
-			struct edge_iter ei;
-			for (edge_set_reset(env->fsm->states[cur].edges, &ei);
-			     edge_set_next(&ei, &e); ) {
-				const unsigned char label = e.symbol;
-				label_set[label/32] |=
-				    ((uint32_t)1 << (label & 31));
+			struct edge_group_iter egi;
+			edge_set_group_iter_reset(env->fsm->states[cur].edges,
+			    EDGE_GROUP_ITER_ALL, &egi);
+			struct edge_group_iter_info info;
+			while (edge_set_group_iter_next(&egi, &info)) {
+				for (size_t i = 0; i < 4; i++) {
+					label_set[i] |= info.symbols[i];
+				}
 			}
 			cur = env->jump[cur];
 		}
@@ -793,12 +787,12 @@ init_label_iterator(const struct min_env *env,
 		li->limit = 0;
 		i = 0;
 		while (i < 256) {
-			/* Check the bitset, skip forward 32 entries at a time
+			/* Check the bitset, skip forward 64 entries at a time
 			 * if they're all zero. */
-			if ((i & 31) == 0 && label_set[i/32] == 0) {
-				i += 32;
+			if ((i & 63) == 0 && label_set[i/64] == 0) {
+				i += 64;
 			} else {
-				if (label_set[i/32] & ((uint32_t)1 << (i & 31))) {
+				if (label_set[i/64] & ((uint64_t)1 << (i & 63))) {
 					li->labels[li->limit] = i;
 					li->limit++;
 				}

--- a/src/libfsm/minimise.c
+++ b/src/libfsm/minimise.c
@@ -19,6 +19,7 @@
 
 #include <adt/edgeset.h>
 #include <adt/set.h>
+#include <adt/u64bitset.h>
 
 #include "internal.h"
 
@@ -158,7 +159,7 @@ collect_labels(const struct fsm *fsm,
 
 	*label_count = 0;
 	for (i = 0; i < 256; i++) {
-		if (label_set[i/64] & ((uint64_t)1 << (i & 63))) {
+		if (u64bitset_get(label_set, i)) {
 			labels[*label_count] = i;
 			(*label_count)++;
 		} else if ((i & 63) == 0 && label_set[i/64] == 0) {
@@ -792,7 +793,7 @@ init_label_iterator(const struct min_env *env,
 			if ((i & 63) == 0 && label_set[i/64] == 0) {
 				i += 64;
 			} else {
-				if (label_set[i/64] & ((uint64_t)1 << (i & 63))) {
+				if (u64bitset_get(label_set, i)) {
 					li->labels[li->limit] = i;
 					li->limit++;
 				}

--- a/src/libfsm/minimise_internal.h
+++ b/src/libfsm/minimise_internal.h
@@ -96,7 +96,9 @@ enum init_ec { INIT_EC_NOT_FINAL, INIT_EC_FINAL };
  * small. In that case, it's probably more efficient to do an extra
  * pass and collect which labels are actually used, then just check
  * for possible partitions on those, rather than trying every label
- * used in the entire DFA. */
+ * used in the entire DFA.
+ *
+ * Setting SMALL_EC_THRESHOLD to 0 disables the optimization. */
 #define SMALL_EC_FLAG (UINT_MAX ^ (UINT_MAX >> 1))
 #define SMALL_EC_THRESHOLD 16	/* a guess -- needs experimentation */
 #define DFA_LABELS_THRESHOLD 4

--- a/tests/internedstateset/internedstateset_basic.c
+++ b/tests/internedstateset/internedstateset_basic.c
@@ -12,67 +12,18 @@
 
 #include <adt/internedstateset.h>
 
-static void
-reverse(size_t length, fsm_state_t *states)
-{
-	size_t i;
-	for (i = 0; i < length/2; i++) {
-		const size_t rev_i = length - i - 1;
-		const fsm_state_t tmp = states[rev_i];
-		states[rev_i] = states[i];
-		states[i] = tmp;
-	}
-}
-
-static void
-fisher_yates_shuffle(size_t length, fsm_state_t *states, unsigned seed)
-{
-	size_t i;
-	srandom(seed);
-	assert(length > 1);
-	for (i = 0; i < length - 1; i++) {
-		/* pick j: i <= j < n */
-		const size_t j = i + (random() % (length - i));
-
-		const fsm_state_t tmp = states[i];
-		assert(j < length);
-		states[i] = states[j];
-		states[j] = tmp;
-	}
-}
-
 static interned_state_set_id
 add_states_from_array(struct interned_state_set_pool *issp,
     size_t length, const fsm_state_t *states, unsigned verbosity)
 {
-	size_t i;
-	interned_state_set_id empty = interned_state_set_empty(issp);
-	interned_state_set_id cur, prev;
-
-	cur = empty;
-
-	for (i = 0; i < length; i++) {
-		interned_state_set_id next;
-		const fsm_state_t s = states[i];
-		if (verbosity > 1) {
-			fprintf(stderr, "-- %zu: adding %d\n", i, s);
-		}
-		prev = cur;
-
-		/* This is handing off the older reference. */
-		if (!interned_state_set_add(issp, &cur, s, &next)) {
-			fprintf(stderr, "interned_state_set_add failed, exiting\n");
-			exit(EXIT_FAILURE);
-		}
-		cur = next;
+	(void)verbosity;
+	interned_state_set_id res;
+	if (!interned_state_set_intern_set(issp, length, states, &res)) {
+		fprintf(stderr, "interned_state_set_intern_set failed, exiting\n");
+		exit(EXIT_FAILURE);
 	}
 
-	if (verbosity > 0) {
-		fprintf(stderr, "== %s: done\n", __func__);
-		interned_state_set_dump(issp, cur);
-	}
-
-	return cur;
+	return res;
 }
 
 #define DEF_VERBOSITY 0
@@ -91,19 +42,10 @@ get_limit(void)
 	return (v == NULL ? DEF_LIMIT : atoi(v));
 }
 
-#define DEF_SHUFFLE_CYCLES 10
-static unsigned
-get_shuffle_cycles(void)
-{
-	const char *v = getenv("SHUFFLE");
-	return (v == NULL ? DEF_SHUFFLE_CYCLES : atoi(v));
-}
-
 int main(void) {
-	interned_state_set_id set_up, set_up2, set_down, set_down2, doubled;
+	interned_state_set_id set_up, set_up2;
 	fsm_state_t i;
 	const size_t limit = get_limit();
-	const size_t shuffle_cycles = get_shuffle_cycles();
 	fsm_state_t *states;
 	const unsigned verbosity = get_verbosity();
 
@@ -125,45 +67,6 @@ int main(void) {
 
 	/* Check that they match. */
 	assert(set_up == set_up2);
-	interned_state_set_release(issp, &set_up2);
-
-	/* Create state sets [], [limit-1], [limit-2, limit-1], ... */
-	reverse(limit, states);
-	set_down = add_states_from_array(issp, limit, states, verbosity);
-
-	/* Both should end up with the same state set once all are added. */
-	assert(set_up == set_down);
-
-	/* Create the state set in descending order again. These should all
-	 * be cached. */
-	set_down2 = add_states_from_array(issp, limit, states, verbosity);
-
-	/* These should also be equal. */
-	assert(set_down2 == set_down);
-	interned_state_set_release(issp, &set_down);
-	interned_state_set_release(issp, &set_down2);
-
-	/* Repeatedly shuffle with different seeds and compare */
-	for (i = 0; i < shuffle_cycles; i++) {
-		interned_state_set_id shuffled;
-		fisher_yates_shuffle(limit, states, i);
-		shuffled = add_states_from_array(issp, limit, states, verbosity);
-		assert(shuffled == set_up);
-		interned_state_set_release(issp, &shuffled);
-	}
-
-	/* This should be able to handle duplicated values, so write [0..n]
-	 * into the array twice and build up the array with repeated values. */
-	for (i = 0; i < limit; i++) {
-		states[i + 0] = i;
-		states[i + limit] = i;
-	}
-	doubled = add_states_from_array(issp, 2*limit, states, verbosity);
-
-	assert(doubled == set_up);
-
-	interned_state_set_release(issp, &doubled);
-	interned_state_set_release(issp, &set_up);
 
 	interned_state_set_pool_free(issp);
 	free(states);


### PR DESCRIPTION
- Switch minimise to grouped edge label iterators.
- Add `uint64_t` bitset ADT.
- Switch `adt/bitset` ADT to use `uint64_t[4]` and bit parallelism.
- Add `bm_nth_word`, use it to speed up `edge_set_hasnondeterminism`.
- Replace `internedstateset` with a simpler and considerably faster implementation.
- Avoid unnecessary priority queue bookkeeping during determinisation.
- Move priority queue alloc/free outside of per-state-set loop.

The largest gains here come from the interned state set replacement -- I realized that the code in determinisation using it always constructs the state set all at once, so we don't need the complicated bookkeeping for a state set that converges on the same result when built incrementally.