### PR TITLE
ir.h: Add indirection to large union variant, to reduce memory usage.

### DIFF
--- a/src/libfsm/print/ir.h
+++ b/src/libfsm/print/ir.h
@@ -85,7 +85,11 @@ struct ir_state {
 		} error;
 
 		struct {
-			unsigned to[FSM_SIGMA_COUNT];
+			/* Note: This is allocated separately, to avoid
+			 * making the union significantly larger. */
+			struct ir_state_table {
+				unsigned to[FSM_SIGMA_COUNT];
+			} *table;
 		} table;
 	} u;
 };


### PR DESCRIPTION
make_ir allocates `fsm_countstates(fsm) * sizeof *ir->states`, so having one union variant taking up `sizeof(unsigned) * FSM_SIGMA_COUNT` (1024 bytes) when the other variants are only 8-24 bytes wastes quite a lot of space: this makes printing an FSM with 10,000 states allocate over 10 MB for the ir_state array, when otherwise it would only need about 240 KB.

Currently ir_state's table variant isn't being used, it is only referenced by a couple TODOs. In cases where that variant is used, it should do a separate allocation for the destination state table.