### PR TITLE
fsm_remove_epsilons performance improvements via grouped edge set iterator and `edge_set_add_bulk`

### DIFF
--- a/src/libfsm/pred/hasincoming.c
+++ b/src/libfsm/pred/hasincoming.c
@@ -25,15 +25,16 @@ fsm_hasincoming(const struct fsm *fsm, fsm_state_t state)
 	assert(state < fsm->statecount);
 
 	for (i = 0; i < fsm->statecount; i++) {
-		struct fsm_edge e;
-		struct edge_iter it;
+		struct edge_group_iter it;
+		struct edge_group_iter_info info;
 
 		if (state_set_contains(fsm->states[i].epsilons, state)) {
 			return 1;
 		}
 
-		for (edge_set_reset(fsm->states[i].edges, &it); edge_set_next(&it, &e); ) {
-			if (e.state == state) {
+		edge_set_group_iter_reset(fsm->states[i].edges, EDGE_GROUP_ITER_ALL, &it);
+		while (edge_set_group_iter_next(&it, &info)) {
+			if (info.to == state) {
 				return 1;
 			}
 		}

--- a/src/libfsm/pred/iscomplete.c
+++ b/src/libfsm/pred/iscomplete.c
@@ -24,8 +24,8 @@
 int
 fsm_iscomplete(const struct fsm *fsm, fsm_state_t state)
 {
-	struct fsm_edge e;
-	struct edge_iter it;
+	struct edge_group_iter it;
+	struct edge_group_iter_info info;
 	struct bm bm;
 
 	assert(fsm != NULL);
@@ -36,12 +36,15 @@ fsm_iscomplete(const struct fsm *fsm, fsm_state_t state)
 
 	bm_clear(&bm);
 
-	for (edge_set_reset(fsm->states[state].edges, &it); edge_set_next(&it, &e); ) {
-		assert(e.state < fsm->statecount);
+	edge_set_group_iter_reset(fsm->states[state].edges, EDGE_GROUP_ITER_ALL, &it);
+	while (edge_set_group_iter_next(&it, &info)) {
+		assert(info.to < fsm->statecount);
 
-		bm_set(&bm, e.symbol);
+		for (size_t i = 0; i < 4; i++) {
+			uint64_t *w = bm_nth_word(&bm, i);
+			*w |= info.symbols[i];
+		}
 	}
 
 	return bm_count(&bm) == FSM_SIGMA_COUNT;
 }
-

--- a/src/libfsm/trim.c
+++ b/src/libfsm/trim.c
@@ -125,8 +125,8 @@ mark_states(struct fsm *fsm, enum fsm_trim_mode mode,
 	 * collect edges & end states. */
 	while (queue_pop(q, &s_id)) {
 		fsm_state_t next;
-		struct fsm_edge e;
-		struct edge_iter edge_iter;
+		struct edge_group_iter_info edge_iter_info;
+		struct edge_group_iter edge_iter;
 		struct state_iter state_iter;
 
 		if (LOG_TRIM > 0) {
@@ -179,12 +179,13 @@ mark_states(struct fsm *fsm, enum fsm_trim_mode mode,
 			}
 		}
 
-		for (edge_set_reset(fsm->states[s_id].edges, &edge_iter);
-		     edge_set_next(&edge_iter, &e); ) {
-			next = e.state;
+		edge_set_group_iter_reset(fsm->states[s_id].edges,
+		    EDGE_GROUP_ITER_ALL, &edge_iter);
+		while (edge_set_group_iter_next(&edge_iter, &edge_iter_info)) {
+			next = edge_iter_info.to;
 			if (LOG_TRIM > 0) {
-				fprintf(stderr, "mark_states: edge: 0x%x to %d, visited? %d\n",
-				    e.symbol, next, fsm->states[next].visited);
+				fprintf(stderr, "mark_states: edge: %d to %d, visited? %d\n",
+				    s_id, next, fsm->states[next].visited);
 			}
 
 			if (!fsm->states[next].visited) {


### PR DESCRIPTION
Replace the implementation of `fsm_remove_epsilons` with one that takes advantage of edge sets' new grouped labels. Instead of stepping through every single labeled edge on every single state, copy over edge sets from the epsilon closure in bulk.

The previous implementation had a lot of redundant overhead because it would incrementally construct the edge sets' state sets an edge at a time, which caused the state set to repeatedly `qsort` itself to maintain invariants along the way.

For example, the command `re -rpcre '^.{0,100}$'` previously took about 15.6 seconds to complete on my laptop, now it takes about 25 msec.

Also:
- change a couple predicate functions' edge set iterators to use grouping.
- switch the timer code in minimise.c to the version in `internal.h` used by everything else.