### PR TITLE
wip: go unsafe

### DIFF
--- a/include/fsm/print.h
+++ b/include/fsm/print.h
@@ -52,7 +52,8 @@ fsm_print fsm_print_vmasm_amd64_att;  /* output amd64 assembler in AT&T format *
 fsm_print fsm_print_vmasm_amd64_nasm; /* output amd64 assembler in NASM format */
 fsm_print fsm_print_vmasm_amd64_go;   /* output amd64 assembler in Go format */
 fsm_print fsm_print_sh;
-fsm_print fsm_print_go;
+fsm_print fsm_print_go_safe;
+fsm_print fsm_print_go_unsafe;
 fsm_print fsm_print_rust;
 
 #endif

--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -166,7 +166,9 @@ print_name(const char *name)
 		{ "vmdot", fsm_print_vmdot },
 		{ "rust",  fsm_print_rust  },
 		{ "sh",    fsm_print_sh    },
-		{ "go",    fsm_print_go    },
+
+		{ "go",        fsm_print_go_safe   },
+		{ "go_unsafe", fsm_print_go_unsafe },
 
 		{ "amd64",      fsm_print_vmasm            },
 		{ "amd64_att",  fsm_print_vmasm_amd64_att  },

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -47,7 +47,8 @@ fsm_print_vmasm_amd64_nasm
 fsm_print_vmasm_amd64_go
 fsm_print_rust
 fsm_print_sh
-fsm_print_go
+fsm_print_go_safe
+fsm_print_go_unsafe
 
 # <fsm/fsm.h>
 fsm_clone

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -121,7 +121,9 @@ print_name(const char *name,
 		{ "vmdot",  fsm_print_vmdot,  NULL },
 		{ "rust",   fsm_print_rust,   NULL },
 		{ "sh",     fsm_print_sh,     NULL },
-		{ "go",     fsm_print_go,     NULL },
+
+		{ "go",        fsm_print_go_safe,   NULL },
+		{ "go_unsafe", fsm_print_go_unsafe, NULL },
 
 		{ "amd64",      fsm_print_vmasm,            NULL },
 		{ "amd64_att",  fsm_print_vmasm_amd64_att,  NULL },


### PR DESCRIPTION
Using lots of `unsafe` code can sometimes be faster depending on the compiler, optimization level, and target platform.

Not sure I want to actually have this merged.  Just putting here so I don't forget it.