### PR TITLE
Add `fsm_generate_matches` to cli

### DIFF
--- a/include/fsm/walk.h
+++ b/include/fsm/walk.h
@@ -115,5 +115,10 @@ int
 fsm_generate_matches(struct fsm *fsm, size_t max_length,
     fsm_generate_matches_cb *cb, void *opaque);
 
+/* Callback provided for the most basic use case for
+ * fsm_generate_matches: exhaustively generate input up to
+ * max_length and print each to stdout. */
+fsm_generate_matches_cb fsm_generate_cb_printf;
+
 #endif
 

--- a/include/fsm/walk.h
+++ b/include/fsm/walk.h
@@ -120,5 +120,13 @@ fsm_generate_matches(struct fsm *fsm, size_t max_length,
  * max_length and print each to stdout. */
 fsm_generate_matches_cb fsm_generate_cb_printf;
 
+/* Same as fsm_generate_cb_printf, but call c_escputc_str
+ * internally to escape characters.
+ *
+ * Note: This MUST be called with opaque set to a `const struct
+ * fsm_options *`, because c_escputc_str will use that to decide whether
+ * to escape all characters or just nonprintable ones. */
+fsm_generate_matches_cb fsm_generate_cb_printf_escaped;
+
 #endif
 

--- a/man/fsm.1/fsm.1.xml
+++ b/man/fsm.1/fsm.1.xml
@@ -21,6 +21,7 @@
 -->
 	<!ENTITY io.arg "<replaceable>io</replaceable>">
 	<!ENTITY iterations.arg "<replaceable>iterations</replaceable>">
+	<!ENTITY length.arg "<replaceable>length</replaceable>">
 
 	<!ENTITY a.opt "<option>-a</option>">
 	<!ENTITY w.opt "<option>-w</option>">
@@ -28,6 +29,7 @@
 	<!ENTITY c.opt "<option>-c</option>">
 	<!ENTITY e.opt "<option>-e</option>&nbsp;&prefix.arg;">
 	<!ENTITY E.opt "<option>-E</option>">
+	<!ENTITY G.opt "<option>-G</option>&nbsp;&length.arg;">
 	<!ENTITY k.opt "<option>-k</option>&nbsp;&io.arg;">
 	<!ENTITY i.opt "<option>-i</option>&nbsp;&iterations.arg;">
 	<!ENTITY X.opt "<option>-X</option>">
@@ -275,6 +277,14 @@
 
 				<listitem>
 					<para>Equivalent to <code>-t&nbsp;remove_epsilons</code>.</para>
+				</listitem>
+			</varlistentry>
+
+			<varlistentry>
+				<term>&G.opt;</term>
+
+				<listitem>
+					<para>Print example matching inputs up to a maximum length.</para>
 				</listitem>
 			</varlistentry>
 

--- a/man/re.1/re.1.xml
+++ b/man/re.1/re.1.xml
@@ -17,6 +17,7 @@
 	<!ENTITY file.arg    "<replaceable>file</replaceable>">
 	<!ENTITY dialect.arg "<replaceable>dialect</replaceable>">
 	<!ENTITY prefix.arg  "<replaceable>prefix</replaceable>">
+	<!ENTITY length.arg  "<replaceable>length</replaceable>">
 	<!ENTITY group.arg   "<replaceable>group</replaceable>">
 	<!ENTITY query.arg   "<replaceable>query</replaceable>">
 
@@ -32,6 +33,7 @@
 	<!ENTITY X.opt "<option>-X</option>">
 	<!ENTITY e.opt "<option>-e</option>&nbsp;&prefix.arg;">
 	<!ENTITY E.opt "<option>-E</option>&nbsp;&prefix.arg;">
+	<!ENTITY G.opt "<option>-G</option>&nbsp;&length.arg;">
 
 	<!ENTITY a.opt "<option>-a</option>">
 	<!ENTITY d.opt "<option>-d</option>">
@@ -294,6 +296,14 @@ group (for dialects which have them) (rather than a "whole" regexp)
 					<para>Set a package prefix for output,
 						per the <code>package_prefix</code> option for &fsm_print.3;.
 						The default is to output with the value of <code>prefix.</code></para>
+				</listitem>
+			</varlistentry>
+
+			<varlistentry>
+				<term>&G.opt;</term>
+
+				<listitem>
+					<para>Print example matching inputs up to a maximum length.</para>
 				</listitem>
 			</varlistentry>
 

--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -109,6 +109,7 @@ usage(void)
 	printf("       fsm {-p} [-l <language>] [-aCcEgwX] [-k <io>] [-e <prefix>]\n");
 	printf("       fsm {-dmr | -t <transformation>} [-i <iterations>] [<file.fsm> | <file-a> <file-b>]\n");
 	printf("       fsm {-q <query>} [<file>]\n");
+	printf("       fsm {-G <max_length>} [<file>]\n");
 	printf("       fsm {-W <maxlen>} <file.fsm>\n");
 	printf("       fsm -h\n");
 }
@@ -369,6 +370,7 @@ main(int argc, char *argv[])
 	struct fsm *fsm;
 	int xfiles;
 	int r;
+	size_t generate_bounds = 0;
 
 	int (*query)(const struct fsm *, fsm_state_t);
 	int (*walk )(const struct fsm *,
@@ -392,7 +394,7 @@ main(int argc, char *argv[])
 	{
 		int c;
 
-		while (c = getopt(argc, argv, "h" "aCcgwXe:k:i:" "xpq:l:dmrt:EW:"), c != -1) {
+		while (c = getopt(argc, argv, "h" "aCcgwXe:k:i:" "xpq:l:dG:mrt:EW:"), c != -1) {
 			switch (c) {
 			case 'a': opt.anonymous_states  = 1;          break;
 			case 'c': opt.consolidate_edges = 1;          break;
@@ -424,6 +426,13 @@ main(int argc, char *argv[])
 				/* XXX: error handling */
 				fprintf(stderr, "not yet implemented.\n");
 				exit(EXIT_FAILURE);
+				break;
+			case 'G':
+				generate_bounds = strtoul(optarg, NULL, 10);
+				if (generate_bounds == 0) {
+					usage();
+					exit(EXIT_FAILURE);
+				}
 				break;
 
 			case 'h':
@@ -659,6 +668,10 @@ main(int argc, char *argv[])
 
 	if (print != NULL) {
 		print(stdout, fsm);
+	}
+
+	if (generate_bounds > 0) {
+		r = fsm_generate_matches(fsm, generate_bounds, fsm_generate_cb_printf, NULL);
 	}
 
 	fsm_free(fsm);

--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -671,7 +671,7 @@ main(int argc, char *argv[])
 	}
 
 	if (generate_bounds > 0) {
-		r = fsm_generate_matches(fsm, generate_bounds, fsm_generate_cb_printf, NULL);
+		r = fsm_generate_matches(fsm, generate_bounds, fsm_generate_cb_printf_escaped, &opt);
 	}
 
 	fsm_free(fsm);

--- a/src/libfsm/gen.c
+++ b/src/libfsm/gen.c
@@ -16,6 +16,9 @@
 #include <adt/edgeset.h>
 #include <adt/stateset.h>
 
+#include <stdio.h>
+#include <print/esc.h>
+
 #include <assert.h>
 
 #include <ctype.h>
@@ -146,6 +149,28 @@ fsm_generate_matches(struct fsm *fsm, size_t max_length,
 }
 
 enum fsm_generate_matches_cb_res
+fsm_generate_cb_printf_escaped(const struct fsm *fsm,
+	size_t depth, size_t match_count, size_t steps,
+	const char *input, size_t input_length,
+	fsm_state_t end_state, void *opaque)
+{
+	(void)fsm;
+	(void)end_state;
+	(void)depth;
+	(void)match_count;
+	(void)steps;
+
+	assert(opaque != NULL);
+	const struct fsm_options *opt = opaque;
+
+	for (size_t i = 0; i < input_length; i++) {
+		c_escputc_str(stdout, opt, input[i]);
+	}
+	printf("\n");
+	return FSM_GENERATE_MATCHES_CB_RES_CONTINUE;
+}
+
+enum fsm_generate_matches_cb_res
 fsm_generate_cb_printf(const struct fsm *fsm,
 	size_t depth, size_t match_count, size_t steps,
 	const char *input, size_t input_length,
@@ -158,6 +183,7 @@ fsm_generate_cb_printf(const struct fsm *fsm,
 	(void)depth;
 	(void)match_count;
 	(void)steps;
+
 	printf("%s\n", input);
 	return FSM_GENERATE_MATCHES_CB_RES_CONTINUE;
 }

--- a/src/libfsm/gen.c
+++ b/src/libfsm/gen.c
@@ -145,6 +145,23 @@ fsm_generate_matches(struct fsm *fsm, size_t max_length,
 	return res;
 }
 
+enum fsm_generate_matches_cb_res
+fsm_generate_cb_printf(const struct fsm *fsm,
+	size_t depth, size_t match_count, size_t steps,
+	const char *input, size_t input_length,
+	fsm_state_t end_state, void *opaque)
+{
+	(void)fsm;
+	(void)input_length;
+	(void)end_state;
+	(void)opaque;
+	(void)depth;
+	(void)match_count;
+	(void)steps;
+	printf("%s\n", input);
+	return FSM_GENERATE_MATCHES_CB_RES_CONTINUE;
+}
+
 static bool
 gen_init_outer(struct fsm *fsm, size_t max_length,
     fsm_generate_matches_cb *cb, void *opaque,

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -28,6 +28,7 @@ fsm_hasepsilons
 fsm_hasnondeterminism
 fsm_generate_matches
 fsm_generate_cb_printf
+fsm_generate_cb_printf_escaped
 
 # <fsm/parser.h>
 fsm_parse

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -27,6 +27,7 @@ fsm_hasoutgoing
 fsm_hasepsilons
 fsm_hasnondeterminism
 fsm_generate_matches
+fsm_generate_cb_printf
 
 # <fsm/parser.h>
 fsm_parse

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -1183,8 +1183,7 @@ main(int argc, char *argv[])
 	}
 
 	if (generate_bounds > 0) {
-		int r = fsm_generate_matches(fsm, generate_bounds, fsm_generate_cb_printf, NULL);
-		return r;
+		return fsm_generate_matches(fsm, generate_bounds, fsm_generate_cb_printf, NULL);
 	}
 
 	if (print_fsm != NULL) {

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -1183,7 +1183,7 @@ main(int argc, char *argv[])
 	}
 
 	if (generate_bounds > 0) {
-		return fsm_generate_matches(fsm, generate_bounds, fsm_generate_cb_printf, NULL);
+		return fsm_generate_matches(fsm, generate_bounds, fsm_generate_cb_printf_escaped, &opt);
 	}
 
 	if (print_fsm != NULL) {


### PR DESCRIPTION
This adds a `-G <max_length>` option to `re` and `fsm`.

Also, add a default / basic use case callback, `fsm_generate_cb_printf`, which is what re and fsm use.