### PR TITLE
pcre lexer: Add comment about nested parens in comments.

### DIFF
--- a/src/libre/dialect/pcre/lexer.lx
+++ b/src/libre/dialect/pcre/lexer.lx
@@ -184,7 +184,11 @@
 
 # Comments are just ignored... no token emitted
 '(?#' .. ')' {
-	# emit a token if the comment has nested parens (which are not permitted)
+	# emit a token if the comment has nested parens, which are
+        # explicitly not permitted according to the pcrepattern(3)
+        # documentation -- see COMMENTS. While the PCRE library does
+        # accept them (example: `echo x | pcregrep '(?#...(abc)x'`),
+        # this is a bug in PCRE.
 	'(' -> $invalid__comment;
 	/[^()]+/;
 }


### PR DESCRIPTION
pcregrep accepts nested parens in comments even though its own documentation quite explicitly says it should not.

This is only a comment change, I confirmed that regenerating the lexer with lx did not change the generated lexer code.

Closes #417.