### PR TITLE
provide more control over generated function and package names for Go

### DIFF
--- a/include/fsm/options.h
+++ b/include/fsm/options.h
@@ -58,6 +58,9 @@ struct fsm_options {
 	/* a prefix for namespacing generated identifiers. NULL if not required. */
 	const char *prefix;
 
+	/* the name of the enclosing package; NULL to use `prefix` (default). */
+	const char *package_prefix;
+
 	/* character pointer, for C code fragment output. NULL for the default. */
 	const char *cp;
 

--- a/man/re.1/re.1.xml
+++ b/man/re.1/re.1.xml
@@ -30,6 +30,7 @@
 	<!ENTITY w.opt "<option>-w</option>">
 	<!ENTITY X.opt "<option>-X</option>">
 	<!ENTITY e.opt "<option>-e</option>&nbsp;&prefix.arg;">
+	<!ENTITY E.opt "<option>-E</option>&nbsp;&prefix.arg;">
 
 	<!ENTITY a.opt "<option>-a</option>">
 	<!ENTITY d.opt "<option>-d</option>">
@@ -273,6 +274,16 @@ group (for dialects which have them) (rather than a "whole" regexp)
 					<para>Set a prefix for output,
 						per the <code>prefix</code> option for &fsm_print.3;.
 						The default is to output with no prefix.</para>
+				</listitem>
+			</varlistentry>
+
+			<varlistentry>
+				<term>&E.opt;</term>
+
+				<listitem>
+					<para>Set a package prefix for output,
+						per the <code>package_prefix</code> option for &fsm_print.3;.
+						The default is to output with the value of <code>prefix.</code></para>
 				</listitem>
 			</varlistentry>
 

--- a/src/libfsm/print/go.c
+++ b/src/libfsm/print/go.c
@@ -228,6 +228,7 @@ fsm_print_go(FILE *f, const struct fsm *fsm)
 {
 	struct ir *ir;
 	const char *prefix;
+	const char *package_prefix;
 
 	assert(f != NULL);
 	assert(fsm != NULL);
@@ -251,10 +252,16 @@ fsm_print_go(FILE *f, const struct fsm *fsm)
 		return;
 	}
 
-	fprintf(f, "package %sfsm\n", prefix);
+	if (fsm->opt->package_prefix != NULL) {
+		package_prefix = fsm->opt->package_prefix;
+	} else {
+		package_prefix = prefix;
+	}
+
+	fprintf(f, "package %sfsm\n", package_prefix);
 	fprintf(f, "\n");
 
-	fprintf(f, "func Match");
+	fprintf(f, "func %sMatch", prefix);
 
 	switch (fsm->opt->io) {
 	case FSM_IO_PAIR:

--- a/src/libfsm/print/vmasm.c
+++ b/src/libfsm/print/vmasm.c
@@ -108,12 +108,12 @@ print_asm_amd64(FILE *f, const char *funcname, const struct ir *ir, const struct
 		fprintf(f, "\n");
 		switch (opt->io) {
 		case FSM_IO_STR:
-			fprintf(f, "// func Match(data string) int\n");
-			fprintf(f, "TEXT    ·Match(SB), NOSPLIT, $0-24\n");
+			fprintf(f, "// func %s(data string) int\n", funcname);
+			fprintf(f, "TEXT    ·%s(SB), NOSPLIT, $0-24\n", funcname);
 			break;
 		case FSM_IO_PAIR:
-			fprintf(f, "// func Match(data []byte) int\n");
-			fprintf(f, "TEXT    ·Match(SB), NOSPLIT, $0-32\n");
+			fprintf(f, "// func %s(data []byte) int\n", funcname);
+			fprintf(f, "TEXT    ·%s(SB), NOSPLIT, $0-32\n", funcname);
 			break;
 
 		default:
@@ -404,7 +404,7 @@ print_vmasm_encoding(FILE *f, const struct fsm *fsm, enum asm_dialect dialect)
 	}
 
 	if (dialect == AMD64_GO) {
-		snprintf(funcname, sizeof funcname, "Match");
+		snprintf(funcname, sizeof funcname, "%sMatch", prefix);
 	} else {
 		snprintf(funcname, sizeof funcname, "%smatch", prefix);
 	}

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -668,13 +668,14 @@ main(int argc, char *argv[])
 	{
 		int c;
 
-		while (c = getopt(argc, argv, "h" "acwXe:k:" "bi" "sq:r:l:F:" "upMmnftxyz"), c != -1) {
+		while (c = getopt(argc, argv, "h" "acwXe:E:k:" "bi" "sq:r:l:F:" "upMmnftxyz"), c != -1) {
 			switch (c) {
 			case 'a': opt.anonymous_states  = 0;          break;
 			case 'c': opt.consolidate_edges = 0;          break;
 			case 'w': opt.fragment          = 1;          break;
 			case 'X': opt.always_hex        = 1;          break;
 			case 'e': opt.prefix            = optarg;     break;
+			case 'E': opt.package_prefix	= optarg;     break;
 			case 'k': opt.io                = io(optarg); break;
 
 			case 'b': flags |= RE_ANCHORED; break;


### PR DESCRIPTION
Fixes #360

	$ re -r pcre -k pair -e Meow -E 'matchers' -pl amd64_go meow |head -4
	#include "textflag.h"

	// func MeowMatch(data []byte) int
	TEXT    ·MeowMatch(SB), NOSPLIT, $0-32

	$ re -r pcre -k pair -e Meow -E 'matchers'-pl go meow |head -4
	package matchersfsm

	func MeowMatch(data []byte) int {
		var idx = ^uint(0)