### PR TITLE
Some terminology

### DIFF
--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -313,7 +313,7 @@ fsm_trim(struct fsm *fsm, enum fsm_trim_mode mode,
 /*
  * Produce a short legible string that matches up to a goal state.
  *
- * The given FSM is expected to be a Glushkov NFA.
+ * The given FSM is expected to be an epsilon-free NFA.
  */
 int
 fsm_example(const struct fsm *fsm, fsm_state_t goal,
@@ -328,8 +328,8 @@ int
 fsm_reverse(struct fsm *fsm);
 
 /*
- * Convert an NFA with epsilon transitions to a Glushkov NFA (NFA without
- * epsilon transitions).
+ * Convert an NFA with epsilon transitions to an NFA without
+ * epsilon transitions.
  *
  * Returns false on error; see errno.
  */
@@ -388,7 +388,7 @@ fsm_equal(const struct fsm *a, const struct fsm *b);
  * reachable, then the path returned will be non-NULL but will not contain
  * the goal state.
  *
- * The given FSM is expected to be a Glushkov NFA.
+ * The given FSM is expected to be an epsilon-free NFA.
  */
 struct path *
 fsm_shortest(const struct fsm *fsm,

--- a/include/re/re.h
+++ b/include/re/re.h
@@ -54,22 +54,24 @@ enum re_errno {
 	RE_EOCTRANGE    =  1 | RE_MARK | RE_ESC,
 	RE_ECOUNTRANGE  =  2 | RE_MARK | RE_ESC,
 
-	RE_EXSUB        =  0 | RE_MARK,
-	RE_EXTERM       =  1 | RE_MARK,
-	RE_EXGROUP      =  2 | RE_MARK,
-	RE_EXATOM       =  3 | RE_MARK,
-	RE_EXCOUNT      =  4 | RE_MARK,
-	RE_EXALTS       =  5 | RE_MARK,
-	RE_EXRANGE      =  6 | RE_MARK,
-	RE_EXCLOSEGROUP =  7 | RE_MARK,
-	RE_EXGROUPBODY  =  8 | RE_MARK,
-	RE_EXEOF        =  9 | RE_MARK,
-	RE_EXESC        = 10 | RE_MARK,
-	RE_EFLAG        = 11 | RE_MARK,
+	RE_EUNSUPPORTED =  0 | RE_MARK,
+	RE_EFLAG        =  1 | RE_MARK,
+	RE_EBADCP       =  2 | RE_MARK,
+	RE_EBADCOMMENT  =  3 | RE_MARK,
+
+	/* the X means "Expected", these are all syntax errors */
+	RE_EXSUB        =  4 | RE_MARK,
+	RE_EXTERM       =  5 | RE_MARK,
+	RE_EXGROUP      =  6 | RE_MARK,
+	RE_EXATOM       =  7 | RE_MARK,
+	RE_EXCOUNT      =  8 | RE_MARK,
+	RE_EXALTS       =  9 | RE_MARK,
+	RE_EXRANGE      = 10 | RE_MARK,
+	RE_EXCLOSEGROUP = 11 | RE_MARK,
 	RE_EXCLOSEFLAGS = 12 | RE_MARK,
-	RE_EXUNSUPPORTD = 13 | RE_MARK,
-	RE_EBADCP       = 14 | RE_MARK,
-	RE_EBADCOMMENT  = 15 | RE_MARK
+	RE_EXGROUPBODY  = 13 | RE_MARK,
+	RE_EXEOF        = 14 | RE_MARK,
+	RE_EXESC        = 15 | RE_MARK
 };
 
 struct re_pos {
@@ -83,17 +85,17 @@ struct re_err {
 
 	/* XXX: these should be a union */
 
-	/* populated for RE_ECOUNTRANGE; ignored otherwise */
+	/* populated for RE_ECOUNTRANGE; unused otherwise */
 	unsigned m;
 	unsigned n;
 
-	/* populated for RE_ESC; ignored otherwise */
+	/* populated for RE_ESC; unused otherwise */
 	char esc[32];
 
-	/* populated for RE_GROUP; ignored otherwise */
+	/* populated for RE_GROUP; unused otherwise */
 	char set[128];
 
-	/* populated for RE_EBADCP; ignored otherwise */
+	/* populated for RE_EXBADCP; unused otherwise */
 	unsigned long cp;
 };
 

--- a/man/fsm.1/fsm.1.xml
+++ b/man/fsm.1/fsm.1.xml
@@ -27,7 +27,7 @@
 	<!ENTITY C.opt "<option>-C</option>">
 	<!ENTITY c.opt "<option>-c</option>">
 	<!ENTITY e.opt "<option>-e</option>&nbsp;&prefix.arg;">
-	<!ENTITY G.opt "<option>-G</option>">
+	<!ENTITY E.opt "<option>-E</option>">
 	<!ENTITY k.opt "<option>-k</option>&nbsp;&io.arg;">
 	<!ENTITY i.opt "<option>-i</option>&nbsp;&iterations.arg;">
 	<!ENTITY X.opt "<option>-X</option>">
@@ -271,10 +271,10 @@
 			</varlistentry>
 
 			<varlistentry>
-				<term>&G.opt;</term>
+				<term>&E.opt;</term>
 
 				<listitem>
-					<para>Equivalent to <code>-t&nbsp;glushkovise</code>.</para>
+					<para>Equivalent to <code>-t&nbsp;remove_epsilons</code>.</para>
 				</listitem>
 			</varlistentry>
 
@@ -352,13 +352,9 @@
 								<td><code>dfa</code></td>
 							</tr>
 							<tr>
-								<td><code>glushkovise</code></td>
-								<td rowspan="2">&fsm_remove_epsilons.3;</td>
-								<td rowspan="2">Eliminate epsilon transitions from the &fsm;, converting a
-									Thompson NFA into a Glushkov NFA.</td>
-							</tr>
-							<tr>
-								<td><code>glush</code></td>
+								<td><code>remove_epsilons</code></td>
+								<td>&fsm_remove_epsilons.3;</td>
+								<td>Eliminate epsilon transitions from the &fsm;.</td>
 							</tr>
 							<tr>
 								<td><code>minimise</code></td>

--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -259,29 +259,29 @@ op_name(const char *name)
 		const char *name;
 		enum op op;
 	} a[] = {
-		{ "complete",    OP_COMPLETE    },
+		{ "complete",        OP_COMPLETE    },
 
-		{ "complement",  OP_COMPLEMENT  },
-		{ "invert",      OP_COMPLEMENT  },
-		{ "reverse",     OP_REVERSE     },
-		{ "rev",         OP_REVERSE     },
-		{ "determinise", OP_DETERMINISE },
-		{ "dfa",         OP_DETERMINISE },
-		{ "todfa",       OP_DETERMINISE },
-		{ "min",         OP_MINIMISE    },
-		{ "minimise",    OP_MINIMISE    },
-		{ "trim",        OP_TRIM        },
+		{ "complement",      OP_COMPLEMENT  },
+		{ "invert",          OP_COMPLEMENT  },
+		{ "reverse",         OP_REVERSE     },
+		{ "rev",             OP_REVERSE     },
+		{ "determinise",     OP_DETERMINISE },
+		{ "dfa",             OP_DETERMINISE },
+		{ "todfa",           OP_DETERMINISE },
+		{ "min",             OP_MINIMISE    },
+		{ "minimise",        OP_MINIMISE    },
+		{ "trim",            OP_TRIM        },
 		{ "remove_epsilons", OP_RM_EPSILONS },
 
-		{ "cat",         OP_CONCAT      },
-		{ "concat",      OP_CONCAT      },
-		{ "union",       OP_UNION       },
-		{ "intersect",   OP_INTERSECT   },
-		{ "subtract",    OP_SUBTRACT    },
-		{ "sub",         OP_SUBTRACT    },
-		{ "minus",       OP_SUBTRACT    },
-		{ "equals",      OP_EQUAL       },
-		{ "equal",       OP_EQUAL       }
+		{ "cat",             OP_CONCAT      },
+		{ "concat",          OP_CONCAT      },
+		{ "union",           OP_UNION       },
+		{ "intersect",       OP_INTERSECT   },
+		{ "subtract",        OP_SUBTRACT    },
+		{ "sub",             OP_SUBTRACT    },
+		{ "minus",           OP_SUBTRACT    },
+		{ "equals",          OP_EQUAL       },
+		{ "equal",           OP_EQUAL       }
 	};
 
 	assert(name != NULL);

--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -268,12 +268,9 @@ op_name(const char *name)
 		{ "determinise", OP_DETERMINISE },
 		{ "dfa",         OP_DETERMINISE },
 		{ "todfa",       OP_DETERMINISE },
-		{ "glush",       OP_RM_EPSILONS },
-		{ "glushovize",  OP_RM_EPSILONS },
 		{ "min",         OP_MINIMISE    },
 		{ "minimise",    OP_MINIMISE    },
 		{ "trim",        OP_TRIM        },
-		{ "glushkovise", OP_RM_EPSILONS },
 		{ "remove_epsilons", OP_RM_EPSILONS },
 
 		{ "cat",         OP_CONCAT      },
@@ -395,11 +392,11 @@ main(int argc, char *argv[])
 	{
 		int c;
 
-		while (c = getopt(argc, argv, "h" "aCcgwXEe:k:i:" "xpq:l:dGmrt:W:"), c != -1) {
+		while (c = getopt(argc, argv, "h" "aCcgwXe:k:i:" "xpq:l:dmrt:EW:"), c != -1) {
 			switch (c) {
 			case 'a': opt.anonymous_states  = 1;          break;
 			case 'c': opt.consolidate_edges = 1;          break;
-			case 'C': opt.comments		= 0;          break;
+			case 'C': opt.comments          = 0;          break;
 			case 'g': opt.group_edges       = 1;          break;
 			case 'w': opt.fragment          = 1;          break;
 			case 'X': opt.always_hex        = 1;          break;
@@ -420,7 +417,6 @@ main(int argc, char *argv[])
 			case 'm': op = op_name("minimise");           break;
 			case 'r': op = op_name("reverse");            break;
 			case 't': op = op_name(optarg);               break;
-			case 'G': op = op_name("glushkovise");        break;
 			case 'E': op = op_name("remove_epsilons");    break;
 			case 'W':
 				/* print = gen_words; */

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -34,9 +34,9 @@ fsm_determinise(struct fsm *nfa)
 	map.alloc = nfa->opt->alloc;
 
 	/*
-	 * This NFA->DFA implementation is for Glushkov NFA only; it keeps things
-	 * a little simpler by avoiding epsilon closures here, and also a little
-	 * faster where we can start with a Glushkov NFA in the first place.
+	 * This NFA->DFA implementation is for epsilon-free NFA only. This keeps
+	 * things a little simpler by avoiding epsilon closures, and also a little
+	 * faster where we can start with an epsilon-free NFA in the first place.
 	 */
 	if (fsm_has(nfa, fsm_hasepsilons)) {
 		if (!fsm_remove_epsilons(nfa)) {

--- a/src/libfsm/reverse.c
+++ b/src/libfsm/reverse.c
@@ -187,8 +187,8 @@ fsm_reverse(struct fsm *fsm)
 	 * transitions (or an epsilon closure).
 	 *
 	 * We avoid introducing epsilon transitions to an FSM where
-	 * there potentially were none before. That is, a Glushkov NFA
-	 * will not be converted to a Thompson NFA.
+	 * there potentially were none before. A Glushkov NFA will
+	 * not be converted to a Thompson NFA.
 	 *
 	 * Conceptually this is equivalent to hooking the start state
 	 * up with epsilons, then taking the epsilon closure of that

--- a/src/libre/dialect/native/parser.c
+++ b/src/libre/dialect/native/parser.c
@@ -1943,7 +1943,7 @@ p_181(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 
 		if ((ZIlower).type != AST_ENDPOINT_LITERAL ||
 			(ZIupper).type != AST_ENDPOINT_LITERAL) {
-			err->e = RE_EXUNSUPPORTD;
+			err->e = RE_EUNSUPPORTED;
 			goto ZL1;
 		}
 
@@ -2268,7 +2268,7 @@ p_196(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 
 		if ((ZIlower).type != AST_ENDPOINT_LITERAL ||
 			(ZIupper).type != AST_ENDPOINT_LITERAL) {
-			err->e = RE_EXUNSUPPORTD;
+			err->e = RE_EUNSUPPORTED;
 			goto ZL1;
 		}
 
@@ -2809,7 +2809,7 @@ p_249(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 
 		if ((ZIlower).type != AST_ENDPOINT_LITERAL ||
 			(ZIupper).type != AST_ENDPOINT_LITERAL) {
-			err->e = RE_EXUNSUPPORTD;
+			err->e = RE_EUNSUPPORTED;
 			goto ZL1;
 		}
 
@@ -2949,7 +2949,7 @@ p_253(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 		if ((ZIlower).type != AST_ENDPOINT_LITERAL ||
 			(ZIupper).type != AST_ENDPOINT_LITERAL) {
-			err->e = RE_EXUNSUPPORTD;
+			err->e = RE_EUNSUPPORTED;
 			goto ZL1;
 		}
 

--- a/src/libre/dialect/pcre/parser.c
+++ b/src/libre/dialect/pcre/parser.c
@@ -532,7 +532,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 #line 702 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
-			err->e = RE_EXUNSUPPORTD;
+			err->e = RE_EUNSUPPORTED;
 		}
 		goto ZL1;
 	
@@ -705,7 +705,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 #line 702 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
-			err->e = RE_EXUNSUPPORTD;
+			err->e = RE_EUNSUPPORTED;
 		}
 		goto ZL1;
 	
@@ -925,7 +925,7 @@ p_296(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 
 		if ((ZIlower).type != AST_ENDPOINT_LITERAL ||
 			(ZIupper).type != AST_ENDPOINT_LITERAL) {
-			err->e = RE_EXUNSUPPORTD;
+			err->e = RE_EUNSUPPORTED;
 			goto ZL1;
 		}
 
@@ -1301,7 +1301,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 #line 702 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
-			err->e = RE_EXUNSUPPORTD;
+			err->e = RE_EUNSUPPORTED;
 		}
 		goto ZL1;
 	
@@ -1422,7 +1422,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 #line 702 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
-			err->e = RE_EXUNSUPPORTD;
+			err->e = RE_EUNSUPPORTED;
 		}
 		goto ZL1;
 	
@@ -1698,7 +1698,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 #line 702 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
-			err->e = RE_EXUNSUPPORTD;
+			err->e = RE_EUNSUPPORTED;
 		}
 		goto ZL1;
 	
@@ -2463,7 +2463,7 @@ p_320(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 		if ((ZIlower).type != AST_ENDPOINT_LITERAL ||
 			(ZIupper).type != AST_ENDPOINT_LITERAL) {
-			err->e = RE_EXUNSUPPORTD;
+			err->e = RE_EUNSUPPORTED;
 			goto ZL1;
 		}
 
@@ -2655,7 +2655,7 @@ p_195(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 
 		if ((ZIlower).type != AST_ENDPOINT_LITERAL ||
 			(ZIupper).type != AST_ENDPOINT_LITERAL) {
-			err->e = RE_EXUNSUPPORTD;
+			err->e = RE_EUNSUPPORTED;
 			goto ZL1;
 		}
 
@@ -3217,7 +3217,7 @@ p_expr_C_Cpiece_C_Clist_Hof_Hcounts(flags flags, lex_state lex_state, act_state 
 #line 702 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
-			err->e = RE_EXUNSUPPORTD;
+			err->e = RE_EUNSUPPORTED;
 		}
 		goto ZL1;
 	
@@ -3234,7 +3234,7 @@ p_expr_C_Cpiece_C_Clist_Hof_Hcounts(flags flags, lex_state lex_state, act_state 
 #line 702 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
-			err->e = RE_EXUNSUPPORTD;
+			err->e = RE_EUNSUPPORTED;
 		}
 		goto ZL1;
 	
@@ -3446,7 +3446,7 @@ p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 
 		if ((ZIlower).type != AST_ENDPOINT_LITERAL ||
 			(ZIupper).type != AST_ENDPOINT_LITERAL) {
-			err->e = RE_EXUNSUPPORTD;
+			err->e = RE_EUNSUPPORTED;
 			goto ZL1;
 		}
 

--- a/src/libre/dialect/sql/parser.c
+++ b/src/libre/dialect/sql/parser.c
@@ -1304,7 +1304,7 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 		if ((ZIa).type != AST_ENDPOINT_LITERAL ||
 			(ZIz).type != AST_ENDPOINT_LITERAL) {
-			err->e = RE_EXUNSUPPORTD;
+			err->e = RE_EUNSUPPORTED;
 			goto ZL1;
 		}
 

--- a/src/libre/parser.act
+++ b/src/libre/parser.act
@@ -701,7 +701,7 @@
 
 	<err-unsupported> = @{
 		if (err->e == RE_ESUCCESS) {
-			err->e = RE_EXUNSUPPORTD;
+			err->e = RE_EUNSUPPORTED;
 		}
 		@!;
 	@};
@@ -972,7 +972,7 @@
 
 		if (@from.type != AST_ENDPOINT_LITERAL ||
 			@to.type != AST_ENDPOINT_LITERAL) {
-			err->e = RE_EXUNSUPPORTD;
+			err->e = RE_EUNSUPPORTED;
 			@!;
 		}
 

--- a/src/libre/strerror.c
+++ b/src/libre/strerror.c
@@ -28,7 +28,10 @@ re_strerror(enum re_errno e)
 	case RE_EOCTRANGE:    return "Octal escape out of range";
 	case RE_ECOUNTRANGE:  return "Count out of range";
 
+	case RE_EUNSUPPORTED: return "Unsupported operator";
 	case RE_EFLAG:        return "Unknown control flag";
+	case RE_EBADCP:       return "Invalid codepoint";
+	case RE_EBADCOMMENT:  return "Comments may not nest";
 
 	case RE_EXSUB:        return "Syntax error: expected sub-expression";
 	case RE_EXTERM:       return "Syntax error: expected group term";
@@ -38,13 +41,10 @@ re_strerror(enum re_errno e)
 	case RE_EXALTS:       return "Syntax error: expected alternative list";
 	case RE_EXRANGE:      return "Syntax error: expected range separator";
 	case RE_EXCLOSEGROUP: return "Syntax error: group is not closed";
+	case RE_EXCLOSEFLAGS: return "Syntax error: flags are not closed";
 	case RE_EXGROUPBODY:  return "Syntax error: expected group body";
 	case RE_EXEOF:        return "Syntax error: expected EOF";
 	case RE_EXESC:        return "Syntax error: expected character escape";
-	case RE_EXCLOSEFLAGS: return "Syntax error: flags are not closed";
-	case RE_EXUNSUPPORTD: return "Syntax error: unsupported operator";
-	case RE_EBADCP:       return "Syntax error: invalid codepoint";
-	case RE_EBADCOMMENT:  return "Syntax error: bad comment";
 	}
 
 	assert(!"unreached");

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -811,7 +811,7 @@ main(int argc, char *argv[])
 				 yfiles ? argv[0] : NULL,
 				!yfiles ? argv[0] : NULL);
 
-			if (err.e == RE_EXUNSUPPORTD) {
+			if (err.e == RE_EUNSUPPORTED) {
 				return 2;
 			}
 
@@ -899,7 +899,7 @@ main(int argc, char *argv[])
 				 yfiles ? argv[0] : NULL,
 				!yfiles ? argv[0] : NULL);
 
-			if (err.e == RE_EXUNSUPPORTD) {
+			if (err.e == RE_EUNSUPPORTED) {
 				return 2;
 			}
 
@@ -968,7 +968,7 @@ main(int argc, char *argv[])
 					 yfiles ? argv[i] : NULL,
 					!yfiles ? argv[i] : NULL);
 
-				if (err.e == RE_EXUNSUPPORTD) {
+				if (err.e == RE_EUNSUPPORTED) {
 					return 2;
 				}
 

--- a/tests/epsilons/Makefile
+++ b/tests/epsilons/Makefile
@@ -9,7 +9,7 @@ FSM=${BUILD}/bin/fsm
 .for n in ${TEST.tests/epsilons:T:R:C/^out//}
 
 ${TEST_OUTDIR.tests/epsilons}/got${n}.fsm: ${TEST_SRCDIR.tests/epsilons}/in${n}.fsm
-	${FSM} -pG ${.ALLSRC:M*.fsm} \
+	${FSM} -pE ${.ALLSRC:M*.fsm} \
 	> $@
 
 ${TEST_OUTDIR.tests/epsilons}/res${n}: \

--- a/tests/pcre/out10.err
+++ b/tests/pcre/out10.err
@@ -1,1 +1,1 @@
-tests/pcre/in10.re:3: Syntax error: unsupported operator
+tests/pcre/in10.re:3: Unsupported operator

--- a/tests/pcre/out30.err
+++ b/tests/pcre/out30.err
@@ -1,1 +1,1 @@
-tests/pcre/in30.re:8: Syntax error: unsupported operator
+tests/pcre/in30.re:8: Unsupported operator

--- a/tests/pcre/out43.err
+++ b/tests/pcre/out43.err
@@ -1,1 +1,1 @@
-tests/pcre/in43.re:7: Syntax error: bad comment
+tests/pcre/in43.re:7: Comments may not nest


### PR DESCRIPTION
Two small things here:
- I Removed the term "Glushkovise" where we just mean "epsilon-free".
    I'm not comfortable with using the term Glushkov NFA, because that implies using Glushkov's construction, which gives a particular NFA structure from parsing a regex. Not having epislons isn't enough to satisfy that, and I think it's confusing to mix the two things.
- Naming about errors; the `X` means "expected". And unsupported operators are not syntax errors