### PR TITLE
Improve determinisation performance with pairwise analysis cache

### DIFF
--- a/include/adt/hash.h
+++ b/include/adt/hash.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#ifndef FSM_HASH_H
+#define FSM_HASH_H
+
+#include <stdint.h>
+
+#include "common/check.h"
+
+/* 32 and 64-bit approximations of the golden ratio. */
+#define FSM_PHI_32 0x9e3779b9UL
+#define FSM_PHI_64 (uint64_t)0x9e3779b97f4a7c15UL
+
+/* A suitable hash function for individual sequentially allocated
+ * identifiers. See Knuth 6.4, Fibonacci hashing. */
+
+SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
+static __inline__ uint64_t
+fsm_hash_id(unsigned id)
+{
+	return FSM_PHI_64 * (uint64_t)(id + (unsigned)1);
+}
+
+/* FNV-1a hash function, 32 and 64 bit versions. This is in the public
+ * domain. For details, see:
+ *
+ *     http://www.isthe.com/chongo/tech/comp/fnv/index.html
+ */
+
+SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
+static __inline__ uint32_t
+fsm_hash_fnv1a_32(const uint8_t *buf, size_t length)
+{
+#define FNV1a_32_OFFSET_BASIS 	0x811c9dc5UL
+#define FNV1a_32_PRIME		0x01000193UL
+	uint32_t h = FNV1a_32_OFFSET_BASIS;
+	size_t i;
+	for (i = 0; i < length; i++) {
+		h ^= buf[i];
+		h *= FNV1a_32_PRIME;
+	}
+	return h;
+}
+
+SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
+static __inline__ uint64_t
+fsm_hash_fnv1a_64(const uint8_t *buf, size_t length)
+{
+#define FNV1a_64_OFFSET_BASIS   0xcbf29ce484222325UL
+#define FNV1a_64_PRIME		0x100000001b3UL
+	uint64_t h = FNV1a_64_OFFSET_BASIS;
+	size_t i;
+	for (i = 0; i < length; i++) {
+		h ^= buf[i];
+		h *= FNV1a_64_PRIME;
+	}
+	return h;
+}
+
+#endif

--- a/include/adt/hash.h
+++ b/include/adt/hash.h
@@ -20,7 +20,7 @@
 
 SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
 static __inline__ uint64_t
-fsm_hash_id(unsigned id)
+hash_id(unsigned id)
 {
 	return FSM_PHI_64 * (uint64_t)(id + (unsigned)1);
 }
@@ -33,7 +33,7 @@ fsm_hash_id(unsigned id)
 
 SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
 static __inline__ uint32_t
-fsm_hash_fnv1a_32(const uint8_t *buf, size_t length)
+hash_fnv1a_32(const uint8_t *buf, size_t length)
 {
 #define FNV1a_32_OFFSET_BASIS 	0x811c9dc5UL
 #define FNV1a_32_PRIME		0x01000193UL
@@ -48,7 +48,7 @@ fsm_hash_fnv1a_32(const uint8_t *buf, size_t length)
 
 SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
 static __inline__ uint64_t
-fsm_hash_fnv1a_64(const uint8_t *buf, size_t length)
+hash_fnv1a_64(const uint8_t *buf, size_t length)
 {
 #define FNV1a_64_OFFSET_BASIS   0xcbf29ce484222325UL
 #define FNV1a_64_PRIME		0x100000001b3UL

--- a/src/adt/internedstateset.c
+++ b/src/adt/internedstateset.c
@@ -282,6 +282,13 @@ interned_state_set_intern_set(struct interned_state_set_pool *pool,
 	fprintf(stderr, "%s: state_count %zu\n", __func__, state_count);
 #endif
 
+#if EXPENSIVE_CHECKS
+	/* input must be ordered */
+	for (size_t i = 1; i < state_count; i++) {
+		assert(states[i - 1] <= states[i]);
+	}
+#endif
+
 	assert(state_count > 0);
 
 	/* If there's only one state, return a singleton. */

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -952,7 +952,12 @@ analyze_closures__init_iterators(struct analyze_closures_env *env,
 
 	/* Init all the edge group iterators so we can step them in
 	 * parallel and merge. Each will yield edge groups in order,
-	 * sorted by .to, so we can merge them that way. */
+	 * sorted by .to, so we can merge them that way.
+	 *
+	 * This ordering also leads to gathering the state sets in
+	 * ascending order in analyze_closures__analyze, so we can avoid
+	 * overhead from sorting the state sets before passing them to
+	 * interned_state_set_intern_set, which needs sorted input. */
 	i_i = 0;
 	state_set_reset(ss, &it);
 

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -898,7 +898,12 @@ analyze_closures__pairwise_grouping(struct analyze_closures_env *env,
 		return analyze_single_state(env, id);
 	}
 
-	/* FIXME: block comment describing design */
+	/* Reduce via pairwise merging, flip/flopping between the
+	 * two buffers, until there is only one state/pair id, then
+	 * intern the resulting state sets and push any new ones onto
+	 * the stack for later processing.
+	 *
+	 * Cache intermediate results of merging each pair. */
 	size_t round = 0;	/* used to flip buffers */
 	size_t cur_used = set_count;
 	size_t next_used = 0;
@@ -907,12 +912,6 @@ analyze_closures__pairwise_grouping(struct analyze_closures_env *env,
 	fsm_state_t *cbuf = env->pbuf[(round + 0) & 1];
 	fsm_state_t *nbuf = env->pbuf[(round + 1) & 1];
 
-	/* reduce via pairwise merging, flip/flopping between the
-	 * two buffers, until there is only one state/pair id, then
-	 * intern the resulting state sets and push any new ones onto
-	 * the stack for later processing.
-	 *
-	 * cache intermediate results of merging each pair. */
 	while (cur_used > 1) {
 #if LOG_GROUPING > 1
 		if (cur_i == 0) {
@@ -949,7 +948,7 @@ analyze_closures__pairwise_grouping(struct analyze_closures_env *env,
 			 * the same ID pairs tend to repeat frequently. */
 			fsm_state_t a = cbuf[cur_i++];
 			fsm_state_t b = cbuf[cur_i++];
-			fsm_state_t result_id = a;
+			fsm_state_t result_id = a; /* out-of-bounds value */
 			if (!combine_pair(env, a, b, &result_id)) {
 				return 0;
 			}

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -1436,7 +1436,7 @@ save_to_set(struct analyze_closures_env *env,
 	 * because it can be relocated. */
 	if (env->to_sets.buf != NULL) {
 		assert(dst < &env->to_sets.buf[0]
-		    || dst > &env->to_sets.buf[env->to_sets.ceil]);
+		    || dst >= &env->to_sets.buf[env->to_sets.ceil]);
 	}
 
 	/* There is substantial duplication of these sets, so

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -2239,7 +2239,7 @@ combine_result_pair_and_commit(struct analyze_closures_env *env,
 
 static int
 analyze_closures__save_output(struct analyze_closures_env *env,
-    const uint64_t labels[256/4], interned_state_set_id iss)
+    const uint64_t labels[256/64], interned_state_set_id iss)
 {
 	if (env->output_count + 1 >= env->output_ceil) {
 		if (!analyze_closures__grow_outputs(env)) {

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -129,7 +129,8 @@ fsm_determinise(struct fsm *nfa)
 			interned_state_set_id iss = output->iss;
 
 #if LOG_DETERMINISE_CLOSURES
-			fprintf(stderr, "fsm_determinise: cur (dfa %zu) label [", curr->dfastate);
+			fprintf(stderr, "fsm_determinise: output %zu/%zu: cur (dfa %zu) label [",
+			    o_i, ac_env.output_count, curr->dfastate);
 			dump_labels(stderr, output->labels);
 			fprintf(stderr, "] -> iss:%ld: ", output->iss);
 			interned_state_set_dump(stderr, issp, output->iss);
@@ -191,6 +192,7 @@ fsm_determinise(struct fsm *nfa)
 			 * of the new DFA state Y, then add Y to a list for X */
 			for (m = map_first(&map, &it); m != NULL; m = map_next(&it)) {
 				struct state_iter si;
+				interned_state_set_id iss_id = m->iss;
 				fsm_state_t state;
 				struct state_set *ss = interned_state_set_get_state_set(ac_env.issp, iss_id);
 				fprintf(stderr, "%zu:", m->dfastate);
@@ -252,6 +254,10 @@ fsm_determinise(struct fsm *nfa)
 
 		fsm_move(nfa, dfa);
 	}
+
+#if EXPENSIVE_CHECKS
+	assert(fsm_all(nfa, fsm_isdfa));
+#endif
 
 	res = 1;
 
@@ -2775,9 +2781,9 @@ analyze_closures__save_output(struct analyze_closures_env *env,
 	dst->iss = iss;
 
 #if LOG_AC
-	fprintf(stderr, "ac_save_output: labels [");
+	fprintf(stderr, "%s: output %zu: labels [", __func__, env->output_count);
 	dump_labels(stderr, labels);
-	fprintf(stderr, "] -> iss:%p\n", (void *)iss);
+	fprintf(stderr, "] -> iss:%ld\n", iss);
 #endif
 
 	env->output_count++;

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -4,6 +4,7 @@
  * See LICENCE for the full copyright terms.
  */
 
+#define NEW_ANALYSIS 1
 #include "determinise_internal.h"
 
 static void
@@ -44,8 +45,8 @@ fsm_determinise(struct fsm *nfa)
 		}
 	}
 
-#if LOG_DETERMINISE_CAPTURES
-	fprintf(stderr, "# post_remove_epsilons\n");
+#if LOG_DETERMINISE_CAPTURES || LOG_INPUT
+	fprintf(stderr, "# post_remove_epsilons, pre_determinise\n");
 	fsm_print_fsm(stderr, nfa);
 	fsm_capture_dump(stderr, "#### post_remove_epsilons", nfa);
 #endif
@@ -262,21 +263,38 @@ cleanup:
 	if (ac_env.iters != NULL) {
 		f_free(ac_env.alloc, ac_env.iters);
 	}
-	if (ac_env.groups != NULL) {
-		f_free(ac_env.alloc, ac_env.groups);
-	}
 	if (ac_env.outputs != NULL) {
 		f_free(ac_env.alloc, ac_env.outputs);
 	}
 	if (ac_env.dst != NULL) {
 		f_free(ac_env.alloc, ac_env.dst);
 	}
-	if (ac_env.pq != NULL) {
-		ipriq_free(ac_env.pq);
-	}
 	if (ac_env.cvect.ids != NULL) {
 		f_free(ac_env.alloc, ac_env.cvect.ids);
 	}
+	if (ac_env.groups != NULL) {
+		f_free(ac_env.alloc, ac_env.groups);
+	}
+
+#if !NEW_ANALYSIS
+	if (ac_env.pq != NULL) {
+		ipriq_free(ac_env.pq);
+	}
+#endif
+
+#if NEW_ANALYSIS
+	f_free(ac_env.alloc, ac_env.pbuf[0]);
+	f_free(ac_env.alloc, ac_env.pbuf[1]);
+	f_free(ac_env.alloc, ac_env.htab.buckets);
+	f_free(ac_env.alloc, ac_env.to_sets.buf);
+	f_free(ac_env.alloc, ac_env.to_set_htab.buckets);
+	f_free(ac_env.alloc, ac_env.dst_tmp.buf);
+	for (size_t i = 0; i < ac_env.results.used; i++) {
+		f_free(ac_env.alloc, ac_env.results.rs[i]);
+	}
+	f_free(ac_env.alloc, ac_env.results.rs);
+	f_free(ac_env.alloc, ac_env.results.buffer.entries);
+#endif
 
 	return res;
 }
@@ -764,6 +782,9 @@ static int
 analyze_closures_for_iss(struct analyze_closures_env *env,
     interned_state_set_id cur_iss)
 {
+#if NEW_ANALYSIS
+	return analyze_closures__pairwise_grouping(env, cur_iss);
+#else
 	int res = 0;
 
 	/* Save the ID in a local variable, because release
@@ -772,6 +793,20 @@ analyze_closures_for_iss(struct analyze_closures_env *env,
 
 	struct state_set *ss = interned_state_set_get_state_set(env->issp, iss_id);
 	const size_t set_count = state_set_count(ss);
+
+#if LOG_DETERMINISE_STATE_SETS
+	{
+		static size_t ss_id;
+		struct state_iter it;
+		fsm_state_t s;
+		fprintf(stderr, "ss %zu :", ss_id++);
+		state_set_reset(ss, &it);
+		while (state_set_next(&it, &s)) {
+			fprintf(stderr, " %d", s);
+		}
+		fprintf(stderr, "\n");
+	}
+#endif
 
 	INIT_TIMERS();
 
@@ -822,9 +857,31 @@ analyze_closures_for_iss(struct analyze_closures_env *env,
 
 cleanup:
 	return res;
-
+#endif
 }
 
+static int
+analyze_closures__init_groups(struct analyze_closures_env *env)
+{
+	if (env->group_ceil == 0) {
+		const size_t nceil = DEF_GROUP_CEIL;
+		struct ac_group *ngs = f_malloc(env->alloc,
+		    nceil * sizeof(env->groups[0]));
+		if (ngs == NULL) {
+			return 0;
+		}
+		env->groups = ngs;
+		env->group_ceil = nceil;
+	}
+
+	assert(env->groups != NULL);
+	env->group_count = 0;
+	memset(&env->groups[0], 0x00, sizeof(env->groups[0]));
+	env->groups[0].to = AC_NO_STATE;
+	return 1;
+}
+
+#if !NEW_ANALYSIS
 static enum ipriq_cmp_res
 cmp_iterator_cb(size_t a, size_t b, void *opaque)
 {
@@ -931,23 +988,27 @@ analyze_closures__init_iterators(struct analyze_closures_env *env,
 }
 
 static int
-analyze_closures__init_groups(struct analyze_closures_env *env)
+analyze_closures__grow_iters(struct analyze_closures_env *env,
+    size_t set_count)
 {
-	if (env->group_ceil == 0) {
-		const size_t nceil = DEF_GROUP_CEIL;
-		struct ac_group *ngs = f_malloc(env->alloc,
-		    nceil * sizeof(env->groups[0]));
-		if (ngs == NULL) {
-			return 0;
-		}
-		env->groups = ngs;
-		env->group_ceil = nceil;
+	size_t nceil = (env->iter_ceil == 0
+	    ? DEF_ITER_CEIL : env->iter_ceil);
+	while (nceil < set_count) {
+		assert(nceil > 0);
+		nceil *= 2;
 	}
 
-	assert(env->groups != NULL);
-	env->group_count = 0;
-	memset(&env->groups[0], 0x00, sizeof(env->groups[0]));
-	env->groups[0].to = AC_NO_STATE;
+#if LOG_AC
+	fprintf(stderr, "ac_init: growing iters to %zu\n", nceil);
+#endif
+
+	struct ac_iter *niters = f_realloc(env->alloc,
+	    env->iters, nceil * sizeof(env->iters[0]));
+	if (niters == NULL) {
+		return 0;
+	}
+	env->iters = niters;
+	env->iter_ceil = nceil;
 	return 1;
 }
 
@@ -1059,6 +1120,7 @@ advance_current_iterator:;
 
 	return AC_COLLECT_DONE;
 }
+#endif
 
 static int
 grow_clearing_vector(struct analyze_closures_env *env)
@@ -1077,6 +1139,7 @@ grow_clearing_vector(struct analyze_closures_env *env)
 	return 1;
 }
 
+#if !NEW_ANALYSIS
 static int
 analyze_closures__analyze(struct analyze_closures_env *env)
 {
@@ -1088,11 +1151,14 @@ analyze_closures__analyze(struct analyze_closures_env *env)
 		for (g_i = 0; g_i < env->group_count; g_i++) {
 			const struct ac_group *g = &env->groups[g_i];
 			fprintf(stderr,
-			    "g[%zu]: to %d: [0x%lx, 0x%lx, 0x%lx, 0x%lx] -- ",
+			    "g[%03zu]: to %4d: 0x%016lx%016lx%016lx%016lx",
 			    g_i, g->to,
 			    g->labels[0], g->labels[1],
 			    g->labels[2], g->labels[3]);
-			dump_labels(stderr, g->labels);
+			if (LOG_AC > 1) {
+				fprintf(stderr, " -- ");
+				dump_labels(stderr, g->labels);
+			}
 			fprintf(stderr, "\n");
 		}
 	}
@@ -1267,6 +1333,1291 @@ analyze_closures__analyze(struct analyze_closures_env *env)
 
 	return 1;
 }
+#endif
+
+#if NEW_ANALYSIS
+static int
+analyze_closures__pairwise_grouping(struct analyze_closures_env *env,
+	interned_state_set_id iss_id)
+{
+#if LOG_GROUPING > 1
+	fprintf(stderr, "%s: iss_id %lu\n", __func__, iss_id);
+#endif
+
+	analyze_closures__init_groups(env);
+
+	INIT_TIMERS();
+	TIME(&pre);
+	struct state_set *ss = interned_state_set_get_state_set(env->issp, iss_id);
+	const size_t set_count = state_set_count(ss);
+
+#if LOG_DETERMINISE_STATE_SETS || LOG_GROUPING > 1
+	{
+		static size_t ss_id;
+		struct state_iter it;
+		fsm_state_t s;
+		fprintf(stderr, "ss %zu :", ss_id++);
+		state_set_reset(ss, &it);
+		while (state_set_next(&it, &s)) {
+			fprintf(stderr, " %d", s);
+		}
+		fprintf(stderr, "\n");
+	}
+#endif
+
+	/* grow buffers as necessary */
+	if (set_count > env->pbuf_ceil) {
+		size_t nceil = env->pbuf_ceil == 0
+		    ? DEF_PBUF_CEIL
+		    : 2*env->pbuf_ceil;
+		while (nceil < set_count) {
+			nceil *= 2;
+		}
+		fsm_state_t *a = f_realloc(env->alloc,
+		    env->pbuf[0],
+		    nceil * sizeof(env->pbuf[0]));
+		if (a == NULL) { return 0; }
+		fsm_state_t *b = f_realloc(env->alloc,
+		    env->pbuf[1],
+		    nceil * sizeof(env->pbuf[1]));
+		if (b == NULL) { return 0; }
+		env->pbuf_ceil = nceil;
+		env->pbuf[0] = a;
+		env->pbuf[1] = b;
+	}
+
+	{
+		/* init round 0
+		 * should be possible to do this using state_set_array */
+		size_t i = 0;
+		struct state_iter it;
+		fsm_state_t s;
+		state_set_reset(ss, &it);
+		while (state_set_next(&it, &s)) {
+			assert(i < env->pbuf_ceil);
+			env->pbuf[0][i] = s;
+			i++;
+		}
+	}
+
+	if (set_count == 1) {
+		const fsm_state_t id = env->pbuf[0][0];
+		assert(0 == (id & RESULT_BIT));
+		return analyze_single_state(env, id);
+	}
+
+	/* FIXME: block comment describing design */
+	size_t round = 0;	/* used to flip buffers */
+	size_t cur_used = set_count;
+	size_t next_used = 0;
+
+	size_t cur_i = 0;
+	fsm_state_t *cbuf = env->pbuf[(round + 0) & 1];
+	fsm_state_t *nbuf = env->pbuf[(round + 1) & 1];
+
+	/* reduce via pairwise merging, flip/flopping between the
+	 * two buffers, until there is only one state/pair id, then
+	 * intern the resulting state sets and push any new ones onto
+	 * the stack for later processing.
+	 *
+	 * cache intermediate results of merging each pair. */
+	while (cur_used > 1) {
+#if LOG_GROUPING > 1
+		if (cur_i == 0) {
+			fprintf(stderr, "%s: round %zu:", __func__, round);
+			for (size_t i = 0; i < cur_used; i++) {
+				const fsm_state_t id = cbuf[i];
+				fprintf(stderr, " %d%s", ID_WITH_SUFFIX(id));
+			}
+			fprintf(stderr, "\n");
+		}
+#endif
+
+		if (cur_i == cur_used) { /* flip */
+			cur_used = next_used;
+			next_used = 0;
+			cur_i = 0;
+			round++;
+			cbuf = env->pbuf[(round + 0) & 1];
+			nbuf = env->pbuf[(round + 1) & 1];
+		} else if ((cur_used & 0x01) && cur_i == cur_used - 1) {
+			/* if the total count is odd and there's only one
+			 * left, bounce it to the next round, because
+			 * (count/2)+1 will be even */
+			assert(next_used + 1 < env->pbuf_ceil);
+			nbuf[next_used] = cbuf[cur_i];
+			next_used++;
+			cur_i++;
+		} else {
+			assert(cur_i + 2 <= cur_used);
+
+			/* Take two IDs, which are either state IDs or
+			 * result IDs, and get a result_id for the group with
+			 * their combined result. This will be cached, because
+			 * the same ID pairs tend to repeat frequently. */
+			fsm_state_t a = cbuf[cur_i++];
+			fsm_state_t b = cbuf[cur_i++];
+			fsm_state_t result_id = a;
+			if (!combine_pair(env, a, b, &result_id)) {
+				return 0;
+			}
+#if LOG_GROUPING > 1
+			fprintf(stderr, "%s: combine_pair a %d, b %d => result_id %d\n",
+			    __func__, a, b, result_id);
+#endif
+			/* the result_id cannot match either of these */
+			result_id |= RESULT_BIT;
+			assert(result_id != a);
+			assert(result_id != b);
+			nbuf[next_used++] = result_id;
+		}
+	}
+
+	assert(cur_used == 1);
+	const fsm_state_t result_id = cbuf[0];
+
+#if LOG_GROUPING > 1
+	fprintf(stderr, "%s: result %d in %zu rounds\n", __func__, result_id &~ RESULT_BIT, round);
+#endif
+
+	assert(result_id & RESULT_BIT);
+	if (!build_output_from_cached_analysis(env, result_id &~ RESULT_BIT)) {
+		return 0;
+	}
+	TIME(&post);
+	DIFF_MSEC("det_pairwise_grouping", pre, post, NULL);
+
+	return 1;
+}
+
+static int
+cache_single_state_analysis(struct analyze_closures_env *env, fsm_state_t state_id,
+    fsm_state_t *cached_result_id)
+{
+#if LOG_GROUPING > 1
+	fprintf(stderr, "%s: state_id %d\n", __func__, state_id);
+#endif
+
+	/* build up outputs
+	 *
+	 * info.to will be ascending
+	 *
+	 * look at analyze_closures__collect */
+	const struct fsm_state *s = &env->fsm->states[state_id];
+	struct edge_group_iter iter;
+	struct edge_group_iter_info info;
+
+	analyze_closures__init_groups(env);
+	assert(env->group_count == 0);
+
+	/* collect groups */
+	edge_set_group_iter_reset(s->edges, EDGE_GROUP_ITER_ALL, &iter);
+	while (edge_set_group_iter_next(&iter, &info)) {
+#if LOG_GROUPING > 2
+		fprintf(stderr, "%s: to %d, symbols 0x%016lx%016lx%016lx%016lx\n",
+		    __func__, info.to,
+		    info.symbols[0], info.symbols[1], info.symbols[2], info.symbols[3]);
+#endif
+
+		if (env->group_count + 1 == env->group_ceil) {
+			if (!analyze_closures__grow_groups(env)) {
+				return 0;
+			}
+		}
+		assert(env->group_count < env->group_ceil);
+		struct ac_group *g = &env->groups[env->group_count];
+
+		if (g->to == AC_NO_STATE) { /* init new group */
+			memset(g, 0x00, sizeof(*g));
+			g->to = info.to;
+			union_with(g->labels, info.symbols);
+		} else if (g->to == info.to) { /* update current group */
+			union_with(g->labels, info.symbols);
+		} else {	/* switch to next group */
+			assert(info.to > g->to);
+			env->group_count++;
+
+			if (env->group_count + 1 == env->group_ceil) {
+				if (!analyze_closures__grow_groups(env)) {
+					return 0;
+				}
+			}
+			assert(env->group_count < env->group_ceil);
+
+			struct ac_group *ng = &env->groups[env->group_count];
+			memset(ng, 0x00, sizeof(*ng));
+			ng->to = info.to;
+			union_with(ng->labels, info.symbols);
+		}
+	}
+	if (env->groups[env->group_count].to != AC_NO_STATE) {
+		env->group_count++;	/* commit current group */
+	}
+
+	/* Initialize words_used for each group. */
+	for (size_t g_i = 0; g_i < env->group_count; g_i++) {
+		size_t w_i;
+		uint8_t bit;
+		struct ac_group *g = &env->groups[g_i];
+		g->words_used = 0;
+		for (w_i = 0, bit = 0x01; w_i < 4; w_i++, bit <<= 1) {
+			if (g->labels[w_i] != 0) {
+				g->words_used |= bit;
+			}
+		}
+	}
+
+	if (env->group_count == 0) {
+#if LOG_GROUPING > 1
+		fprintf(stderr, "Caching empty group analysis\n");
+#endif
+
+		if (!commit_buffered_group(env, cached_result_id)) {
+			return 0;
+		}
+#if LOG_GROUPING > 1
+		fprintf(stderr, "%s: cached analysis as result %d\n", __func__, *cached_result_id);
+#endif
+
+		if (!analysis_cache_save_single_state(env, state_id, *cached_result_id)) {
+			return 0;
+		}
+
+		return 1;
+	}
+
+	/* now we have groups */
+#if LOG_GROUPING > 1
+	for (size_t i = 0; i < env->group_count; i++) {
+		const struct ac_group *g = &env->groups[i];
+		fprintf(stderr, "%s: group[%zu]: to %d, labels 0x%016lx%016lx%016lx%016lx\n",
+		    __func__, i, g->to, g->labels[0], g->labels[1], g->labels[2], g->labels[3]);
+	}
+#endif
+
+	/* This partitions the table into an array of non-overlapping
+	 * (label set -> state set) pairs.
+	 *
+	 * For the first group in the table, find labels in that group that
+	 * are shared by later groups, create a set of the states those
+	 * groups lead to, then clear those labels. If the first group is
+	 * empty, advance base_i to the next group, and repeat until all
+	 * the groups in the table have been cleared. Because each pass
+	 * clears lables, this must eventually terminate.
+	 *
+	 * The pass that clears the labels on groups that were just
+	 * added to the result set benefits from the groups being sorted
+	 * by ascending .to fields, but other approaches may be faster.
+	 * I tried sorting the table by ascending count of bits used in
+	 * the label sets, so earlier groups with only a few labels
+	 * would be cleared faster and reduce the overall working set
+	 * sooner, but neither approach seemed to be clearly faster for
+	 * my test data sets. There is also a lot of room here for
+	 * speeding up the group label set unioning, intersecting, and
+	 * clearing. Casual experiments suggested small improvements but
+	 * not drastic improvements, so I'm leaving that performance
+	 * work for later. */
+	size_t base_i, o_i; /* base_i, other_i */
+
+	base_i = 0;
+	env->output_count = 0;
+
+	if (env->dst_ceil == 0) {
+		if (!analyze_closures__grow_dst(env)) {
+			return 0;
+		}
+	}
+
+	while (base_i < env->group_count) {
+		/* labels assigned in current sweep. The g_labels wrapper
+		 * is used for g_labels.words_used. */
+		struct ac_group g_labels = { 0 };
+		uint64_t *labels = g_labels.labels;
+		size_t dst_count = 0;
+
+#if LOG_AC
+		fprintf(stderr, "base_i %zu/%zu\n",
+		    base_i, env->group_count);
+#endif
+
+		const struct ac_group *bg = &env->groups[base_i];
+		memcpy(&g_labels, bg, sizeof(*bg));
+
+		/* At least one bit should be set; otherwise
+		 * we should have incremented base_i. */
+		assert(labels[0] || labels[1]
+		    || labels[2] || labels[3]);
+
+#if LOG_AC
+		fprintf(stderr, "ac_analyze: dst[%zu] <- %d (base)\n", dst_count, bg->to);
+#endif
+
+		if (dst_count + 1 == env->dst_ceil) {
+			if (!analyze_closures__grow_dst(env)) {
+				return 0;
+			}
+		}
+		env->dst[dst_count] = bg->to;
+		dst_count++;
+
+		if (env->cvect.ceil == 0) {
+			if (!grow_clearing_vector(env)) { return 0; }
+		}
+		env->cvect.ids[0] = base_i;
+		env->cvect.used = 1;
+
+		for (o_i = base_i + 1; o_i < env->group_count; o_i++) {
+			const struct ac_group *og = &env->groups[o_i];
+			if (og->words_used == 0) {
+				continue; /* skip empty groups */
+			}
+
+			/* TODO: Combining checking for overlap and intersecting
+			 * into one pass would be ugly, but a little faster, and
+			 * this loop has a big impact on performance. */
+			if (group_labels_overlap(&g_labels, og)) {
+				intersect_with(labels, og->labels);
+#if LOG_AC
+				fprintf(stderr, "ac_analyze: dst[%zu] <- %d (other w/ overlapping labels)\n", dst_count, og->to);
+#endif
+
+				if (dst_count + 1 == env->dst_ceil) {
+					if (!analyze_closures__grow_dst(env)) {
+						return 0;
+					}
+				}
+
+				env->dst[dst_count] = og->to;
+				dst_count++;
+
+				if (env->cvect.used == env->cvect.ceil) {
+					if (!grow_clearing_vector(env)) { return 0; }
+				}
+				env->cvect.ids[env->cvect.used] = o_i;
+				env->cvect.used++;
+			}
+		}
+
+#if LOG_AC
+		fprintf(stderr, "ac_analyze: dst_count: %zu\n", dst_count);
+#endif
+
+		assert(labels[0] || labels[1]
+		    || labels[2] || labels[3]);
+
+		for (size_t c_i = 0; c_i < env->cvect.used; c_i++) {
+			const fsm_state_t g_id = env->cvect.ids[c_i];
+			assert(g_id < env->group_count);
+			struct ac_group *g = &env->groups[g_id];
+			clear_group_labels(g, labels);
+		}
+
+		if (LOG_AC) {
+			size_t i;
+			fprintf(stderr, "new_edge_group:");
+			for (i = 0; i < dst_count; i++) {
+				fprintf(stderr, " %d", env->dst[i]);
+			}
+			fprintf(stderr, " -- ");
+			dump_labels(stderr, labels);
+			fprintf(stderr, "\n");
+		}
+
+		{		/* add dst set and labels to buffer */
+#if LOG_GROUPING > 1
+			fprintf(stderr, "-- dst [");
+			for (size_t i = 0; i < dst_count; i++) {
+				fprintf(stderr, "%s%d", i > 0 ? " " : "", env->dst[i]);
+			}
+			fprintf(stderr, "] <- labels 0x%016lx%016lx%016lx%016lx\n",
+			    labels[0], labels[1], labels[2], labels[3]);
+#endif
+			/* reserve to-set and copy env->dst[] there */
+			/* push a group onto env->results.buffer.entries[] */
+			if (!add_group_dst_info_to_buffer(env,
+				dst_count, env->dst, labels)) {
+				return 0;
+			}
+		}
+
+		while (base_i < env->group_count && env->groups[base_i].words_used == 0) {
+#if LOG_AC
+			fprintf(stderr, "ac_analyze: base %zu all clear, advancing\n", base_i);
+#endif
+			base_i++;
+		}
+	}
+
+	if (!commit_buffered_group(env, cached_result_id)) {
+		return 0;
+	}
+#if LOG_GROUPING > 1
+	fprintf(stderr, "%s: cached analysis as result %d\n", __func__, *cached_result_id);
+#endif
+
+	if (!analysis_cache_save_single_state(env, state_id, *cached_result_id)) {
+		return 0;
+	}
+
+	return 1;
+}
+
+static int
+analyze_single_state(struct analyze_closures_env *env, fsm_state_t id)
+{
+	assert(id < env->fsm->statecount);
+	fsm_state_t cached_result_id;
+	if (!analysis_cache_check_single_state(env, id, &cached_result_id)) {
+		if (!cache_single_state_analysis(env, id, &cached_result_id)) {
+			return 0;
+		}
+	}
+
+	return build_output_from_cached_analysis(env, cached_result_id);
+}
+
+static int
+build_output_from_cached_analysis(struct analyze_closures_env *env, fsm_state_t cached_result_id)
+{
+	/* collect (ISS, labels) outputs for single group */
+	const struct analysis_result *r = env->results.rs[cached_result_id];
+	for (size_t i = 0; i < r->count; i++) {
+		const struct result_entry *e = &r->entries[i];
+		const uint64_t *labels = e->labels;
+
+		const size_t dst_count = e->to_set_count;
+		assert(e->to_set_offset + dst_count <= env->to_sets.used);
+		const fsm_state_t *dst = &env->to_sets.buf[e->to_set_offset];
+
+		interned_state_set_id iss;
+		if (!interned_state_set_intern_set(env->issp, dst_count, dst, &iss)) {
+			return 0;
+		}
+
+		if (!analyze_closures__save_output(env, labels, iss)) {
+			return 0;
+		}
+	}
+
+	return 1;
+}
+
+#define LOG_TO_SET_HTAB 0
+
+static int
+to_set_htab_check(struct analyze_closures_env *env,
+    size_t count, const fsm_state_t *dst, uint64_t *hash, uint32_t *out_offset)
+{
+	uint64_t h = fsm_hash_id(count);
+	for (size_t i = 0; i < count; i++) {
+		h += fsm_hash_id(dst[i]);
+	}
+	*hash = h;
+
+	struct to_set_htab *htab = &env->to_set_htab;
+	const size_t bcount = htab->bucket_count;
+	if (bcount == 0) {
+		return 0;
+	}
+
+	const uint64_t mask = bcount - 1;
+	for (size_t b_i = 0; b_i < bcount; b_i++) {
+		const struct to_set_bucket *b = &htab->buckets[(h + b_i) & mask];
+		if (b->count == 0) {
+			return 0; /* empty bucket -> not found */
+		} else if (b->count == count) {
+			assert(b->offset + count <= env->to_sets.used);
+			const fsm_state_t *ids = &env->to_sets.buf[b->offset];
+			if (0 == memcmp(ids, dst, count * sizeof(dst[0]))) {
+				*out_offset = b->offset;
+				return 1; /* cache hit */
+			} else {
+				    continue; /* collision */
+			}
+		} else {
+			continue; /* collision */
+		}
+	}
+
+	return 0;
+}
+
+static int
+to_set_htab_save(struct analyze_closures_env *env,
+    size_t count, uint64_t hash, uint32_t offset)
+{
+	struct to_set_htab *htab = &env->to_set_htab;
+	if (htab->buckets_used >= htab->bucket_count/2) {
+		const uint64_t ocount = htab->bucket_count;
+		const size_t ncount = (ocount == 0
+		    ? DEF_TO_SET_HTAB_BUCKET_COUNT
+		    : 2*ocount);
+#if LOG_TO_SET_HTAB
+		fprintf(stderr, "%s: growing %zu -> %zu\n",
+		    __func__, ocount, ncount);
+#endif
+		struct to_set_bucket *nbuckets = f_calloc(env->alloc,
+		    ncount, sizeof(nbuckets[0]));
+		if (nbuckets == NULL) {
+			return 0;
+		}
+
+		const struct to_set_bucket *obuckets = htab->buckets;
+		const uint64_t nmask = ncount - 1;
+		if (ocount > 0) {
+			for (size_t ob_i = 0; ob_i < ocount; ob_i++) {
+				const struct to_set_bucket *ob = &obuckets[ob_i];
+				if (ob->count == 0) {
+					continue; /* empty */
+				}
+				uint64_t h = fsm_hash_id(ob->count);
+				assert(ob->offset + ob->count <= env->to_sets.used);
+				const fsm_state_t *ids = &env->to_sets.buf[ob->offset];
+				for (size_t i = 0; i < ob->count; i++) {
+					h += fsm_hash_id(ids[i]);
+				}
+
+				for (size_t nb_i = 0; nb_i < ncount; nb_i++) {
+					struct to_set_bucket *nb = &nbuckets[(h + nb_i) & nmask];
+					if (nb->count == 0) {
+						nb->count = ob->count;
+						nb->offset = ob->offset;
+						break;
+					} else {
+						continue; /* collision */
+					}
+				}
+			}
+		}
+		f_free(env->alloc, htab->buckets);
+		htab->buckets = nbuckets;
+		htab->bucket_count = ncount;
+	}
+
+	const size_t bcount = htab->bucket_count;
+	assert(htab->buckets_used <= bcount/2);
+	assert(bcount > 1);
+	const uint64_t mask = bcount - 1;
+	for (size_t b_i = 0; b_i < htab->bucket_count; b_i++) {
+		struct to_set_bucket *b = &htab->buckets[(hash + b_i) & mask];
+		if (b->count == 0) {
+			b->count = count;
+			b->offset = offset;
+			htab->buckets_used++;
+			return 1;
+		} else if (b->count == count) {
+			assert(b->offset != offset); /* no duplicates */
+			continue; /* collision */
+		}
+	}
+
+	assert(!"unreachable");
+	return 0;
+}
+
+static int
+save_to_set(struct analyze_closures_env *env,
+    size_t count, const fsm_state_t *dst, uint32_t *out_offset)
+{
+#define LOG_TO_SET 0
+	/* dst should not be a pointer into the to_sets buffer,
+	 * because it can be relocated. */
+	if (env->to_sets.buf != NULL) {
+		assert(dst < &env->to_sets.buf[0]
+		    || dst > &env->to_sets.buf[env->to_sets.ceil]);
+	}
+
+	/* There is substantial duplication of these sets, so
+	 * check the cache hash table first. */
+	uint64_t hash;
+	if (to_set_htab_check(env, count, dst, &hash, out_offset)) {
+		return 1;
+	}
+
+	if (env->to_sets.used + count >= env->to_sets.ceil) {
+		size_t nceil = (env->to_sets.ceil == 0
+		    ? DEF_TO_SET_CEIL
+		    : 2*env->to_sets.ceil);
+		while (nceil < env->to_sets.used + count) {
+			nceil *= 2;
+		}
+
+#if LOG_GROUPING || LOG_TO_SET
+		fprintf(stderr, "%s: growing %zu -> %zu\n",
+		    __func__, env->to_sets.ceil, nceil);
+#endif
+		fsm_state_t *nbuf = f_realloc(env->alloc, env->to_sets.buf,
+		    nceil * sizeof(nbuf[0]));
+		if (nbuf == NULL) {
+			return 0;
+		}
+		env->to_sets.ceil = nceil;
+		env->to_sets.buf = nbuf;
+	}
+
+#if LOG_TO_SET
+	static size_t to_set_id;
+	fprintf(stderr, "%s: %zu:", __func__, to_set_id++);
+	for (size_t i = 0; i < count; i++) {
+		fprintf(stderr, " %d", dst[i]);
+	}
+	fprintf(stderr, "\n");
+#endif
+
+	uint32_t offset = env->to_sets.used;
+	assert(offset + count <= env->to_sets.ceil);
+	memcpy(&env->to_sets.buf[offset], dst, count * sizeof(dst[0]));
+	env->to_sets.used += count;
+	assert(env->to_sets.used <= env->to_sets.ceil);
+
+	if (!to_set_htab_save(env, count, hash, offset)) {
+		return 0;
+	}
+
+	*out_offset = offset;
+	return 1;
+}
+
+static int
+add_group_dst_info_to_buffer(struct analyze_closures_env *env,
+	size_t dst_count, const fsm_state_t *dst,
+	const uint64_t labels[256/64])
+{
+	struct result_buffer *buf = &env->results.buffer;
+
+	if (buf->used == buf->ceil) {
+		const size_t nceil = (buf->ceil == 0
+		    ? DEF_GROUP_BUFFER_CEIL
+		    : 2*buf->ceil);
+		struct result_entry *nentries = f_realloc(env->alloc,
+		    buf->entries, nceil * sizeof(buf->entries[0]));
+		if (nentries == NULL) { return 0; }
+		buf->entries = nentries;
+		buf->ceil = nceil;
+	}
+
+	struct result_entry *ge = &buf->entries[buf->used];
+	if (!save_to_set(env, dst_count, dst,
+		&ge->to_set_offset)) {
+		return 0;
+	}
+	ge->to_set_count = dst_count;
+	ge->words_used = 0;
+	memcpy(ge->labels, labels, sizeof(ge->labels));
+
+	for (size_t i = 0; i < 4; i++) {
+		if (labels[i] != 0) {
+			ge->words_used |= (uint8_t)1 << i;
+		}
+	}
+
+	buf->used++;
+	return 1;
+}
+
+static int
+commit_buffered_group(struct analyze_closures_env *env, uint32_t *cache_result_id)
+{
+#define LOG_COMMIT_BUFFERED_GROUP 0
+
+	/* Based on logging hashes from benchmarks, there is usually
+	 * little to no duplication here, so they are stored as-is. */
+
+	if (env->results.used == env->results.ceil) {
+		const size_t nceil = (env->results.ceil == 0
+		    ? DEF_GROUP_GS
+		    : 2*env->results.ceil);
+		struct analysis_result **ngs = f_realloc(env->alloc,
+		    env->results.rs, nceil * sizeof(env->results.rs[0]));
+#if LOG_GROUPING || LOG_COMMIT_BUFFERED_GROUP
+		fprintf(stderr, "%s: growing %zu -> %zu\n",
+		    __func__, env->results.ceil, nceil);
+#endif
+		if (ngs == NULL) {
+			return 0;
+		}
+		env->results.ceil = nceil;
+		env->results.rs = ngs;
+	}
+
+	struct analysis_result *ng;
+	const size_t alloc_sz = sizeof(*ng)
+	    + env->results.buffer.used * sizeof(ng->entries[0]);
+	ng = f_malloc(env->alloc, alloc_sz);
+#if LOG_GROUPING || LOG_COMMIT_BUFFERED_GROUP
+	fprintf(stderr, "%s: alloc %zu\n",
+	    __func__, sizeof(*ng) + env->results.buffer.used * sizeof(ng->entries[0]));
+#endif
+	if (ng == NULL) {
+		return 0;
+	}
+	ng->count = env->results.buffer.used;
+
+	if (ng->count > 0) {
+		assert(env->results.buffer.entries != NULL);
+		memcpy(&ng->entries[0], env->results.buffer.entries,
+		    ng->count * sizeof(env->results.buffer.entries[0]));
+#if LOG_GROUPING || LOG_COMMIT_BUFFERED_GROUP
+		fprintf(stderr, "%s: alloc %zu, hash 0x%016lx\n",
+		    __func__, alloc_sz, fsm_hash_fnv1a_64((const uint8_t *)ng, alloc_sz));
+#endif
+	}
+
+	const uint32_t cache_id = env->results.used;
+	env->results.rs[cache_id] = ng;
+	env->results.used++;
+
+	/* clear buffer */
+	env->results.buffer.used = 0;
+
+	*cache_result_id = cache_id;
+	return 1;
+}
+
+SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
+static uint64_t
+hash_pair(fsm_state_t a, fsm_state_t b)
+{
+	assert(a != b);
+	assert(a & RESULT_BIT);
+	assert(b & RESULT_BIT);
+	return fsm_hash_id(a) ^ fsm_hash_id(b);
+}
+
+static int
+analysis_cache_check_pair(struct analyze_closures_env *env, fsm_state_t pa, fsm_state_t pb,
+	fsm_state_t *result_id)
+{
+	assert(pa & RESULT_BIT);
+	assert(pb & RESULT_BIT);
+	const struct result_pair_htab *htab = &env->htab;
+	if (htab->bucket_count == 0) {
+#if LOG_GROUPING > 1
+		fprintf(stderr, "%s: empty cache -> cache miss for pair { %d_R, %d_R }\n",
+		    __func__, pa &~ RESULT_BIT, pb &~ RESULT_BIT);
+#endif
+		return 0;
+	}
+
+	const uint64_t h = hash_pair(pa, pb);
+	const uint64_t mask = htab->bucket_count - 1;
+	for (size_t i = 0; i < htab->bucket_count; i++) {
+		struct result_pair_bucket *b = &htab->buckets[(h + i) & mask];
+		if (b->t == RPBT_UNUSED) {
+			break;	/* not found */
+		} else if (b->t == RPBT_PAIR && b->ids[0] == pa && b->ids[1] == pb) {
+			*result_id = b->result_id; /* hit */
+#if LOG_GROUPING > 1
+		fprintf(stderr, "%s: cache hit for pair { %d_R, %d_R } => %d\n",
+		    __func__, pa &~ RESULT_BIT, pb &~ RESULT_BIT, b->result_id);
+#endif
+			return 1;
+		} else {
+			continue; /* collision */
+		}
+	}
+
+#if LOG_GROUPING > 1
+		fprintf(stderr, "%s: cache miss for pair { %d_R, %d_R }\n",
+		    __func__, pa &~ RESULT_BIT, pb &~ RESULT_BIT);
+#endif
+	return 0;
+}
+
+static int
+analysis_cache_check_single_state(struct analyze_closures_env *env, fsm_state_t id,
+	fsm_state_t *result_id)
+{
+	assert(0 == (id & RESULT_BIT));
+	const struct result_pair_htab *htab = &env->htab;
+	if (htab->bucket_count == 0) {
+#if LOG_GROUPING > 1
+		fprintf(stderr, "%s: empty cache -> cache miss for state %d\n",
+		    __func__, id);
+#endif
+		return 0;
+	}
+
+	const uint64_t h = fsm_hash_id(id);
+	const uint64_t mask = htab->bucket_count - 1;
+	for (size_t i = 0; i < htab->bucket_count; i++) {
+		struct result_pair_bucket *b = &htab->buckets[(h + i) & mask];
+		if (b->t == RPBT_UNUSED) {
+			break;	/* not found */
+		} else if (b->t == RPBT_SINGLE_STATE && b->ids[0] == id) {
+			assert(b->ids[1] == id);
+			*result_id = b->result_id; /* hit */
+#if LOG_GROUPING > 1
+			fprintf(stderr, "%s: cache hit for state %d -> result_id %d\n",
+			    __func__, id, b->result_id);
+#endif
+			return 1;
+		} else {
+			continue; /* collision */
+		}
+	}
+
+#if LOG_GROUPING > 1
+		fprintf(stderr, "%s: cache miss for state %d\n",
+		    __func__, id);
+#endif
+	return 0;
+}
+
+#if LOG_GROUPING
+static void
+dump_group(FILE *f, struct analyze_closures_env *env, const struct analysis_result *r)
+{
+	for (size_t i = 0; i < r->count; i++) {
+		const struct result_entry *e = &r->entries[i];
+		const uint64_t *labels = e->labels;
+		fprintf(f, "-- 0x%016lx%016lx%016lx%016lx -> [",
+		    labels[0], labels[1], labels[2], labels[3]);
+		for (size_t to_i = 0; to_i < e->to_set_count; to_i++) {
+			fprintf(f, "%s%d", to_i > 0 ? " " : "",
+			    env->to_sets.buf[e->to_set_offset + to_i]);
+		}
+		fprintf(f, "]\n");
+	}
+}
+#endif
+
+static int
+pair_cache_save(struct analyze_closures_env *env,
+	enum result_pair_bucket_type type,
+	fsm_state_t pa, fsm_state_t pb, fsm_state_t result_id)
+{
+	if (type == RPBT_SINGLE_STATE) {
+		assert(pa == pb);
+	} else {
+		assert(type == RPBT_PAIR);
+		assert(pa != pb);
+	}
+
+#if LOG_GROUPING > 1
+	fprintf(stderr, "%s: type %s { %d%s, %d%s } => %d\n",
+	    __func__,
+	    type == RPBT_SINGLE_STATE ? "SINGLE" : "PAIR",
+	    ID_WITH_SUFFIX(pa), ID_WITH_SUFFIX(pb), result_id);
+#endif
+
+	struct result_pair_htab *htab = &env->htab;
+	if (htab->buckets_used >= htab->bucket_count/2) {
+		const size_t ncount = (htab->bucket_count == 0
+		    ? DEF_PAIR_CACHE_HTAB_BUCKET_COUNT
+		    : 2*htab->bucket_count);
+		struct result_pair_bucket *nbuckets = f_calloc(env->alloc,
+		    ncount, sizeof(nbuckets[0]));
+		if (nbuckets == NULL) {
+			return 0;
+		}
+
+		if (htab->bucket_count > 0) {
+			const uint32_t ocount = htab->bucket_count;
+			const uint32_t nmask = ncount - 1;
+			for (size_t ob_i = 0; ob_i < ocount; ob_i++) {
+				const struct result_pair_bucket *ob = &htab->buckets[ob_i];
+				if (ob->t == RPBT_UNUSED) {
+					continue;
+				}
+
+				const uint64_t h = (ob->t == RPBT_SINGLE_STATE
+				    ? fsm_hash_id(ob->ids[0])
+				    : (fsm_hash_id(ob->ids[0]) ^ fsm_hash_id(ob->ids[1])));
+				if (ob->t == RPBT_SINGLE_STATE) {
+					assert(ob->ids[0] == ob->ids[1]);
+				}
+
+				for (size_t nb_i = 0; nb_i < ncount; nb_i++) {
+					struct result_pair_bucket *nb = &nbuckets[(h + nb_i) & nmask];
+					if (nb->t == RPBT_UNUSED) {
+						memcpy(nb, ob, sizeof(*ob));
+						break;
+					} else {
+						continue; /* collision */
+					}
+				}
+			}
+			f_free(env->alloc, htab->buckets);
+		}
+		htab->buckets = nbuckets;
+		htab->bucket_count = ncount;
+	}
+
+	const uint64_t h = (pa == pb
+	    ? fsm_hash_id(pa)
+	    : (hash_pair(pa, pb)));
+
+	const uint64_t mask = htab->bucket_count - 1;
+	for (size_t i = 0; i < htab->bucket_count; i++) {
+		const size_t b_id = (h + i) & mask;
+		struct result_pair_bucket *b = &htab->buckets[b_id];
+#if LOG_GROUPING > 1
+		fprintf(stderr, "%s: bucket[%zu]: t %d, ids[%d%s %d%s], result_id %d\n",
+		    __func__, b_id, b->t,
+		    ID_WITH_SUFFIX(b->ids[0]), ID_WITH_SUFFIX(b->ids[1]),
+		    b->result_id);
+#endif
+
+		if (b->t == RPBT_UNUSED) { /* empty */
+			b->ids[0] = pa;
+			b->ids[1] = pb;
+			b->t = type;
+			b->result_id = result_id;
+			htab->buckets_used++;
+
+#if LOG_GROUPING > 1
+			const struct analysis_result *r = env->results.rs[result_id];
+			if (b->t == RPBT_SINGLE_STATE) {
+				fprintf(stderr, "%s: cached result_id %u for single state %d_s, with %u entries, in bucket %zu:\n",
+				    __func__, result_id, pa, r->count, b_id);
+			} else {
+				fprintf(stderr, "%s: cached result_id %u for { %d_R, %d_R }, with %u entries, in bucket %zu:\n",
+				    __func__, result_id, pa &~ RESULT_BIT, pb &~ RESULT_BIT, r->count, b_id);
+			}
+			dump_group(stderr, env, r);
+#endif
+
+			return 1;
+		} else {
+			/* should not save duplicates */
+			assert(b->ids[0] != pa || b->ids[1] != pb);
+			continue; /* collision */
+		}
+	}
+
+	assert(!"unreachable");
+	return 0;
+}
+
+static int
+analysis_cache_save_single_state(struct analyze_closures_env *env,
+	fsm_state_t state_id, fsm_state_t result_id)
+{
+	return pair_cache_save(env, RPBT_SINGLE_STATE, state_id, state_id, result_id);
+}
+
+static int
+analysis_cache_save_pair(struct analyze_closures_env *env,
+	fsm_state_t a, fsm_state_t b, fsm_state_t result_id)
+{
+	assert(a != b);
+	return pair_cache_save(env, RPBT_PAIR, a | RESULT_BIT, b | RESULT_BIT, result_id);
+}
+
+static size_t pair_cache_hit, pair_cache_miss;
+
+static int
+combine_pair(struct analyze_closures_env *env, fsm_state_t pa, fsm_state_t pb,
+	fsm_state_t *result_id)
+{
+#if LOG_GROUPING
+	fprintf(stderr, "%s: pa %d, pb %d\n", __func__, pa, pb);
+#endif
+
+	/* If the IDs are for single states, check if they've already been
+	 * analyzed. If not, do that and cache it. Either way, switch to the
+	 * ID for their cached analysis result. */
+	if (0 == (pa & RESULT_BIT)) {
+		fsm_state_t cached_result_id;
+		if (!analysis_cache_check_single_state(env, pa, &cached_result_id)) {
+			if (!cache_single_state_analysis(env, pa, &cached_result_id)) {
+				return 0;
+			}
+		}
+		pa = cached_result_id | RESULT_BIT;
+	}
+
+	if (0 == (pb & RESULT_BIT)) {
+		fsm_state_t cached_result_id;
+		if (!analysis_cache_check_single_state(env, pb, &cached_result_id)) {
+			if (!cache_single_state_analysis(env, pb, &cached_result_id)) {
+				return 0;
+			}
+		}
+		pb = cached_result_id | RESULT_BIT;
+	}
+
+	if (analysis_cache_check_pair(env, pa, pb, result_id)) {
+#if LOG_GROUPING
+		fprintf(stderr, "%s: cache hit for { %d%s %d%s }: %d\n",
+		    __func__, ID_WITH_SUFFIX(pa), ID_WITH_SUFFIX(pb), *result_id);
+#endif
+		pair_cache_hit++;
+		return 1;
+	} else {
+#if LOG_GROUPING
+		fprintf(stderr, "%s: cache miss for { %d%s %d%s }\n",
+		    __func__, ID_WITH_SUFFIX(pa), ID_WITH_SUFFIX(pb));
+#endif
+		pair_cache_miss++;
+	}
+
+	assert((pa & RESULT_BIT) && (pb & RESULT_BIT));
+	pa &=~ RESULT_BIT;
+	pb &=~ RESULT_BIT;
+
+	if (!combine_result_pair_and_commit(env, pa, pb, result_id)) {
+		return 0;
+	}
+
+#if LOG_GROUPING
+	fprintf(stderr, "%s: combined and committed as result_id %d\n",
+	    __func__, *result_id);
+#endif
+
+	if (!analysis_cache_save_pair(env, pa, pb, *result_id)) {
+		return 0;
+	}
+
+	return 1;
+}
+
+#if EXPENSIVE_CHECKS
+static void
+assert_entry_labels_are_mutually_exclusive(const struct analysis_result *r)
+{
+	uint64_t seen[4] = { 0 };
+	for (size_t e_i = 0; e_i < r->count; e_i++) {
+		const struct result_entry *e = &r->entries[e_i];
+		const uint64_t *labels = e->labels;
+		for (size_t i = 0; i < 4; i++) {
+			assert((seen[i] & labels[i]) == 0);
+			seen[i] |= labels[i];
+		}
+	}
+}
+#endif
+
+static int
+cmp_fsm_state_t(const void *pa, const void *pb)
+{
+	const fsm_state_t a = *(const fsm_state_t *)pa;
+	const fsm_state_t b = *(const fsm_state_t *)pb;
+	return a < b ? -1 : a > b ? 1 : 0;
+}
+
+static void
+sort_and_dedup_dst_buf(fsm_state_t *buf, size_t *used)
+{
+	const size_t orig_used = *used;
+	qsort(buf, orig_used, sizeof(buf[0]), cmp_fsm_state_t);
+
+	/* squash out duplicates */
+	size_t rd = 1;
+	size_t wr = 1;
+	while (rd < orig_used) {
+		if (buf[rd - 1] == buf[rd]) {
+			rd++;	/* skip */
+		} else {
+			buf[wr] = buf[rd];
+			rd++;
+			wr++;
+		}
+	}
+
+	*used = wr;
+#if EXPENSIVE_CHECKS
+	assert(wr <= orig_used);
+	for (size_t i = 1; i < *used; i++) {
+		assert(buf[i - 1] < buf[i]);
+	}
+#endif
+}
+
+static int
+dst_tmp_buf_append(struct analyze_closures_env *env,
+    fsm_state_t id)
+{
+	if (env->dst_tmp.used == env->dst_tmp.ceil) {
+		const size_t nceil = (env->dst_tmp.ceil == 0
+		    ? DEF_DST_TMP_CEIL
+		    : 2*env->dst_tmp.ceil);
+		fsm_state_t *nbuf = f_realloc(env->alloc, env->dst_tmp.buf,
+		    nceil * sizeof(nbuf[0]));
+		if (nbuf == NULL) {
+			return 0;
+		}
+		env->dst_tmp.buf = nbuf;
+		env->dst_tmp.ceil = nceil;
+	}
+	env->dst_tmp.buf[env->dst_tmp.used] = id;
+	env->dst_tmp.used++;
+	return 1;
+}
+
+static int
+combine_result_pair_and_commit(struct analyze_closures_env *env,
+    fsm_state_t result_id_a, fsm_state_t result_id_b,
+    fsm_state_t *committed_result_id)
+{
+	assert(result_id_a < env->results.used);
+	assert(result_id_b < env->results.used);
+	const struct analysis_result *ra = env->results.rs[result_id_a];
+	const struct analysis_result *rb = env->results.rs[result_id_b];
+
+	#if LOG_GROUPING
+	fprintf(stderr, "\n");
+	fprintf(stderr, "%s: result_id a %d, %u entries\n", __func__, result_id_a, ra->count);
+	dump_group(stderr, env, ra);
+	fprintf(stderr, "%s: result_id b %d, %u entries\n", __func__, result_id_b, rb->count);
+	dump_group(stderr, env, rb);
+	#endif
+
+	#if EXPENSIVE_CHECKS
+	assert_entry_labels_are_mutually_exclusive(ra);
+	assert_entry_labels_are_mutually_exclusive(rb);
+	#endif
+
+	/* but they can overlap; union them, collecting all to-states associate
+	 * with each subset of the labels */
+
+	/* for whichever group is smaller (has less entries), find every overlap
+	 * it has with the other, and then emit all remaning from the other as-is */
+	const struct analysis_result *rl = (ra->count <= rb->count ? ra : rb);
+	const struct analysis_result *rr = (ra->count > rb->count ? ra : rb);
+	assert(rl != rr);
+
+	env->results.buffer.used = 0;
+	env->dst_tmp.used = 0;
+
+	uint64_t checked[256/64] = { 0 };
+	#if LOG_GROUPING > 2
+	fprintf(stderr, "%s: rl %d, rr %d\n",
+	    __func__,
+	    rl == ra ? result_id_a : result_id_b,
+	    rl == rb ? result_id_b : result_id_a);
+#endif
+
+	size_t rl_i = 0;
+	while (rl_i < rl->count) {
+		uint64_t labels[256/64];
+
+		const struct result_entry *el = &rl->entries[rl_i];
+		uint8_t wu = 0;
+		for (size_t w_i = 0; w_i < 4; w_i++) {
+			labels[w_i] = el->labels[w_i] &~ checked[w_i];
+			if (labels[w_i] != 0) { wu |= ((uint8_t)1 << w_i); }
+		}
+		if (wu == 0) {
+			rl_i++;
+			continue;
+		}
+
+		/* copy all to-states from the left group's entry */
+		{
+			assert(el->to_set_offset + el->to_set_count <= env->to_sets.used);
+			const fsm_state_t *e_to = &env->to_sets.buf[el->to_set_offset];
+			for (size_t i = 0; i < el->to_set_count; i++) {
+				if (!dst_tmp_buf_append(env, e_to[i])) {
+					return 0;
+				}
+			}
+		}
+
+		/* intersect with any overlapping entries on the right group */
+		for (size_t rr_i = 0; rr_i < rr->count; rr_i++) {
+			const struct result_entry *er = &rr->entries[rr_i];
+			assert(er->words_used != 0);
+			if (er->words_used & wu) {
+				int found_any = 0; /* check that wu remains accurate */
+				for (size_t w_i = 0; w_i < 4; w_i++) {
+					if (labels[w_i] & er->labels[w_i]) {
+						found_any = 1;
+						break;
+					}
+				}
+				if (found_any) {
+					for (size_t w_i = 0; w_i < 4; w_i++) {
+						labels[w_i] &= er->labels[w_i];
+						if (labels[w_i] == 0) {
+							wu &=~ ((uint8_t)1 << w_i);
+						}
+					}
+
+					assert(er->to_set_offset + er->to_set_count <= env->to_sets.used);
+					const fsm_state_t *e_to = &env->to_sets.buf[er->to_set_offset];
+					for (size_t i = 0; i < er->to_set_count; i++) {
+						if (!dst_tmp_buf_append(env, e_to[i])) {
+							return 0;
+						}
+					}
+				}
+			}
+		}
+
+		assert(labels[0] || labels[1] || labels[2] || labels[3]);
+		sort_and_dedup_dst_buf(env->dst_tmp.buf, &env->dst_tmp.used);
+
+		if (!add_group_dst_info_to_buffer(env,
+			env->dst_tmp.used, env->dst_tmp.buf,
+			labels)) {
+			return 0;
+		}
+		env->dst_tmp.used = 0;
+
+		for (size_t w_i = 0; w_i < 4; w_i++) {
+			checked[w_i] |= labels[w_i];
+		}
+	}
+
+	/* second pass, emit any unchecked labels in rr */
+	for (size_t rr_i = 0; rr_i < rr->count; rr_i++) {
+		const struct result_entry *er = &rr->entries[rr_i];
+		uint64_t labels[256/64];
+		memcpy(labels, er->labels, sizeof(labels));
+
+		/* check for intersection with remaining unchecked labels */
+		int any_labels_remaining = 0;
+		for (size_t w_i = 0; w_i < 4; w_i++) {
+			/* todo: could negate checked above to avoid ~ here */
+			if (labels[w_i] & ~checked[w_i]) {
+				any_labels_remaining = 1;
+				break;
+			}
+		}
+
+		/* Add those labels and their to-states to the group
+		 * buffer, since rr's entries' labels do not overlap we
+		 * can add it immediately and do not need to update
+		 * checked[]. */
+		if (any_labels_remaining) {
+			for (size_t w_i = 0; w_i < 4; w_i++) {
+				labels[w_i] &=~ checked[w_i];
+			}
+			assert(er->to_set_offset + er->to_set_count <= env->to_sets.used);
+
+			const fsm_state_t *e_to = &env->to_sets.buf[er->to_set_offset];
+
+			for (size_t i = 0; i < er->to_set_count; i++) {
+				if (!dst_tmp_buf_append(env, e_to[i])) {
+					return 0;
+				}
+			}
+
+			if (!add_group_dst_info_to_buffer(env,
+				env->dst_tmp.used, env->dst_tmp.buf,
+				labels)) {
+				return 0;
+			}
+			env->dst_tmp.used = 0;
+		}
+	}
+
+	if (!commit_buffered_group(env, committed_result_id)) {
+		return 0;
+	}
+
+	#if LOG_GROUPING
+	const struct analysis_result *rz = env->results.rs[*committed_result_id];
+	fprintf(stderr, "%s: result, %u entries, committed as %d\n",
+	    __func__, rz->count, *committed_result_id);
+	dump_group(stderr, env, rz);
+	#endif
+
+	return 1;
+}
+#endif
 
 static int
 analyze_closures__save_output(struct analyze_closures_env *env,
@@ -1289,31 +2640,6 @@ analyze_closures__save_output(struct analyze_closures_env *env,
 #endif
 
 	env->output_count++;
-	return 1;
-}
-
-static int
-analyze_closures__grow_iters(struct analyze_closures_env *env,
-    size_t set_count)
-{
-	size_t nceil = (env->iter_ceil == 0
-	    ? DEF_ITER_CEIL : env->iter_ceil);
-	while (nceil < set_count) {
-		assert(nceil > 0);
-		nceil *= 2;
-	}
-
-#if LOG_AC
-	fprintf(stderr, "ac_init: growing iters to %zu\n", nceil);
-#endif
-
-	struct ac_iter *niters = f_realloc(env->alloc,
-	    env->iters, nceil * sizeof(env->iters[0]));
-	if (niters == NULL) {
-		return 0;
-	}
-	env->iters = niters;
-	env->iter_ceil = nceil;
 	return 1;
 }
 

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -1313,9 +1313,9 @@ SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
 static uint64_t
 to_set_hash(size_t count, const fsm_state_t *ids)
 {
-	uint64_t h = fsm_hash_id(count);
+	uint64_t h = hash_id(count);
 	for (size_t i = 0; i < count; i++) {
-		h += fsm_hash_id(ids[i]);
+		h += hash_id(ids[i]);
 	}
 	return h;
 }
@@ -1570,7 +1570,7 @@ commit_buffered_result(struct analyze_closures_env *env, uint32_t *cache_result_
 		    nr->count * sizeof(env->results.buffer.entries[0]));
 #if LOG_GROUPING || LOG_COMMIT_BUFFERED_GROUP
 		fprintf(stderr, "%s: alloc %zu, hash 0x%016lx\n",
-		    __func__, alloc_sz, fsm_hash_fnv1a_64((const uint8_t *)nr, alloc_sz));
+		    __func__, alloc_sz, hash_fnv1a_64((const uint8_t *)nr, alloc_sz));
 #endif
 	}
 
@@ -1630,14 +1630,14 @@ hash_pair(fsm_state_t a, fsm_state_t b)
 	b &=~ RESULT_BIT;
 
 	/* Don't hash a and b separately and combine them with
-	 * fsm_hash_id, because it's common to have adjacent pairs of
-	 * result IDs, and with how fsm_hash_id works that leads to
+	 * hash_id, because it's common to have adjacent pairs of
+	 * result IDs, and with how hash_id works that leads to
 	 * multiples of similar hash values bunching up.
 	 *
 	 * This could be replaced with a better hash function later,
 	 * but use LOG_CACHE_HTAB to ensure there aren't visually obvious
 	 * runs of collisions appearing in the tables. */
-	const uint64_t res = fsm_hash_id(a + b);
+	const uint64_t res = hash_id(a + b);
 	/* fprintf(stderr, "%s: a %d, b %d -> %016lx\n", __func__, a, b, res); */
 	return res;
 }
@@ -1708,7 +1708,7 @@ analysis_cache_check_single_state(struct analyze_closures_env *env, fsm_state_t 
 
 	CACHE_HTAB_INIT_STATS();
 
-	const uint64_t h = fsm_hash_id(id);
+	const uint64_t h = hash_id(id);
 	const uint64_t mask = htab->bucket_count - 1;
 	for (size_t i = 0; i < htab->bucket_count; i++) {
 		struct result_pair_bucket *b = &htab->buckets[(h + i) & mask];
@@ -1834,7 +1834,7 @@ pair_cache_save(struct analyze_closures_env *env,
 				}
 
 				const uint64_t h = (ob->t == RPBT_SINGLE_STATE
-				    ? fsm_hash_id(ob->ids[0])
+				    ? hash_id(ob->ids[0])
 				    : hash_pair(ob->ids[0], ob->ids[1]));
 				if (ob->t == RPBT_SINGLE_STATE) {
 					assert(ob->ids[0] == ob->ids[1]);
@@ -1857,7 +1857,7 @@ pair_cache_save(struct analyze_closures_env *env,
 	}
 
 	const uint64_t h = (pa == pb
-	    ? fsm_hash_id(pa)
+	    ? hash_id(pa)
 	    : (hash_pair(pa, pb)));
 
 	const uint64_t mask = htab->bucket_count - 1;

--- a/src/libfsm/determinise_internal.h
+++ b/src/libfsm/determinise_internal.h
@@ -103,7 +103,6 @@ struct mappingstack {
 #define DEF_OUTPUT_CEIL 4
 #define DEF_DST_CEIL 4
 
-#if NEW_ANALYSIS
 /* Mark an ID as a cached result ID (1) rather than a state ID (0). */
 #define RESULT_BIT ((fsm_state_t)1U << (8U*sizeof(fsm_state_t) - 1))
 #define DEF_PBUF_CEIL 4
@@ -160,27 +159,11 @@ analysis_cache_save_single_state(struct analyze_closures_env *env,
 static int
 analysis_cache_save_pair(struct analyze_closures_env *env,
 	fsm_state_t a, fsm_state_t b, fsm_state_t result_id);
-#endif
 
 struct analyze_closures_env {
 	const struct fsm_alloc *alloc;
 	const struct fsm *fsm;
 	struct interned_state_set_pool *issp;
-
-	/* TODO: iters and outputs are never in use at the same time, so
-	 * they could potentially share the same underlying allocation.
-	 * It may not be worth the extra complexity though. */
-
-	/* Temporary state for iterators */
-	size_t iter_ceil;
-	size_t iter_count;
-	struct ac_iter {
-		/* if info.to is AC_NO_STATE then it's done */
-		struct edge_group_iter iter;
-		struct edge_group_iter_info info;
-	} *iters;
-
-	struct ipriq *pq;
 
 	/* All sets of labels leading to states,
 	 * stored in ascending order. */
@@ -207,7 +190,6 @@ struct analyze_closures_env {
 		fsm_state_t *ids;
 	} cvect;
 
-#if NEW_ANALYSIS
 	/* Pair of buffers used to store IDs as the list is combined
 	 * and reduced, switching back and forth. */
 	size_t pbuf_ceil;
@@ -286,40 +268,14 @@ struct analyze_closures_env {
 	size_t usec_single;
 	size_t count_pair;
 	size_t usec_pair;
-#endif
 
+	/* Buffer for building up destination state set. */
 	size_t dst_ceil;
 	fsm_state_t *dst;
 };
 
 static int
-analyze_closures_for_iss(struct analyze_closures_env *env,
-	interned_state_set_id curr_iss);
-
-static int
 analyze_closures__init_groups(struct analyze_closures_env *env);
-
-#if !NEW_ANALYSIS
-static int
-analyze_closures__init_iterators(struct analyze_closures_env *env,
-	const struct state_set *ss, size_t set_count);
-
-enum ac_collect_res {
-	AC_COLLECT_DONE,
-	AC_COLLECT_EMPTY,
-	AC_COLLECT_ERROR = -1,
-};
-
-static enum ac_collect_res
-analyze_closures__collect(struct analyze_closures_env *env);
-
-static int
-analyze_closures__analyze(struct analyze_closures_env *env);
-
-static int
-analyze_closures__grow_iters(struct analyze_closures_env *env,
-    size_t set_count);
-#endif
 
 static int
 analyze_closures__save_output(struct analyze_closures_env *env,

--- a/src/libfsm/determinise_internal.h
+++ b/src/libfsm/determinise_internal.h
@@ -34,6 +34,7 @@
 #define LOG_SYMBOL_CLOSURE 0
 #define LOG_AC 0
 #define LOG_GROUPING 0
+#define LOG_ANALYSIS_STATS 0
 
 #if LOG_DETERMINISE_CAPTURES || LOG_INPUT
 #include <fsm/print.h>
@@ -280,6 +281,11 @@ struct analyze_closures_env {
 			struct result_entry *entries;
 		} buffer;
 	} results;
+
+	size_t count_single;
+	size_t usec_single;
+	size_t count_pair;
+	size_t usec_pair;
 #endif
 
 	size_t dst_ceil;

--- a/src/libfsm/determinise_internal.h
+++ b/src/libfsm/determinise_internal.h
@@ -134,7 +134,7 @@ add_group_dst_info_to_buffer(struct analyze_closures_env *env,
 	const uint64_t labels[256/64]);
 
 static int
-commit_buffered_group(struct analyze_closures_env *env, uint32_t *cache_result_id);
+commit_buffered_result(struct analyze_closures_env *env, uint32_t *cache_result_id);
 
 static int
 combine_pair(struct analyze_closures_env *env, fsm_state_t pa, fsm_state_t pb,

--- a/src/libfsm/determinise_internal.h
+++ b/src/libfsm/determinise_internal.h
@@ -279,7 +279,7 @@ analyze_closures__init_groups(struct analyze_closures_env *env);
 
 static int
 analyze_closures__save_output(struct analyze_closures_env *env,
-    const uint64_t labels[256/4], interned_state_set_id iss);
+    const uint64_t labels[256/64], interned_state_set_id iss);
 
 static int
 analyze_closures__grow_groups(struct analyze_closures_env *env);

--- a/src/libfsm/fsm.c
+++ b/src/libfsm/fsm.c
@@ -127,6 +127,7 @@ fsm_move(struct fsm *dst, struct fsm *src)
 
 	dst->states     = src->states;
 	dst->start      = src->start;
+	dst->hasstart   = src->hasstart;
 	dst->statecount = src->statecount;
 	dst->statealloc = src->statealloc;
 	dst->endcount   = src->endcount;


### PR DESCRIPTION
This replaces the transitive closure analysis in determinisation (essentially, everything currently within `analyze_closures_for_iss`) with a faster approach.

The previous analysis found the overall result for the entire relation of (all states in the interned state set) x (all labels appearing on outgoing edges) => (all destination states), but this tends to have a great deal of redundant work in larger FSMs, especially ones produced by combining partially overlapping FSMs.

This implementation instead analyses single states and pairs of cached analysis results. Since each cached result's labels have no overlap (each label leads to at most one state set), this reduces both the input sizes per analysis run and also the total amount of label overlap that needs to be handled at once, and then the cache eliminates redundant label analysis between duplicated subsets of state sets.

This significantly speeds up determinisation for NFAs with lots of nondeterministic edges, without negatively impacting the runtime for less nondeterministic inputs. It increases memory usage somewhat, since results that were previously derived over and over are stored, but this should be an acceptable tradeoff.

On the current branch this can lead to a slightly slower result (due to greater pressure on minimisation), but in combination with a separate incoming PR that improves minimisation the overall result should be much faster.

Also, a couple misc. bugfixes that I've had on a working branch for too long:

- `fsm_move` should set `dst->hasstart` rather than leaving it uninitialized. I haven't seen a case where this breaks anything, but still.
- Add `include/adt/hash.h` and use that in the new code.