### PR TITLE
-Werror, long overdue

### DIFF
--- a/src/libre/dialect/glob/parser.c
+++ b/src/libre/dialect/glob/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 22 "src/libre/parser.act"
+#line 149 "src/libre/parser.act"
 
 
 	#include <assert.h>
@@ -238,7 +238,7 @@
 
 		n = sprintf(s, "%.*s", (int) sz - 3 - 1, msg);
 		if (n == sz - 3 - 1) {
-			strcpy(s + sz, "...");
+			strcpy(s + n, "...");
 		}
 	}
 
@@ -322,7 +322,7 @@ ZL2_list_Hof_Hatoms:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 1006 "src/libre/parser.act"
+#line 1078 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
@@ -340,7 +340,7 @@ ZL2_list_Hof_Hatoms:;
 					goto ZL2_list_Hof_Hatoms;
 					/* END OF INLINE: list-of-atoms */
 				}
-				/* UNREACHED */
+				/*UNREACHED*/
 			default:
 				break;
 			}
@@ -366,7 +366,7 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: class-any */
 			{
-#line 739 "src/libre/parser.act"
+#line 812 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
 		(ZIa) = (*flags & RE_SINGLE) ? &class_any : &class_notnl;
@@ -376,7 +376,7 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 999 "src/libre/parser.act"
+#line 1071 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_named(act_state->poolp, *flags, (ZIa));
 		if ((ZIe) == NULL) {
@@ -396,7 +396,7 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
-#line 532 "src/libre/parser.act"
+#line 592 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -404,22 +404,25 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 		ZI112 = lex_state->lx.start;
 		ZI113   = lex_state->lx.end;
 
+		(void) ZI112;
+		(void) ZI113;
+
 		ZIc = lex_state->buf.a[0];
 	
-#line 410 "src/libre/dialect/glob/parser.c"
+#line 413 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 836 "src/libre/parser.act"
+#line 908 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 423 "src/libre/dialect/glob/parser.c"
+#line 426 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -433,38 +436,38 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: class-any */
 			{
-#line 739 "src/libre/parser.act"
+#line 812 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
 		(ZIa) = (*flags & RE_SINGLE) ? &class_any : &class_notnl;
 	
-#line 442 "src/libre/dialect/glob/parser.c"
+#line 445 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 999 "src/libre/parser.act"
+#line 1071 "src/libre/parser.act"
 
 		(ZIg) = ast_make_expr_named(act_state->poolp, *flags, (ZIa));
 		if ((ZIg) == NULL) {
 			goto ZL1;
 		}
 	
-#line 454 "src/libre/dialect/glob/parser.c"
+#line 457 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 			/* BEGINNING OF ACTION: count-zero-or-more */
 			{
-#line 765 "src/libre/parser.act"
+#line 837 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 463 "src/libre/dialect/glob/parser.c"
+#line 466 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 			/* BEGINNING OF ACTION: ast-make-piece */
 			{
-#line 859 "src/libre/parser.act"
+#line 931 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
@@ -478,7 +481,7 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			goto ZL1;
 		}
 	
-#line 482 "src/libre/dialect/glob/parser.c"
+#line 485 "src/libre/dialect/glob/parser.c"
 			}
 			/* END OF ACTION: ast-make-piece */
 		}
@@ -493,26 +496,26 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-atom */
 		{
-#line 646 "src/libre/parser.act"
+#line 721 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXATOM;
 		}
 		goto ZL2;
 	
-#line 504 "src/libre/dialect/glob/parser.c"
+#line 507 "src/libre/dialect/glob/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 815 "src/libre/parser.act"
+#line 887 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZIe) == NULL) {
 			goto ZL2;
 		}
 	
-#line 516 "src/libre/dialect/glob/parser.c"
+#line 519 "src/libre/dialect/glob/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -540,14 +543,14 @@ p_re__glob(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 				{
 					/* BEGINNING OF ACTION: ast-make-concat */
 					{
-#line 822 "src/libre/parser.act"
+#line 894 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_concat(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 551 "src/libre/dialect/glob/parser.c"
+#line 554 "src/libre/dialect/glob/parser.c"
 					}
 					/* END OF ACTION: ast-make-concat */
 					p_list_Hof_Hatoms (flags, lex_state, act_state, err, ZInode);
@@ -561,14 +564,14 @@ p_re__glob(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 				{
 					/* BEGINNING OF ACTION: ast-make-empty */
 					{
-#line 815 "src/libre/parser.act"
+#line 887 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 572 "src/libre/dialect/glob/parser.c"
+#line 575 "src/libre/dialect/glob/parser.c"
 					}
 					/* END OF ACTION: ast-make-empty */
 				}
@@ -592,14 +595,14 @@ p_re__glob(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 695 "src/libre/parser.act"
+#line 770 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
 		}
 		goto ZL1;
 	
-#line 603 "src/libre/dialect/glob/parser.c"
+#line 606 "src/libre/dialect/glob/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
@@ -617,7 +620,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 1018 "src/libre/parser.act"
+#line 1247 "src/libre/parser.act"
 
 
 	static int
@@ -776,6 +779,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 780 "src/libre/dialect/glob/parser.c"
+#line 783 "src/libre/dialect/glob/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/glob/parser.h
+++ b/src/libre/dialect/glob/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 299 "src/libre/parser.act"
+#line 310 "src/libre/parser.act"
 
 
 	#include <re/re.h>
@@ -28,7 +28,7 @@
 extern void p_re__glob(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 1176 "src/libre/parser.act"
+#line 1249 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/glob/parser.h"

--- a/src/libre/dialect/like/parser.c
+++ b/src/libre/dialect/like/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 22 "src/libre/parser.act"
+#line 149 "src/libre/parser.act"
 
 
 	#include <assert.h>
@@ -238,7 +238,7 @@
 
 		n = sprintf(s, "%.*s", (int) sz - 3 - 1, msg);
 		if (n == sz - 3 - 1) {
-			strcpy(s + sz, "...");
+			strcpy(s + n, "...");
 		}
 	}
 
@@ -322,7 +322,7 @@ ZL2_list_Hof_Hatoms:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 1006 "src/libre/parser.act"
+#line 1078 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
@@ -340,7 +340,7 @@ ZL2_list_Hof_Hatoms:;
 					goto ZL2_list_Hof_Hatoms;
 					/* END OF INLINE: list-of-atoms */
 				}
-				/* UNREACHED */
+				/*UNREACHED*/
 			default:
 				break;
 			}
@@ -366,7 +366,7 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: class-any */
 			{
-#line 739 "src/libre/parser.act"
+#line 812 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
 		(ZIa) = (*flags & RE_SINGLE) ? &class_any : &class_notnl;
@@ -376,7 +376,7 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 999 "src/libre/parser.act"
+#line 1071 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_named(act_state->poolp, *flags, (ZIa));
 		if ((ZIe) == NULL) {
@@ -396,7 +396,7 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
-#line 532 "src/libre/parser.act"
+#line 592 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -404,22 +404,25 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 		ZI114 = lex_state->lx.start;
 		ZI115   = lex_state->lx.end;
 
+		(void) ZI114;
+		(void) ZI115;
+
 		ZIc = lex_state->buf.a[0];
 	
-#line 410 "src/libre/dialect/like/parser.c"
+#line 413 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 836 "src/libre/parser.act"
+#line 908 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 423 "src/libre/dialect/like/parser.c"
+#line 426 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -433,38 +436,38 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: class-any */
 			{
-#line 739 "src/libre/parser.act"
+#line 812 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
 		(ZIa) = (*flags & RE_SINGLE) ? &class_any : &class_notnl;
 	
-#line 442 "src/libre/dialect/like/parser.c"
+#line 445 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 999 "src/libre/parser.act"
+#line 1071 "src/libre/parser.act"
 
 		(ZIg) = ast_make_expr_named(act_state->poolp, *flags, (ZIa));
 		if ((ZIg) == NULL) {
 			goto ZL1;
 		}
 	
-#line 454 "src/libre/dialect/like/parser.c"
+#line 457 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 			/* BEGINNING OF ACTION: count-zero-or-more */
 			{
-#line 765 "src/libre/parser.act"
+#line 837 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 463 "src/libre/dialect/like/parser.c"
+#line 466 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 			/* BEGINNING OF ACTION: ast-make-piece */
 			{
-#line 859 "src/libre/parser.act"
+#line 931 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
@@ -478,7 +481,7 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			goto ZL1;
 		}
 	
-#line 482 "src/libre/dialect/like/parser.c"
+#line 485 "src/libre/dialect/like/parser.c"
 			}
 			/* END OF ACTION: ast-make-piece */
 		}
@@ -493,26 +496,26 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-atom */
 		{
-#line 646 "src/libre/parser.act"
+#line 721 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXATOM;
 		}
 		goto ZL2;
 	
-#line 504 "src/libre/dialect/like/parser.c"
+#line 507 "src/libre/dialect/like/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 815 "src/libre/parser.act"
+#line 887 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZIe) == NULL) {
 			goto ZL2;
 		}
 	
-#line 516 "src/libre/dialect/like/parser.c"
+#line 519 "src/libre/dialect/like/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -540,14 +543,14 @@ p_re__like(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 				{
 					/* BEGINNING OF ACTION: ast-make-concat */
 					{
-#line 822 "src/libre/parser.act"
+#line 894 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_concat(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 551 "src/libre/dialect/like/parser.c"
+#line 554 "src/libre/dialect/like/parser.c"
 					}
 					/* END OF ACTION: ast-make-concat */
 					p_list_Hof_Hatoms (flags, lex_state, act_state, err, ZInode);
@@ -561,14 +564,14 @@ p_re__like(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 				{
 					/* BEGINNING OF ACTION: ast-make-empty */
 					{
-#line 815 "src/libre/parser.act"
+#line 887 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 572 "src/libre/dialect/like/parser.c"
+#line 575 "src/libre/dialect/like/parser.c"
 					}
 					/* END OF ACTION: ast-make-empty */
 				}
@@ -592,14 +595,14 @@ p_re__like(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 695 "src/libre/parser.act"
+#line 770 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
 		}
 		goto ZL1;
 	
-#line 603 "src/libre/dialect/like/parser.c"
+#line 606 "src/libre/dialect/like/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
@@ -617,7 +620,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 1018 "src/libre/parser.act"
+#line 1247 "src/libre/parser.act"
 
 
 	static int
@@ -776,6 +779,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 780 "src/libre/dialect/like/parser.c"
+#line 783 "src/libre/dialect/like/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/like/parser.h
+++ b/src/libre/dialect/like/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 299 "src/libre/parser.act"
+#line 310 "src/libre/parser.act"
 
 
 	#include <re/re.h>
@@ -28,7 +28,7 @@
 extern void p_re__like(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 1176 "src/libre/parser.act"
+#line 1249 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/like/parser.h"

--- a/src/libre/dialect/literal/parser.c
+++ b/src/libre/dialect/literal/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 22 "src/libre/parser.act"
+#line 149 "src/libre/parser.act"
 
 
 	#include <assert.h>
@@ -238,7 +238,7 @@
 
 		n = sprintf(s, "%.*s", (int) sz - 3 - 1, msg);
 		if (n == sz - 3 - 1) {
-			strcpy(s + sz, "...");
+			strcpy(s + n, "...");
 		}
 	}
 
@@ -322,7 +322,7 @@ ZL2_list_Hof_Hatoms:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 1006 "src/libre/parser.act"
+#line 1078 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
@@ -340,7 +340,7 @@ ZL2_list_Hof_Hatoms:;
 					goto ZL2_list_Hof_Hatoms;
 					/* END OF INLINE: list-of-atoms */
 				}
-				/* UNREACHED */
+				/*UNREACHED*/
 			default:
 				break;
 			}
@@ -369,7 +369,7 @@ p_re__literal(flags flags, lex_state lex_state, act_state act_state, err err, t_
 				{
 					/* BEGINNING OF ACTION: ast-make-concat */
 					{
-#line 822 "src/libre/parser.act"
+#line 894 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_concat(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
@@ -390,7 +390,7 @@ p_re__literal(flags flags, lex_state lex_state, act_state act_state, err err, t_
 				{
 					/* BEGINNING OF ACTION: ast-make-empty */
 					{
-#line 815 "src/libre/parser.act"
+#line 887 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
@@ -421,7 +421,7 @@ p_re__literal(flags flags, lex_state lex_state, act_state act_state, err err, t_
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 695 "src/libre/parser.act"
+#line 770 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
@@ -461,7 +461,7 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 		case (TOK_CHAR):
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
-#line 532 "src/libre/parser.act"
+#line 592 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -469,9 +469,12 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 		ZI112 = lex_state->lx.start;
 		ZI113   = lex_state->lx.end;
 
+		(void) ZI112;
+		(void) ZI113;
+
 		ZIc = lex_state->buf.a[0];
 	
-#line 475 "src/libre/dialect/literal/parser.c"
+#line 478 "src/libre/dialect/literal/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			break;
@@ -481,14 +484,14 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-make-literal */
 		{
-#line 836 "src/libre/parser.act"
+#line 908 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 492 "src/libre/dialect/literal/parser.c"
+#line 495 "src/libre/dialect/literal/parser.c"
 		}
 		/* END OF ACTION: ast-make-literal */
 	}
@@ -497,26 +500,26 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-atom */
 		{
-#line 646 "src/libre/parser.act"
+#line 721 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXATOM;
 		}
 		goto ZL2;
 	
-#line 508 "src/libre/dialect/literal/parser.c"
+#line 511 "src/libre/dialect/literal/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 815 "src/libre/parser.act"
+#line 887 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL2;
 		}
 	
-#line 520 "src/libre/dialect/literal/parser.c"
+#line 523 "src/libre/dialect/literal/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -530,7 +533,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 1018 "src/libre/parser.act"
+#line 1247 "src/libre/parser.act"
 
 
 	static int
@@ -689,6 +692,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 693 "src/libre/dialect/literal/parser.c"
+#line 696 "src/libre/dialect/literal/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/literal/parser.h
+++ b/src/libre/dialect/literal/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 299 "src/libre/parser.act"
+#line 310 "src/libre/parser.act"
 
 
 	#include <re/re.h>
@@ -28,7 +28,7 @@
 extern void p_re__literal(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 1176 "src/libre/parser.act"
+#line 1249 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/literal/parser.h"

--- a/src/libre/dialect/native/parser.c
+++ b/src/libre/dialect/native/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 22 "src/libre/parser.act"
+#line 149 "src/libre/parser.act"
 
 
 	#include <assert.h>
@@ -238,7 +238,7 @@
 
 		n = sprintf(s, "%.*s", (int) sz - 3 - 1, msg);
 		if (n == sz - 3 - 1) {
-			strcpy(s + sz, "...");
+			strcpy(s + n, "...");
 		}
 	}
 
@@ -344,7 +344,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 				{
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
-#line 532 "src/libre/parser.act"
+#line 592 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -352,9 +352,12 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 
+		(void) ZIstart;
+		(void) ZIend;
+
 		ZIc = lex_state->buf.a[0];
 	
-#line 358 "src/libre/dialect/native/parser.c"
+#line 361 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: CHAR */
 					ADVANCE_LEXER;
@@ -364,7 +367,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 				{
 					/* BEGINNING OF EXTRACT: ESC */
 					{
-#line 366 "src/libre/parser.act"
+#line 409 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -386,8 +389,11 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
+
+		(void) ZIstart;
+		(void) ZIend;
 	
-#line 391 "src/libre/dialect/native/parser.c"
+#line 397 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: ESC */
 					ADVANCE_LEXER;
@@ -397,7 +403,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 				{
 					/* BEGINNING OF EXTRACT: HEX */
 					{
-#line 487 "src/libre/parser.act"
+#line 548 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -408,6 +414,9 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
+
+		(void) ZIstart;
+		(void) ZIend;
 
 		errno = 0;
 
@@ -442,7 +451,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 446 "src/libre/dialect/native/parser.c"
+#line 455 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: HEX */
 					ADVANCE_LEXER;
@@ -452,7 +461,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 				{
 					/* BEGINNING OF EXTRACT: OCT */
 					{
-#line 447 "src/libre/parser.act"
+#line 505 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -463,6 +472,9 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
+
+		(void) ZIstart;
+		(void) ZIend;
 
 		errno = 0;
 
@@ -492,7 +504,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 496 "src/libre/dialect/native/parser.c"
+#line 508 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: OCT */
 					ADVANCE_LEXER;
@@ -505,12 +517,12 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 		/* END OF INLINE: 142 */
 		/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 		{
-#line 801 "src/libre/parser.act"
+#line 873 "src/libre/parser.act"
 
 		(ZIr).type = AST_ENDPOINT_LITERAL;
 		(ZIr).u.literal.c = (unsigned char)(ZIc);
 	
-#line 514 "src/libre/dialect/native/parser.c"
+#line 526 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-range-endpoint-literal */
 	}
@@ -537,28 +549,31 @@ p_268(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 
 			/* BEGINNING OF EXTRACT: CLOSECOUNT */
 			{
-#line 361 "src/libre/parser.act"
+#line 397 "src/libre/parser.act"
 
 		ZI218 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
+
+		(void) ZI218;
+		(void) ZIend;
 	
-#line 546 "src/libre/dialect/native/parser.c"
+#line 561 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: CLOSECOUNT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 719 "src/libre/parser.act"
+#line 791 "src/libre/parser.act"
 
 		mark(&act_state->countstart, &(*ZI266));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 557 "src/libre/dialect/native/parser.c"
+#line 572 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 781 "src/libre/parser.act"
+#line 855 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -578,7 +593,7 @@ p_268(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (*ZIm), &ast_end);
 	
-#line 582 "src/libre/dialect/native/parser.c"
+#line 597 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: count-range */
 		}
@@ -594,7 +609,7 @@ p_268(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			case (TOK_COUNT):
 				/* BEGINNING OF EXTRACT: COUNT */
 				{
-#line 572 "src/libre/parser.act"
+#line 649 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -614,7 +629,7 @@ p_268(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 
 		ZIn = (unsigned int) u;
 	
-#line 618 "src/libre/dialect/native/parser.c"
+#line 633 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -626,12 +641,15 @@ p_268(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			case (TOK_CLOSECOUNT):
 				/* BEGINNING OF EXTRACT: CLOSECOUNT */
 				{
-#line 361 "src/libre/parser.act"
+#line 397 "src/libre/parser.act"
 
 		ZI221 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
+
+		(void) ZI221;
+		(void) ZIend;
 	
-#line 635 "src/libre/dialect/native/parser.c"
+#line 653 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF EXTRACT: CLOSECOUNT */
 				break;
@@ -641,17 +659,17 @@ p_268(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 719 "src/libre/parser.act"
+#line 791 "src/libre/parser.act"
 
 		mark(&act_state->countstart, &(*ZI266));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 650 "src/libre/dialect/native/parser.c"
+#line 668 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 781 "src/libre/parser.act"
+#line 855 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -671,7 +689,7 @@ p_268(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (ZIn), &ast_end);
 	
-#line 675 "src/libre/dialect/native/parser.c"
+#line 693 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: count-range */
 		}
@@ -706,20 +724,20 @@ ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 			}
 			/* BEGINNING OF ACTION: ast-add-alt */
 			{
-#line 1012 "src/libre/parser.act"
+#line 1084 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIclass), (ZInode))) {
 			goto ZL1;
 		}
 	
-#line 716 "src/libre/dialect/native/parser.c"
+#line 734 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 			/* BEGINNING OF INLINE: expr::character-class::list-of-class-terms */
 			goto ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms;
 			/* END OF INLINE: expr::character-class::list-of-class-terms */
 		}
-		/* UNREACHED */
+		/*UNREACHED*/
 	case (ERROR_TERMINAL):
 		return;
 	default:
@@ -746,13 +764,17 @@ p_155(flags flags, lex_state lex_state, act_state act_state, err err)
 		case (TOK_RANGE):
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 318 "src/libre/parser.act"
+#line 327 "src/libre/parser.act"
 
 		ZI156 = '-';
 		ZI157 = lex_state->lx.start;
 		ZI158   = lex_state->lx.end;
+
+		(void) ZI156;
+		(void) ZI157;
+		(void) ZI158;
 	
-#line 756 "src/libre/dialect/native/parser.c"
+#line 778 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			break;
@@ -766,14 +788,14 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-range */
 		{
-#line 660 "src/libre/parser.act"
+#line 735 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXRANGE;
 		}
 		goto ZL2;
 	
-#line 777 "src/libre/dialect/native/parser.c"
+#line 799 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: err-expected-range */
 	}
@@ -801,13 +823,13 @@ ZL2_expr_C_Clist_Hof_Hpieces:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 1006 "src/libre/parser.act"
+#line 1078 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
 		}
 	
-#line 811 "src/libre/dialect/native/parser.c"
+#line 833 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-add-concat */
 		/* BEGINNING OF INLINE: 225 */
@@ -821,7 +843,7 @@ ZL2_expr_C_Clist_Hof_Hpieces:;
 					goto ZL2_expr_C_Clist_Hof_Hpieces;
 					/* END OF INLINE: expr::list-of-pieces */
 				}
-				/* UNREACHED */
+				/*UNREACHED*/
 			default:
 				break;
 			}
@@ -855,7 +877,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
-#line 532 "src/libre/parser.act"
+#line 592 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -863,9 +885,12 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		ZI118 = lex_state->lx.start;
 		ZI119   = lex_state->lx.end;
 
+		(void) ZI118;
+		(void) ZI119;
+
 		ZIc = lex_state->buf.a[0];
 	
-#line 869 "src/libre/dialect/native/parser.c"
+#line 894 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: CHAR */
 					ADVANCE_LEXER;
@@ -878,7 +903,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 					/* BEGINNING OF EXTRACT: ESC */
 					{
-#line 366 "src/libre/parser.act"
+#line 409 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -900,8 +925,11 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZI112 = lex_state->lx.start;
 		ZI113   = lex_state->lx.end;
+
+		(void) ZI112;
+		(void) ZI113;
 	
-#line 905 "src/libre/dialect/native/parser.c"
+#line 933 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: ESC */
 					ADVANCE_LEXER;
@@ -914,7 +942,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 					/* BEGINNING OF EXTRACT: HEX */
 					{
-#line 487 "src/libre/parser.act"
+#line 548 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -925,6 +953,9 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZI116 = lex_state->lx.start;
 		ZI117   = lex_state->lx.end;
+
+		(void) ZI116;
+		(void) ZI117;
 
 		errno = 0;
 
@@ -959,7 +990,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 963 "src/libre/dialect/native/parser.c"
+#line 994 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: HEX */
 					ADVANCE_LEXER;
@@ -972,7 +1003,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 					/* BEGINNING OF EXTRACT: OCT */
 					{
-#line 447 "src/libre/parser.act"
+#line 505 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -983,6 +1014,9 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZI114 = lex_state->lx.start;
 		ZI115   = lex_state->lx.end;
+
+		(void) ZI114;
+		(void) ZI115;
 
 		errno = 0;
 
@@ -1012,7 +1046,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 1016 "src/libre/dialect/native/parser.c"
+#line 1050 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: OCT */
 					ADVANCE_LEXER;
@@ -1025,14 +1059,14 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		/* END OF INLINE: 110 */
 		/* BEGINNING OF ACTION: ast-make-literal */
 		{
-#line 836 "src/libre/parser.act"
+#line 908 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1036 "src/libre/dialect/native/parser.c"
+#line 1070 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-make-literal */
 	}
@@ -1058,7 +1092,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
-#line 532 "src/libre/parser.act"
+#line 592 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -1066,9 +1100,12 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		ZI263 = lex_state->lx.start;
 		ZI264   = lex_state->lx.end;
 
+		(void) ZI263;
+		(void) ZI264;
+
 		ZI262 = lex_state->buf.a[0];
 	
-#line 1072 "src/libre/dialect/native/parser.c"
+#line 1109 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
@@ -1087,7 +1124,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: ESC */
 			{
-#line 366 "src/libre/parser.act"
+#line 409 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -1109,8 +1146,11 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 		ZI251 = lex_state->lx.start;
 		ZI252   = lex_state->lx.end;
+
+		(void) ZI251;
+		(void) ZI252;
 	
-#line 1114 "src/libre/dialect/native/parser.c"
+#line 1154 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: ESC */
 			ADVANCE_LEXER;
@@ -1129,7 +1169,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: HEX */
 			{
-#line 487 "src/libre/parser.act"
+#line 548 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -1140,6 +1180,9 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 		ZI259 = lex_state->lx.start;
 		ZI260   = lex_state->lx.end;
+
+		(void) ZI259;
+		(void) ZI260;
 
 		errno = 0;
 
@@ -1174,7 +1217,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 		ZI258 = (char) (unsigned char) u;
 	
-#line 1178 "src/libre/dialect/native/parser.c"
+#line 1221 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: HEX */
 			ADVANCE_LEXER;
@@ -1193,7 +1236,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: NAMED_CLASS */
 			{
-#line 592 "src/libre/parser.act"
+#line 661 "src/libre/parser.act"
 
 		ZI246 = DIALECT_CLASS(lex_state->buf.a);
 		if (ZI246 == NULL) {
@@ -1203,8 +1246,11 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 		ZI247 = lex_state->lx.start;
 		ZI248   = lex_state->lx.end;
+
+		(void) ZI247;
+		(void) ZI248;
 	
-#line 1208 "src/libre/dialect/native/parser.c"
+#line 1254 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			ADVANCE_LEXER;
@@ -1223,7 +1269,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: OCT */
 			{
-#line 447 "src/libre/parser.act"
+#line 505 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -1234,6 +1280,9 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 		ZI255 = lex_state->lx.start;
 		ZI256   = lex_state->lx.end;
+
+		(void) ZI255;
+		(void) ZI256;
 
 		errno = 0;
 
@@ -1263,7 +1312,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 		ZI254 = (char) (unsigned char) u;
 	
-#line 1267 "src/libre/dialect/native/parser.c"
+#line 1316 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: OCT */
 			ADVANCE_LEXER;
@@ -1304,7 +1353,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hclass(flags fl
 		case (TOK_NAMED__CLASS):
 			/* BEGINNING OF EXTRACT: NAMED_CLASS */
 			{
-#line 592 "src/libre/parser.act"
+#line 661 "src/libre/parser.act"
 
 		ZIid = DIALECT_CLASS(lex_state->buf.a);
 		if (ZIid == NULL) {
@@ -1314,8 +1363,11 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hclass(flags fl
 
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
+
+		(void) ZIstart;
+		(void) ZIend;
 	
-#line 1319 "src/libre/dialect/native/parser.c"
+#line 1371 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			break;
@@ -1325,12 +1377,12 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hclass(flags fl
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-range-endpoint-class */
 		{
-#line 806 "src/libre/parser.act"
+#line 878 "src/libre/parser.act"
 
 		(ZIr).type = AST_ENDPOINT_NAMED;
 		(ZIr).u.named.class = (ZIid);
 	
-#line 1334 "src/libre/dialect/native/parser.c"
+#line 1386 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-range-endpoint-class */
 	}
@@ -1366,25 +1418,28 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 					/* BEGINNING OF EXTRACT: OPENGROUP */
 					{
-#line 324 "src/libre/parser.act"
+#line 337 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
 		ZI168   = lex_state->lx.end;
+
+		(void) ZIstart;
+		(void) ZI168;
 	
-#line 1375 "src/libre/dialect/native/parser.c"
+#line 1430 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: OPENGROUP */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-alt */
 					{
-#line 829 "src/libre/parser.act"
+#line 901 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1388 "src/libre/dialect/native/parser.c"
+#line 1443 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: ast-make-alt */
 					ZItmp = ZInode;
@@ -1404,35 +1459,38 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 					/* BEGINNING OF EXTRACT: OPENGROUPCB */
 					{
-#line 334 "src/libre/parser.act"
+#line 353 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
 		ZI187   = lex_state->lx.end;
+
+		(void) ZIstart;
+		(void) ZI187;
 	
-#line 1413 "src/libre/dialect/native/parser.c"
+#line 1471 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: OPENGROUPCB */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-alt */
 					{
-#line 829 "src/libre/parser.act"
+#line 901 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1426 "src/libre/dialect/native/parser.c"
+#line 1484 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: ast-make-alt */
 					ZItmp = ZInode;
 					/* BEGINNING OF ACTION: make-literal-cbrak */
 					{
-#line 847 "src/libre/parser.act"
+#line 919 "src/libre/parser.act"
 
 		(ZIcbrak) = ']';
 	
-#line 1436 "src/libre/dialect/native/parser.c"
+#line 1494 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: make-literal-cbrak */
 					p_196 (flags, lex_state, act_state, err, &ZIstart, &ZIcbrak, &ZInode1);
@@ -1442,13 +1500,13 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 					}
 					/* BEGINNING OF ACTION: ast-add-alt */
 					{
-#line 1012 "src/libre/parser.act"
+#line 1084 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZItmp), (ZInode1))) {
 			goto ZL1;
 		}
 	
-#line 1452 "src/libre/dialect/native/parser.c"
+#line 1510 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: ast-add-alt */
 					p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, ZItmp);
@@ -1464,31 +1522,34 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 					/* BEGINNING OF EXTRACT: OPENGROUPINV */
 					{
-#line 329 "src/libre/parser.act"
+#line 345 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
 		ZI179   = lex_state->lx.end;
+
+		(void) ZIstart;
+		(void) ZI179;
 	
-#line 1473 "src/libre/dialect/native/parser.c"
+#line 1534 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: OPENGROUPINV */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-alt */
 					{
-#line 829 "src/libre/parser.act"
+#line 901 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1486 "src/libre/dialect/native/parser.c"
+#line 1547 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: ast-make-alt */
 					ZItmp = ZInode;
 					/* BEGINNING OF ACTION: ast-make-invert */
 					{
-#line 928 "src/libre/parser.act"
+#line 1028 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -1526,7 +1587,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			goto ZL1;
 		}
 	
-#line 1530 "src/libre/dialect/native/parser.c"
+#line 1591 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: ast-make-invert */
 					p_181 (flags, lex_state, act_state, err, &ZItmp);
@@ -1545,31 +1606,34 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 					/* BEGINNING OF EXTRACT: OPENGROUPINVCB */
 					{
-#line 339 "src/libre/parser.act"
+#line 361 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
 		ZI194   = lex_state->lx.end;
+
+		(void) ZIstart;
+		(void) ZI194;
 	
-#line 1554 "src/libre/dialect/native/parser.c"
+#line 1618 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: OPENGROUPINVCB */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-alt */
 					{
-#line 829 "src/libre/parser.act"
+#line 901 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1567 "src/libre/dialect/native/parser.c"
+#line 1631 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: ast-make-alt */
 					ZItmp = ZInode;
 					/* BEGINNING OF ACTION: ast-make-invert */
 					{
-#line 928 "src/libre/parser.act"
+#line 1028 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -1607,16 +1671,16 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			goto ZL1;
 		}
 	
-#line 1611 "src/libre/dialect/native/parser.c"
+#line 1675 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: ast-make-invert */
 					/* BEGINNING OF ACTION: make-literal-cbrak */
 					{
-#line 847 "src/libre/parser.act"
+#line 919 "src/libre/parser.act"
 
 		(ZIcbrak) = ']';
 	
-#line 1620 "src/libre/dialect/native/parser.c"
+#line 1684 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: make-literal-cbrak */
 					p_196 (flags, lex_state, act_state, err, &ZIstart, &ZIcbrak, &ZInode1);
@@ -1626,13 +1690,13 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 					}
 					/* BEGINNING OF ACTION: ast-add-alt */
 					{
-#line 1012 "src/libre/parser.act"
+#line 1084 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZItmp), (ZInode1))) {
 			goto ZL1;
 		}
 	
-#line 1636 "src/libre/dialect/native/parser.c"
+#line 1700 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: ast-add-alt */
 					p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, ZItmp);
@@ -1657,24 +1721,28 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 					/* BEGINNING OF EXTRACT: CLOSEGROUP */
 					{
-#line 344 "src/libre/parser.act"
+#line 369 "src/libre/parser.act"
 
 		ZI201 = ']';
 		ZI202 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
+
+		(void) ZI201;
+		(void) ZI202;
+		(void) ZIend;
 	
-#line 1667 "src/libre/dialect/native/parser.c"
+#line 1735 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: CLOSEGROUP */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: mark-group */
 					{
-#line 709 "src/libre/parser.act"
+#line 781 "src/libre/parser.act"
 
 		mark(&act_state->groupstart, &(ZIstart));
 		mark(&act_state->groupend,   &(ZIend));
 	
-#line 1678 "src/libre/dialect/native/parser.c"
+#line 1746 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: mark-group */
 				}
@@ -1687,47 +1755,51 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 					/* BEGINNING OF EXTRACT: CLOSEGROUPRANGE */
 					{
-#line 350 "src/libre/parser.act"
+#line 379 "src/libre/parser.act"
 
 		ZIcrange = '-';
 		ZI204 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
+
+		(void) ZIcrange;
+		(void) ZI204;
+		(void) ZIend;
 	
-#line 1697 "src/libre/dialect/native/parser.c"
+#line 1769 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: CLOSEGROUPRANGE */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-literal */
 					{
-#line 836 "src/libre/parser.act"
+#line 908 "src/libre/parser.act"
 
 		(ZIrange) = ast_make_expr_literal(act_state->poolp, *flags, (ZIcrange));
 		if ((ZIrange) == NULL) {
 			goto ZL4;
 		}
 	
-#line 1710 "src/libre/dialect/native/parser.c"
+#line 1782 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: ast-make-literal */
 					/* BEGINNING OF ACTION: ast-add-alt */
 					{
-#line 1012 "src/libre/parser.act"
+#line 1084 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZItmp), (ZIrange))) {
 			goto ZL4;
 		}
 	
-#line 1721 "src/libre/dialect/native/parser.c"
+#line 1793 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: ast-add-alt */
 					/* BEGINNING OF ACTION: mark-group */
 					{
-#line 709 "src/libre/parser.act"
+#line 781 "src/libre/parser.act"
 
 		mark(&act_state->groupstart, &(ZIstart));
 		mark(&act_state->groupend,   &(ZIend));
 	
-#line 1731 "src/libre/dialect/native/parser.c"
+#line 1803 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: mark-group */
 				}
@@ -1740,14 +1812,14 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			{
 				/* BEGINNING OF ACTION: err-expected-closegroup */
 				{
-#line 667 "src/libre/parser.act"
+#line 742 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCLOSEGROUP;
 		}
 		goto ZL1;
 	
-#line 1751 "src/libre/dialect/native/parser.c"
+#line 1823 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF ACTION: err-expected-closegroup */
 				ZIend = ZIstart;
@@ -1757,7 +1829,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		/* END OF INLINE: 200 */
 		/* BEGINNING OF ACTION: mark-expr */
 		{
-#line 724 "src/libre/parser.act"
+#line 798 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -1772,7 +1844,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		(ZItmp)->u.class.end   = ast_end;
 */
 	
-#line 1776 "src/libre/dialect/native/parser.c"
+#line 1848 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: mark-expr */
 	}
@@ -1804,24 +1876,28 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_Hend(flags flags, lex_state lex_st
 
 					/* BEGINNING OF EXTRACT: RANGE */
 					{
-#line 318 "src/libre/parser.act"
+#line 327 "src/libre/parser.act"
 
 		ZIc = '-';
 		ZI150 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
+
+		(void) ZIc;
+		(void) ZI150;
+		(void) ZIend;
 	
-#line 1814 "src/libre/dialect/native/parser.c"
+#line 1890 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF EXTRACT: RANGE */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 					{
-#line 801 "src/libre/parser.act"
+#line 873 "src/libre/parser.act"
 
 		(ZIr).type = AST_ENDPOINT_LITERAL;
 		(ZIr).u.literal.c = (unsigned char)(ZIc);
 	
-#line 1825 "src/libre/dialect/native/parser.c"
+#line 1901 "src/libre/dialect/native/parser.c"
 					}
 					/* END OF ACTION: ast-range-endpoint-literal */
 				}
@@ -1866,13 +1942,17 @@ p_181(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 318 "src/libre/parser.act"
+#line 327 "src/libre/parser.act"
 
 		ZIc = '-';
 		ZIrstart = lex_state->lx.start;
 		ZI182   = lex_state->lx.end;
+
+		(void) ZIc;
+		(void) ZIrstart;
+		(void) ZI182;
 	
-#line 1876 "src/libre/dialect/native/parser.c"
+#line 1956 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
@@ -1883,14 +1963,14 @@ p_181(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 					{
 						/* BEGINNING OF ACTION: ast-make-literal */
 						{
-#line 836 "src/libre/parser.act"
+#line 908 "src/libre/parser.act"
 
 		(ZInode1) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZInode1) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1894 "src/libre/dialect/native/parser.c"
+#line 1974 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF ACTION: ast-make-literal */
 					}
@@ -1906,23 +1986,27 @@ p_181(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 
 						/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 						{
-#line 801 "src/libre/parser.act"
+#line 873 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_LITERAL;
 		(ZIlower).u.literal.c = (unsigned char)(ZIc);
 	
-#line 1915 "src/libre/dialect/native/parser.c"
+#line 1995 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF ACTION: ast-range-endpoint-literal */
 						/* BEGINNING OF EXTRACT: RANGE */
 						{
-#line 318 "src/libre/parser.act"
+#line 327 "src/libre/parser.act"
 
 		ZI184 = '-';
 		ZI185 = lex_state->lx.start;
 		ZI186   = lex_state->lx.end;
+
+		(void) ZI184;
+		(void) ZI185;
+		(void) ZI186;
 	
-#line 1926 "src/libre/dialect/native/parser.c"
+#line 2010 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF EXTRACT: RANGE */
 						ADVANCE_LEXER;
@@ -1933,7 +2017,7 @@ p_181(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 						}
 						/* BEGINNING OF ACTION: ast-make-range */
 						{
-#line 966 "src/libre/parser.act"
+#line 1041 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -1966,7 +2050,7 @@ p_181(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			goto ZL1;
 		}
 	
-#line 1970 "src/libre/dialect/native/parser.c"
+#line 2054 "src/libre/dialect/native/parser.c"
 						}
 						/* END OF ACTION: ast-make-range */
 					}
@@ -1976,13 +2060,13 @@ p_181(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			/* END OF INLINE: 183 */
 			/* BEGINNING OF ACTION: ast-add-alt */
 			{
-#line 1012 "src/libre/parser.act"
+#line 1084 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((*ZItmp), (ZInode1))) {
 			goto ZL1;
 		}
 	
-#line 1986 "src/libre/dialect/native/parser.c"
+#line 2070 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 		}
@@ -2018,7 +2102,7 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 		}
 		/* BEGINNING OF ACTION: ast-make-piece */
 		{
-#line 859 "src/libre/parser.act"
+#line 931 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
@@ -2032,7 +2116,7 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 			goto ZL1;
 		}
 	
-#line 2036 "src/libre/dialect/native/parser.c"
+#line 2120 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-make-piece */
 	}
@@ -2056,14 +2140,14 @@ p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__ex
 		{
 			/* BEGINNING OF ACTION: ast-make-alt */
 			{
-#line 829 "src/libre/parser.act"
+#line 901 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2067 "src/libre/dialect/native/parser.c"
+#line 2151 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-alt */
 			p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, ZInode);
@@ -2077,14 +2161,14 @@ p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__ex
 		{
 			/* BEGINNING OF ACTION: ast-make-empty */
 			{
-#line 815 "src/libre/parser.act"
+#line 887 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2088 "src/libre/dialect/native/parser.c"
+#line 2172 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-empty */
 		}
@@ -2097,26 +2181,26 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-alts */
 		{
-#line 653 "src/libre/parser.act"
+#line 728 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXALTS;
 		}
 		goto ZL2;
 	
-#line 2108 "src/libre/dialect/native/parser.c"
+#line 2192 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 815 "src/libre/parser.act"
+#line 887 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL2;
 		}
 	
-#line 2120 "src/libre/dialect/native/parser.c"
+#line 2204 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -2164,14 +2248,14 @@ p_re__native(flags flags, lex_state lex_state, act_state act_state, err err, t_a
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 695 "src/libre/parser.act"
+#line 770 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
 		}
 		goto ZL1;
 	
-#line 2175 "src/libre/dialect/native/parser.c"
+#line 2259 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
@@ -2197,14 +2281,14 @@ p_196(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 		{
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 836 "src/libre/parser.act"
+#line 908 "src/libre/parser.act"
 
 		(ZInode1) = ast_make_expr_literal(act_state->poolp, *flags, (*ZIcbrak));
 		if ((ZInode1) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2208 "src/libre/dialect/native/parser.c"
+#line 2292 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -2221,23 +2305,27 @@ p_196(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 801 "src/libre/parser.act"
+#line 873 "src/libre/parser.act"
 
 		(ZIr).type = AST_ENDPOINT_LITERAL;
 		(ZIr).u.literal.c = (unsigned char)(*ZIcbrak);
 	
-#line 2230 "src/libre/dialect/native/parser.c"
+#line 2314 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 318 "src/libre/parser.act"
+#line 327 "src/libre/parser.act"
 
 		ZI197 = '-';
 		ZI198 = lex_state->lx.start;
 		ZI199   = lex_state->lx.end;
+
+		(void) ZI197;
+		(void) ZI198;
+		(void) ZI199;
 	
-#line 2241 "src/libre/dialect/native/parser.c"
+#line 2329 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
@@ -2248,17 +2336,17 @@ p_196(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 			}
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 801 "src/libre/parser.act"
+#line 873 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_LITERAL;
 		(ZIlower).u.literal.c = (unsigned char)(*ZIcbrak);
 	
-#line 2257 "src/libre/dialect/native/parser.c"
+#line 2345 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 966 "src/libre/parser.act"
+#line 1041 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -2291,7 +2379,7 @@ p_196(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 			goto ZL1;
 		}
 	
-#line 2295 "src/libre/dialect/native/parser.c"
+#line 2383 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -2372,13 +2460,13 @@ ZL2_expr_C_Clist_Hof_Halts:;
 		}
 		/* BEGINNING OF ACTION: ast-add-alt */
 		{
-#line 1012 "src/libre/parser.act"
+#line 1084 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIalts), (ZIa))) {
 			goto ZL1;
 		}
 	
-#line 2382 "src/libre/dialect/native/parser.c"
+#line 2470 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-add-alt */
 		/* BEGINNING OF INLINE: 231 */
@@ -2391,7 +2479,7 @@ ZL2_expr_C_Clist_Hof_Halts:;
 					goto ZL2_expr_C_Clist_Hof_Halts;
 					/* END OF INLINE: expr::list-of-alts */
 				}
-				/* UNREACHED */
+				/*UNREACHED*/
 			default:
 				break;
 			}
@@ -2403,14 +2491,14 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-alts */
 		{
-#line 653 "src/libre/parser.act"
+#line 728 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXALTS;
 		}
 		goto ZL4;
 	
-#line 2414 "src/libre/dialect/native/parser.c"
+#line 2502 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
 	}
@@ -2435,12 +2523,15 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 			/* BEGINNING OF EXTRACT: OPENCOUNT */
 			{
-#line 356 "src/libre/parser.act"
+#line 389 "src/libre/parser.act"
 
 		ZI266 = lex_state->lx.start;
 		ZI267   = lex_state->lx.end;
+
+		(void) ZI266;
+		(void) ZI267;
 	
-#line 2444 "src/libre/dialect/native/parser.c"
+#line 2535 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: OPENCOUNT */
 			ADVANCE_LEXER;
@@ -2448,7 +2539,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			case (TOK_COUNT):
 				/* BEGINNING OF EXTRACT: COUNT */
 				{
-#line 572 "src/libre/parser.act"
+#line 649 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -2468,7 +2559,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		ZIm = (unsigned int) u;
 	
-#line 2472 "src/libre/dialect/native/parser.c"
+#line 2563 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -2488,11 +2579,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-zero-or-one */
 			{
-#line 773 "src/libre/parser.act"
+#line 845 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, 1, NULL);
 	
-#line 2496 "src/libre/dialect/native/parser.c"
+#line 2587 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-one */
 		}
@@ -2502,11 +2593,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-one-or-more */
 			{
-#line 769 "src/libre/parser.act"
+#line 841 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 2510 "src/libre/dialect/native/parser.c"
+#line 2601 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: count-one-or-more */
 		}
@@ -2516,11 +2607,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-zero-or-more */
 			{
-#line 765 "src/libre/parser.act"
+#line 837 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 2524 "src/libre/dialect/native/parser.c"
+#line 2615 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 		}
@@ -2529,11 +2620,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 		{
 			/* BEGINNING OF ACTION: count-one */
 			{
-#line 777 "src/libre/parser.act"
+#line 849 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 2537 "src/libre/dialect/native/parser.c"
+#line 2628 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: count-one */
 		}
@@ -2546,23 +2637,23 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-count */
 		{
-#line 639 "src/libre/parser.act"
+#line 714 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCOUNT;
 		}
 		goto ZL2;
 	
-#line 2557 "src/libre/dialect/native/parser.c"
+#line 2648 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: err-expected-count */
 		/* BEGINNING OF ACTION: count-one */
 		{
-#line 777 "src/libre/parser.act"
+#line 849 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 2566 "src/libre/dialect/native/parser.c"
+#line 2657 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: count-one */
 	}
@@ -2587,24 +2678,24 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: class-any */
 			{
-#line 739 "src/libre/parser.act"
+#line 812 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
 		(ZIa) = (*flags & RE_SINGLE) ? &class_any : &class_notnl;
 	
-#line 2596 "src/libre/dialect/native/parser.c"
+#line 2687 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 999 "src/libre/parser.act"
+#line 1071 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_named(act_state->poolp, *flags, (ZIa));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2608 "src/libre/dialect/native/parser.c"
+#line 2699 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 		}
@@ -2614,14 +2705,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-anchor-end */
 			{
-#line 904 "src/libre/parser.act"
+#line 976 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_anchor(act_state->poolp, *flags, AST_ANCHOR_END);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2625 "src/libre/dialect/native/parser.c"
+#line 2716 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-end */
 		}
@@ -2634,11 +2725,11 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-id */
 			{
-#line 843 "src/libre/parser.act"
+#line 915 "src/libre/parser.act"
 
 		(ZIid) = act_state->group_id++;
 	
-#line 2642 "src/libre/dialect/native/parser.c"
+#line 2733 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: make-group-id */
 			p_expr (flags, lex_state, act_state, err, &ZIg);
@@ -2648,14 +2739,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			}
 			/* BEGINNING OF ACTION: ast-make-group */
 			{
-#line 873 "src/libre/parser.act"
+#line 945 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_group(act_state->poolp, *flags, (ZIg), (ZIid));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2659 "src/libre/dialect/native/parser.c"
+#line 2750 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-group */
 			switch (CURRENT_TERMINAL) {
@@ -2672,14 +2763,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-anchor-start */
 			{
-#line 897 "src/libre/parser.act"
+#line 969 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_anchor(act_state->poolp, *flags, AST_ANCHOR_START);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2683 "src/libre/dialect/native/parser.c"
+#line 2774 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-start */
 		}
@@ -2712,26 +2803,26 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-atom */
 		{
-#line 646 "src/libre/parser.act"
+#line 721 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXATOM;
 		}
 		goto ZL2;
 	
-#line 2723 "src/libre/dialect/native/parser.c"
+#line 2814 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 815 "src/libre/parser.act"
+#line 887 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZIe) == NULL) {
 			goto ZL2;
 		}
 	
-#line 2735 "src/libre/dialect/native/parser.c"
+#line 2826 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -2753,14 +2844,14 @@ p_249(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 		{
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 999 "src/libre/parser.act"
+#line 1071 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_named(act_state->poolp, *flags, (*ZI246));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2764 "src/libre/dialect/native/parser.c"
+#line 2855 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 		}
@@ -2773,12 +2864,12 @@ p_249(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-class */
 			{
-#line 806 "src/libre/parser.act"
+#line 878 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_NAMED;
 		(ZIlower).u.named.class = (*ZI246);
 	
-#line 2782 "src/libre/dialect/native/parser.c"
+#line 2873 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-class */
 			p_155 (flags, lex_state, act_state, err);
@@ -2789,17 +2880,17 @@ p_249(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 			}
 			/* BEGINNING OF ACTION: mark-range */
 			{
-#line 714 "src/libre/parser.act"
+#line 786 "src/libre/parser.act"
 
 		mark(&act_state->rangestart, &(*ZI247));
 		mark(&act_state->rangeend,   &(ZIend));
 	
-#line 2798 "src/libre/dialect/native/parser.c"
+#line 2889 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 966 "src/libre/parser.act"
+#line 1041 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -2832,7 +2923,7 @@ p_249(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 			goto ZL1;
 		}
 	
-#line 2836 "src/libre/dialect/native/parser.c"
+#line 2927 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -2859,14 +2950,14 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 	{
 		/* BEGINNING OF ACTION: ast-make-concat */
 		{
-#line 822 "src/libre/parser.act"
+#line 894 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_concat(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2870 "src/libre/dialect/native/parser.c"
+#line 2961 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-make-concat */
 		p_expr_C_Clist_Hof_Hpieces (flags, lex_state, act_state, err, ZInode);
@@ -2893,14 +2984,14 @@ p_253(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		{
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 836 "src/libre/parser.act"
+#line 908 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (*ZI250));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2904 "src/libre/dialect/native/parser.c"
+#line 2995 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -2913,12 +3004,12 @@ p_253(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 801 "src/libre/parser.act"
+#line 873 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_LITERAL;
 		(ZIlower).u.literal.c = (unsigned char)(*ZI250);
 	
-#line 2922 "src/libre/dialect/native/parser.c"
+#line 3013 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			p_155 (flags, lex_state, act_state, err);
@@ -2929,17 +3020,17 @@ p_253(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			}
 			/* BEGINNING OF ACTION: mark-range */
 			{
-#line 714 "src/libre/parser.act"
+#line 786 "src/libre/parser.act"
 
 		mark(&act_state->rangestart, &(*ZI251));
 		mark(&act_state->rangeend,   &(ZIend));
 	
-#line 2938 "src/libre/dialect/native/parser.c"
+#line 3029 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 966 "src/libre/parser.act"
+#line 1041 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -2972,7 +3063,7 @@ p_253(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			goto ZL1;
 		}
 	
-#line 2976 "src/libre/dialect/native/parser.c"
+#line 3067 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -2990,7 +3081,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 1018 "src/libre/parser.act"
+#line 1247 "src/libre/parser.act"
 
 
 	static int
@@ -3149,6 +3240,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 3153 "src/libre/dialect/native/parser.c"
+#line 3244 "src/libre/dialect/native/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/native/parser.h
+++ b/src/libre/dialect/native/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 299 "src/libre/parser.act"
+#line 310 "src/libre/parser.act"
 
 
 	#include <re/re.h>
@@ -28,7 +28,7 @@
 extern void p_re__native(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 1176 "src/libre/parser.act"
+#line 1249 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/native/parser.h"

--- a/src/libre/dialect/pcre/parser.c
+++ b/src/libre/dialect/pcre/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 22 "src/libre/parser.act"
+#line 149 "src/libre/parser.act"
 
 
 	#include <assert.h>
@@ -238,7 +238,7 @@
 
 		n = sprintf(s, "%.*s", (int) sz - 3 - 1, msg);
 		if (n == sz - 3 - 1) {
-			strcpy(s + sz, "...");
+			strcpy(s + n, "...");
 		}
 	}
 
@@ -343,7 +343,7 @@ p_expr_C_Cflags_C_Cflag__set(flags flags, lex_state lex_state, act_state act_sta
 
 			/* BEGINNING OF EXTRACT: FLAG_EXTENDED */
 			{
-#line 607 "src/libre/parser.act"
+#line 679 "src/libre/parser.act"
 
 		ZIc = RE_EXTENDED;
 	
@@ -353,7 +353,7 @@ p_expr_C_Cflags_C_Cflag__set(flags flags, lex_state lex_state, act_state act_sta
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: re-flag-union */
 			{
-#line 757 "src/libre/parser.act"
+#line 829 "src/libre/parser.act"
 
 		(ZIo) = (ZIi) | (ZIc);
 	
@@ -374,7 +374,7 @@ p_expr_C_Cflags_C_Cflag__set(flags flags, lex_state lex_state, act_state act_sta
 
 			/* BEGINNING OF EXTRACT: FLAG_INSENSITIVE */
 			{
-#line 603 "src/libre/parser.act"
+#line 675 "src/libre/parser.act"
 
 		ZIc = RE_ICASE;
 	
@@ -384,7 +384,7 @@ p_expr_C_Cflags_C_Cflag__set(flags flags, lex_state lex_state, act_state act_sta
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: re-flag-union */
 			{
-#line 757 "src/libre/parser.act"
+#line 829 "src/libre/parser.act"
 
 		(ZIo) = (ZIi) | (ZIc);
 	
@@ -399,7 +399,7 @@ p_expr_C_Cflags_C_Cflag__set(flags flags, lex_state lex_state, act_state act_sta
 
 			/* BEGINNING OF EXTRACT: FLAG_SINGLE */
 			{
-#line 611 "src/libre/parser.act"
+#line 683 "src/libre/parser.act"
 
 		ZIc = RE_SINGLE;
 	
@@ -409,7 +409,7 @@ p_expr_C_Cflags_C_Cflag__set(flags flags, lex_state lex_state, act_state act_sta
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: re-flag-union */
 			{
-#line 757 "src/libre/parser.act"
+#line 829 "src/libre/parser.act"
 
 		(ZIo) = (ZIi) | (ZIc);
 	
@@ -424,7 +424,7 @@ p_expr_C_Cflags_C_Cflag__set(flags flags, lex_state lex_state, act_state act_sta
 			ZIo = ZIi;
 			/* BEGINNING OF ACTION: err-unknown-flag */
 			{
-#line 681 "src/libre/parser.act"
+#line 756 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EFLAG;
@@ -469,7 +469,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 				{
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
-#line 532 "src/libre/parser.act"
+#line 592 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -477,9 +477,12 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 
+		(void) ZIstart;
+		(void) ZIend;
+
 		ZIc = lex_state->buf.a[0];
 	
-#line 483 "src/libre/dialect/pcre/parser.c"
+#line 486 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CHAR */
 					ADVANCE_LEXER;
@@ -489,7 +492,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 				{
 					/* BEGINNING OF EXTRACT: CONTROL */
 					{
-#line 413 "src/libre/parser.act"
+#line 466 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] == 'c');
@@ -522,21 +525,24 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
+
+		(void) ZIstart;
+		(void) ZIend;
 	
-#line 527 "src/libre/dialect/pcre/parser.c"
+#line 533 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CONTROL */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: err-unsupported */
 					{
-#line 702 "src/libre/parser.act"
+#line 777 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EUNSUPPORTED;
 		}
 		goto ZL1;
 	
-#line 540 "src/libre/dialect/pcre/parser.c"
+#line 546 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: err-unsupported */
 				}
@@ -545,7 +551,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 				{
 					/* BEGINNING OF EXTRACT: ESC */
 					{
-#line 366 "src/libre/parser.act"
+#line 409 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -567,8 +573,11 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
+
+		(void) ZIstart;
+		(void) ZIend;
 	
-#line 572 "src/libre/dialect/pcre/parser.c"
+#line 581 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: ESC */
 					ADVANCE_LEXER;
@@ -578,7 +587,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 				{
 					/* BEGINNING OF EXTRACT: HEX */
 					{
-#line 487 "src/libre/parser.act"
+#line 548 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -589,6 +598,9 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
+
+		(void) ZIstart;
+		(void) ZIend;
 
 		errno = 0;
 
@@ -623,7 +635,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 627 "src/libre/dialect/pcre/parser.c"
+#line 639 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: HEX */
 					ADVANCE_LEXER;
@@ -633,7 +645,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 				{
 					/* BEGINNING OF EXTRACT: OCT */
 					{
-#line 447 "src/libre/parser.act"
+#line 505 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -644,6 +656,9 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
+
+		(void) ZIstart;
+		(void) ZIend;
 
 		errno = 0;
 
@@ -673,7 +688,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 677 "src/libre/dialect/pcre/parser.c"
+#line 692 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OCT */
 					ADVANCE_LEXER;
@@ -683,7 +698,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 				{
 					/* BEGINNING OF EXTRACT: UNSUPPORTED */
 					{
-#line 400 "src/libre/parser.act"
+#line 447 "src/libre/parser.act"
 
 		/* handle \1-\9 back references */
 		if (lex_state->buf.a[0] == '\\' && lex_state->buf.a[1] != '\0' && lex_state->buf.a[2] == '\0') {
@@ -695,21 +710,24 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
+
+		(void) ZIstart;
+		(void) ZIend;
 	
-#line 700 "src/libre/dialect/pcre/parser.c"
+#line 718 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: UNSUPPORTED */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: err-unsupported */
 					{
-#line 702 "src/libre/parser.act"
+#line 777 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EUNSUPPORTED;
 		}
 		goto ZL1;
 	
-#line 713 "src/libre/dialect/pcre/parser.c"
+#line 731 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: err-unsupported */
 				}
@@ -721,12 +739,12 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags 
 		/* END OF INLINE: 156 */
 		/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 		{
-#line 801 "src/libre/parser.act"
+#line 873 "src/libre/parser.act"
 
 		(ZIr).type = AST_ENDPOINT_LITERAL;
 		(ZIr).u.literal.c = (unsigned char)(ZIc);
 	
-#line 730 "src/libre/dialect/pcre/parser.c"
+#line 748 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-range-endpoint-literal */
 	}
@@ -757,20 +775,20 @@ ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 			}
 			/* BEGINNING OF ACTION: ast-add-alt */
 			{
-#line 1012 "src/libre/parser.act"
+#line 1084 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIclass), (ZInode))) {
 			goto ZL1;
 		}
 	
-#line 767 "src/libre/dialect/pcre/parser.c"
+#line 785 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 			/* BEGINNING OF INLINE: expr::character-class::list-of-class-terms */
 			goto ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms;
 			/* END OF INLINE: expr::character-class::list-of-class-terms */
 		}
-		/* UNREACHED */
+		/*UNREACHED*/
 	case (ERROR_TERMINAL):
 		return;
 	default:
@@ -817,13 +835,13 @@ ZL2_expr_C_Clist_Hof_Hpieces:;
 					}
 					/* BEGINNING OF ACTION: ast-add-concat */
 					{
-#line 1006 "src/libre/parser.act"
+#line 1078 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
 		}
 	
-#line 827 "src/libre/dialect/pcre/parser.c"
+#line 845 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-add-concat */
 				}
@@ -846,7 +864,7 @@ ZL2_expr_C_Clist_Hof_Hpieces:;
 					goto ZL2_expr_C_Clist_Hof_Hpieces;
 					/* END OF INLINE: expr::list-of-pieces */
 				}
-				/* UNREACHED */
+				/*UNREACHED*/
 			default:
 				break;
 			}
@@ -869,14 +887,14 @@ p_296(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 		{
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 999 "src/libre/parser.act"
+#line 1071 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_named(act_state->poolp, *flags, (*ZI293));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 880 "src/libre/dialect/pcre/parser.c"
+#line 898 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 		}
@@ -889,12 +907,12 @@ p_296(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-class */
 			{
-#line 806 "src/libre/parser.act"
+#line 878 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_NAMED;
 		(ZIlower).u.named.class = (*ZI293);
 	
-#line 898 "src/libre/dialect/pcre/parser.c"
+#line 916 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-class */
 			p_169 (flags, lex_state, act_state, err);
@@ -905,17 +923,17 @@ p_296(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 			}
 			/* BEGINNING OF ACTION: mark-range */
 			{
-#line 714 "src/libre/parser.act"
+#line 786 "src/libre/parser.act"
 
 		mark(&act_state->rangestart, &(*ZI294));
 		mark(&act_state->rangeend,   &(ZIend));
 	
-#line 914 "src/libre/dialect/pcre/parser.c"
+#line 932 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 966 "src/libre/parser.act"
+#line 1041 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -948,7 +966,7 @@ p_296(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 			goto ZL1;
 		}
 	
-#line 952 "src/libre/dialect/pcre/parser.c"
+#line 970 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -979,13 +997,17 @@ p_169(flags flags, lex_state lex_state, act_state act_state, err err)
 		case (TOK_RANGE):
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 318 "src/libre/parser.act"
+#line 327 "src/libre/parser.act"
 
 		ZI170 = '-';
 		ZI171 = lex_state->lx.start;
 		ZI172   = lex_state->lx.end;
+
+		(void) ZI170;
+		(void) ZI171;
+		(void) ZI172;
 	
-#line 989 "src/libre/dialect/pcre/parser.c"
+#line 1011 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			break;
@@ -999,14 +1021,14 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-range */
 		{
-#line 660 "src/libre/parser.act"
+#line 735 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXRANGE;
 		}
 		goto ZL2;
 	
-#line 1010 "src/libre/dialect/pcre/parser.c"
+#line 1032 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-expected-range */
 	}
@@ -1038,7 +1060,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 					/* BEGINNING OF EXTRACT: CHAR */
 					{
-#line 532 "src/libre/parser.act"
+#line 592 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -1046,9 +1068,12 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		ZI122 = lex_state->lx.start;
 		ZI123   = lex_state->lx.end;
 
+		(void) ZI122;
+		(void) ZI123;
+
 		ZIc = lex_state->buf.a[0];
 	
-#line 1052 "src/libre/dialect/pcre/parser.c"
+#line 1077 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CHAR */
 					ADVANCE_LEXER;
@@ -1061,7 +1086,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 					/* BEGINNING OF EXTRACT: CONTROL */
 					{
-#line 413 "src/libre/parser.act"
+#line 466 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] == 'c');
@@ -1094,8 +1119,11 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZI124 = lex_state->lx.start;
 		ZI125   = lex_state->lx.end;
+
+		(void) ZI124;
+		(void) ZI125;
 	
-#line 1099 "src/libre/dialect/pcre/parser.c"
+#line 1127 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CONTROL */
 					ADVANCE_LEXER;
@@ -1108,7 +1136,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 					/* BEGINNING OF EXTRACT: ESC */
 					{
-#line 366 "src/libre/parser.act"
+#line 409 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -1130,8 +1158,11 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZI114 = lex_state->lx.start;
 		ZI115   = lex_state->lx.end;
+
+		(void) ZI114;
+		(void) ZI115;
 	
-#line 1135 "src/libre/dialect/pcre/parser.c"
+#line 1166 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: ESC */
 					ADVANCE_LEXER;
@@ -1144,7 +1175,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 					/* BEGINNING OF EXTRACT: HEX */
 					{
-#line 487 "src/libre/parser.act"
+#line 548 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -1155,6 +1186,9 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZI120 = lex_state->lx.start;
 		ZI121   = lex_state->lx.end;
+
+		(void) ZI120;
+		(void) ZI121;
 
 		errno = 0;
 
@@ -1189,7 +1223,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 1193 "src/libre/dialect/pcre/parser.c"
+#line 1227 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: HEX */
 					ADVANCE_LEXER;
@@ -1202,7 +1236,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 					/* BEGINNING OF EXTRACT: NOESC */
 					{
-#line 389 "src/libre/parser.act"
+#line 435 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -1212,8 +1246,11 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZI116 = lex_state->lx.start;
 		ZI117   = lex_state->lx.end;
+
+		(void) ZI116;
+		(void) ZI117;
 	
-#line 1217 "src/libre/dialect/pcre/parser.c"
+#line 1254 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: NOESC */
 					ADVANCE_LEXER;
@@ -1226,7 +1263,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 					/* BEGINNING OF EXTRACT: OCT */
 					{
-#line 447 "src/libre/parser.act"
+#line 505 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -1237,6 +1274,9 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZI118 = lex_state->lx.start;
 		ZI119   = lex_state->lx.end;
+
+		(void) ZI118;
+		(void) ZI119;
 
 		errno = 0;
 
@@ -1266,7 +1306,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZIc = (char) (unsigned char) u;
 	
-#line 1270 "src/libre/dialect/pcre/parser.c"
+#line 1310 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OCT */
 					ADVANCE_LEXER;
@@ -1279,7 +1319,7 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 					/* BEGINNING OF EXTRACT: UNSUPPORTED */
 					{
-#line 400 "src/libre/parser.act"
+#line 447 "src/libre/parser.act"
 
 		/* handle \1-\9 back references */
 		if (lex_state->buf.a[0] == '\\' && lex_state->buf.a[1] != '\0' && lex_state->buf.a[2] == '\0') {
@@ -1291,21 +1331,24 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 
 		ZI126 = lex_state->lx.start;
 		ZI127   = lex_state->lx.end;
+
+		(void) ZI126;
+		(void) ZI127;
 	
-#line 1296 "src/libre/dialect/pcre/parser.c"
+#line 1339 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: UNSUPPORTED */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: err-unsupported */
 					{
-#line 702 "src/libre/parser.act"
+#line 777 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EUNSUPPORTED;
 		}
 		goto ZL1;
 	
-#line 1309 "src/libre/dialect/pcre/parser.c"
+#line 1352 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: err-unsupported */
 				}
@@ -1317,14 +1360,14 @@ p_expr_C_Cliteral(flags flags, lex_state lex_state, act_state act_state, err err
 		/* END OF INLINE: 112 */
 		/* BEGINNING OF ACTION: ast-make-literal */
 		{
-#line 836 "src/libre/parser.act"
+#line 908 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1328 "src/libre/dialect/pcre/parser.c"
+#line 1371 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-literal */
 	}
@@ -1350,7 +1393,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
-#line 532 "src/libre/parser.act"
+#line 592 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -1358,9 +1401,12 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		ZI310 = lex_state->lx.start;
 		ZI311   = lex_state->lx.end;
 
+		(void) ZI310;
+		(void) ZI311;
+
 		ZI309 = lex_state->buf.a[0];
 	
-#line 1364 "src/libre/dialect/pcre/parser.c"
+#line 1410 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
@@ -1379,7 +1425,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: CONTROL */
 			{
-#line 413 "src/libre/parser.act"
+#line 466 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] == 'c');
@@ -1412,21 +1458,24 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 		ZI314 = lex_state->lx.start;
 		ZI315   = lex_state->lx.end;
+
+		(void) ZI314;
+		(void) ZI315;
 	
-#line 1417 "src/libre/dialect/pcre/parser.c"
+#line 1466 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: CONTROL */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: err-unsupported */
 			{
-#line 702 "src/libre/parser.act"
+#line 777 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EUNSUPPORTED;
 		}
 		goto ZL1;
 	
-#line 1430 "src/libre/dialect/pcre/parser.c"
+#line 1479 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: err-unsupported */
 			p_320 (flags, lex_state, act_state, err, &ZI313, &ZI314, &ZInode);
@@ -1444,7 +1493,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: ESC */
 			{
-#line 366 "src/libre/parser.act"
+#line 409 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -1466,8 +1515,11 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 		ZI298 = lex_state->lx.start;
 		ZI299   = lex_state->lx.end;
+
+		(void) ZI298;
+		(void) ZI299;
 	
-#line 1471 "src/libre/dialect/pcre/parser.c"
+#line 1523 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: ESC */
 			ADVANCE_LEXER;
@@ -1486,7 +1538,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: HEX */
 			{
-#line 487 "src/libre/parser.act"
+#line 548 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -1497,6 +1549,9 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 		ZI306 = lex_state->lx.start;
 		ZI307   = lex_state->lx.end;
+
+		(void) ZI306;
+		(void) ZI307;
 
 		errno = 0;
 
@@ -1531,7 +1586,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 		ZI305 = (char) (unsigned char) u;
 	
-#line 1535 "src/libre/dialect/pcre/parser.c"
+#line 1590 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: HEX */
 			ADVANCE_LEXER;
@@ -1550,7 +1605,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: NAMED_CLASS */
 			{
-#line 592 "src/libre/parser.act"
+#line 661 "src/libre/parser.act"
 
 		ZI293 = DIALECT_CLASS(lex_state->buf.a);
 		if (ZI293 == NULL) {
@@ -1560,8 +1615,11 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 		ZI294 = lex_state->lx.start;
 		ZI295   = lex_state->lx.end;
+
+		(void) ZI294;
+		(void) ZI295;
 	
-#line 1565 "src/libre/dialect/pcre/parser.c"
+#line 1623 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			ADVANCE_LEXER;
@@ -1580,7 +1638,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: NOESC */
 			{
-#line 389 "src/libre/parser.act"
+#line 435 "src/libre/parser.act"
 
 		assert(lex_state->buf.a[0] == '\\');
 		assert(lex_state->buf.a[1] != '\0');
@@ -1590,21 +1648,24 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 		ZI135 = lex_state->lx.start;
 		ZI136   = lex_state->lx.end;
+
+		(void) ZI135;
+		(void) ZI136;
 	
-#line 1595 "src/libre/dialect/pcre/parser.c"
+#line 1656 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: NOESC */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 836 "src/libre/parser.act"
+#line 908 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1608 "src/libre/dialect/pcre/parser.c"
+#line 1669 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -1617,7 +1678,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: OCT */
 			{
-#line 447 "src/libre/parser.act"
+#line 505 "src/libre/parser.act"
 
 		unsigned long u;
 		char *s, *e;
@@ -1628,6 +1689,9 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 		ZI302 = lex_state->lx.start;
 		ZI303   = lex_state->lx.end;
+
+		(void) ZI302;
+		(void) ZI303;
 
 		errno = 0;
 
@@ -1657,7 +1721,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 		ZI301 = (char) (unsigned char) u;
 	
-#line 1661 "src/libre/dialect/pcre/parser.c"
+#line 1725 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: OCT */
 			ADVANCE_LEXER;
@@ -1676,7 +1740,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: UNSUPPORTED */
 			{
-#line 400 "src/libre/parser.act"
+#line 447 "src/libre/parser.act"
 
 		/* handle \1-\9 back references */
 		if (lex_state->buf.a[0] == '\\' && lex_state->buf.a[1] != '\0' && lex_state->buf.a[2] == '\0') {
@@ -1688,21 +1752,24 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 		ZI318 = lex_state->lx.start;
 		ZI319   = lex_state->lx.end;
+
+		(void) ZI318;
+		(void) ZI319;
 	
-#line 1693 "src/libre/dialect/pcre/parser.c"
+#line 1760 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: UNSUPPORTED */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: err-unsupported */
 			{
-#line 702 "src/libre/parser.act"
+#line 777 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EUNSUPPORTED;
 		}
 		goto ZL1;
 	
-#line 1706 "src/libre/dialect/pcre/parser.c"
+#line 1773 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: err-unsupported */
 			p_320 (flags, lex_state, act_state, err, &ZI317, &ZI318, &ZInode);
@@ -1741,14 +1808,14 @@ p_expr_C_Ccomment(flags flags, lex_state lex_state, act_state act_state, err err
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: err-invalid-comment */
 		{
-#line 625 "src/libre/parser.act"
+#line 700 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EBADCOMMENT;
 		}
 		goto ZL1;
 	
-#line 1752 "src/libre/dialect/pcre/parser.c"
+#line 1819 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-invalid-comment */
 	}
@@ -1775,7 +1842,7 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hclass(flags fl
 		case (TOK_NAMED__CLASS):
 			/* BEGINNING OF EXTRACT: NAMED_CLASS */
 			{
-#line 592 "src/libre/parser.act"
+#line 661 "src/libre/parser.act"
 
 		ZIid = DIALECT_CLASS(lex_state->buf.a);
 		if (ZIid == NULL) {
@@ -1785,8 +1852,11 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hclass(flags fl
 
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
+
+		(void) ZIstart;
+		(void) ZIend;
 	
-#line 1790 "src/libre/dialect/pcre/parser.c"
+#line 1860 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			break;
@@ -1796,12 +1866,12 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hclass(flags fl
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-range-endpoint-class */
 		{
-#line 806 "src/libre/parser.act"
+#line 878 "src/libre/parser.act"
 
 		(ZIr).type = AST_ENDPOINT_NAMED;
 		(ZIr).u.named.class = (ZIid);
 	
-#line 1805 "src/libre/dialect/pcre/parser.c"
+#line 1875 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-range-endpoint-class */
 	}
@@ -1837,25 +1907,28 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 					/* BEGINNING OF EXTRACT: OPENGROUP */
 					{
-#line 324 "src/libre/parser.act"
+#line 337 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
 		ZI182   = lex_state->lx.end;
+
+		(void) ZIstart;
+		(void) ZI182;
 	
-#line 1846 "src/libre/dialect/pcre/parser.c"
+#line 1919 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OPENGROUP */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-alt */
 					{
-#line 829 "src/libre/parser.act"
+#line 901 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1859 "src/libre/dialect/pcre/parser.c"
+#line 1932 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-alt */
 					ZItmp = ZInode;
@@ -1875,35 +1948,38 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 					/* BEGINNING OF EXTRACT: OPENGROUPCB */
 					{
-#line 334 "src/libre/parser.act"
+#line 353 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
 		ZI201   = lex_state->lx.end;
+
+		(void) ZIstart;
+		(void) ZI201;
 	
-#line 1884 "src/libre/dialect/pcre/parser.c"
+#line 1960 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OPENGROUPCB */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-alt */
 					{
-#line 829 "src/libre/parser.act"
+#line 901 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1897 "src/libre/dialect/pcre/parser.c"
+#line 1973 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-alt */
 					ZItmp = ZInode;
 					/* BEGINNING OF ACTION: make-literal-cbrak */
 					{
-#line 847 "src/libre/parser.act"
+#line 919 "src/libre/parser.act"
 
 		(ZIcbrak) = ']';
 	
-#line 1907 "src/libre/dialect/pcre/parser.c"
+#line 1983 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: make-literal-cbrak */
 					p_210 (flags, lex_state, act_state, err, &ZIstart, &ZIcbrak, &ZInode1);
@@ -1913,13 +1989,13 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 					}
 					/* BEGINNING OF ACTION: ast-add-alt */
 					{
-#line 1012 "src/libre/parser.act"
+#line 1084 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZItmp), (ZInode1))) {
 			goto ZL1;
 		}
 	
-#line 1923 "src/libre/dialect/pcre/parser.c"
+#line 1999 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-add-alt */
 					p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, ZItmp);
@@ -1935,31 +2011,34 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 					/* BEGINNING OF EXTRACT: OPENGROUPINV */
 					{
-#line 329 "src/libre/parser.act"
+#line 345 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
 		ZI193   = lex_state->lx.end;
+
+		(void) ZIstart;
+		(void) ZI193;
 	
-#line 1944 "src/libre/dialect/pcre/parser.c"
+#line 2023 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OPENGROUPINV */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-alt */
 					{
-#line 829 "src/libre/parser.act"
+#line 901 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1957 "src/libre/dialect/pcre/parser.c"
+#line 2036 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-alt */
 					ZItmp = ZInode;
 					/* BEGINNING OF ACTION: ast-make-invert */
 					{
-#line 928 "src/libre/parser.act"
+#line 1028 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -1997,7 +2076,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			goto ZL1;
 		}
 	
-#line 2001 "src/libre/dialect/pcre/parser.c"
+#line 2080 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-invert */
 					p_195 (flags, lex_state, act_state, err, &ZItmp);
@@ -2016,31 +2095,34 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 					/* BEGINNING OF EXTRACT: OPENGROUPINVCB */
 					{
-#line 339 "src/libre/parser.act"
+#line 361 "src/libre/parser.act"
 
 		ZIstart = lex_state->lx.start;
 		ZI208   = lex_state->lx.end;
+
+		(void) ZIstart;
+		(void) ZI208;
 	
-#line 2025 "src/libre/dialect/pcre/parser.c"
+#line 2107 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: OPENGROUPINVCB */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-alt */
 					{
-#line 829 "src/libre/parser.act"
+#line 901 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2038 "src/libre/dialect/pcre/parser.c"
+#line 2120 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-alt */
 					ZItmp = ZInode;
 					/* BEGINNING OF ACTION: ast-make-invert */
 					{
-#line 928 "src/libre/parser.act"
+#line 1028 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -2078,16 +2160,16 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			goto ZL1;
 		}
 	
-#line 2082 "src/libre/dialect/pcre/parser.c"
+#line 2164 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-invert */
 					/* BEGINNING OF ACTION: make-literal-cbrak */
 					{
-#line 847 "src/libre/parser.act"
+#line 919 "src/libre/parser.act"
 
 		(ZIcbrak) = ']';
 	
-#line 2091 "src/libre/dialect/pcre/parser.c"
+#line 2173 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: make-literal-cbrak */
 					p_210 (flags, lex_state, act_state, err, &ZIstart, &ZIcbrak, &ZInode1);
@@ -2097,13 +2179,13 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 					}
 					/* BEGINNING OF ACTION: ast-add-alt */
 					{
-#line 1012 "src/libre/parser.act"
+#line 1084 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZItmp), (ZInode1))) {
 			goto ZL1;
 		}
 	
-#line 2107 "src/libre/dialect/pcre/parser.c"
+#line 2189 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-add-alt */
 					p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms (flags, lex_state, act_state, err, ZItmp);
@@ -2128,24 +2210,28 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 					/* BEGINNING OF EXTRACT: CLOSEGROUP */
 					{
-#line 344 "src/libre/parser.act"
+#line 369 "src/libre/parser.act"
 
 		ZI215 = ']';
 		ZI216 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
+
+		(void) ZI215;
+		(void) ZI216;
+		(void) ZIend;
 	
-#line 2138 "src/libre/dialect/pcre/parser.c"
+#line 2224 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CLOSEGROUP */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: mark-group */
 					{
-#line 709 "src/libre/parser.act"
+#line 781 "src/libre/parser.act"
 
 		mark(&act_state->groupstart, &(ZIstart));
 		mark(&act_state->groupend,   &(ZIend));
 	
-#line 2149 "src/libre/dialect/pcre/parser.c"
+#line 2235 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: mark-group */
 				}
@@ -2158,47 +2244,51 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 					/* BEGINNING OF EXTRACT: CLOSEGROUPRANGE */
 					{
-#line 350 "src/libre/parser.act"
+#line 379 "src/libre/parser.act"
 
 		ZIcrange = '-';
 		ZI218 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
+
+		(void) ZIcrange;
+		(void) ZI218;
+		(void) ZIend;
 	
-#line 2168 "src/libre/dialect/pcre/parser.c"
+#line 2258 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: CLOSEGROUPRANGE */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-literal */
 					{
-#line 836 "src/libre/parser.act"
+#line 908 "src/libre/parser.act"
 
 		(ZIrange) = ast_make_expr_literal(act_state->poolp, *flags, (ZIcrange));
 		if ((ZIrange) == NULL) {
 			goto ZL4;
 		}
 	
-#line 2181 "src/libre/dialect/pcre/parser.c"
+#line 2271 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-literal */
 					/* BEGINNING OF ACTION: ast-add-alt */
 					{
-#line 1012 "src/libre/parser.act"
+#line 1084 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZItmp), (ZIrange))) {
 			goto ZL4;
 		}
 	
-#line 2192 "src/libre/dialect/pcre/parser.c"
+#line 2282 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-add-alt */
 					/* BEGINNING OF ACTION: mark-group */
 					{
-#line 709 "src/libre/parser.act"
+#line 781 "src/libre/parser.act"
 
 		mark(&act_state->groupstart, &(ZIstart));
 		mark(&act_state->groupend,   &(ZIend));
 	
-#line 2202 "src/libre/dialect/pcre/parser.c"
+#line 2292 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: mark-group */
 				}
@@ -2211,14 +2301,14 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			{
 				/* BEGINNING OF ACTION: err-expected-closegroup */
 				{
-#line 667 "src/libre/parser.act"
+#line 742 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCLOSEGROUP;
 		}
 		goto ZL1;
 	
-#line 2222 "src/libre/dialect/pcre/parser.c"
+#line 2312 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: err-expected-closegroup */
 				ZIend = ZIstart;
@@ -2228,7 +2318,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		/* END OF INLINE: 214 */
 		/* BEGINNING OF ACTION: mark-expr */
 		{
-#line 724 "src/libre/parser.act"
+#line 798 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -2243,7 +2333,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		(ZItmp)->u.class.end   = ast_end;
 */
 	
-#line 2247 "src/libre/dialect/pcre/parser.c"
+#line 2337 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: mark-expr */
 	}
@@ -2275,24 +2365,28 @@ p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_Hend(flags flags, lex_state lex_st
 
 					/* BEGINNING OF EXTRACT: RANGE */
 					{
-#line 318 "src/libre/parser.act"
+#line 327 "src/libre/parser.act"
 
 		ZIc = '-';
 		ZI164 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
+
+		(void) ZIc;
+		(void) ZI164;
+		(void) ZIend;
 	
-#line 2285 "src/libre/dialect/pcre/parser.c"
+#line 2379 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF EXTRACT: RANGE */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 					{
-#line 801 "src/libre/parser.act"
+#line 873 "src/libre/parser.act"
 
 		(ZIr).type = AST_ENDPOINT_LITERAL;
 		(ZIr).u.literal.c = (unsigned char)(ZIc);
 	
-#line 2296 "src/libre/dialect/pcre/parser.c"
+#line 2390 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-range-endpoint-literal */
 				}
@@ -2354,16 +2448,16 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 
 					/* BEGINNING OF ACTION: count-one */
 					{
-#line 777 "src/libre/parser.act"
+#line 849 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 2362 "src/libre/dialect/pcre/parser.c"
+#line 2456 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: count-one */
 					/* BEGINNING OF ACTION: ast-make-piece */
 					{
-#line 859 "src/libre/parser.act"
+#line 931 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
@@ -2377,7 +2471,7 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 			goto ZL1;
 		}
 	
-#line 2381 "src/libre/dialect/pcre/parser.c"
+#line 2475 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-piece */
 				}
@@ -2407,14 +2501,14 @@ p_320(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		{
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 836 "src/libre/parser.act"
+#line 908 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (*ZI317));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2418 "src/libre/dialect/pcre/parser.c"
+#line 2512 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -2427,12 +2521,12 @@ p_320(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 801 "src/libre/parser.act"
+#line 873 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_LITERAL;
 		(ZIlower).u.literal.c = (unsigned char)(*ZI317);
 	
-#line 2436 "src/libre/dialect/pcre/parser.c"
+#line 2530 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			p_169 (flags, lex_state, act_state, err);
@@ -2443,17 +2537,17 @@ p_320(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			}
 			/* BEGINNING OF ACTION: mark-range */
 			{
-#line 714 "src/libre/parser.act"
+#line 786 "src/libre/parser.act"
 
 		mark(&act_state->rangestart, &(*ZI318));
 		mark(&act_state->rangeend,   &(ZIend));
 	
-#line 2452 "src/libre/dialect/pcre/parser.c"
+#line 2546 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 966 "src/libre/parser.act"
+#line 1041 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -2486,7 +2580,7 @@ p_320(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			goto ZL1;
 		}
 	
-#line 2490 "src/libre/dialect/pcre/parser.c"
+#line 2584 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -2513,14 +2607,14 @@ p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__ex
 	{
 		/* BEGINNING OF ACTION: ast-make-alt */
 		{
-#line 829 "src/libre/parser.act"
+#line 901 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2524 "src/libre/dialect/pcre/parser.c"
+#line 2618 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-alt */
 		p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, ZInode);
@@ -2534,26 +2628,26 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-alts */
 		{
-#line 653 "src/libre/parser.act"
+#line 728 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXALTS;
 		}
 		goto ZL2;
 	
-#line 2545 "src/libre/dialect/pcre/parser.c"
+#line 2639 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 815 "src/libre/parser.act"
+#line 887 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL2;
 		}
 	
-#line 2557 "src/libre/dialect/pcre/parser.c"
+#line 2651 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -2578,13 +2672,17 @@ p_195(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 318 "src/libre/parser.act"
+#line 327 "src/libre/parser.act"
 
 		ZIc = '-';
 		ZIrstart = lex_state->lx.start;
 		ZI196   = lex_state->lx.end;
+
+		(void) ZIc;
+		(void) ZIrstart;
+		(void) ZI196;
 	
-#line 2588 "src/libre/dialect/pcre/parser.c"
+#line 2686 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
@@ -2595,14 +2693,14 @@ p_195(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 					{
 						/* BEGINNING OF ACTION: ast-make-literal */
 						{
-#line 836 "src/libre/parser.act"
+#line 908 "src/libre/parser.act"
 
 		(ZInode1) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZInode1) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2606 "src/libre/dialect/pcre/parser.c"
+#line 2704 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF ACTION: ast-make-literal */
 					}
@@ -2618,23 +2716,27 @@ p_195(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 
 						/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 						{
-#line 801 "src/libre/parser.act"
+#line 873 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_LITERAL;
 		(ZIlower).u.literal.c = (unsigned char)(ZIc);
 	
-#line 2627 "src/libre/dialect/pcre/parser.c"
+#line 2725 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF ACTION: ast-range-endpoint-literal */
 						/* BEGINNING OF EXTRACT: RANGE */
 						{
-#line 318 "src/libre/parser.act"
+#line 327 "src/libre/parser.act"
 
 		ZI198 = '-';
 		ZI199 = lex_state->lx.start;
 		ZI200   = lex_state->lx.end;
+
+		(void) ZI198;
+		(void) ZI199;
+		(void) ZI200;
 	
-#line 2638 "src/libre/dialect/pcre/parser.c"
+#line 2740 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF EXTRACT: RANGE */
 						ADVANCE_LEXER;
@@ -2645,7 +2747,7 @@ p_195(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 						}
 						/* BEGINNING OF ACTION: ast-make-range */
 						{
-#line 966 "src/libre/parser.act"
+#line 1041 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -2678,7 +2780,7 @@ p_195(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			goto ZL1;
 		}
 	
-#line 2682 "src/libre/dialect/pcre/parser.c"
+#line 2784 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF ACTION: ast-make-range */
 					}
@@ -2688,13 +2790,13 @@ p_195(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			/* END OF INLINE: 197 */
 			/* BEGINNING OF ACTION: ast-add-alt */
 			{
-#line 1012 "src/libre/parser.act"
+#line 1084 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((*ZItmp), (ZInode1))) {
 			goto ZL1;
 		}
 	
-#line 2698 "src/libre/dialect/pcre/parser.c"
+#line 2800 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 		}
@@ -2723,28 +2825,31 @@ p_323(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI3
 
 			/* BEGINNING OF EXTRACT: CLOSECOUNT */
 			{
-#line 361 "src/libre/parser.act"
+#line 397 "src/libre/parser.act"
 
 		ZI258 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
+
+		(void) ZI258;
+		(void) ZIend;
 	
-#line 2732 "src/libre/dialect/pcre/parser.c"
+#line 2837 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: CLOSECOUNT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 719 "src/libre/parser.act"
+#line 791 "src/libre/parser.act"
 
 		mark(&act_state->countstart, &(*ZI321));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 2743 "src/libre/dialect/pcre/parser.c"
+#line 2848 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 781 "src/libre/parser.act"
+#line 855 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -2764,7 +2869,7 @@ p_323(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI3
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (*ZIm), &ast_end);
 	
-#line 2768 "src/libre/dialect/pcre/parser.c"
+#line 2873 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-range */
 		}
@@ -2806,37 +2911,40 @@ p_324(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI3
 
 			/* BEGINNING OF EXTRACT: CLOSECOUNT */
 			{
-#line 361 "src/libre/parser.act"
+#line 397 "src/libre/parser.act"
 
 		ZI263 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
+
+		(void) ZI263;
+		(void) ZIend;
 	
-#line 2815 "src/libre/dialect/pcre/parser.c"
+#line 2923 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: CLOSECOUNT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 719 "src/libre/parser.act"
+#line 791 "src/libre/parser.act"
 
 		mark(&act_state->countstart, &(*ZI321));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 2826 "src/libre/dialect/pcre/parser.c"
+#line 2934 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-unbounded */
 			{
-#line 761 "src/libre/parser.act"
+#line 833 "src/libre/parser.act"
 
 		(ZIn) = AST_COUNT_UNBOUNDED;
 	
-#line 2835 "src/libre/dialect/pcre/parser.c"
+#line 2943 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-unbounded */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 781 "src/libre/parser.act"
+#line 855 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -2856,7 +2964,7 @@ p_324(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI3
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (ZIn), &ast_end);
 	
-#line 2860 "src/libre/dialect/pcre/parser.c"
+#line 2968 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-range */
 		}
@@ -2869,7 +2977,7 @@ p_324(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI3
 
 			/* BEGINNING OF EXTRACT: COUNT */
 			{
-#line 572 "src/libre/parser.act"
+#line 649 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -2889,7 +2997,7 @@ p_324(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI3
 
 		ZIn = (unsigned int) u;
 	
-#line 2893 "src/libre/dialect/pcre/parser.c"
+#line 3001 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: COUNT */
 			ADVANCE_LEXER;
@@ -2897,12 +3005,15 @@ p_324(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI3
 			case (TOK_CLOSECOUNT):
 				/* BEGINNING OF EXTRACT: CLOSECOUNT */
 				{
-#line 361 "src/libre/parser.act"
+#line 397 "src/libre/parser.act"
 
 		ZI261 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
+
+		(void) ZI261;
+		(void) ZIend;
 	
-#line 2906 "src/libre/dialect/pcre/parser.c"
+#line 3017 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF EXTRACT: CLOSECOUNT */
 				break;
@@ -2912,17 +3023,17 @@ p_324(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI3
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 719 "src/libre/parser.act"
+#line 791 "src/libre/parser.act"
 
 		mark(&act_state->countstart, &(*ZI321));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 2921 "src/libre/dialect/pcre/parser.c"
+#line 3032 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 781 "src/libre/parser.act"
+#line 855 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -2942,7 +3053,7 @@ p_324(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI3
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (ZIn), &ast_end);
 	
-#line 2946 "src/libre/dialect/pcre/parser.c"
+#line 3057 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-range */
 		}
@@ -2983,20 +3094,20 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: re-flag-none */
 		{
-#line 753 "src/libre/parser.act"
+#line 825 "src/libre/parser.act"
 
 		(ZIempty__pos) = RE_FLAGS_NONE;
 	
-#line 2991 "src/libre/dialect/pcre/parser.c"
+#line 3102 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: re-flag-none */
 		/* BEGINNING OF ACTION: re-flag-none */
 		{
-#line 753 "src/libre/parser.act"
+#line 825 "src/libre/parser.act"
 
 		(ZIempty__neg) = RE_FLAGS_NONE;
 	
-#line 3000 "src/libre/dialect/pcre/parser.c"
+#line 3111 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: re-flag-none */
 		/* BEGINNING OF INLINE: 233 */
@@ -3049,7 +3160,7 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-mask-re-flags */
 					{
-#line 888 "src/libre/parser.act"
+#line 964 "src/libre/parser.act"
 
 		/*
 		 * Note: in cases like `(?i-i)`, the negative is
@@ -3058,19 +3169,19 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 		*flags |= (ZIpos);
 		*flags &= ~(ZIneg);
 	
-#line 3062 "src/libre/dialect/pcre/parser.c"
+#line 3173 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-mask-re-flags */
 					/* BEGINNING OF ACTION: ast-make-empty */
 					{
-#line 815 "src/libre/parser.act"
+#line 887 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL5;
 		}
 	
-#line 3074 "src/libre/dialect/pcre/parser.c"
+#line 3185 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-empty */
 				}
@@ -3083,16 +3194,16 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-get-re-flags */
 					{
-#line 880 "src/libre/parser.act"
+#line 952 "src/libre/parser.act"
 
 		(ZIflags) = *flags;
 	
-#line 3091 "src/libre/dialect/pcre/parser.c"
+#line 3202 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-get-re-flags */
 					/* BEGINNING OF ACTION: ast-mask-re-flags */
 					{
-#line 888 "src/libre/parser.act"
+#line 964 "src/libre/parser.act"
 
 		/*
 		 * Note: in cases like `(?i-i)`, the negative is
@@ -3101,7 +3212,7 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 		*flags |= (ZIpos);
 		*flags &= ~(ZIneg);
 	
-#line 3105 "src/libre/dialect/pcre/parser.c"
+#line 3216 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-mask-re-flags */
 					p_expr (flags, lex_state, act_state, err, &ZIe);
@@ -3111,11 +3222,11 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 					}
 					/* BEGINNING OF ACTION: ast-set-re-flags */
 					{
-#line 884 "src/libre/parser.act"
+#line 956 "src/libre/parser.act"
 
 		*flags = (ZIflags);
 	
-#line 3119 "src/libre/dialect/pcre/parser.c"
+#line 3230 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-set-re-flags */
 					switch (CURRENT_TERMINAL) {
@@ -3136,26 +3247,26 @@ p_expr_C_Cflags(flags flags, lex_state lex_state, act_state act_state, err err, 
 			{
 				/* BEGINNING OF ACTION: err-expected-closeflags */
 				{
-#line 688 "src/libre/parser.act"
+#line 763 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCLOSEFLAGS;
 		}
 		goto ZL1;
 	
-#line 3147 "src/libre/dialect/pcre/parser.c"
+#line 3258 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: err-expected-closeflags */
 				/* BEGINNING OF ACTION: ast-make-empty */
 				{
-#line 815 "src/libre/parser.act"
+#line 887 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3159 "src/libre/dialect/pcre/parser.c"
+#line 3270 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: ast-make-empty */
 			}
@@ -3189,7 +3300,7 @@ p_expr_C_Cpiece_C_Clist_Hof_Hcounts(flags flags, lex_state lex_state, act_state 
 		}
 		/* BEGINNING OF ACTION: ast-make-piece */
 		{
-#line 859 "src/libre/parser.act"
+#line 931 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
@@ -3203,7 +3314,7 @@ p_expr_C_Cpiece_C_Clist_Hof_Hcounts(flags flags, lex_state lex_state, act_state 
 			goto ZL1;
 		}
 	
-#line 3207 "src/libre/dialect/pcre/parser.c"
+#line 3318 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-piece */
 		/* BEGINNING OF INLINE: 266 */
@@ -3214,14 +3325,14 @@ p_expr_C_Cpiece_C_Clist_Hof_Hcounts(flags flags, lex_state lex_state, act_state 
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: err-unsupported */
 					{
-#line 702 "src/libre/parser.act"
+#line 777 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EUNSUPPORTED;
 		}
 		goto ZL1;
 	
-#line 3225 "src/libre/dialect/pcre/parser.c"
+#line 3336 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: err-unsupported */
 				}
@@ -3231,14 +3342,14 @@ p_expr_C_Cpiece_C_Clist_Hof_Hcounts(flags flags, lex_state lex_state, act_state 
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: err-unsupported */
 					{
-#line 702 "src/libre/parser.act"
+#line 777 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EUNSUPPORTED;
 		}
 		goto ZL1;
 	
-#line 3242 "src/libre/dialect/pcre/parser.c"
+#line 3353 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: err-unsupported */
 				}
@@ -3323,7 +3434,7 @@ p_class_Hnamed(flags flags, lex_state lex_state, act_state act_state, err err, t
 		case (TOK_NAMED__CLASS):
 			/* BEGINNING OF EXTRACT: NAMED_CLASS */
 			{
-#line 592 "src/libre/parser.act"
+#line 661 "src/libre/parser.act"
 
 		ZIid = DIALECT_CLASS(lex_state->buf.a);
 		if (ZIid == NULL) {
@@ -3333,8 +3444,11 @@ p_class_Hnamed(flags flags, lex_state lex_state, act_state act_state, err err, t
 
 		ZIstart = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
+
+		(void) ZIstart;
+		(void) ZIend;
 	
-#line 3338 "src/libre/dialect/pcre/parser.c"
+#line 3452 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			break;
@@ -3344,14 +3458,14 @@ p_class_Hnamed(flags flags, lex_state lex_state, act_state act_state, err err, t
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-make-named */
 		{
-#line 999 "src/libre/parser.act"
+#line 1071 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_named(act_state->poolp, *flags, (ZIid));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3355 "src/libre/dialect/pcre/parser.c"
+#line 3469 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-named */
 	}
@@ -3375,14 +3489,14 @@ p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 		{
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 836 "src/libre/parser.act"
+#line 908 "src/libre/parser.act"
 
 		(ZInode1) = ast_make_expr_literal(act_state->poolp, *flags, (*ZIcbrak));
 		if ((ZInode1) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3386 "src/libre/dialect/pcre/parser.c"
+#line 3500 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -3399,23 +3513,27 @@ p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 801 "src/libre/parser.act"
+#line 873 "src/libre/parser.act"
 
 		(ZIr).type = AST_ENDPOINT_LITERAL;
 		(ZIr).u.literal.c = (unsigned char)(*ZIcbrak);
 	
-#line 3408 "src/libre/dialect/pcre/parser.c"
+#line 3522 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 318 "src/libre/parser.act"
+#line 327 "src/libre/parser.act"
 
 		ZI211 = '-';
 		ZI212 = lex_state->lx.start;
 		ZI213   = lex_state->lx.end;
+
+		(void) ZI211;
+		(void) ZI212;
+		(void) ZI213;
 	
-#line 3419 "src/libre/dialect/pcre/parser.c"
+#line 3537 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
@@ -3426,17 +3544,17 @@ p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 			}
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 801 "src/libre/parser.act"
+#line 873 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_LITERAL;
 		(ZIlower).u.literal.c = (unsigned char)(*ZIcbrak);
 	
-#line 3435 "src/libre/dialect/pcre/parser.c"
+#line 3553 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 966 "src/libre/parser.act"
+#line 1041 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -3469,7 +3587,7 @@ p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 			goto ZL1;
 		}
 	
-#line 3473 "src/libre/dialect/pcre/parser.c"
+#line 3591 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -3502,13 +3620,13 @@ ZL2_expr_C_Clist_Hof_Halts:;
 		}
 		/* BEGINNING OF ACTION: ast-add-alt */
 		{
-#line 1012 "src/libre/parser.act"
+#line 1084 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIalts), (ZIa))) {
 			goto ZL1;
 		}
 	
-#line 3512 "src/libre/dialect/pcre/parser.c"
+#line 3630 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-add-alt */
 		/* BEGINNING OF INLINE: 280 */
@@ -3521,7 +3639,7 @@ ZL2_expr_C_Clist_Hof_Halts:;
 					goto ZL2_expr_C_Clist_Hof_Halts;
 					/* END OF INLINE: expr::list-of-alts */
 				}
-				/* UNREACHED */
+				/*UNREACHED*/
 			default:
 				break;
 			}
@@ -3533,14 +3651,14 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-alts */
 		{
-#line 653 "src/libre/parser.act"
+#line 728 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXALTS;
 		}
 		goto ZL4;
 	
-#line 3544 "src/libre/dialect/pcre/parser.c"
+#line 3662 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
 	}
@@ -3565,12 +3683,15 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 			/* BEGINNING OF EXTRACT: OPENCOUNT */
 			{
-#line 356 "src/libre/parser.act"
+#line 389 "src/libre/parser.act"
 
 		ZI321 = lex_state->lx.start;
 		ZI322   = lex_state->lx.end;
+
+		(void) ZI321;
+		(void) ZI322;
 	
-#line 3574 "src/libre/dialect/pcre/parser.c"
+#line 3695 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: OPENCOUNT */
 			ADVANCE_LEXER;
@@ -3578,7 +3699,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			case (TOK_COUNT):
 				/* BEGINNING OF EXTRACT: COUNT */
 				{
-#line 572 "src/libre/parser.act"
+#line 649 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -3598,7 +3719,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		ZIm = (unsigned int) u;
 	
-#line 3602 "src/libre/dialect/pcre/parser.c"
+#line 3723 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -3618,11 +3739,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-zero-or-one */
 			{
-#line 773 "src/libre/parser.act"
+#line 845 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, 1, NULL);
 	
-#line 3626 "src/libre/dialect/pcre/parser.c"
+#line 3747 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-one */
 		}
@@ -3632,11 +3753,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-one-or-more */
 			{
-#line 769 "src/libre/parser.act"
+#line 841 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 3640 "src/libre/dialect/pcre/parser.c"
+#line 3761 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-one-or-more */
 		}
@@ -3646,11 +3767,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-zero-or-more */
 			{
-#line 765 "src/libre/parser.act"
+#line 837 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 3654 "src/libre/dialect/pcre/parser.c"
+#line 3775 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 		}
@@ -3665,23 +3786,23 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-count */
 		{
-#line 639 "src/libre/parser.act"
+#line 714 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCOUNT;
 		}
 		goto ZL2;
 	
-#line 3676 "src/libre/dialect/pcre/parser.c"
+#line 3797 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-expected-count */
 		/* BEGINNING OF ACTION: count-one */
 		{
-#line 777 "src/libre/parser.act"
+#line 849 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 3685 "src/libre/dialect/pcre/parser.c"
+#line 3806 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: count-one */
 	}
@@ -3710,11 +3831,11 @@ p_re__pcre(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 
 				/* BEGINNING OF ACTION: make-group-id */
 				{
-#line 843 "src/libre/parser.act"
+#line 915 "src/libre/parser.act"
 
 		(ZIid) = act_state->group_id++;
 	
-#line 3718 "src/libre/dialect/pcre/parser.c"
+#line 3839 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: make-group-id */
 				p_expr (flags, lex_state, act_state, err, &ZIe);
@@ -3724,14 +3845,14 @@ p_re__pcre(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 				}
 				/* BEGINNING OF ACTION: ast-make-group */
 				{
-#line 873 "src/libre/parser.act"
+#line 945 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_group(act_state->poolp, *flags, (ZIe), (ZIid));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3735 "src/libre/dialect/pcre/parser.c"
+#line 3856 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: ast-make-group */
 			}
@@ -3753,14 +3874,14 @@ p_re__pcre(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 695 "src/libre/parser.act"
+#line 770 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
 		}
 		goto ZL1;
 	
-#line 3764 "src/libre/dialect/pcre/parser.c"
+#line 3885 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
@@ -3789,24 +3910,24 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: class-any */
 			{
-#line 739 "src/libre/parser.act"
+#line 812 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
 		(ZIa) = (*flags & RE_SINGLE) ? &class_any : &class_notnl;
 	
-#line 3798 "src/libre/dialect/pcre/parser.c"
+#line 3919 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 999 "src/libre/parser.act"
+#line 1071 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_named(act_state->poolp, *flags, (ZIa));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3810 "src/libre/dialect/pcre/parser.c"
+#line 3931 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 		}
@@ -3816,14 +3937,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-anchor-end */
 			{
-#line 904 "src/libre/parser.act"
+#line 976 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_anchor(act_state->poolp, *flags, AST_ANCHOR_END);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3827 "src/libre/dialect/pcre/parser.c"
+#line 3948 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-end */
 		}
@@ -3833,7 +3954,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-anchor-end-nl */
 			{
-#line 911 "src/libre/parser.act"
+#line 983 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_anchor(act_state->poolp, *flags, AST_ANCHOR_END);
 		if ((ZIe) == NULL) {
@@ -3843,7 +3964,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			(ZIe)->u.anchor.is_end_nl = 1;
 		}
 	
-#line 3847 "src/libre/dialect/pcre/parser.c"
+#line 3968 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-end-nl */
 		}
@@ -3861,134 +3982,134 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: class-bsr */
 			{
-#line 744 "src/libre/parser.act"
+#line 817 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
 		(ZIclass__bsr) = &class_bsr;
 	
-#line 3870 "src/libre/dialect/pcre/parser.c"
+#line 3991 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: class-bsr */
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 999 "src/libre/parser.act"
+#line 1071 "src/libre/parser.act"
 
 		(ZIbsr) = ast_make_expr_named(act_state->poolp, *flags, (ZIclass__bsr));
 		if ((ZIbsr) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3882 "src/libre/dialect/pcre/parser.c"
+#line 4003 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 			/* BEGINNING OF ACTION: ast-make-concat */
 			{
-#line 822 "src/libre/parser.act"
+#line 894 "src/libre/parser.act"
 
 		(ZIcrlf) = ast_make_expr_concat(act_state->poolp, *flags);
 		if ((ZIcrlf) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3894 "src/libre/dialect/pcre/parser.c"
+#line 4015 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-concat */
 			/* BEGINNING OF ACTION: make-literal-cr */
 			{
-#line 851 "src/libre/parser.act"
+#line 923 "src/libre/parser.act"
 
 		(ZIcr) = '\r';
 	
-#line 3903 "src/libre/dialect/pcre/parser.c"
+#line 4024 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: make-literal-cr */
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 836 "src/libre/parser.act"
+#line 908 "src/libre/parser.act"
 
 		(ZIecr) = ast_make_expr_literal(act_state->poolp, *flags, (ZIcr));
 		if ((ZIecr) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3915 "src/libre/dialect/pcre/parser.c"
+#line 4036 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 			/* BEGINNING OF ACTION: make-literal-nl */
 			{
-#line 855 "src/libre/parser.act"
+#line 927 "src/libre/parser.act"
 
 		(ZInl) = '\n';
 	
-#line 3924 "src/libre/dialect/pcre/parser.c"
+#line 4045 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: make-literal-nl */
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 836 "src/libre/parser.act"
+#line 908 "src/libre/parser.act"
 
 		(ZIenl) = ast_make_expr_literal(act_state->poolp, *flags, (ZInl));
 		if ((ZIenl) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3936 "src/libre/dialect/pcre/parser.c"
+#line 4057 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 			/* BEGINNING OF ACTION: ast-add-concat */
 			{
-#line 1006 "src/libre/parser.act"
+#line 1078 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcrlf), (ZIecr))) {
 			goto ZL1;
 		}
 	
-#line 3947 "src/libre/dialect/pcre/parser.c"
+#line 4068 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-concat */
 			/* BEGINNING OF ACTION: ast-add-concat */
 			{
-#line 1006 "src/libre/parser.act"
+#line 1078 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcrlf), (ZIenl))) {
 			goto ZL1;
 		}
 	
-#line 3958 "src/libre/dialect/pcre/parser.c"
+#line 4079 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-concat */
 			/* BEGINNING OF ACTION: ast-make-alt */
 			{
-#line 829 "src/libre/parser.act"
+#line 901 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 3970 "src/libre/dialect/pcre/parser.c"
+#line 4091 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-alt */
 			/* BEGINNING OF ACTION: ast-add-alt */
 			{
-#line 1012 "src/libre/parser.act"
+#line 1084 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIe), (ZIcrlf))) {
 			goto ZL1;
 		}
 	
-#line 3981 "src/libre/dialect/pcre/parser.c"
+#line 4102 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 			/* BEGINNING OF ACTION: ast-add-alt */
 			{
-#line 1012 "src/libre/parser.act"
+#line 1084 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIe), (ZIbsr))) {
 			goto ZL1;
 		}
 	
-#line 3992 "src/libre/dialect/pcre/parser.c"
+#line 4113 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 		}
@@ -4002,20 +4123,20 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-get-re-flags */
 			{
-#line 880 "src/libre/parser.act"
+#line 952 "src/libre/parser.act"
 
 		(ZIflags) = *flags;
 	
-#line 4010 "src/libre/dialect/pcre/parser.c"
+#line 4131 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-get-re-flags */
 			/* BEGINNING OF ACTION: make-group-id */
 			{
-#line 843 "src/libre/parser.act"
+#line 915 "src/libre/parser.act"
 
 		(ZIid) = act_state->group_id++;
 	
-#line 4019 "src/libre/dialect/pcre/parser.c"
+#line 4140 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: make-group-id */
 			p_expr (flags, lex_state, act_state, err, &ZIg);
@@ -4025,23 +4146,23 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			}
 			/* BEGINNING OF ACTION: ast-set-re-flags */
 			{
-#line 884 "src/libre/parser.act"
+#line 956 "src/libre/parser.act"
 
 		*flags = (ZIflags);
 	
-#line 4033 "src/libre/dialect/pcre/parser.c"
+#line 4154 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-set-re-flags */
 			/* BEGINNING OF ACTION: ast-make-group */
 			{
-#line 873 "src/libre/parser.act"
+#line 945 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_group(act_state->poolp, *flags, (ZIg), (ZIid));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 4045 "src/libre/dialect/pcre/parser.c"
+#line 4166 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-group */
 			switch (CURRENT_TERMINAL) {
@@ -4058,14 +4179,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-anchor-start */
 			{
-#line 897 "src/libre/parser.act"
+#line 969 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_anchor(act_state->poolp, *flags, AST_ANCHOR_START);
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 4069 "src/libre/dialect/pcre/parser.c"
+#line 4190 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-start */
 		}
@@ -4117,26 +4238,26 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-atom */
 		{
-#line 646 "src/libre/parser.act"
+#line 721 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXATOM;
 		}
 		goto ZL2;
 	
-#line 4128 "src/libre/dialect/pcre/parser.c"
+#line 4249 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 815 "src/libre/parser.act"
+#line 887 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZIe) == NULL) {
 			goto ZL2;
 		}
 	
-#line 4140 "src/libre/dialect/pcre/parser.c"
+#line 4261 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -4162,14 +4283,14 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 		{
 			/* BEGINNING OF ACTION: ast-make-concat */
 			{
-#line 822 "src/libre/parser.act"
+#line 894 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_concat(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 4173 "src/libre/dialect/pcre/parser.c"
+#line 4294 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-concat */
 			p_expr_C_Clist_Hof_Hpieces (flags, lex_state, act_state, err, ZInode);
@@ -4183,14 +4304,14 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 		{
 			/* BEGINNING OF ACTION: ast-make-empty */
 			{
-#line 815 "src/libre/parser.act"
+#line 887 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 4194 "src/libre/dialect/pcre/parser.c"
+#line 4315 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-empty */
 		}
@@ -4226,30 +4347,30 @@ p_expr_C_Ctype(flags flags, lex_state lex_state, act_state act_state, err err, t
 		}
 		/* BEGINNING OF ACTION: ast-make-alt */
 		{
-#line 829 "src/libre/parser.act"
+#line 901 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 4237 "src/libre/dialect/pcre/parser.c"
+#line 4358 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-alt */
 		/* BEGINNING OF ACTION: ast-add-alt */
 		{
-#line 1012 "src/libre/parser.act"
+#line 1084 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZInode), (ZIclass))) {
 			goto ZL1;
 		}
 	
-#line 4248 "src/libre/dialect/pcre/parser.c"
+#line 4369 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-add-alt */
 		/* BEGINNING OF ACTION: mark-expr */
 		{
-#line 724 "src/libre/parser.act"
+#line 798 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -4264,7 +4385,7 @@ p_expr_C_Ctype(flags flags, lex_state lex_state, act_state act_state, err err, t
 		(ZInode)->u.class.end   = ast_end;
 */
 	
-#line 4268 "src/libre/dialect/pcre/parser.c"
+#line 4389 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: mark-expr */
 	}
@@ -4278,7 +4399,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 1018 "src/libre/parser.act"
+#line 1247 "src/libre/parser.act"
 
 
 	static int
@@ -4437,6 +4558,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 4441 "src/libre/dialect/pcre/parser.c"
+#line 4562 "src/libre/dialect/pcre/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/pcre/parser.h
+++ b/src/libre/dialect/pcre/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 299 "src/libre/parser.act"
+#line 310 "src/libre/parser.act"
 
 
 	#include <re/re.h>
@@ -28,7 +28,7 @@
 extern void p_re__pcre(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 1176 "src/libre/parser.act"
+#line 1249 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/pcre/parser.h"

--- a/src/libre/dialect/sql/parser.c
+++ b/src/libre/dialect/sql/parser.c
@@ -305,9 +305,9 @@ static void p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags, lex_state, act_stat
 static void p_expr_C_Ccharacter_Hclass(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Cpiece(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_208(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_212(flags, lex_state, act_state, err, t_char *, t_pos *, t_ast__expr *);
-static void p_215(flags, lex_state, act_state, err, t_pos *, t_unsigned *, t_ast__count *);
+static void p_206(flags, lex_state, act_state, err, t_ast__expr *);
+static void p_210(flags, lex_state, act_state, err, t_char *, t_pos *, t_ast__expr *);
+static void p_213(flags, lex_state, act_state, err, t_pos *, t_unsigned *, t_ast__count *);
 static void p_expr_C_Clist_Hof_Halts(flags, lex_state, act_state, err, t_ast__expr);
 static void p_expr_C_Cpiece_C_Ccount(flags, lex_state, act_state, err, t_ast__count *);
 static void p_expr_C_Cpiece_C_Catom(flags, lex_state, act_state, err, t_ast__expr *);
@@ -325,21 +325,21 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead(flags flags, lex_state lex_state, act_
 	switch (CURRENT_TERMINAL) {
 	case (TOK_INVERT):
 		{
-			t_char ZI207;
+			t_char ZI205;
 
 			/* BEGINNING OF EXTRACT: INVERT */
 			{
 #line 321 "src/libre/parser.act"
 
-		ZI207 = '^';
+		ZI205 = '^';
 
-		(void) ZI207;
+		(void) ZI205;
 	
 #line 339 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: INVERT */
 			ADVANCE_LEXER;
-			p_208 (flags, lex_state, act_state, err, ZIclass);
+			p_206 (flags, lex_state, act_state, err, ZIclass);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -414,7 +414,7 @@ p_re__sql(flags flags, lex_state lex_state, act_state act_state, err err, t_ast_
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 194 */
+		/* BEGINNING OF INLINE: 192 */
 		{
 			{
 				p_expr (flags, lex_state, act_state, err, &ZInode);
@@ -424,8 +424,8 @@ p_re__sql(flags flags, lex_state lex_state, act_state act_state, err err, t_ast_
 				}
 			}
 		}
-		/* END OF INLINE: 194 */
-		/* BEGINNING OF INLINE: 195 */
+		/* END OF INLINE: 192 */
+		/* BEGINNING OF INLINE: 193 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -454,7 +454,7 @@ p_re__sql(flags flags, lex_state lex_state, act_state act_state, err err, t_ast_
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 195 */
+		/* END OF INLINE: 193 */
 	}
 	goto ZL0;
 ZL1:;
@@ -569,7 +569,7 @@ ZL2_expr_C_Clist_Hof_Hpieces:;
 #line 570 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-add-concat */
-		/* BEGINNING OF INLINE: 186 */
+		/* BEGINNING OF INLINE: 184 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_MANY): case (TOK_OPENSUB): case (TOK_OPENGROUP):
@@ -584,7 +584,7 @@ ZL2_expr_C_Clist_Hof_Hpieces:;
 				break;
 			}
 		}
-		/* END OF INLINE: 186 */
+		/* END OF INLINE: 184 */
 	}
 	return;
 ZL1:;
@@ -600,9 +600,9 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CHAR):
 		{
-			t_char ZI209;
-			t_pos ZI210;
-			t_pos ZI211;
+			t_char ZI207;
+			t_pos ZI208;
+			t_pos ZI209;
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
@@ -611,19 +611,19 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI210 = lex_state->lx.start;
-		ZI211   = lex_state->lx.end;
+		ZI208 = lex_state->lx.start;
+		ZI209   = lex_state->lx.end;
 
-		(void) ZI210;
-		(void) ZI211;
+		(void) ZI208;
+		(void) ZI209;
 
-		ZI209 = lex_state->buf.a[0];
+		ZI207 = lex_state->buf.a[0];
 	
 #line 623 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
-			p_212 (flags, lex_state, act_state, err, &ZI209, &ZI210, &ZInode);
+			p_210 (flags, lex_state, act_state, err, &ZI207, &ZI208, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -765,7 +765,6 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 					t_char ZI159;
 					t_ast__expr ZImask;
 					t_ast__expr ZImask__tmp;
-					t_pos ZIclose__end;
 
 					/* BEGINNING OF EXTRACT: INVERT */
 					{
@@ -775,7 +774,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 		(void) ZI159;
 	
-#line 779 "src/libre/dialect/sql/parser.c"
+#line 778 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF EXTRACT: INVERT */
 					ADVANCE_LEXER;
@@ -788,7 +787,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			goto ZL3;
 		}
 	
-#line 792 "src/libre/dialect/sql/parser.c"
+#line 791 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: ast-make-alt */
 					ZImask__tmp = ZImask;
@@ -804,6 +803,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 						{
 							t_char ZI164;
 							t_pos ZIclose__start;
+							t_pos ZIclose__end;
 
 							switch (CURRENT_TERMINAL) {
 							case (TOK_CLOSEGROUP):
@@ -837,32 +837,8 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 #line 838 "src/libre/dialect/sql/parser.c"
 							}
 							/* END OF ACTION: mark-group */
-						}
-						goto ZL4;
-					ZL5:;
-						{
-							t_pos ZIclose__start;
-
-							/* BEGINNING OF ACTION: err-expected-closegroup */
+							/* BEGINNING OF ACTION: mark-expr */
 							{
-#line 742 "src/libre/parser.act"
-
-		if (err->e == RE_ESUCCESS) {
-			err->e = RE_EXCLOSEGROUP;
-		}
-		goto ZL3;
-	
-#line 856 "src/libre/dialect/sql/parser.c"
-							}
-							/* END OF ACTION: err-expected-closegroup */
-							ZIclose__start = ZIopen__end;
-							ZIclose__end = ZIopen__end;
-						}
-					ZL4:;
-					}
-					/* END OF INLINE: 163 */
-					/* BEGINNING OF ACTION: mark-expr */
-					{
 #line 798 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
@@ -878,11 +854,11 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		(ZItmp)->u.class.end   = ast_end;
 */
 	
-#line 882 "src/libre/dialect/sql/parser.c"
-					}
-					/* END OF ACTION: mark-expr */
-					/* BEGINNING OF ACTION: mark-expr */
-					{
+#line 858 "src/libre/dialect/sql/parser.c"
+							}
+							/* END OF ACTION: mark-expr */
+							/* BEGINNING OF ACTION: mark-expr */
+							{
 #line 798 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
@@ -898,9 +874,29 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		(ZImask__tmp)->u.class.end   = ast_end;
 */
 	
-#line 902 "src/libre/dialect/sql/parser.c"
+#line 878 "src/libre/dialect/sql/parser.c"
+							}
+							/* END OF ACTION: mark-expr */
+						}
+						goto ZL4;
+					ZL5:;
+						{
+							/* BEGINNING OF ACTION: err-expected-closegroup */
+							{
+#line 742 "src/libre/parser.act"
+
+		if (err->e == RE_ESUCCESS) {
+			err->e = RE_EXCLOSEGROUP;
+		}
+		goto ZL3;
+	
+#line 894 "src/libre/dialect/sql/parser.c"
+							}
+							/* END OF ACTION: err-expected-closegroup */
+						}
+					ZL4:;
 					}
-					/* END OF ACTION: mark-expr */
+					/* END OF INLINE: 163 */
 					/* BEGINNING OF ACTION: ast-make-subtract */
 					{
 #line 993 "src/libre/parser.act"
@@ -910,7 +906,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			goto ZL3;
 		}
 	
-#line 914 "src/libre/dialect/sql/parser.c"
+#line 910 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: ast-make-subtract */
 				}
@@ -933,7 +929,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		}
 		goto ZL1;
 	
-#line 937 "src/libre/dialect/sql/parser.c"
+#line 933 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: err-expected-closegroup */
 				/* BEGINNING OF ACTION: ast-make-empty */
@@ -945,7 +941,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			goto ZL1;
 		}
 	
-#line 949 "src/libre/dialect/sql/parser.c"
+#line 945 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: ast-make-empty */
 			}
@@ -995,7 +991,7 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 			goto ZL1;
 		}
 	
-#line 999 "src/libre/dialect/sql/parser.c"
+#line 995 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-piece */
 	}
@@ -1025,7 +1021,7 @@ p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__ex
 			goto ZL1;
 		}
 	
-#line 1029 "src/libre/dialect/sql/parser.c"
+#line 1025 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-alt */
 		p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, ZInode);
@@ -1046,7 +1042,7 @@ ZL1:;
 		}
 		goto ZL2;
 	
-#line 1050 "src/libre/dialect/sql/parser.c"
+#line 1046 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
 		/* BEGINNING OF ACTION: ast-make-empty */
@@ -1058,7 +1054,7 @@ ZL1:;
 			goto ZL2;
 		}
 	
-#line 1062 "src/libre/dialect/sql/parser.c"
+#line 1058 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -1071,7 +1067,7 @@ ZL0:;
 }
 
 static void
-p_208(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZIclass)
+p_206(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZIclass)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_RANGE):
@@ -1093,7 +1089,7 @@ p_208(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 		(void) ZI118;
 		(void) ZI119;
 	
-#line 1097 "src/libre/dialect/sql/parser.c"
+#line 1093 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
@@ -1106,7 +1102,7 @@ p_208(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			goto ZL1;
 		}
 	
-#line 1110 "src/libre/dialect/sql/parser.c"
+#line 1106 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 			/* BEGINNING OF ACTION: ast-add-alt */
@@ -1117,7 +1113,7 @@ p_208(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			goto ZL1;
 		}
 	
-#line 1121 "src/libre/dialect/sql/parser.c"
+#line 1117 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 			/* BEGINNING OF ACTION: ast-make-invert */
@@ -1160,7 +1156,7 @@ p_208(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			goto ZL1;
 		}
 	
-#line 1164 "src/libre/dialect/sql/parser.c"
+#line 1160 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-invert */
 		}
@@ -1207,7 +1203,7 @@ p_208(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			goto ZL1;
 		}
 	
-#line 1211 "src/libre/dialect/sql/parser.c"
+#line 1207 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-invert */
 		}
@@ -1222,7 +1218,7 @@ ZL1:;
 }
 
 static void
-p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI209, t_pos *ZI210, t_ast__expr *ZOnode)
+p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI207, t_pos *ZI208, t_ast__expr *ZOnode)
 {
 	t_ast__expr ZInode;
 
@@ -1233,12 +1229,12 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			{
 #line 908 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (*ZI209));
+		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (*ZI207));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1242 "src/libre/dialect/sql/parser.c"
+#line 1238 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -1259,9 +1255,9 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 #line 873 "src/libre/parser.act"
 
 		(ZIa).type = AST_ENDPOINT_LITERAL;
-		(ZIa).u.literal.c = (unsigned char)(*ZI209);
+		(ZIa).u.literal.c = (unsigned char)(*ZI207);
 	
-#line 1265 "src/libre/dialect/sql/parser.c"
+#line 1261 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF EXTRACT: RANGE */
@@ -1276,7 +1272,7 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		(void) ZI138;
 		(void) ZI139;
 	
-#line 1280 "src/libre/dialect/sql/parser.c"
+#line 1276 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
@@ -1297,7 +1293,7 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 		ZIcz = lex_state->buf.a[0];
 	
-#line 1301 "src/libre/dialect/sql/parser.c"
+#line 1297 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: CHAR */
 				break;
@@ -1312,17 +1308,17 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		(ZIz).type = AST_ENDPOINT_LITERAL;
 		(ZIz).u.literal.c = (unsigned char)(ZIcz);
 	
-#line 1316 "src/libre/dialect/sql/parser.c"
+#line 1312 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF ACTION: mark-range */
 			{
 #line 786 "src/libre/parser.act"
 
-		mark(&act_state->rangestart, &(*ZI210));
+		mark(&act_state->rangestart, &(*ZI208));
 		mark(&act_state->rangeend,   &(ZIend));
 	
-#line 1326 "src/libre/dialect/sql/parser.c"
+#line 1322 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-make-range */
@@ -1332,7 +1328,7 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI210));
+		AST_POS_OF_LX_POS(ast_start, (*ZI208));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		if ((ZIa).type != AST_ENDPOINT_LITERAL ||
@@ -1360,7 +1356,7 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			goto ZL1;
 		}
 	
-#line 1364 "src/libre/dialect/sql/parser.c"
+#line 1360 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -1377,27 +1373,27 @@ ZL0:;
 }
 
 static void
-p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI213, t_unsigned *ZIm, t_ast__count *ZOc)
+p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI211, t_unsigned *ZIm, t_ast__count *ZOc)
 {
 	t_ast__count ZIc;
 
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CLOSECOUNT):
 		{
-			t_pos ZI179;
+			t_pos ZI177;
 			t_pos ZIend;
 
 			/* BEGINNING OF EXTRACT: CLOSECOUNT */
 			{
 #line 397 "src/libre/parser.act"
 
-		ZI179 = lex_state->lx.start;
+		ZI177 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 
-		(void) ZI179;
+		(void) ZI177;
 		(void) ZIend;
 	
-#line 1401 "src/libre/dialect/sql/parser.c"
+#line 1397 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: CLOSECOUNT */
 			ADVANCE_LEXER;
@@ -1405,10 +1401,10 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			{
 #line 791 "src/libre/parser.act"
 
-		mark(&act_state->countstart, &(*ZI213));
+		mark(&act_state->countstart, &(*ZI211));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 1412 "src/libre/dialect/sql/parser.c"
+#line 1408 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
@@ -1422,18 +1418,18 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			err->m = (*ZIm);
 			err->n = (*ZIm);
 
-			mark(&act_state->countstart, &(*ZI213));
+			mark(&act_state->countstart, &(*ZI211));
 			mark(&act_state->countend,   &(ZIend));
 
 			goto ZL1;
 		}
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI213));
+		AST_POS_OF_LX_POS(ast_start, (*ZI211));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (*ZIm), &ast_end);
 	
-#line 1437 "src/libre/dialect/sql/parser.c"
+#line 1433 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-range */
 		}
@@ -1441,7 +1437,7 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 	case (TOK_SEP):
 		{
 			t_unsigned ZIn;
-			t_pos ZI182;
+			t_pos ZI180;
 			t_pos ZIend;
 
 			ADVANCE_LEXER;
@@ -1469,7 +1465,7 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 
 		ZIn = (unsigned int) u;
 	
-#line 1473 "src/libre/dialect/sql/parser.c"
+#line 1469 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -1483,13 +1479,13 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 				{
 #line 397 "src/libre/parser.act"
 
-		ZI182 = lex_state->lx.start;
+		ZI180 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 
-		(void) ZI182;
+		(void) ZI180;
 		(void) ZIend;
 	
-#line 1493 "src/libre/dialect/sql/parser.c"
+#line 1489 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: CLOSECOUNT */
 				break;
@@ -1501,10 +1497,10 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			{
 #line 791 "src/libre/parser.act"
 
-		mark(&act_state->countstart, &(*ZI213));
+		mark(&act_state->countstart, &(*ZI211));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 1508 "src/libre/dialect/sql/parser.c"
+#line 1504 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
@@ -1518,18 +1514,18 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			err->m = (*ZIm);
 			err->n = (ZIn);
 
-			mark(&act_state->countstart, &(*ZI213));
+			mark(&act_state->countstart, &(*ZI211));
 			mark(&act_state->countend,   &(ZIend));
 
 			goto ZL1;
 		}
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI213));
+		AST_POS_OF_LX_POS(ast_start, (*ZI211));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (ZIn), &ast_end);
 	
-#line 1533 "src/libre/dialect/sql/parser.c"
+#line 1529 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-range */
 		}
@@ -1570,10 +1566,10 @@ ZL2_expr_C_Clist_Hof_Halts:;
 			goto ZL1;
 		}
 	
-#line 1574 "src/libre/dialect/sql/parser.c"
+#line 1570 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-add-alt */
-		/* BEGINNING OF INLINE: 192 */
+		/* BEGINNING OF INLINE: 190 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ALT):
@@ -1588,7 +1584,7 @@ ZL2_expr_C_Clist_Hof_Halts:;
 				break;
 			}
 		}
-		/* END OF INLINE: 192 */
+		/* END OF INLINE: 190 */
 	}
 	return;
 ZL1:;
@@ -1602,7 +1598,7 @@ ZL1:;
 		}
 		goto ZL4;
 	
-#line 1606 "src/libre/dialect/sql/parser.c"
+#line 1602 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
 	}
@@ -1621,21 +1617,21 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 	switch (CURRENT_TERMINAL) {
 	case (TOK_OPENCOUNT):
 		{
-			t_pos ZI213;
-			t_pos ZI214;
+			t_pos ZI211;
+			t_pos ZI212;
 			t_unsigned ZIm;
 
 			/* BEGINNING OF EXTRACT: OPENCOUNT */
 			{
 #line 389 "src/libre/parser.act"
 
-		ZI213 = lex_state->lx.start;
-		ZI214   = lex_state->lx.end;
+		ZI211 = lex_state->lx.start;
+		ZI212   = lex_state->lx.end;
 
-		(void) ZI213;
-		(void) ZI214;
+		(void) ZI211;
+		(void) ZI212;
 	
-#line 1639 "src/libre/dialect/sql/parser.c"
+#line 1635 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: OPENCOUNT */
 			ADVANCE_LEXER;
@@ -1663,7 +1659,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		ZIm = (unsigned int) u;
 	
-#line 1667 "src/libre/dialect/sql/parser.c"
+#line 1663 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -1671,7 +1667,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 				goto ZL1;
 			}
 			ADVANCE_LEXER;
-			p_215 (flags, lex_state, act_state, err, &ZI213, &ZIm, &ZIc);
+			p_213 (flags, lex_state, act_state, err, &ZI211, &ZIm, &ZIc);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1687,7 +1683,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		(ZIc) = ast_make_count(0, NULL, 1, NULL);
 	
-#line 1691 "src/libre/dialect/sql/parser.c"
+#line 1687 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-one */
 		}
@@ -1701,7 +1697,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		(ZIc) = ast_make_count(1, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 1705 "src/libre/dialect/sql/parser.c"
+#line 1701 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-one-or-more */
 		}
@@ -1715,7 +1711,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 1719 "src/libre/dialect/sql/parser.c"
+#line 1715 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 		}
@@ -1728,7 +1724,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 1732 "src/libre/dialect/sql/parser.c"
+#line 1728 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-one */
 		}
@@ -1748,7 +1744,7 @@ ZL1:;
 		}
 		goto ZL2;
 	
-#line 1752 "src/libre/dialect/sql/parser.c"
+#line 1748 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: err-expected-count */
 		/* BEGINNING OF ACTION: count-one */
@@ -1757,7 +1753,7 @@ ZL1:;
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 1761 "src/libre/dialect/sql/parser.c"
+#line 1757 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: count-one */
 	}
@@ -1787,7 +1783,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 		/* TODO: or the unicode equivalent */
 		(ZIa) = (*flags & RE_SINGLE) ? &class_any : &class_notnl;
 	
-#line 1791 "src/libre/dialect/sql/parser.c"
+#line 1787 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
@@ -1799,7 +1795,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 1803 "src/libre/dialect/sql/parser.c"
+#line 1799 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 		}
@@ -1807,8 +1803,8 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 	case (TOK_CHAR):
 		{
 			t_char ZIa;
-			t_pos ZI173;
-			t_pos ZI174;
+			t_pos ZI171;
+			t_pos ZI172;
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
@@ -1817,15 +1813,15 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI173 = lex_state->lx.start;
-		ZI174   = lex_state->lx.end;
+		ZI171 = lex_state->lx.start;
+		ZI172   = lex_state->lx.end;
 
-		(void) ZI173;
-		(void) ZI174;
+		(void) ZI171;
+		(void) ZI172;
 
 		ZIa = lex_state->buf.a[0];
 	
-#line 1829 "src/libre/dialect/sql/parser.c"
+#line 1825 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
@@ -1838,7 +1834,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 1842 "src/libre/dialect/sql/parser.c"
+#line 1838 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -1857,7 +1853,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 		/* TODO: or the unicode equivalent */
 		(ZIa) = (*flags & RE_SINGLE) ? &class_any : &class_notnl;
 	
-#line 1861 "src/libre/dialect/sql/parser.c"
+#line 1857 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
@@ -1869,7 +1865,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 1873 "src/libre/dialect/sql/parser.c"
+#line 1869 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 			/* BEGINNING OF ACTION: count-zero-or-more */
@@ -1878,7 +1874,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 1882 "src/libre/dialect/sql/parser.c"
+#line 1878 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 			/* BEGINNING OF ACTION: ast-make-piece */
@@ -1897,7 +1893,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 1901 "src/libre/dialect/sql/parser.c"
+#line 1897 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-piece */
 		}
@@ -1914,7 +1910,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 
 		(ZIid) = act_state->group_id++;
 	
-#line 1918 "src/libre/dialect/sql/parser.c"
+#line 1914 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: make-group-id */
 			p_expr (flags, lex_state, act_state, err, &ZIg);
@@ -1931,7 +1927,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 1935 "src/libre/dialect/sql/parser.c"
+#line 1931 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-group */
 			switch (CURRENT_TERMINAL) {
@@ -1969,7 +1965,7 @@ ZL1:;
 		}
 		goto ZL2;
 	
-#line 1973 "src/libre/dialect/sql/parser.c"
+#line 1969 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-empty */
@@ -1981,7 +1977,7 @@ ZL1:;
 			goto ZL2;
 		}
 	
-#line 1985 "src/libre/dialect/sql/parser.c"
+#line 1981 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -2024,7 +2020,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed(flags flags, lex_state lex_state, act
 		(void) ZI129;
 		(void) ZI130;
 	
-#line 2028 "src/libre/dialect/sql/parser.c"
+#line 2024 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			break;
@@ -2041,7 +2037,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed(flags flags, lex_state lex_state, act
 			goto ZL1;
 		}
 	
-#line 2045 "src/libre/dialect/sql/parser.c"
+#line 2041 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-named */
 	}
@@ -2071,7 +2067,7 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 			goto ZL1;
 		}
 	
-#line 2075 "src/libre/dialect/sql/parser.c"
+#line 2071 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-concat */
 			p_expr_C_Clist_Hof_Hpieces (flags, lex_state, act_state, err, ZInode);
@@ -2092,7 +2088,7 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 			goto ZL1;
 		}
 	
-#line 2096 "src/libre/dialect/sql/parser.c"
+#line 2092 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-empty */
 		}
@@ -2269,6 +2265,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 2273 "src/libre/dialect/sql/parser.c"
+#line 2269 "src/libre/dialect/sql/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/sql/parser.c
+++ b/src/libre/dialect/sql/parser.c
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 22 "src/libre/parser.act"
+#line 149 "src/libre/parser.act"
 
 
 	#include <assert.h>
@@ -238,7 +238,7 @@
 
 		n = sprintf(s, "%.*s", (int) sz - 3 - 1, msg);
 		if (n == sz - 3 - 1) {
-			strcpy(s + sz, "...");
+			strcpy(s + n, "...");
 		}
 	}
 
@@ -329,11 +329,13 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: INVERT */
 			{
-#line 314 "src/libre/parser.act"
+#line 321 "src/libre/parser.act"
 
 		ZI207 = '^';
+
+		(void) ZI207;
 	
-#line 337 "src/libre/dialect/sql/parser.c"
+#line 339 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: INVERT */
 			ADVANCE_LEXER;
@@ -353,37 +355,41 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 318 "src/libre/parser.act"
+#line 327 "src/libre/parser.act"
 
 		ZIc = '-';
 		ZI115 = lex_state->lx.start;
 		ZI116   = lex_state->lx.end;
+
+		(void) ZIc;
+		(void) ZI115;
+		(void) ZI116;
 	
-#line 363 "src/libre/dialect/sql/parser.c"
+#line 369 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 836 "src/libre/parser.act"
+#line 908 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 376 "src/libre/dialect/sql/parser.c"
+#line 382 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 			/* BEGINNING OF ACTION: ast-add-alt */
 			{
-#line 1012 "src/libre/parser.act"
+#line 1084 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((*ZIclass), (ZInode))) {
 			goto ZL1;
 		}
 	
-#line 387 "src/libre/dialect/sql/parser.c"
+#line 393 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 		}
@@ -435,14 +441,14 @@ p_re__sql(flags flags, lex_state lex_state, act_state act_state, err err, t_ast_
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
-#line 695 "src/libre/parser.act"
+#line 770 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXEOF;
 		}
 		goto ZL1;
 	
-#line 446 "src/libre/dialect/sql/parser.c"
+#line 452 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
@@ -478,13 +484,13 @@ ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 				}
 				/* BEGINNING OF ACTION: ast-add-alt */
 				{
-#line 1012 "src/libre/parser.act"
+#line 1084 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIclass), (ZInode))) {
 			goto ZL4;
 		}
 	
-#line 488 "src/libre/dialect/sql/parser.c"
+#line 494 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: ast-add-alt */
 			}
@@ -493,14 +499,14 @@ ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 			{
 				/* BEGINNING OF ACTION: err-expected-term */
 				{
-#line 632 "src/libre/parser.act"
+#line 707 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXTERM;
 		}
 		goto ZL1;
 	
-#line 504 "src/libre/dialect/sql/parser.c"
+#line 510 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: err-expected-term */
 			}
@@ -516,7 +522,7 @@ ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 					goto ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms;
 					/* END OF INLINE: expr::character-class::list-of-class-terms */
 				}
-				/* UNREACHED */
+				/*UNREACHED*/
 			default:
 				break;
 			}
@@ -554,13 +560,13 @@ ZL2_expr_C_Clist_Hof_Hpieces:;
 		}
 		/* BEGINNING OF ACTION: ast-add-concat */
 		{
-#line 1006 "src/libre/parser.act"
+#line 1078 "src/libre/parser.act"
 
 		if (!ast_add_expr_concat((ZIcat), (ZIa))) {
 			goto ZL1;
 		}
 	
-#line 564 "src/libre/dialect/sql/parser.c"
+#line 570 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-add-concat */
 		/* BEGINNING OF INLINE: 186 */
@@ -573,7 +579,7 @@ ZL2_expr_C_Clist_Hof_Hpieces:;
 					goto ZL2_expr_C_Clist_Hof_Hpieces;
 					/* END OF INLINE: expr::list-of-pieces */
 				}
-				/* UNREACHED */
+				/*UNREACHED*/
 			default:
 				break;
 			}
@@ -600,7 +606,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
-#line 532 "src/libre/parser.act"
+#line 592 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -608,9 +614,12 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		ZI210 = lex_state->lx.start;
 		ZI211   = lex_state->lx.end;
 
+		(void) ZI210;
+		(void) ZI211;
+
 		ZI209 = lex_state->buf.a[0];
 	
-#line 614 "src/libre/dialect/sql/parser.c"
+#line 623 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
@@ -661,12 +670,15 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		case (TOK_OPENGROUP):
 			/* BEGINNING OF EXTRACT: OPENGROUP */
 			{
-#line 324 "src/libre/parser.act"
+#line 337 "src/libre/parser.act"
 
 		ZIopen__start = lex_state->lx.start;
 		ZIopen__end   = lex_state->lx.end;
+
+		(void) ZIopen__start;
+		(void) ZIopen__end;
 	
-#line 670 "src/libre/dialect/sql/parser.c"
+#line 682 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: OPENGROUP */
 			break;
@@ -676,14 +688,14 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-make-alt */
 		{
-#line 829 "src/libre/parser.act"
+#line 901 "src/libre/parser.act"
 
 		(ZIclass) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZIclass) == NULL) {
 			goto ZL1;
 		}
 	
-#line 687 "src/libre/dialect/sql/parser.c"
+#line 699 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-alt */
 		ZItmp = ZIclass;
@@ -701,29 +713,33 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 					/* BEGINNING OF EXTRACT: CLOSEGROUP */
 					{
-#line 344 "src/libre/parser.act"
+#line 369 "src/libre/parser.act"
 
 		ZI155 = ']';
 		ZIclose__start = lex_state->lx.start;
 		ZIclose__end   = lex_state->lx.end;
+
+		(void) ZI155;
+		(void) ZIclose__start;
+		(void) ZIclose__end;
 	
-#line 711 "src/libre/dialect/sql/parser.c"
+#line 727 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF EXTRACT: CLOSEGROUP */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: mark-group */
 					{
-#line 709 "src/libre/parser.act"
+#line 781 "src/libre/parser.act"
 
 		mark(&act_state->groupstart, &(ZIopen__start));
 		mark(&act_state->groupend,   &(ZIopen__end));
 	
-#line 722 "src/libre/dialect/sql/parser.c"
+#line 738 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: mark-group */
 					/* BEGINNING OF ACTION: mark-expr */
 					{
-#line 724 "src/libre/parser.act"
+#line 798 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -738,7 +754,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		(ZItmp)->u.class.end   = ast_end;
 */
 	
-#line 742 "src/libre/dialect/sql/parser.c"
+#line 758 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: mark-expr */
 					ZInode = ZIclass;
@@ -753,24 +769,26 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 					/* BEGINNING OF EXTRACT: INVERT */
 					{
-#line 314 "src/libre/parser.act"
+#line 321 "src/libre/parser.act"
 
 		ZI159 = '^';
+
+		(void) ZI159;
 	
-#line 761 "src/libre/dialect/sql/parser.c"
+#line 779 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF EXTRACT: INVERT */
 					ADVANCE_LEXER;
 					/* BEGINNING OF ACTION: ast-make-alt */
 					{
-#line 829 "src/libre/parser.act"
+#line 901 "src/libre/parser.act"
 
 		(ZImask) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZImask) == NULL) {
 			goto ZL3;
 		}
 	
-#line 774 "src/libre/dialect/sql/parser.c"
+#line 792 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: ast-make-alt */
 					ZImask__tmp = ZImask;
@@ -791,13 +809,17 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 							case (TOK_CLOSEGROUP):
 								/* BEGINNING OF EXTRACT: CLOSEGROUP */
 								{
-#line 344 "src/libre/parser.act"
+#line 369 "src/libre/parser.act"
 
 		ZI164 = ']';
 		ZIclose__start = lex_state->lx.start;
 		ZIclose__end   = lex_state->lx.end;
+
+		(void) ZI164;
+		(void) ZIclose__start;
+		(void) ZIclose__end;
 	
-#line 801 "src/libre/dialect/sql/parser.c"
+#line 823 "src/libre/dialect/sql/parser.c"
 								}
 								/* END OF EXTRACT: CLOSEGROUP */
 								break;
@@ -807,12 +829,12 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 							ADVANCE_LEXER;
 							/* BEGINNING OF ACTION: mark-group */
 							{
-#line 709 "src/libre/parser.act"
+#line 781 "src/libre/parser.act"
 
 		mark(&act_state->groupstart, &(ZIclose__start));
 		mark(&act_state->groupend,   &(ZIclose__end));
 	
-#line 816 "src/libre/dialect/sql/parser.c"
+#line 838 "src/libre/dialect/sql/parser.c"
 							}
 							/* END OF ACTION: mark-group */
 						}
@@ -823,14 +845,14 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 							/* BEGINNING OF ACTION: err-expected-closegroup */
 							{
-#line 667 "src/libre/parser.act"
+#line 742 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCLOSEGROUP;
 		}
 		goto ZL3;
 	
-#line 834 "src/libre/dialect/sql/parser.c"
+#line 856 "src/libre/dialect/sql/parser.c"
 							}
 							/* END OF ACTION: err-expected-closegroup */
 							ZIclose__start = ZIopen__end;
@@ -841,7 +863,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 					/* END OF INLINE: 163 */
 					/* BEGINNING OF ACTION: mark-expr */
 					{
-#line 724 "src/libre/parser.act"
+#line 798 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -856,12 +878,12 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		(ZItmp)->u.class.end   = ast_end;
 */
 	
-#line 860 "src/libre/dialect/sql/parser.c"
+#line 882 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: mark-expr */
 					/* BEGINNING OF ACTION: mark-expr */
 					{
-#line 724 "src/libre/parser.act"
+#line 798 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -876,19 +898,19 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		(ZImask__tmp)->u.class.end   = ast_end;
 */
 	
-#line 880 "src/libre/dialect/sql/parser.c"
+#line 902 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: mark-expr */
 					/* BEGINNING OF ACTION: ast-make-subtract */
 					{
-#line 921 "src/libre/parser.act"
+#line 993 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_subtract(act_state->poolp, *flags, (ZIclass), (ZImask));
 		if ((ZInode) == NULL) {
 			goto ZL3;
 		}
 	
-#line 892 "src/libre/dialect/sql/parser.c"
+#line 914 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: ast-make-subtract */
 				}
@@ -904,26 +926,26 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			{
 				/* BEGINNING OF ACTION: err-expected-closegroup */
 				{
-#line 667 "src/libre/parser.act"
+#line 742 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCLOSEGROUP;
 		}
 		goto ZL1;
 	
-#line 915 "src/libre/dialect/sql/parser.c"
+#line 937 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: err-expected-closegroup */
 				/* BEGINNING OF ACTION: ast-make-empty */
 				{
-#line 815 "src/libre/parser.act"
+#line 887 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 927 "src/libre/dialect/sql/parser.c"
+#line 949 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: ast-make-empty */
 			}
@@ -959,7 +981,7 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 		}
 		/* BEGINNING OF ACTION: ast-make-piece */
 		{
-#line 859 "src/libre/parser.act"
+#line 931 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
@@ -973,7 +995,7 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 			goto ZL1;
 		}
 	
-#line 977 "src/libre/dialect/sql/parser.c"
+#line 999 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-piece */
 	}
@@ -996,14 +1018,14 @@ p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__ex
 	{
 		/* BEGINNING OF ACTION: ast-make-alt */
 		{
-#line 829 "src/libre/parser.act"
+#line 901 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_alt(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1007 "src/libre/dialect/sql/parser.c"
+#line 1029 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-alt */
 		p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, ZInode);
@@ -1017,26 +1039,26 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-alts */
 		{
-#line 653 "src/libre/parser.act"
+#line 728 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXALTS;
 		}
 		goto ZL2;
 	
-#line 1028 "src/libre/dialect/sql/parser.c"
+#line 1050 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 815 "src/libre/parser.act"
+#line 887 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL2;
 		}
 	
-#line 1040 "src/libre/dialect/sql/parser.c"
+#line 1062 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -1061,42 +1083,46 @@ p_208(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 318 "src/libre/parser.act"
+#line 327 "src/libre/parser.act"
 
 		ZIc = '-';
 		ZI118 = lex_state->lx.start;
 		ZI119   = lex_state->lx.end;
+
+		(void) ZIc;
+		(void) ZI118;
+		(void) ZI119;
 	
-#line 1071 "src/libre/dialect/sql/parser.c"
+#line 1097 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 836 "src/libre/parser.act"
+#line 908 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (ZIc));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1084 "src/libre/dialect/sql/parser.c"
+#line 1110 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 			/* BEGINNING OF ACTION: ast-add-alt */
 			{
-#line 1012 "src/libre/parser.act"
+#line 1084 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((*ZIclass), (ZInode))) {
 			goto ZL1;
 		}
 	
-#line 1095 "src/libre/dialect/sql/parser.c"
+#line 1121 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 			/* BEGINNING OF ACTION: ast-make-invert */
 			{
-#line 928 "src/libre/parser.act"
+#line 1028 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -1134,7 +1160,7 @@ p_208(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			goto ZL1;
 		}
 	
-#line 1138 "src/libre/dialect/sql/parser.c"
+#line 1164 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-invert */
 		}
@@ -1143,7 +1169,7 @@ p_208(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 		{
 			/* BEGINNING OF ACTION: ast-make-invert */
 			{
-#line 928 "src/libre/parser.act"
+#line 1028 "src/libre/parser.act"
 
 		struct ast_expr *any;
 
@@ -1181,7 +1207,7 @@ p_208(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			goto ZL1;
 		}
 	
-#line 1185 "src/libre/dialect/sql/parser.c"
+#line 1211 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-invert */
 		}
@@ -1205,14 +1231,14 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		{
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 836 "src/libre/parser.act"
+#line 908 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (*ZI209));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1216 "src/libre/dialect/sql/parser.c"
+#line 1242 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -1230,23 +1256,27 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 801 "src/libre/parser.act"
+#line 873 "src/libre/parser.act"
 
 		(ZIa).type = AST_ENDPOINT_LITERAL;
 		(ZIa).u.literal.c = (unsigned char)(*ZI209);
 	
-#line 1239 "src/libre/dialect/sql/parser.c"
+#line 1265 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF EXTRACT: RANGE */
 			{
-#line 318 "src/libre/parser.act"
+#line 327 "src/libre/parser.act"
 
 		ZI137 = '-';
 		ZI138 = lex_state->lx.start;
 		ZI139   = lex_state->lx.end;
+
+		(void) ZI137;
+		(void) ZI138;
+		(void) ZI139;
 	
-#line 1250 "src/libre/dialect/sql/parser.c"
+#line 1280 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
@@ -1254,7 +1284,7 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			case (TOK_CHAR):
 				/* BEGINNING OF EXTRACT: CHAR */
 				{
-#line 532 "src/libre/parser.act"
+#line 592 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -1262,9 +1292,12 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		ZI141 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
 
+		(void) ZI141;
+		(void) ZIend;
+
 		ZIcz = lex_state->buf.a[0];
 	
-#line 1268 "src/libre/dialect/sql/parser.c"
+#line 1301 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: CHAR */
 				break;
@@ -1274,27 +1307,27 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
 			{
-#line 801 "src/libre/parser.act"
+#line 873 "src/libre/parser.act"
 
 		(ZIz).type = AST_ENDPOINT_LITERAL;
 		(ZIz).u.literal.c = (unsigned char)(ZIcz);
 	
-#line 1283 "src/libre/dialect/sql/parser.c"
+#line 1316 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF ACTION: mark-range */
 			{
-#line 714 "src/libre/parser.act"
+#line 786 "src/libre/parser.act"
 
 		mark(&act_state->rangestart, &(*ZI210));
 		mark(&act_state->rangeend,   &(ZIend));
 	
-#line 1293 "src/libre/dialect/sql/parser.c"
+#line 1326 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-make-range */
 			{
-#line 966 "src/libre/parser.act"
+#line 1041 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
@@ -1327,7 +1360,7 @@ p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			goto ZL1;
 		}
 	
-#line 1331 "src/libre/dialect/sql/parser.c"
+#line 1364 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -1356,28 +1389,31 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 
 			/* BEGINNING OF EXTRACT: CLOSECOUNT */
 			{
-#line 361 "src/libre/parser.act"
+#line 397 "src/libre/parser.act"
 
 		ZI179 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
+
+		(void) ZI179;
+		(void) ZIend;
 	
-#line 1365 "src/libre/dialect/sql/parser.c"
+#line 1401 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: CLOSECOUNT */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 719 "src/libre/parser.act"
+#line 791 "src/libre/parser.act"
 
 		mark(&act_state->countstart, &(*ZI213));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 1376 "src/libre/dialect/sql/parser.c"
+#line 1412 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 781 "src/libre/parser.act"
+#line 855 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -1397,7 +1433,7 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (*ZIm), &ast_end);
 	
-#line 1401 "src/libre/dialect/sql/parser.c"
+#line 1437 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-range */
 		}
@@ -1413,7 +1449,7 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			case (TOK_COUNT):
 				/* BEGINNING OF EXTRACT: COUNT */
 				{
-#line 572 "src/libre/parser.act"
+#line 649 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -1433,7 +1469,7 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 
 		ZIn = (unsigned int) u;
 	
-#line 1437 "src/libre/dialect/sql/parser.c"
+#line 1473 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -1445,12 +1481,15 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			case (TOK_CLOSECOUNT):
 				/* BEGINNING OF EXTRACT: CLOSECOUNT */
 				{
-#line 361 "src/libre/parser.act"
+#line 397 "src/libre/parser.act"
 
 		ZI182 = lex_state->lx.start;
 		ZIend   = lex_state->lx.end;
+
+		(void) ZI182;
+		(void) ZIend;
 	
-#line 1454 "src/libre/dialect/sql/parser.c"
+#line 1493 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: CLOSECOUNT */
 				break;
@@ -1460,17 +1499,17 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: mark-count */
 			{
-#line 719 "src/libre/parser.act"
+#line 791 "src/libre/parser.act"
 
 		mark(&act_state->countstart, &(*ZI213));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 1469 "src/libre/dialect/sql/parser.c"
+#line 1508 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
 			{
-#line 781 "src/libre/parser.act"
+#line 855 "src/libre/parser.act"
 
 		struct ast_pos ast_start, ast_end;
 
@@ -1490,7 +1529,7 @@ p_215(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (ZIn), &ast_end);
 	
-#line 1494 "src/libre/dialect/sql/parser.c"
+#line 1533 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-range */
 		}
@@ -1525,13 +1564,13 @@ ZL2_expr_C_Clist_Hof_Halts:;
 		}
 		/* BEGINNING OF ACTION: ast-add-alt */
 		{
-#line 1012 "src/libre/parser.act"
+#line 1084 "src/libre/parser.act"
 
 		if (!ast_add_expr_alt((ZIalts), (ZIa))) {
 			goto ZL1;
 		}
 	
-#line 1535 "src/libre/dialect/sql/parser.c"
+#line 1574 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-add-alt */
 		/* BEGINNING OF INLINE: 192 */
@@ -1544,7 +1583,7 @@ ZL2_expr_C_Clist_Hof_Halts:;
 					goto ZL2_expr_C_Clist_Hof_Halts;
 					/* END OF INLINE: expr::list-of-alts */
 				}
-				/* UNREACHED */
+				/*UNREACHED*/
 			default:
 				break;
 			}
@@ -1556,14 +1595,14 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-alts */
 		{
-#line 653 "src/libre/parser.act"
+#line 728 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXALTS;
 		}
 		goto ZL4;
 	
-#line 1567 "src/libre/dialect/sql/parser.c"
+#line 1606 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
 	}
@@ -1588,12 +1627,15 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 			/* BEGINNING OF EXTRACT: OPENCOUNT */
 			{
-#line 356 "src/libre/parser.act"
+#line 389 "src/libre/parser.act"
 
 		ZI213 = lex_state->lx.start;
 		ZI214   = lex_state->lx.end;
+
+		(void) ZI213;
+		(void) ZI214;
 	
-#line 1597 "src/libre/dialect/sql/parser.c"
+#line 1639 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: OPENCOUNT */
 			ADVANCE_LEXER;
@@ -1601,7 +1643,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			case (TOK_COUNT):
 				/* BEGINNING OF EXTRACT: COUNT */
 				{
-#line 572 "src/libre/parser.act"
+#line 649 "src/libre/parser.act"
 
 		unsigned long u;
 		char *e;
@@ -1621,7 +1663,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		ZIm = (unsigned int) u;
 	
-#line 1625 "src/libre/dialect/sql/parser.c"
+#line 1667 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -1641,11 +1683,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-zero-or-one */
 			{
-#line 773 "src/libre/parser.act"
+#line 845 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, 1, NULL);
 	
-#line 1649 "src/libre/dialect/sql/parser.c"
+#line 1691 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-one */
 		}
@@ -1655,11 +1697,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-one-or-more */
 			{
-#line 769 "src/libre/parser.act"
+#line 841 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 1663 "src/libre/dialect/sql/parser.c"
+#line 1705 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-one-or-more */
 		}
@@ -1669,11 +1711,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: count-zero-or-more */
 			{
-#line 765 "src/libre/parser.act"
+#line 837 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 1677 "src/libre/dialect/sql/parser.c"
+#line 1719 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 		}
@@ -1682,11 +1724,11 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 		{
 			/* BEGINNING OF ACTION: count-one */
 			{
-#line 777 "src/libre/parser.act"
+#line 849 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 1690 "src/libre/dialect/sql/parser.c"
+#line 1732 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-one */
 		}
@@ -1699,23 +1741,23 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-count */
 		{
-#line 639 "src/libre/parser.act"
+#line 714 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXCOUNT;
 		}
 		goto ZL2;
 	
-#line 1710 "src/libre/dialect/sql/parser.c"
+#line 1752 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: err-expected-count */
 		/* BEGINNING OF ACTION: count-one */
 		{
-#line 777 "src/libre/parser.act"
+#line 849 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 1719 "src/libre/dialect/sql/parser.c"
+#line 1761 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: count-one */
 	}
@@ -1740,24 +1782,24 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: class-any */
 			{
-#line 739 "src/libre/parser.act"
+#line 812 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
 		(ZIa) = (*flags & RE_SINGLE) ? &class_any : &class_notnl;
 	
-#line 1749 "src/libre/dialect/sql/parser.c"
+#line 1791 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 999 "src/libre/parser.act"
+#line 1071 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_named(act_state->poolp, *flags, (ZIa));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1761 "src/libre/dialect/sql/parser.c"
+#line 1803 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 		}
@@ -1770,7 +1812,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
-#line 532 "src/libre/parser.act"
+#line 592 "src/libre/parser.act"
 
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
@@ -1778,22 +1820,25 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 		ZI173 = lex_state->lx.start;
 		ZI174   = lex_state->lx.end;
 
+		(void) ZI173;
+		(void) ZI174;
+
 		ZIa = lex_state->buf.a[0];
 	
-#line 1784 "src/libre/dialect/sql/parser.c"
+#line 1829 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: ast-make-literal */
 			{
-#line 836 "src/libre/parser.act"
+#line 908 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_literal(act_state->poolp, *flags, (ZIa));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1797 "src/libre/dialect/sql/parser.c"
+#line 1842 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -1807,38 +1852,38 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: class-any */
 			{
-#line 739 "src/libre/parser.act"
+#line 812 "src/libre/parser.act"
 
 		/* TODO: or the unicode equivalent */
 		(ZIa) = (*flags & RE_SINGLE) ? &class_any : &class_notnl;
 	
-#line 1816 "src/libre/dialect/sql/parser.c"
+#line 1861 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
 			{
-#line 999 "src/libre/parser.act"
+#line 1071 "src/libre/parser.act"
 
 		(ZIg) = ast_make_expr_named(act_state->poolp, *flags, (ZIa));
 		if ((ZIg) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1828 "src/libre/dialect/sql/parser.c"
+#line 1873 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 			/* BEGINNING OF ACTION: count-zero-or-more */
 			{
-#line 765 "src/libre/parser.act"
+#line 837 "src/libre/parser.act"
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 1837 "src/libre/dialect/sql/parser.c"
+#line 1882 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 			/* BEGINNING OF ACTION: ast-make-piece */
 			{
-#line 859 "src/libre/parser.act"
+#line 931 "src/libre/parser.act"
 
 		if ((ZIc).min == 0 && (ZIc).max == 0) {
 			(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
@@ -1852,7 +1897,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 1856 "src/libre/dialect/sql/parser.c"
+#line 1901 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-piece */
 		}
@@ -1865,11 +1910,11 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			ADVANCE_LEXER;
 			/* BEGINNING OF ACTION: make-group-id */
 			{
-#line 843 "src/libre/parser.act"
+#line 915 "src/libre/parser.act"
 
 		(ZIid) = act_state->group_id++;
 	
-#line 1873 "src/libre/dialect/sql/parser.c"
+#line 1918 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: make-group-id */
 			p_expr (flags, lex_state, act_state, err, &ZIg);
@@ -1879,14 +1924,14 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			}
 			/* BEGINNING OF ACTION: ast-make-group */
 			{
-#line 873 "src/libre/parser.act"
+#line 945 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_group(act_state->poolp, *flags, (ZIg), (ZIid));
 		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1890 "src/libre/dialect/sql/parser.c"
+#line 1935 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-group */
 			switch (CURRENT_TERMINAL) {
@@ -1917,26 +1962,26 @@ ZL1:;
 	{
 		/* BEGINNING OF ACTION: err-expected-atom */
 		{
-#line 646 "src/libre/parser.act"
+#line 721 "src/libre/parser.act"
 
 		if (err->e == RE_ESUCCESS) {
 			err->e = RE_EXATOM;
 		}
 		goto ZL2;
 	
-#line 1928 "src/libre/dialect/sql/parser.c"
+#line 1973 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-empty */
 		{
-#line 815 "src/libre/parser.act"
+#line 887 "src/libre/parser.act"
 
 		(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZIe) == NULL) {
 			goto ZL2;
 		}
 	
-#line 1940 "src/libre/dialect/sql/parser.c"
+#line 1985 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -1965,7 +2010,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed(flags flags, lex_state lex_state, act
 		case (TOK_NAMED__CLASS):
 			/* BEGINNING OF EXTRACT: NAMED_CLASS */
 			{
-#line 592 "src/libre/parser.act"
+#line 661 "src/libre/parser.act"
 
 		ZIid = DIALECT_CLASS(lex_state->buf.a);
 		if (ZIid == NULL) {
@@ -1975,8 +2020,11 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed(flags flags, lex_state lex_state, act
 
 		ZI129 = lex_state->lx.start;
 		ZI130   = lex_state->lx.end;
+
+		(void) ZI129;
+		(void) ZI130;
 	
-#line 1980 "src/libre/dialect/sql/parser.c"
+#line 2028 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			break;
@@ -1986,14 +2034,14 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed(flags flags, lex_state lex_state, act
 		ADVANCE_LEXER;
 		/* BEGINNING OF ACTION: ast-make-named */
 		{
-#line 999 "src/libre/parser.act"
+#line 1071 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_named(act_state->poolp, *flags, (ZIid));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1997 "src/libre/dialect/sql/parser.c"
+#line 2045 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-named */
 	}
@@ -2016,14 +2064,14 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 		{
 			/* BEGINNING OF ACTION: ast-make-concat */
 			{
-#line 822 "src/libre/parser.act"
+#line 894 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_concat(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2027 "src/libre/dialect/sql/parser.c"
+#line 2075 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-concat */
 			p_expr_C_Clist_Hof_Hpieces (flags, lex_state, act_state, err, ZInode);
@@ -2037,14 +2085,14 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 		{
 			/* BEGINNING OF ACTION: ast-make-empty */
 			{
-#line 815 "src/libre/parser.act"
+#line 887 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2048 "src/libre/dialect/sql/parser.c"
+#line 2096 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-empty */
 		}
@@ -2062,7 +2110,7 @@ ZL0:;
 
 /* BEGINNING OF TRAILER */
 
-#line 1018 "src/libre/parser.act"
+#line 1247 "src/libre/parser.act"
 
 
 	static int
@@ -2221,6 +2269,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 2225 "src/libre/dialect/sql/parser.c"
+#line 2273 "src/libre/dialect/sql/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/sql/parser.h
+++ b/src/libre/dialect/sql/parser.h
@@ -9,7 +9,7 @@
 
 /* BEGINNING OF HEADER */
 
-#line 299 "src/libre/parser.act"
+#line 310 "src/libre/parser.act"
 
 
 	#include <re/re.h>
@@ -28,7 +28,7 @@
 extern void p_re__sql(flags, lex_state, act_state, err, t_ast__expr *);
 /* BEGINNING OF TRAILER */
 
-#line 1176 "src/libre/parser.act"
+#line 1249 "src/libre/parser.act"
 
 
 #line 35 "src/libre/dialect/sql/parser.h"

--- a/src/libre/dialect/sql/parser.sid
+++ b/src/libre/dialect/sql/parser.sid
@@ -288,17 +288,13 @@
 				{
 					(!, close_start, close_end) = CLOSEGROUP;
 					<mark-group>(close_start, close_end);
+
+					/* TODO: would prefer to demark class and mask separately */
+					<mark-expr>(tmp, open_start, close_end);
+					<mark-expr>(mask_tmp, open_start, close_end);
 				##
 					<err-expected-closegroup>;
-
-					/* appease sid */
-					close_start = open_end;
-					close_end   = open_end;
 				};
-
-				/* TODO: would prefer to demark class and mask separately */
-				<mark-expr>(tmp, open_start, close_end);
-				<mark-expr>(mask_tmp, open_start, close_end);
 
 				/* TODO: store start, end for the subtract expr */
 				node = <ast-make-subtract>(class, mask);

--- a/src/libre/parser.act
+++ b/src/libre/parser.act
@@ -247,7 +247,7 @@
 
 		n = sprintf(s, "%.*s", (int) sz - 3 - 1, msg);
 		if (n == sz - 3 - 1) {
-			strcpy(s + sz, "...");
+			strcpy(s + n, "...");
 		}
 	}
 

--- a/src/libre/parser.act
+++ b/src/libre/parser.act
@@ -311,56 +311,94 @@
 
 %terminals%
 
+	/*
+	 * The (void) casts on output parameters that are unused in some dialects.
+	 * This keeps gcc from complaining about generated variables that are
+	 * assigned a value but not used, without disabling the warning in general.
+	 */
+
 	INVERT: () -> (c :char) = @{
 		@c = '^';
+
+		(void) @c;
 	@};
 
 	RANGE: () -> (c :char, start :pos, end :pos) = @{
 		@c = '-';
 		@start = lex_state->lx.start;
 		@end   = lex_state->lx.end;
+
+		(void) @c;
+		(void) @start;
+		(void) @end;
 	@};
 
 	OPENGROUP: () -> (start :pos, end :pos) = @{
 		@start = lex_state->lx.start;
 		@end   = lex_state->lx.end;
+
+		(void) @start;
+		(void) @end;
 	@};
 
 	OPENGROUPINV: () -> (start :pos, end :pos) = @{
 		@start = lex_state->lx.start;
 		@end   = lex_state->lx.end;
+
+		(void) @start;
+		(void) @end;
 	@};
 
 	OPENGROUPCB: () -> (start :pos, end :pos) = @{
 		@start = lex_state->lx.start;
 		@end   = lex_state->lx.end;
+
+		(void) @start;
+		(void) @end;
 	@};
 
 	OPENGROUPINVCB: () -> (start :pos, end :pos) = @{
 		@start = lex_state->lx.start;
 		@end   = lex_state->lx.end;
+
+		(void) @start;
+		(void) @end;
 	@};
 
 	CLOSEGROUP: () -> (c :char, start :pos, end :pos) = @{
 		@c = ']';
 		@start = lex_state->lx.start;
 		@end   = lex_state->lx.end;
+
+		(void) @c;
+		(void) @start;
+		(void) @end;
 	@};
 
 	CLOSEGROUPRANGE: () -> (c :char, start :pos, end :pos) = @{
 		@c = '-';
 		@start = lex_state->lx.start;
 		@end   = lex_state->lx.end;
+
+		(void) @c;
+		(void) @start;
+		(void) @end;
 	@};
 
 	OPENCOUNT: () -> (start :pos, end :pos) = @{
 		@start = lex_state->lx.start;
 		@end   = lex_state->lx.end;
+
+		(void) @start;
+		(void) @end;
 	@};
 
 	CLOSECOUNT: () -> (start :pos, end :pos) = @{
 		@start = lex_state->lx.start;
 		@end   = lex_state->lx.end;
+
+		(void) @start;
+		(void) @end;
 	@};
 
 	ESC: () -> (c :char, start :pos, end :pos) = @{
@@ -384,6 +422,9 @@
 
 		@start = lex_state->lx.start;
 		@end   = lex_state->lx.end;
+
+		(void) @start;
+		(void) @end;
 	@};
 
 	NOESC: () -> (c :char, start :pos, end :pos) = @{
@@ -395,6 +436,9 @@
 
 		@start = lex_state->lx.start;
 		@end   = lex_state->lx.end;
+
+		(void) @start;
+		(void) @end;
 	@};
 
 	UNSUPPORTED: () -> (c :char, start :pos, end :pos) = @{
@@ -408,6 +452,9 @@
 
 		@start = lex_state->lx.start;
 		@end   = lex_state->lx.end;
+
+		(void) @start;
+		(void) @end;
 	@};
 
 	CONTROL: () -> (c :char, start :pos, end :pos) = @{
@@ -442,6 +489,9 @@
 
 		@start = lex_state->lx.start;
 		@end   = lex_state->lx.end;
+
+		(void) @start;
+		(void) @end;
 	@};
 
 	OCT: () -> (c :char, start :pos, end :pos) = @{
@@ -454,6 +504,9 @@
 
 		@start = lex_state->lx.start;
 		@end   = lex_state->lx.end;
+
+		(void) @start;
+		(void) @end;
 
 		errno = 0;
 
@@ -494,6 +547,9 @@
 
 		@start = lex_state->lx.start;
 		@end   = lex_state->lx.end;
+
+		(void) @start;
+		(void) @end;
 
 		errno = 0;
 
@@ -536,6 +592,9 @@
 		@start = lex_state->lx.start;
 		@end   = lex_state->lx.end;
 
+		(void) @start;
+		(void) @end;
+
 		@c = lex_state->buf.a[0];
 	@};
 
@@ -545,6 +604,9 @@
 
 		@start = lex_state->lx.start;
 		@end   = lex_state->lx.end;
+
+		(void) @start;
+		(void) @end;
 
 		@c = lex_state->buf.a[0];
 	@};
@@ -556,6 +618,9 @@
 		@start = lex_state->lx.start;
 		@end   = lex_state->lx.end;
 
+		(void) @start;
+		(void) @end;
+
 		@c = lex_state->buf.a[0];
 	@};
 
@@ -565,6 +630,9 @@
 
 		@start = lex_state->lx.start;
 		@end   = lex_state->lx.end;
+
+		(void) @start;
+		(void) @end;
 
 		@c = lex_state->buf.a[0];
 	@};
@@ -598,6 +666,9 @@
 
 		@start = lex_state->lx.start;
 		@end   = lex_state->lx.end;
+
+		(void) @start;
+		(void) @end;
 	@};
 
 	FLAG_INSENSITIVE: () -> (flag :re_flags) = @{

--- a/src/retest/runner.c
+++ b/src/retest/runner.c
@@ -87,9 +87,9 @@ runner_init_compiled(struct fsm *fsm, struct fsm_runner *r, enum implementation 
 		fprintf(f, "\n");
 
 		fprintf(f, "#[no_mangle]\n");
-		fprintf(f, "pub extern \"C\" fn reperf_trampoline(ptr: *const c_uchar, len: usize) -> usize {\n");
+		fprintf(f, "pub extern \"C\" fn reperf_trampoline(ptr: *const c_uchar, len: usize) -> i64 {\n");
 		fprintf(f, "    let a: &[u8] = unsafe { slice::from_raw_parts(ptr, len as usize) };\n");
-		fprintf(f, "    fsm_main(a).unwrap_or(0)\n");
+		fprintf(f, "    fsm_main(a).unwrap_or(-1)\n");
 		fprintf(f, "}\n");
 	}
 
@@ -262,7 +262,7 @@ runner_init_compiled(struct fsm *fsm, struct fsm_runner *r, enum implementation 
 
 	case IMPL_RUST:
 		r->u.impl_rust.h = h;
-		r->u.impl_rust.func = (size_t (*)(const unsigned char *, size_t)) (uintptr_t) dlsym(h, "reperf_trampoline");
+		r->u.impl_rust.func = (int64_t (*)(const unsigned char *, size_t)) (uintptr_t) dlsym(h, "reperf_trampoline");
 		break;
 
 	case IMPL_GO:

--- a/src/retest/runner.h
+++ b/src/retest/runner.h
@@ -47,7 +47,7 @@ struct fsm_runner {
 		struct {
 			/* pub extern "C" fn f(ptr: *const c_uchar, len: usize) -> usize */
 			void *h;
-			size_t (*func)(const unsigned char *, size_t);
+			int64_t (*func)(const unsigned char *, size_t);
 		} impl_rust;
 
 		struct {


### PR DESCRIPTION
I don't like the casts to `(void)` for unused parser attributes (which become variables in SID's generated C), usually by way of an explicit `!` directive (meaning to ignore a value):
```c
	/*
	 * The (void) casts on output parameters that are unused in some dialects.
	 * This keeps gcc from complaining about generated variables that are
	 * assigned a value but not used, without disabling the warning in general.
	 */
```

One problem is C is abstracted from whatever the output language's types are, so it can't cast these itself. I thought about having SID output a macro like `UNUSED(...)` which we could define in the .act file to suit our types. But I'm not confident that this would cover all situations here, and I'm more interested in getting -Werror in place first.