### PR TITLE
Detect crashing/asserting tests as failures.

### DIFF
--- a/tests/complement/Makefile
+++ b/tests/complement/Makefile
@@ -10,7 +10,7 @@ FSM=${BUILD}/bin/fsm
 
 ${TEST_OUTDIR.tests/complement}/got${n}.fsm: ${TEST_SRCDIR.tests/complement}/in${n}.fsm
 	${FSM} -p -t complement ${.ALLSRC:M*.fsm} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/complement}/res${n}
 
 ${TEST_OUTDIR.tests/complement}/res${n}: \
 	${TEST_SRCDIR.tests/complement}/out${n}.fsm \

--- a/tests/determinise/Makefile
+++ b/tests/determinise/Makefile
@@ -10,7 +10,7 @@ FSM=${BUILD}/bin/fsm
 
 ${TEST_OUTDIR.tests/determinise}/got${n}.fsm: ${TEST_SRCDIR.tests/determinise}/in${n}.fsm
 	${FSM} -pd ${.ALLSRC:M*.fsm} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/determinise}/res${n}
 
 ${TEST_OUTDIR.tests/determinise}/res${n}: \
 	${TEST_SRCDIR.tests/determinise}/out${n}.fsm \

--- a/tests/eclosure/Makefile
+++ b/tests/eclosure/Makefile
@@ -10,7 +10,7 @@ FSM=${BUILD}/bin/fsm
 
 ${TEST_OUTDIR.tests/eclosure}/got${n}.txt: ${TEST_SRCDIR.tests/eclosure}/in${n}.fsm
 	${FSM} -cq epsilonclosure ${.ALLSRC:M*.fsm} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/eclosure}/res${n}
 
 ${TEST_OUTDIR.tests/eclosure}/res${n}: \
 	${TEST_SRCDIR.tests/eclosure}/out${n}.txt \

--- a/tests/epsilons/Makefile
+++ b/tests/epsilons/Makefile
@@ -10,7 +10,7 @@ FSM=${BUILD}/bin/fsm
 
 ${TEST_OUTDIR.tests/epsilons}/got${n}.fsm: ${TEST_SRCDIR.tests/epsilons}/in${n}.fsm
 	${FSM} -pG ${.ALLSRC:M*.fsm} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/epsilons}/res${n}
 
 ${TEST_OUTDIR.tests/epsilons}/res${n}: \
 	${TEST_SRCDIR.tests/epsilons}/out${n}.fsm \

--- a/tests/glob/Makefile
+++ b/tests/glob/Makefile
@@ -10,11 +10,11 @@ RE=${BUILD}/bin/re
 
 ${TEST_OUTDIR.tests/glob}/got${n}.fsm: ${TEST_SRCDIR.tests/glob}/in${n}.re
 	${RE} -r glob -py ${.ALLSRC:M*.re} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/glob}/res${n}
 
 ${TEST_OUTDIR.tests/glob}/nfa${n}.fsm: ${TEST_SRCDIR.tests/glob}/in${n}.re
 	${RE} -r glob -n -py ${.ALLSRC:M*.re} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/glob}/res${n}
 
 ${TEST_OUTDIR.tests/glob}/res${n}: \
 	${TEST_SRCDIR.tests/glob}/out${n}.fsm \

--- a/tests/intersect/Makefile
+++ b/tests/intersect/Makefile
@@ -20,19 +20,19 @@ FSM=${BUILD}/bin/fsm
 
 ${TEST_OUTDIR.tests/intersect-ccuc}/compl${n}a.fsm: ${TEST_SRCDIR.tests/intersect}/in${n}a.fsm
 	  ${FSM} -p -t complement ${.ALLSRC:M*.fsm} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/intersect}/res${n}
 
 ${TEST_OUTDIR.tests/intersect-ccuc}/compl${n}b.fsm: ${TEST_SRCDIR.tests/intersect}/in${n}b.fsm
 	  ${FSM} -p -t complement ${.ALLSRC:M*.fsm} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/intersect}/res${n}
 
 ${TEST_OUTDIR.tests/intersect-ccuc}/union${n}.fsm: ${TEST_OUTDIR.tests/intersect-ccuc}/compl${n}a.fsm ${TEST_OUTDIR.tests/intersect-ccuc}/compl${n}b.fsm
 	  ${FSM} -p -t union ${.ALLSRC:M*.fsm} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/intersect}/res${n}
 
 ${TEST_OUTDIR.tests/intersect-ccuc}/got${n}.fsm: ${TEST_OUTDIR.tests/intersect-ccuc}/union${n}.fsm
 	  ${FSM} -p -t complement ${.ALLSRC:M*.fsm} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/intersect}/res${n}
 
 ${TEST_OUTDIR.tests/intersect-ccuc}/res${n}: \
 	${TEST_SRCDIR.tests/intersect-ccuc}/out${n}.fsm \

--- a/tests/ir/Makefile
+++ b/tests/ir/Makefile
@@ -10,7 +10,7 @@ RE=${BUILD}/bin/re
 
 ${TEST_OUTDIR.tests/ir}/got${n}.json: ${TEST_SRCDIR.tests/ir}/in${n}.re
 	${RE} -pl irjson -y ${.ALLSRC:M*.re} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/ir}/res${n}
 
 ${TEST_OUTDIR.tests/ir}/res${n}: \
 	${TEST_SRCDIR.tests/ir}/out${n}.json \

--- a/tests/like/Makefile
+++ b/tests/like/Makefile
@@ -10,11 +10,11 @@ RE=${BUILD}/bin/re
 
 ${TEST_OUTDIR.tests/like}/got${n}.fsm: ${TEST_SRCDIR.tests/like}/in${n}.re
 	${RE} -r like -py ${.ALLSRC:M*.re} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/like}/res${n}
 
 ${TEST_OUTDIR.tests/like}/nfa${n}.fsm: ${TEST_SRCDIR.tests/like}/in${n}.re
 	${RE} -r like -n -py ${.ALLSRC:M*.re} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/like}/res${n}
 
 ${TEST_OUTDIR.tests/like}/res${n}: \
 	${TEST_SRCDIR.tests/like}/out${n}.fsm \

--- a/tests/literal/Makefile
+++ b/tests/literal/Makefile
@@ -10,11 +10,11 @@ RE=${BUILD}/bin/re
 
 ${TEST_OUTDIR.tests/literal}/got${n}.fsm: ${TEST_SRCDIR.tests/literal}/in${n}.re
 	${RE} -r literal -py ${.ALLSRC:M*.re} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/literal}/res${n}
 
 ${TEST_OUTDIR.tests/literal}/nfa${n}.fsm: ${TEST_SRCDIR.tests/literal}/in${n}.re
 	${RE} -r literal -n -py ${.ALLSRC:M*.re} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/literal}/res${n}
 
 ${TEST_OUTDIR.tests/literal}/res${n}: \
 	${TEST_SRCDIR.tests/literal}/out${n}.fsm \

--- a/tests/minimise/Makefile
+++ b/tests/minimise/Makefile
@@ -19,22 +19,22 @@ ${TEST_OUTDIR.tests/minimise-rdrd}/got${n}.fsm: ${TEST_SRCDIR.tests/minimise}/in
 	| ${FSM} -pd \
 	| ${FSM} -pr \
 	| ${FSM} -pd \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/minimise}/res${n}
 
 ${TEST_OUTDIR.tests/minimise-rdrd}/rdr${n}.fsm: ${TEST_SRCDIR.tests/minimise}/in${n}.fsm
 	  ${FSM} -pr ${.ALLSRC:M*.fsm} \
 	| ${FSM} -pd \
 	| ${FSM} -pr \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/minimise}/res${n}
 
 ${TEST_OUTDIR.tests/minimise-rdrd}/rd${n}.fsm: ${TEST_SRCDIR.tests/minimise}/in${n}.fsm
 	  ${FSM} -pr ${.ALLSRC:M*.fsm} \
 	| ${FSM} -pd \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/minimise}/res${n}
 
 ${TEST_OUTDIR.tests/minimise-rdrd}/r${n}.fsm: ${TEST_SRCDIR.tests/minimise}/in${n}.fsm
 	  ${FSM} -pr ${.ALLSRC:M*.fsm} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/minimise}/res${n}
 
 ${TEST_OUTDIR.tests/minimise-rdrd}/res${n}: \
 	${TEST_SRCDIR.tests/minimise-rdrd}/out${n}.fsm \
@@ -48,7 +48,7 @@ FSMTEST_RESULT += ${TEST_OUTDIR.tests/minimise-rdrd}/res${n}
 
 ${TEST_OUTDIR.tests/minimise}/got${n}.fsm: ${TEST_SRCDIR.tests/minimise}/in${n}.fsm
 	${FSM} -pm ${.ALLSRC:M*.fsm} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/minimise}/res${n}
 
 ${TEST_OUTDIR.tests/minimise}/res${n}: \
 	${TEST_SRCDIR.tests/minimise}/out${n}.fsm \

--- a/tests/native/Makefile
+++ b/tests/native/Makefile
@@ -10,11 +10,11 @@ RE=${BUILD}/bin/re
 
 ${TEST_OUTDIR.tests/native}/got${n}.fsm: ${TEST_SRCDIR.tests/native}/in${n}.re
 	${RE} -r native -py ${.ALLSRC:M*.re} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/native}/res${n}
 
 ${TEST_OUTDIR.tests/native}/nfa${n}.fsm: ${TEST_SRCDIR.tests/native}/in${n}.re
 	${RE} -r native -n -py ${.ALLSRC:M*.re} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/native}/res${n}
 
 ${TEST_OUTDIR.tests/native}/res${n}: \
 	${TEST_SRCDIR.tests/native}/out${n}.fsm \

--- a/tests/pcre-anchor/Makefile
+++ b/tests/pcre-anchor/Makefile
@@ -10,11 +10,11 @@ RE=${BUILD}/bin/re
 
 ${TEST_OUTDIR.tests/pcre-anchor}/got${n}.fsm: ${TEST_SRCDIR.tests/pcre-anchor}/in${n}.re
 	${RE} -r pcre -py ${.ALLSRC:M*.re} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/pcre-anchor}/res${n}
 
 ${TEST_OUTDIR.tests/pcre-anchor}/nfa${n}.fsm: ${TEST_SRCDIR.tests/pcre-anchor}/in${n}.re
 	${RE} -r pcre -n -py ${.ALLSRC:M*.re} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/pcre-anchor}/res${n}
 
 ${TEST_OUTDIR.tests/pcre-anchor}/res${n}: \
 	${TEST_SRCDIR.tests/pcre-anchor}/out${n}.fsm \

--- a/tests/pcre-classes/Makefile
+++ b/tests/pcre-classes/Makefile
@@ -33,15 +33,15 @@ ${TEST_OUTDIR.tests/pcre-classes}/dot-all.fsm:
 
 ${TEST_OUTDIR.tests/pcre-classes}/got${n}.fsm: ${TEST_SRCDIR.tests/pcre-classes}/in${n}.re
 	${RE} -r pcre -py ${.ALLSRC:M*/in*.re} | ${FSM} -pm \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/pcre-classes}/res${n}
 
 ${TEST_OUTDIR.tests/pcre-classes}/got-compl${n}.fsm: ${TEST_OUTDIR.tests/pcre-classes}/got${n}.fsm ${TEST_OUTDIR.tests/pcre-classes}/dot-all.fsm
 	${FSM} -p -t subtract ${.ALLSRC:M*/dot-all.fsm} ${.ALLSRC:M*/got*.fsm} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/pcre-classes}/res${n}
 
 ${TEST_OUTDIR.tests/pcre-classes}/expect-compl${n}.fsm: ${TEST_SRCDIR.tests/pcre-classes}/compl${n}.re
 	${RE} -r pcre -py ${.ALLSRC:M*/compl*.re} | ${FSM} -pm \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/pcre-classes}/res${n}
 
 ${TEST_OUTDIR.tests/pcre-classes}/res${n}: \
 	${TEST_OUTDIR.tests/pcre-classes}/got-compl${n}.fsm \
@@ -67,11 +67,11 @@ FSMTEST_RESULT += ${TEST_OUTDIR.tests/pcre-classes}/res${n}
 
 ${TEST_OUTDIR.tests/pcre-classes}/got${n}.fsm: ${TEST_SRCDIR.tests/pcre-classes}/in${n}.re
 	${RE} -r pcre -py ${.ALLSRC:M*/in*.re} | ${FSM} -pm \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/pcre-classes}/res${n}
 
 ${TEST_OUTDIR.tests/pcre-classes}/out${n}.fsm: ${TEST_SRCDIR.tests/pcre-classes}/equal${n}.re
 	${RE} -r pcre -py ${.ALLSRC:M*/equal*.re} | ${FSM} -pm \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/pcre-classes}/res${n}
 
 ${TEST_OUTDIR.tests/pcre-classes}/res${n}: \
 	${TEST_OUTDIR.tests/pcre-classes}/got${n}.fsm \

--- a/tests/pcre-flags/Makefile
+++ b/tests/pcre-flags/Makefile
@@ -14,21 +14,21 @@ TEST_OUTDIR.tests/pcre-flags/mode${n} != cat ${TEST_SRCDIR.tests/pcre-flags}/mod
 
 ${TEST_OUTDIR.tests/pcre-flags}/got${n}.fsm: ${TEST_SRCDIR.tests/pcre-flags}/in${n}.re
 	${RE} -F "${TEST_OUTDIR.tests/pcre-flags/mode${n}}" -b -r pcre -py ${.ALLSRC:M*.re} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/pcre-flags}/res${n}
 
 ${TEST_OUTDIR.tests/pcre-flags}/nfa${n}.fsm: ${TEST_SRCDIR.tests/pcre-flags}/in${n}.re
 	${RE} -F "${TEST_OUTDIR.tests/pcre-flags/mode${n}}" -b -r pcre -n -py ${.ALLSRC:M*.re} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/pcre-flags}/res${n}
 
 .else
 
 ${TEST_OUTDIR.tests/pcre-flags}/got${n}.fsm: ${TEST_SRCDIR.tests/pcre-flags}/in${n}.re
 	${RE} -b -r pcre -py ${.ALLSRC:M*.re} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/pcre-flags}/res${n}
 
 ${TEST_OUTDIR.tests/pcre-flags}/nfa${n}.fsm: ${TEST_SRCDIR.tests/pcre-flags}/in${n}.re
 	${RE} -b -r pcre -n -py ${.ALLSRC:M*.re} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/pcre-flags}/res${n}
 
 .endif
 

--- a/tests/pcre-repeat/Makefile
+++ b/tests/pcre-repeat/Makefile
@@ -13,11 +13,11 @@ RE=${BUILD}/bin/re
 
 ${TEST_OUTDIR.tests/pcre-repeat}/got${n}.fsm: ${TEST_SRCDIR.tests/pcre-repeat}/in${n}.re
 	${RE} -r pcre -py ${.ALLSRC:M*.re} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/pcre-repeat}/res${n}
 
 ${TEST_OUTDIR.tests/pcre-repeat}/nfa${n}.fsm: ${TEST_SRCDIR.tests/pcre-repeat}/in${n}.re
 	${RE} -r pcre -n -py ${.ALLSRC:M*.re} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/pcre-repeat}/res${n}
 
 ${TEST_OUTDIR.tests/pcre-repeat}/res${n}: \
 	${TEST_SRCDIR.tests/pcre-repeat}/out${n}.fsm \

--- a/tests/pcre/Makefile
+++ b/tests/pcre/Makefile
@@ -42,16 +42,16 @@ test:: ${TEST_OUTDIR.tests/pcre-pcregrep}/res${n}
 TEST_OUTDIR.tests/pcre/mode${n} != cat ${TEST_SRCDIR.tests/pcre}/mode$n
 ${TEST_OUTDIR.tests/pcre}/got${n}.fsm: ${TEST_SRCDIR.tests/pcre}/in${n}.re
 	${RE} -F "${TEST_OUTDIR.tests/pcre/mode${n}}" -r pcre -py ${.ALLSRC:M*.re} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/pcre}/res${n}
 .else
 ${TEST_OUTDIR.tests/pcre}/got${n}.fsm: ${TEST_SRCDIR.tests/pcre}/in${n}.re
 	${RE} -r pcre -py ${.ALLSRC:M*.re} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/pcre}/res${n}
 .endif
 
 ${TEST_OUTDIR.tests/pcre}/nfa${n}.fsm: ${TEST_SRCDIR.tests/pcre}/in${n}.re
 	${RE} -r pcre -n -py ${.ALLSRC:M*.re} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/pcre}/res${n}
 
 ${TEST_OUTDIR.tests/pcre}/res${n}: \
 	${TEST_SRCDIR.tests/pcre}/out${n}.fsm \

--- a/tests/reverse/Makefile
+++ b/tests/reverse/Makefile
@@ -10,7 +10,7 @@ FSM=${BUILD}/bin/fsm
 
 ${TEST_OUTDIR.tests/reverse}/got${n}.fsm: ${TEST_SRCDIR.tests/reverse}/in${n}.fsm
 	${FSM} -pr ${.ALLSRC:M*.fsm} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/reverse}/res${n}
 
 ${TEST_OUTDIR.tests/reverse}/res${n}: \
 	${TEST_SRCDIR.tests/reverse}/out${n}.fsm \

--- a/tests/sql/Makefile
+++ b/tests/sql/Makefile
@@ -10,11 +10,11 @@ RE=${BUILD}/bin/re
 
 ${TEST_OUTDIR.tests/sql}/got${n}.fsm: ${TEST_SRCDIR.tests/sql}/in${n}.re
 	${RE} -r sql -py ${.ALLSRC:M*.re} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/sql}/res${n}
 
 ${TEST_OUTDIR.tests/sql}/nfa${n}.fsm: ${TEST_SRCDIR.tests/sql}/in${n}.re
 	${RE} -r sql -n -py ${.ALLSRC:M*.re} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/sql}/res${n}
 
 ${TEST_OUTDIR.tests/sql}/res${n}: \
 	${TEST_SRCDIR.tests/sql}/out${n}.fsm \

--- a/tests/subtract/Makefile
+++ b/tests/subtract/Makefile
@@ -22,15 +22,15 @@ FSM=${BUILD}/bin/fsm
 
 ${TEST_OUTDIR.tests/subtract-cuc}/compl${n}a.fsm: ${TEST_SRCDIR.tests/subtract}/in${n}a.fsm
 	  ${FSM} -p -t complement ${.ALLSRC:M*.fsm} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/subtract}/res${n}
 
 ${TEST_OUTDIR.tests/subtract-cuc}/union${n}.fsm: ${TEST_OUTDIR.tests/subtract-cuc}/compl${n}a.fsm ${TEST_SRCDIR.tests/subtract}/in${n}b.fsm
 	  ${FSM} -p -t union ${.ALLSRC:M*.fsm} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/subtract}/res${n}
 
 ${TEST_OUTDIR.tests/subtract-cuc}/got${n}.fsm: ${TEST_OUTDIR.tests/subtract-cuc}/union${n}.fsm
 	  ${FSM} -p -t complement ${.ALLSRC:M*.fsm} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/subtract}/res${n}
 
 ${TEST_OUTDIR.tests/subtract-cuc}/res${n}: \
 	${TEST_SRCDIR.tests/subtract-cuc}/out${n}.fsm \
@@ -45,7 +45,7 @@ FSMTEST_RESULT += ${TEST_OUTDIR.tests/subtract-cuc}/res${n}
 ${TEST_OUTDIR.tests/subtract}/got${n}.fsm: ${TEST_SRCDIR.tests/subtract}/in${n}a.fsm ${TEST_SRCDIR.tests/subtract}/in${n}b.fsm
 	  ${FSM} -t subtract -p ${.ALLSRC:M*.fsm} 	\
 	| ${FSM} -pm					\
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/subtract}/res${n}
 
 ${TEST_OUTDIR.tests/subtract}/res${n}: \
 	${TEST_SRCDIR.tests/subtract}/out${n}.fsm \

--- a/tests/trim/Makefile
+++ b/tests/trim/Makefile
@@ -10,7 +10,7 @@ FSM=${BUILD}/bin/fsm
 
 ${TEST_OUTDIR.tests/trim}/got${n}.fsm: ${TEST_SRCDIR.tests/trim}/in${n}.fsm
 	${FSM} -pt trim ${.ALLSRC:M*.fsm} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/trim}/res${n}
 
 ${TEST_OUTDIR.tests/trim}/res${n}: \
 	${TEST_SRCDIR.tests/trim}/out${n}.fsm \

--- a/tests/union/Makefile
+++ b/tests/union/Makefile
@@ -10,7 +10,7 @@ FSM=${BUILD}/bin/fsm
 
 ${TEST_OUTDIR.tests/union}/got${n}.fsm: ${TEST_SRCDIR.tests/union}/in${n}a.fsm ${TEST_SRCDIR.tests/union}/in${n}b.fsm
 	${FSM} -p -t union ${.ALLSRC:M*.fsm} \
-	> $@
+	> $@ || echo FAIL > ${TEST_OUTDIR.tests/union}/res${n}
 
 ${TEST_OUTDIR.tests/union}/res${n}: \
 	${TEST_SRCDIR.tests/union}/out${n}.fsm \


### PR DESCRIPTION
Previously, tests that exited unexpectedly did not always produce output, so build targets that depended on them to produce `tests/*/resN` with "PASS" or "FAIL" never got created, and the error output from re, fsm, etc. got buried in several pages of output from make.

I think this is correct, and local testing by intentionally making `pcre-anchor` tests assert has been flagged properly, but I may be misunderstanding the test setup for some subdirectories. In all cases it outputs the `FAIL` file if the earlier stage program exits unexpectedly before producing output to check later.