### PR TITLE
Speed up minimise by working with label sets, not individual labels.

### DIFF
--- a/include/adt/edgeset.h
+++ b/include/adt/edgeset.h
@@ -101,6 +101,13 @@ int
 edge_set_find(const struct edge_set *set, unsigned char symbol,
 	struct fsm_edge *e);
 
+/* Check whether an edge_set has an edge with a particular label. Return
+ * 0 for not found, otherwise set *to_state, and note any other labels
+ * in labels[] that lead to the same state, then return 1. */
+int
+edge_set_check_edges(const struct edge_set *set, unsigned char label,
+    fsm_state_t *to_state, uint64_t labels[256/64]);
+
 int
 edge_set_contains(const struct edge_set *set, unsigned char symbol);
 

--- a/src/libfsm/minimise_internal.h
+++ b/src/libfsm/minimise_internal.h
@@ -36,6 +36,7 @@ struct min_env {
 	 * where either X is ID or following the linked list in
 	 * env.jump[X] eventually leads to ID. Ordering within the
 	 * list does not matter. */
+	size_t ec_map_count;
 	fsm_state_t *state_ecs;
 	fsm_state_t *ecs;
 	fsm_state_t *jump;
@@ -140,13 +141,12 @@ init_label_iterator(const struct min_env *env,
 	fsm_state_t ec_i, int special_handling,
 	struct min_label_iterator *li);
 
-static fsm_state_t
-find_edge_destination(const struct fsm *fsm,
-    fsm_state_t id, unsigned char label);
-
 static int
 try_partition(struct min_env *env, unsigned char label,
     fsm_state_t ec_src, fsm_state_t ec_dst,
-    size_t partition_counts[2]);
+    size_t partition_counts[2], uint64_t checked_labels[256/64]);
+
+static int
+label_sets_match(const uint64_t a[256/64], const uint64_t b[256/64]);
 
 #endif


### PR DESCRIPTION
When checking if a label can be used to partition ECs, also note which other labels led to the same state (and therefore EC). All of those labels are being checked at once, so they can be skipped in later iterations. This cuts down on redundant evaluation when large numbers of labels lead to the same state, which is very common.

This needs an interface change to the edge_set API, and commits us to `USE_EDGE_BITSET == 1` in `src/adt/edgeset.c`. The performance improvements here are coming via better opportunities for bit parallelism in that edge bitset implementation.

This is the PR mentioned in #392. It's probably worth merging this first, since it's smaller and easier to review.