### PR TITLE
Error handling for fsm_print_*()

### DIFF
--- a/fuzz/target.c
+++ b/fuzz/target.c
@@ -1,3 +1,6 @@
+#include <sys/time.h>
+#include <unistd.h>
+
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
@@ -6,8 +9,7 @@
 #include <string.h>
 #include <inttypes.h>
 #include <ctype.h>
-#include <sys/time.h>
-#include <unistd.h>
+#include <errno.h>
 
 #include <fsm/fsm.h>
 #include <fsm/bool.h>

--- a/fuzz/target.c
+++ b/fuzz/target.c
@@ -302,23 +302,25 @@ fuzz_all_print_functions(FILE *f, const char *pattern, bool det, bool min, const
 	}
 
 	/* see if this triggers any asserts */
-	fsm_print_api(f, fsm);
-	fsm_print_awk(f, fsm);
-	fsm_print_c(f, fsm);
-	fsm_print_dot(f, fsm);
-	fsm_print_fsm(f, fsm);
-	fsm_print_ir(f, fsm);
-	fsm_print_irjson(f, fsm);
-	fsm_print_json(f, fsm);
-	fsm_print_vmc(f, fsm);
-	fsm_print_vmdot(f, fsm);
-	fsm_print_vmasm(f, fsm);
-	fsm_print_vmasm_amd64_att(f, fsm);
-	fsm_print_vmasm_amd64_nasm(f, fsm);
-	fsm_print_vmasm_amd64_go(f, fsm);
-	fsm_print_sh(f, fsm);
-	fsm_print_go(f, fsm);
-	fsm_print_rust(f, fsm);
+	int r = 0;
+	r |= fsm_print_api(f, fsm);
+	r |= fsm_print_awk(f, fsm);
+	r |= fsm_print_c(f, fsm);
+	r |= fsm_print_dot(f, fsm);
+	r |= fsm_print_fsm(f, fsm);
+	r |= fsm_print_ir(f, fsm);
+	r |= fsm_print_irjson(f, fsm);
+	r |= fsm_print_json(f, fsm);
+	r |= fsm_print_vmc(f, fsm);
+	r |= fsm_print_vmdot(f, fsm);
+	r |= fsm_print_vmasm(f, fsm);
+	r |= fsm_print_vmasm_amd64_att(f, fsm);
+	r |= fsm_print_vmasm_amd64_nasm(f, fsm);
+	r |= fsm_print_vmasm_amd64_go(f, fsm);
+	r |= fsm_print_sh(f, fsm);
+	r |= fsm_print_go(f, fsm);
+	r |= fsm_print_rust(f, fsm);
+	assert(r == 0 || errno != 0);
 
 	fsm_free(fsm);
 	return EXIT_SUCCESS;

--- a/include/fsm/print.h
+++ b/include/fsm/print.h
@@ -33,9 +33,12 @@ struct fsm;
  *
  * TODO: what to return?
  * TODO: explain constraints
+ *
+ * Returns 0, or -1 on error and errno will be set. An errno of ENOTSUP means
+ * the requested IO API is not implemented for this output format.
  */
 
-typedef void (fsm_print)(FILE *f, const struct fsm *fsm);
+typedef int (fsm_print)(FILE *f, const struct fsm *fsm);
 
 fsm_print fsm_print_api;
 fsm_print fsm_print_awk;

--- a/include/print/esc.h
+++ b/include/print/esc.h
@@ -23,10 +23,10 @@ escputc pcre_escputc;
 escputc rust_escputc_char;
 escputc rust_escputc_str;
 
-void
+int
 awk_escputcharlit(FILE *f, const struct fsm_options *opt, char c);
 
-void
+int
 c_escputcharlit(FILE *f, const struct fsm_options *opt, char c);
 
 void

--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdlib.h>
+#include <errno.h>
 #include <time.h>
 
 #include <fsm/fsm.h>
@@ -667,7 +668,14 @@ main(int argc, char *argv[])
 	}
 
 	if (print != NULL) {
-		print(stdout, fsm);
+		if (-1 == print(stdout, fsm)) {
+			if (errno == ENOTSUP) {
+				fprintf(stderr, "unsupported IO API\n");
+			} else {
+				perror("print_fsm");
+			}
+			exit(EXIT_FAILURE);
+		}
 	}
 
 	if (generate_bounds > 0) {

--- a/src/libfsm/fsm.c
+++ b/src/libfsm/fsm.c
@@ -11,7 +11,6 @@
 #include <fsm/alloc.h>
 #include <fsm/fsm.h>
 #include <fsm/pred.h>
-#include <fsm/print.h>
 #include <fsm/options.h>
 
 #include <adt/alloc.h>

--- a/src/libfsm/print/api.c
+++ b/src/libfsm/print/api.c
@@ -42,7 +42,7 @@ rangeclass(unsigned char x, unsigned char y)
 	return 0;
 }
 
-void
+int
 fsm_print_api(FILE *f, const struct fsm *fsm_orig)
 {
 	struct fsm *fsm;
@@ -56,15 +56,16 @@ fsm_print_api(FILE *f, const struct fsm *fsm_orig)
 
 	if (!fsm_has(fsm_orig, fsm_isend)) {
 		errno = EINVAL;
-		return;
+		return -1;
 	}
 
 	fsm = fsm_clone(fsm_orig);
 	if (fsm == NULL) {
-		return;
+		return -1;
 	}
 
 	if (!fsm_getstart(fsm, &start)) {
+		errno = EINVAL;
 		goto error;
 	}
 
@@ -204,12 +205,16 @@ fsm_print_api(FILE *f, const struct fsm *fsm_orig)
 
 	fsm_free(fsm);
 
-	return;
+	if (ferror(f)) {
+		return -1;
+	}
+
+	return 0;
 
 error:
 
 	fsm_free(fsm);
 
-	return;
+	return -1;
 }
 

--- a/src/libfsm/print/c.c
+++ b/src/libfsm/print/c.c
@@ -94,7 +94,7 @@ print_ranges(FILE *f, const struct fsm_options *opt,
 			}
 		} else for (c = ranges[k].start; c <= ranges[k].end; c++) {
 			fprintf(f, "\t\t\tcase ");
-			c_escputcharlit(f, opt, (char)c);
+			c_escputcharlit(f, opt, (char) c);
 			fprintf(f, ":");
 
 			if (k + 1 < n || c + 1 <= ranges[k].end) {
@@ -132,7 +132,7 @@ print_groups(FILE *f, const struct fsm_options *opt,
 	}
 }
 
-static void
+static int
 print_singlecase(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 	const char *cp,
 	struct ir_state *cs,
@@ -147,15 +147,13 @@ print_singlecase(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 	assert(leaf != NULL);
 
 	switch (cs->strategy) {
-	case IR_TABLE:
-		/* TODO */
-		abort();
-
 	case IR_NONE:
 		fprintf(f, "\t\t\t");
-		leaf(f, cs->end_ids, leaf_opaque);
+		if (-1 == leaf(f, cs->end_ids, leaf_opaque)) {
+			return -1;
+		}
 		fprintf(f, "\n");
-		return;
+		return 0;
 
 	case IR_SAME:
 		fprintf(f, "\t\t\t");
@@ -163,7 +161,7 @@ print_singlecase(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 			fprintf(f, "state = S%u; ", cs->u.same.to);
 		}
 		fprintf(f, "break;\n");
-		return;
+		return 0;
 
 	case IR_COMPLETE:
 		fprintf(f, "\t\t\tswitch ((unsigned char) %s) {\n", cp);
@@ -172,7 +170,7 @@ print_singlecase(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 
 		fprintf(f, "\t\t\t}\n");
 		fprintf(f, "\t\t\tbreak;\n");
-		return;
+		return 0;
 
 	case IR_PARTIAL:
 		fprintf(f, "\t\t\tswitch ((unsigned char) %s) {\n", cp);
@@ -180,12 +178,14 @@ print_singlecase(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 		print_groups(f, opt, ir_indexof(ir, cs), cs->u.partial.groups, cs->u.partial.n);
 
 		fprintf(f, "\t\t\tdefault:  ");
-		leaf(f, cs->end_ids, leaf_opaque);
+		if (-1 == leaf(f, cs->end_ids, leaf_opaque)) {
+			return -1;
+		}
 		fprintf(f, "\n");
 
 		fprintf(f, "\t\t\t}\n");
 		fprintf(f, "\t\t\tbreak;\n");
-		return;
+		return 0;
 
 	case IR_DOMINANT:
 		fprintf(f, "\t\t\tswitch ((unsigned char) %s) {\n", cp);
@@ -200,7 +200,7 @@ print_singlecase(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 
 		fprintf(f, "\t\t\t}\n");
 		fprintf(f, "\t\t\tbreak;\n");
-		return;
+		return 0;
 
 	case IR_ERROR:
 		fprintf(f, "\t\t\tswitch ((unsigned char) %s) {\n", cp);
@@ -209,7 +209,9 @@ print_singlecase(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 
 		print_ranges(f, opt, cs->u.error.error.ranges, cs->u.error.error.n);
 		fprintf(f, " ");
-		leaf(f, cs->end_ids, leaf_opaque);
+		if (-1 == leaf(f, cs->end_ids, leaf_opaque)) {
+			return -1;
+		}
 		fprintf(f, "\n");
 
 		fprintf(f, "\t\t\tdefault: ");
@@ -220,7 +222,11 @@ print_singlecase(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 
 		fprintf(f, "\t\t\t}\n");
 		fprintf(f, "\t\t\tbreak;\n");
-		return;
+		return 0;
+
+	case IR_TABLE:
+		errno = ENOTSUP;
+		return -1;
 	}
 
 	fprintf(f, "\t\t\tswitch ((unsigned char) %s) {\n", cp);
@@ -228,6 +234,8 @@ print_singlecase(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 	fprintf(f, "\t\t\t}\n");
 
 	fprintf(f, "\t\t\tbreak;\n");
+
+	return 0;
 }
 
 static void
@@ -256,7 +264,7 @@ print_stateenum(FILE *f, size_t n)
 	fprintf(f, "\t} state;\n");
 }
 
-static void
+static int
 endstates(FILE *f, const struct fsm_options *opt, const struct ir *ir)
 {
 	unsigned i;
@@ -268,7 +276,7 @@ endstates(FILE *f, const struct fsm_options *opt, const struct ir *ir)
 	/* no end states */
 	if (!ir_hasend(ir)) {
 		fprintf(f, "\treturn -1; /* unexpected EOT */\n");
-		return;
+		return 0;
 	}
 
 	/* usual case */
@@ -281,7 +289,9 @@ endstates(FILE *f, const struct fsm_options *opt, const struct ir *ir)
 
 		fprintf(f, "\tcase S%u: ", i);
 		if (opt->endleaf != NULL) {
-			opt->endleaf(f, ir->states[i].end_ids, opt->endleaf_opaque);
+			if (-1 == opt->endleaf(f, ir->states[i].end_ids, opt->endleaf_opaque)) {
+				return -1;
+			}
 		} else {
 			fprintf(f, "return %u;", i);
 		}
@@ -289,6 +299,8 @@ endstates(FILE *f, const struct fsm_options *opt, const struct ir *ir)
 	}
 	fprintf(f, "\tdefault: return -1; /* unexpected EOT */\n");
 	fprintf(f, "\t}\n");
+
+	return 0;
 }
 
 int
@@ -319,7 +331,9 @@ fsm_print_cfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 		}
 		fprintf(f, "\n");
 
-		print_singlecase(f, ir, opt, cp, &ir->states[i], leaf, leaf_opaque);
+		if (-1 == print_singlecase(f, ir, opt, cp, &ir->states[i], leaf, leaf_opaque)) {
+			return -1;
+		}
 
 		fprintf(f, "\n");
 	}
@@ -327,11 +341,15 @@ fsm_print_cfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 	fprintf(f, "\t\t\t; /* unreached */\n");
 	fprintf(f, "\t\t}\n");
 
+	if (ferror(f)) {
+		return -1;
+	}
+
 	return 0;
 }
 
-static void
-fsm_print_c_complete(FILE *f, const struct ir *ir, const struct fsm_options *opt)
+static int
+fsm_print_c_body(FILE *f, const struct ir *ir, const struct fsm_options *opt)
 {
 	const char *cp;
 
@@ -371,21 +389,94 @@ fsm_print_c_complete(FILE *f, const struct ir *ir, const struct fsm_options *opt
 		break;
 	}
 
-	(void) fsm_print_cfrag(f, ir, opt, cp,
-		opt->leaf != NULL ? opt->leaf : leaf, opt->leaf_opaque);
+	if (-1 == fsm_print_cfrag(f, ir, opt, cp,
+		opt->leaf != NULL ? opt->leaf : leaf, opt->leaf_opaque))
+	{
+		return -1;
+	}
 
 	fprintf(f, "\t}\n");
 	fprintf(f, "\n");
 
 	/* end states */
-	endstates(f, opt, ir);
+	if (-1 == endstates(f, opt, ir)) {
+		return -1;
+	}
+
+	return 0;
 }
 
-void
+static int
+fsm_print_c_complete(FILE *f, const struct ir *ir,
+	const struct fsm_options *opt, const char *prefix)
+{
+	assert(f != NULL);
+	assert(ir != NULL);
+	assert(opt != NULL);
+
+	if (opt->fragment) {
+		if (-1 == fsm_print_c_body(f, ir, opt)) {
+			return -1;
+		}
+	} else {
+		fprintf(f, "\n");
+
+		fprintf(f, "int\n%smain", prefix);
+
+		switch (opt->io) {
+		case FSM_IO_GETC:
+			fprintf(f, "(int (*fsm_getc)(void *opaque), void *opaque)\n");
+			fprintf(f, "{\n");
+			if (ir->n > 0) {
+				fprintf(f, "\tint c;\n");
+				fprintf(f, "\n");
+			}
+			break;
+
+		case FSM_IO_STR:
+			fprintf(f, "(const char *s)\n");
+			fprintf(f, "{\n");
+			if (ir->n > 0) {
+				fprintf(f, "\tconst char *p;\n");
+				fprintf(f, "\n");
+			}
+			break;
+
+		case FSM_IO_PAIR:
+			fprintf(f, "(const char *b, const char *e)\n");
+			fprintf(f, "{\n");
+			if (ir->n > 0) {
+				fprintf(f, "\tconst char *p;\n");
+				fprintf(f, "\n");
+			}
+			break;
+		}
+
+		if (ir->n == 0) {
+			fprintf(f, "\treturn -1; /* no matches */\n");
+		} else {
+			if (-1 == fsm_print_c_body(f, ir, opt)) {
+				return -1;
+			}
+		}
+
+		fprintf(f, "}\n");
+		fprintf(f, "\n");
+	}
+
+	if (ferror(f)) {
+		return -1;
+	}
+
+	return 0;
+}
+
+int
 fsm_print_c(FILE *f, const struct fsm *fsm)
 {
 	struct ir *ir;
 	const char *prefix;
+	int r;
 
 	assert(f != NULL);
 	assert(fsm != NULL);
@@ -393,7 +484,7 @@ fsm_print_c(FILE *f, const struct fsm *fsm)
 
 	ir = make_ir(fsm);
 	if (ir == NULL) {
-		return;
+		return -1;
 	}
 
 	/* henceforth, no function should be passed struct fsm *, only the ir and options */
@@ -404,53 +495,10 @@ fsm_print_c(FILE *f, const struct fsm *fsm)
 		prefix = "fsm_";
 	}
 
-	if (fsm->opt->fragment) {
-		fsm_print_c_complete(f, ir, fsm->opt);
-		return;
-	}
-
-	fprintf(f, "\n");
-
-	fprintf(f, "int\n%smain", prefix);
-
-	switch (fsm->opt->io) {
-	case FSM_IO_GETC:
-		fprintf(f, "(int (*fsm_getc)(void *opaque), void *opaque)\n");
-		fprintf(f, "{\n");
-		if (ir->n > 0) {
-			fprintf(f, "\tint c;\n");
-			fprintf(f, "\n");
-		}
-		break;
-
-	case FSM_IO_STR:
-		fprintf(f, "(const char *s)\n");
-		fprintf(f, "{\n");
-		if (ir->n > 0) {
-			fprintf(f, "\tconst char *p;\n");
-			fprintf(f, "\n");
-		}
-		break;
-
-	case FSM_IO_PAIR:
-		fprintf(f, "(const char *b, const char *e)\n");
-		fprintf(f, "{\n");
-		if (ir->n > 0) {
-			fprintf(f, "\tconst char *p;\n");
-			fprintf(f, "\n");
-		}
-		break;
-	}
-
-	if (ir->n == 0) {
-		fprintf(f, "\treturn -1; /* no matches */\n");
-	} else {
-		fsm_print_c_complete(f, ir, fsm->opt);
-	}
-
-	fprintf(f, "}\n");
-	fprintf(f, "\n");
+	r = fsm_print_c_complete(f, ir, fsm->opt, prefix);
 
 	free_ir(fsm, ir);
+
+	return r;
 }
 

--- a/src/libfsm/print/c.c
+++ b/src/libfsm/print/c.c
@@ -69,16 +69,13 @@ leaf(FILE *f, const struct fsm_end_ids *ids, const void *leaf_opaque)
 }
 
 static void
-print_ranges(FILE *f, const struct ir *ir, const struct fsm_options *opt,
+print_ranges(FILE *f, const struct fsm_options *opt,
 	const struct ir_range *ranges, size_t n)
 {
 	size_t k;
 	size_t c;
 
-	(void)ir; /* unused */
-
 	assert(f != NULL);
-	assert(ir != NULL);
 	assert(opt != NULL);
 	assert(ranges != NULL);
 
@@ -108,21 +105,20 @@ print_ranges(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 }
 
 static void
-print_groups(FILE *f, const struct ir *ir, const struct fsm_options *opt,
+print_groups(FILE *f, const struct fsm_options *opt,
 	unsigned csi,
 	const struct ir_group *groups, size_t n)
 {
 	size_t j;
 
 	assert(f != NULL);
-	assert(ir != NULL);
 	assert(opt != NULL);
 	assert(groups != NULL);
 
 	for (j = 0; j < n; j++) {
 		assert(groups[j].ranges != NULL);
 
-		print_ranges(f, ir, opt, groups[j].ranges, groups[j].n);
+		print_ranges(f, opt, groups[j].ranges, groups[j].n);
 
 		/* TODO: pad S%u out to maximum state width */
 		if (groups[j].to != csi) {
@@ -172,7 +168,7 @@ print_singlecase(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 	case IR_COMPLETE:
 		fprintf(f, "\t\t\tswitch ((unsigned char) %s) {\n", cp);
 
-		print_groups(f, ir, opt, ir_indexof(ir, cs), cs->u.complete.groups, cs->u.complete.n);
+		print_groups(f, opt, ir_indexof(ir, cs), cs->u.complete.groups, cs->u.complete.n);
 
 		fprintf(f, "\t\t\t}\n");
 		fprintf(f, "\t\t\tbreak;\n");
@@ -181,7 +177,7 @@ print_singlecase(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 	case IR_PARTIAL:
 		fprintf(f, "\t\t\tswitch ((unsigned char) %s) {\n", cp);
 
-		print_groups(f, ir, opt, ir_indexof(ir, cs), cs->u.partial.groups, cs->u.partial.n);
+		print_groups(f, opt, ir_indexof(ir, cs), cs->u.partial.groups, cs->u.partial.n);
 
 		fprintf(f, "\t\t\tdefault:  ");
 		leaf(f, cs->end_ids, leaf_opaque);
@@ -194,7 +190,7 @@ print_singlecase(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 	case IR_DOMINANT:
 		fprintf(f, "\t\t\tswitch ((unsigned char) %s) {\n", cp);
 
-		print_groups(f, ir, opt, ir_indexof(ir, cs), cs->u.dominant.groups, cs->u.dominant.n);
+		print_groups(f, opt, ir_indexof(ir, cs), cs->u.dominant.groups, cs->u.dominant.n);
 
 		fprintf(f, "\t\t\tdefault: ");
 		if (cs->u.dominant.mode != ir_indexof(ir, cs)) {
@@ -209,9 +205,9 @@ print_singlecase(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 	case IR_ERROR:
 		fprintf(f, "\t\t\tswitch ((unsigned char) %s) {\n", cp);
 
-		print_groups(f, ir, opt, ir_indexof(ir, cs), cs->u.error.groups, cs->u.error.n);
+		print_groups(f, opt, ir_indexof(ir, cs), cs->u.error.groups, cs->u.error.n);
 
-		print_ranges(f, ir, opt, cs->u.error.error.ranges, cs->u.error.error.n);
+		print_ranges(f, opt, cs->u.error.error.ranges, cs->u.error.error.n);
 		fprintf(f, " ");
 		leaf(f, cs->end_ids, leaf_opaque);
 		fprintf(f, "\n");

--- a/src/libfsm/print/ir.c
+++ b/src/libfsm/print/ir.c
@@ -321,7 +321,7 @@ error:
 
 static int
 make_state(const struct fsm *fsm, fsm_state_t state,
-	const struct ir *ir, struct ir_state *cs)
+	struct ir_state *cs)
 {
 	struct ir_group *groups;
 	struct group_count max;
@@ -334,12 +334,9 @@ make_state(const struct fsm *fsm, fsm_state_t state,
 		unsigned int freq; /* 0 meaning no mode */
 	} mode;
 
-	(void)ir; /* unused */
-
 	assert(fsm != NULL);
 	assert(fsm->opt != NULL);
 	assert(state < fsm->statecount);
-	assert(ir != NULL);
 
 	/* TODO: IR_TABLE */
 
@@ -492,7 +489,7 @@ make_ir(const struct fsm *fsm)
 			}
 		}
 
-		if (make_state(fsm, i, ir, &ir->states[i]) == -1) {
+		if (make_state(fsm, i, &ir->states[i]) == -1) {
 			goto error;
 		}
 

--- a/src/libfsm/print/irdot.c
+++ b/src/libfsm/print/irdot.c
@@ -233,7 +233,7 @@ print_cs(FILE *f, const struct fsm_options *opt,
 		break;
 
 	case IR_TABLE:
-		/* TODO */
+		assert(!"unreached");
 		break;
 
 	default:
@@ -284,6 +284,7 @@ print_cs(FILE *f, const struct fsm_options *opt,
 		break;
 
 	case IR_TABLE:
+		assert(!"unreached");
 		break;
 
 	default:
@@ -291,7 +292,7 @@ print_cs(FILE *f, const struct fsm_options *opt,
 	}
 }
 
-void
+int
 fsm_print_ir(FILE *f, const struct fsm *fsm)
 {
 	struct ir *ir;
@@ -302,7 +303,7 @@ fsm_print_ir(FILE *f, const struct fsm *fsm)
 
 	ir = make_ir(fsm);
 	if (ir == NULL) {
-		return;
+		return -1;
 	}
 
 	fprintf(f, "digraph G {\n");
@@ -325,5 +326,11 @@ fsm_print_ir(FILE *f, const struct fsm *fsm)
 	fprintf(f, "}\n");
 
 	free_ir(fsm, ir);
+
+	if (ferror(f)) {
+		return -1;
+	}
+
+	return 0;
 }
 

--- a/src/libfsm/print/irdot.c
+++ b/src/libfsm/print/irdot.c
@@ -74,18 +74,14 @@ print_state(FILE *f, unsigned to, unsigned self)
 
 static void
 print_errorrows(FILE *f, const struct fsm_options *opt,
-	const struct ir *ir,
 	const struct ir_error *error)
 {
 	size_t k;
 
 	assert(f != NULL);
 	assert(opt != NULL);
-	assert(ir != NULL);
 	assert(error != NULL);
 	assert(error->ranges != NULL);
-
-	(void)ir; /* unused */
 
 	for (k = 0; k < error->n; k++) {
 		fprintf(f, "\t\t  <TR>");
@@ -115,17 +111,14 @@ print_errorrows(FILE *f, const struct fsm_options *opt,
 
 static void
 print_grouprows(FILE *f, const struct fsm_options *opt,
-	const struct ir *ir, unsigned self,
+	unsigned self,
 	const struct ir_group *groups, size_t n)
 {
 	size_t j, k;
 
 	assert(f != NULL);
 	assert(opt != NULL);
-	assert(ir != NULL);
 	assert(groups != NULL);
-
-	(void)ir; /* unused */
 
 	for (j = 0; j < n; j++) {
 		assert(groups[j].ranges != NULL);
@@ -161,16 +154,13 @@ print_grouprows(FILE *f, const struct fsm_options *opt,
 }
 
 static void
-print_grouplinks(FILE *f, const struct ir *ir, unsigned self,
+print_grouplinks(FILE *f, unsigned self,
 	const struct ir_group *groups, size_t n)
 {
 	unsigned j;
 
 	assert(f != NULL);
-	assert(ir != NULL);
 	assert(groups != NULL);
-
-	(void)ir; /* unused */
 
 	for (j = 0; j < n; j++) {
 		if (groups[j].to == self) {
@@ -220,26 +210,26 @@ print_cs(FILE *f, const struct fsm_options *opt,
 		break;
 
 	case IR_COMPLETE:
-		print_grouprows(f, opt, ir, ir_indexof(ir, cs), cs->u.complete.groups, cs->u.complete.n);
+		print_grouprows(f, opt, ir_indexof(ir, cs), cs->u.complete.groups, cs->u.complete.n);
 		break;
 
 	case IR_PARTIAL:
-		print_grouprows(f, opt, ir, ir_indexof(ir, cs), cs->u.partial.groups, cs->u.partial.n);
+		print_grouprows(f, opt, ir_indexof(ir, cs), cs->u.partial.groups, cs->u.partial.n);
 		break;
 
 	case IR_DOMINANT:
 		fprintf(f, "\t\t  <TR><TD COLSPAN='2' ALIGN='LEFT'>mode</TD><TD ALIGN='LEFT' PORT='mode'>");
 		print_state(f, cs->u.dominant.mode, ir_indexof(ir, cs));
 		fprintf(f, "</TD></TR>\n");
-		print_grouprows(f, opt, ir, ir_indexof(ir, cs), cs->u.dominant.groups, cs->u.dominant.n);
+		print_grouprows(f, opt, ir_indexof(ir, cs), cs->u.dominant.groups, cs->u.dominant.n);
 		break;
 
 	case IR_ERROR:
 		fprintf(f, "\t\t  <TR><TD COLSPAN='2' ALIGN='LEFT'>mode</TD><TD ALIGN='LEFT' PORT='mode'>");
 		print_state(f, cs->u.error.mode, ir_indexof(ir, cs));
 		fprintf(f, "</TD></TR>\n");
-		print_errorrows(f, opt, ir, &cs->u.error.error);
-		print_grouprows(f, opt, ir, ir_indexof(ir, cs), cs->u.error.groups, cs->u.error.n);
+		print_errorrows(f, opt, &cs->u.error.error);
+		print_grouprows(f, opt, ir_indexof(ir, cs), cs->u.error.groups, cs->u.error.n);
 		break;
 
 	case IR_TABLE:
@@ -266,11 +256,11 @@ print_cs(FILE *f, const struct fsm_options *opt,
 		break;
 
 	case IR_COMPLETE:
-		print_grouplinks(f, ir, ir_indexof(ir, cs), cs->u.complete.groups, cs->u.complete.n);
+		print_grouplinks(f, ir_indexof(ir, cs), cs->u.complete.groups, cs->u.complete.n);
 		break;
 
 	case IR_PARTIAL:
-		print_grouplinks(f, ir, ir_indexof(ir, cs), cs->u.partial.groups, cs->u.partial.n);
+		print_grouplinks(f, ir_indexof(ir, cs), cs->u.partial.groups, cs->u.partial.n);
 		break;
 
 	case IR_DOMINANT:
@@ -280,7 +270,7 @@ print_cs(FILE *f, const struct fsm_options *opt,
 			fprintf(f, "\tcs%u:mode -> cs%u;\n",
 				ir_indexof(ir, cs), cs->u.dominant.mode);
 		}
-		print_grouplinks(f, ir, ir_indexof(ir, cs), cs->u.dominant.groups, cs->u.dominant.n);
+		print_grouplinks(f, ir_indexof(ir, cs), cs->u.dominant.groups, cs->u.dominant.n);
 		break;
 
 	case IR_ERROR:
@@ -290,7 +280,7 @@ print_cs(FILE *f, const struct fsm_options *opt,
 			fprintf(f, "\tcs%u:mode -> cs%u;\n",
 				ir_indexof(ir, cs), cs->u.error.mode);
 		}
-		print_grouplinks(f, ir, ir_indexof(ir, cs), cs->u.error.groups, cs->u.error.n);
+		print_grouplinks(f, ir_indexof(ir, cs), cs->u.error.groups, cs->u.error.n);
 		break;
 
 	case IR_TABLE:

--- a/src/libfsm/print/irjson.c
+++ b/src/libfsm/print/irjson.c
@@ -55,17 +55,13 @@ print_endpoint(FILE *f, const struct fsm_options *opt, unsigned char c)
 
 static void
 print_ranges(FILE *f, const struct fsm_options *opt,
-	const struct ir *ir,
 	const struct ir_range *ranges, size_t n)
 {
 	size_t k;
 
 	assert(f != NULL);
 	assert(opt != NULL);
-	assert(ir != NULL);
 	assert(ranges != NULL);
-
-	(void)ir; /* unused */
 
 	for (k = 0; k < n; k++) {
 		fprintf(f, "\t\t\t\t\t\t{ ");
@@ -86,14 +82,12 @@ print_ranges(FILE *f, const struct fsm_options *opt,
 
 static void
 print_groups(FILE *f, const struct fsm_options *opt,
-	const struct ir *ir,
 	const struct ir_group *groups, size_t n)
 {
 	size_t j;
 
 	assert(f != NULL);
 	assert(opt != NULL);
-	assert(ir != NULL);
 	assert(groups != NULL);
 
 	fprintf(f, "[\n");
@@ -105,7 +99,7 @@ print_groups(FILE *f, const struct fsm_options *opt,
 
 		fprintf(f, "\t\t\t\t\t\"to\": %u,\n", groups[j].to);
 		fprintf(f, "\t\t\t\t\t\"ranges\": [\n");
-		print_ranges(f, opt, ir, groups[j].ranges, groups[j].n);
+		print_ranges(f, opt, groups[j].ranges, groups[j].n);
 		fprintf(f, "\t\t\t\t\t]\n");
 
 		fprintf(f, "\t\t\t\t}");
@@ -120,11 +114,10 @@ print_groups(FILE *f, const struct fsm_options *opt,
 
 static void
 print_cs(FILE *f, const struct fsm_options *opt,
-	const struct ir *ir, const struct ir_state *cs)
+	const struct ir_state *cs)
 {
 	assert(f != NULL);
 	assert(opt != NULL);
-	assert(ir != NULL);
 	assert(cs != NULL);
 
 	fprintf(f, "\t\t{\n");
@@ -158,27 +151,27 @@ print_cs(FILE *f, const struct fsm_options *opt,
 
 	case IR_COMPLETE:
 		fprintf(f, "\t\t\t\"groups\": ");
-		print_groups(f, opt, ir, cs->u.complete.groups, cs->u.complete.n);
+		print_groups(f, opt, cs->u.complete.groups, cs->u.complete.n);
 		break;
 
 	case IR_PARTIAL:
 		fprintf(f, "\t\t\t\"groups\": ");
-		print_groups(f, opt, ir, cs->u.partial.groups, cs->u.partial.n);
+		print_groups(f, opt, cs->u.partial.groups, cs->u.partial.n);
 		break;
 
 	case IR_DOMINANT:
 		fprintf(f, "\t\t\t\"mode\": %u,\n", cs->u.dominant.mode);
 		fprintf(f, "\t\t\t\"groups\": ");
-		print_groups(f, opt, ir, cs->u.dominant.groups, cs->u.dominant.n);
+		print_groups(f, opt, cs->u.dominant.groups, cs->u.dominant.n);
 		break;
 
 	case IR_ERROR:
 		fprintf(f, "\t\t\t\"mode\": %u,\n", cs->u.error.mode);
 		fprintf(f, "\t\t\t\"error\": [\n");
-		print_ranges(f, opt, ir, cs->u.error.error.ranges, cs->u.error.error.n);
+		print_ranges(f, opt, cs->u.error.error.ranges, cs->u.error.error.n);
 		fprintf(f, "\t\t\t],\n");
 		fprintf(f, "\t\t\t\"groups\": ");
-		print_groups(f, opt, ir, cs->u.error.groups, cs->u.error.n);
+		print_groups(f, opt, cs->u.error.groups, cs->u.error.n);
 		break;
 
 	case IR_TABLE:
@@ -212,7 +205,7 @@ fsm_print_irjson(FILE *f, const struct fsm *fsm)
 	fprintf(f, "\t\"states\": [\n");
 
 	for (i = 0; i < ir->n; i++) {
-		print_cs(f, fsm->opt, ir, &ir->states[i]);
+		print_cs(f, fsm->opt, &ir->states[i]);
 
 		if (i + 1 < ir->n) {
 			fprintf(f, ",");

--- a/src/libfsm/print/irjson.c
+++ b/src/libfsm/print/irjson.c
@@ -175,7 +175,7 @@ print_cs(FILE *f, const struct fsm_options *opt,
 		break;
 
 	case IR_TABLE:
-		/* TODO */
+		assert(!"unreached");
 		break;
 
 	default:
@@ -185,7 +185,7 @@ print_cs(FILE *f, const struct fsm_options *opt,
 	fprintf(f, "\t\t}");
 }
 
-void
+int
 fsm_print_irjson(FILE *f, const struct fsm *fsm)
 {
 	struct ir *ir;
@@ -196,7 +196,7 @@ fsm_print_irjson(FILE *f, const struct fsm *fsm)
 
 	ir = make_ir(fsm);
 	if (ir == NULL) {
-		return;
+		return -1;
 	}
 
 	fprintf(f, "{\n");
@@ -218,5 +218,11 @@ fsm_print_irjson(FILE *f, const struct fsm *fsm)
 	fprintf(f, "}\n");
 
 	free_ir(fsm, ir);
+
+	if (ferror(f)) {
+		return -1;
+	}
+
+	return 0;
 }
 

--- a/src/libfsm/print/rust.c
+++ b/src/libfsm/print/rust.c
@@ -87,20 +87,24 @@ print_cond(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt)
 	fprintf(f, " ");
 }
 
-static void
+static int
 print_end(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt,
 	enum dfavm_op_end end_bits, const struct ir *ir)
 {
 	if (end_bits == VM_END_FAIL) {
 		fprintf(f, "return None");
-		return;
+		return 0;
 	}
 
 	if (opt->endleaf != NULL) {
-		opt->endleaf(f, op->ir_state->end_ids, opt->endleaf_opaque);
+		if (-1 == opt->endleaf(f, op->ir_state->end_ids, opt->endleaf_opaque)) {
+			return -1;
+		}
 	} else {
 		fprintf(f, "return Some(%td)", op->ir_state - ir->states);
 	}
+
+	return 0;
 }
 
 static void
@@ -195,7 +199,7 @@ fsm_print_rustfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 			break;
 
 		default:
-			fprintf(stderr, "unsupported IO API\n");
+			assert(!"unreached");
 			break;
 		}
 	}
@@ -257,7 +261,9 @@ fsm_print_rustfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 			if (op->cmp != VM_CMP_ALWAYS) {
 				fprintf(f, "{ ");
 			}
-			print_end(f, op, opt, op->u.stop.end_bits, ir);
+			if (-1 == print_end(f, op, opt, op->u.stop.end_bits, ir)) {
+				return -1;
+			}
 			fprintf(f, ";");
 			if (op->cmp != VM_CMP_ALWAYS) {
 				fprintf(f, " }");
@@ -350,7 +356,7 @@ fsm_print_rustfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 	return 0;
 }
 
-void
+static int
 fsm_print_rust_complete(FILE *f, const struct ir *ir,
 	const struct fsm_options *opt, const char *prefix, const char *cp)
 {
@@ -361,7 +367,7 @@ fsm_print_rust_complete(FILE *f, const struct ir *ir,
 	if (opt->fragment) {
 		fsm_print_rustfrag(f, ir, opt, cp,
 			opt->leaf != NULL ? opt->leaf : leaf, opt->leaf_opaque);
-		return;
+		return -1;
 	}
 
 	fprintf(f, "\n");
@@ -398,14 +404,20 @@ fsm_print_rust_complete(FILE *f, const struct ir *ir,
 	fprintf(f, "}\n");
 	fprintf(f, "\n");
 
+	if (ferror(f)) {
+		return -1;
+	}
+
+	return 0;
 }
 
-void
+int
 fsm_print_rust(FILE *f, const struct fsm *fsm)
 {
 	struct ir *ir;
 	const char *prefix;
 	const char *cp;
+	int r;
 
 	assert(f != NULL);
 	assert(fsm != NULL);
@@ -413,7 +425,7 @@ fsm_print_rust(FILE *f, const struct fsm *fsm)
 
 	ir = make_ir(fsm);
 	if (ir == NULL) {
-		return;
+		return -1;
 	}
 
 	if (fsm->opt->prefix != NULL) {
@@ -428,8 +440,10 @@ fsm_print_rust(FILE *f, const struct fsm *fsm)
 		cp = "c"; /* XXX */
 	}
 
-	fsm_print_rust_complete(f, ir, fsm->opt, prefix, cp);
+	r = fsm_print_rust_complete(f, ir, fsm->opt, prefix, cp);
 
 	free_ir(fsm, ir);
+
+	return r;
 }
 

--- a/src/libfsm/print/sh.c
+++ b/src/libfsm/print/sh.c
@@ -263,13 +263,13 @@ fsm_print_sh(FILE *f, const struct fsm *fsm)
 	assert(fsm != NULL);
 	assert(fsm->opt != NULL);
 
-	ir = make_ir(fsm);
-	if (ir == NULL) {
+	if (fsm->opt->io != FSM_IO_STR) {
+		errno = ENOTSUP;
 		return -1;
 	}
 
-	if (fsm->opt->io != FSM_IO_STR) {
-		errno = ENOTSUP;
+	ir = make_ir(fsm);
+	if (ir == NULL) {
 		return -1;
 	}
 

--- a/src/libfsm/print/sh.c
+++ b/src/libfsm/print/sh.c
@@ -84,11 +84,9 @@ print_label(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt
 }
 
 static void
-print_cond(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt)
+print_cond(FILE *f, const struct dfavm_op_ir *op)
 {
 	char c;
-
-	(void) opt;
 
 	if (op->cmp == VM_CMP_ALWAYS) {
 		return;
@@ -142,10 +140,8 @@ print_branch(FILE *f, const struct dfavm_op_ir *op)
 }
 
 static void
-print_fetch(FILE *f, const struct fsm_options *opt)
+print_fetch(FILE *f)
 {
-	(void) opt;
-
 	fprintf(f, "read -rn 1 c || ");
 }
 
@@ -214,17 +210,17 @@ fsm_print_shfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt)
 
 		switch (op->instr) {
 		case VM_OP_STOP:
-			print_cond(f, op, opt);
+			print_cond(f, op);
 			print_end(f, op, opt, op->u.stop.end_bits, ir);
 			break;
 
 		case VM_OP_FETCH:
-			print_fetch(f, opt);
+			print_fetch(f);
 			print_end(f, op, opt, op->u.fetch.end_bits, ir);
 			break;
 
 		case VM_OP_BRANCH:
-			print_cond(f, op, opt);
+			print_cond(f, op);
 			print_branch(f, op);
 			break;
 

--- a/src/libfsm/print/vmasm.c
+++ b/src/libfsm/print/vmasm.c
@@ -378,6 +378,18 @@ print_vmasm_encoding(FILE *f, const struct fsm *fsm, enum asm_dialect dialect)
 	assert(fsm != NULL);
 	assert(fsm->opt != NULL);
 
+	if (dialect == AMD64_GO) {
+		if (fsm->opt->io != FSM_IO_STR && fsm->opt->io != FSM_IO_PAIR) {
+			errno = ENOTSUP;
+			return -1;   
+		}
+	} else {
+		if (fsm->opt->io != FSM_IO_PAIR) {
+			errno = ENOTSUP;
+			return -1;   
+		}
+	}
+
 	ir = make_ir(fsm);
 	if (ir == NULL) {
 		return -1;

--- a/src/libfsm/print/vmdot.c
+++ b/src/libfsm/print/vmdot.c
@@ -207,14 +207,13 @@ fsm_print_nodes(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 }
 
 static void
-fsm_print_edges(FILE *f, const struct ir *ir, const struct fsm_options *opt,
+fsm_print_edges(FILE *f, const struct fsm_options *opt,
 	const struct dfavm_assembler_ir *a)
 {
 	const struct dfavm_op_ir *op;
 	unsigned long block;
 	int can_fallthrough;
 
-	(void) ir;
 	(void) opt;
 
 	can_fallthrough = 1;
@@ -294,7 +293,7 @@ fsm_print_vmdotfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt)
 	fsm_print_nodes(f, ir, opt, &a);
 	fprintf(f, "\n");
 
-	fsm_print_edges(f, ir, opt, &a);
+	fsm_print_edges(f, opt, &a);
 
 	dfavm_opasm_finalize_op(&a);
 

--- a/src/libfsm/print/vmdot.c
+++ b/src/libfsm/print/vmdot.c
@@ -82,20 +82,24 @@ print_cond(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt)
 	fprintf(f, "'");
 }
 
-static void
+static int
 print_end(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt,
 	enum dfavm_op_end end_bits, const struct ir *ir)
 {
 	if (end_bits == VM_END_FAIL) {
 		fprintf(f, "fail");
-		return;
+		return 0;
 	}
 
 	if (opt->endleaf != NULL) {
-		opt->endleaf(f, op->ir_state->end_ids, opt->endleaf_opaque);
+		if (-1 == opt->endleaf(f, op->ir_state->end_ids, opt->endleaf_opaque)) {
+			return -1;
+		}
 	} else {
 		fprintf(f, "ret %td", op->ir_state - ir->states);
 	}
+
+	return 0;
 }
 
 static void
@@ -104,7 +108,7 @@ print_branch(FILE *f, const struct dfavm_op_ir *op)
 	fprintf(f, "branch #%" PRIu32, op->u.br.dest_arg->index);
 }
 
-static void
+static int
 fsm_print_nodes(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 	const struct dfavm_assembler_ir *a)
 {
@@ -174,14 +178,18 @@ fsm_print_nodes(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 			print_cond(f, op, opt);
 			fprintf(f, "</td>\n");
 			fprintf(f, "\t\t\t<td align='left' port='b%u'>", op->index);
-			print_end(f, op, opt, op->u.stop.end_bits, ir);
+			if (-1 == print_end(f, op, opt, op->u.stop.end_bits, ir)) {
+				return -1;
+			}
 			fprintf(f, "</td>\n");
 			break;
 
 		case VM_OP_FETCH:
 			fprintf(f, "\t\t\t<td>fetch</td>\n");
 			fprintf(f, "\t\t\t<td align='left' port='b%u'>", op->index);
-			print_end(f, op, opt, op->u.fetch.end_bits, ir);
+			if (-1 == print_end(f, op, opt, op->u.fetch.end_bits, ir)) {
+				return -1;
+			}
 			fprintf(f, "</td>\n");
 			break;
 
@@ -204,6 +212,8 @@ fsm_print_nodes(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 
 	fprintf(f, "\t\t</table>\n");
 	fprintf(f, "\t> ];\n");
+
+	return 0;
 }
 
 static void
@@ -290,7 +300,9 @@ fsm_print_vmdotfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt)
 		return -1;
 	}
 
-	fsm_print_nodes(f, ir, opt, &a);
+	if (-1 == fsm_print_nodes(f, ir, opt, &a)) {
+		return -1;
+	}
 	fprintf(f, "\n");
 
 	fsm_print_edges(f, opt, &a);
@@ -300,10 +312,53 @@ fsm_print_vmdotfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt)
 	return 0;
 }
 
-void
+
+static int
+fsm_print_vmdot_complete(FILE *f, const struct ir *ir, const struct fsm_options *opt)
+{
+	assert(f != NULL);
+	assert(ir != NULL);
+	assert(opt != NULL);
+
+	if (opt->fragment) {
+		if (-1 == fsm_print_vmdotfrag(f, ir, opt)) {
+			return -1;
+		}
+	} else {
+		fprintf(f, "\n");
+
+		fprintf(f, "digraph G {\n");
+
+		fprintf(f, "\tnode [ shape = plaintext ];\n");
+		fprintf(f, "\trankdir = TB;\n");
+		fprintf(f, "\tnodesep = 0.5;\n");
+		fprintf(f, "\troot = S0;\n");
+
+		fprintf(f, "\t{ start; S0; rank= same }\n");
+
+		fprintf(f, "\tstart [ shape = none, label = \"\" ];\n");
+		fprintf(f, "\tstart -> S0:i0:w [ style = bold ];\n");
+
+		if (-1 == fsm_print_vmdotfrag(f, ir, opt)) {
+			return -1;
+		}
+
+		fprintf(f, "}\n");
+		fprintf(f, "\n");
+	}
+
+	if (ferror(f)) {
+		return -1;
+	}
+
+	return 0;
+}
+
+int
 fsm_print_vmdot(FILE *f, const struct fsm *fsm)
 {
 	struct ir *ir;
+	int r;
 
 	assert(f != NULL);
 	assert(fsm != NULL);
@@ -311,35 +366,15 @@ fsm_print_vmdot(FILE *f, const struct fsm *fsm)
 
 	ir = make_ir(fsm);
 	if (ir == NULL) {
-		return;
+		return -1;
 	}
 
 	/* henceforth, no function should be passed struct fsm *, only the ir and options */
 
-	if (fsm->opt->fragment) {
-		fsm_print_vmdotfrag(f, ir, fsm->opt);
-		return;
-	}
-
-	fprintf(f, "\n");
-
-	fprintf(f, "digraph G {\n");
-
-	fprintf(f, "\tnode [ shape = plaintext ];\n");
-	fprintf(f, "\trankdir = TB;\n");
-	fprintf(f, "\tnodesep = 0.5;\n");
-	fprintf(f, "\troot = S0;\n");
-
-	fprintf(f, "\t{ start; S0; rank= same }\n");
-
-	fprintf(f, "\tstart [ shape = none, label = \"\" ];\n");
-	fprintf(f, "\tstart -> S0:i0:w [ style = bold ];\n");
-
-	fsm_print_vmdotfrag(f, ir, fsm->opt);
-
-	fprintf(f, "}\n");
-	fprintf(f, "\n");
+	r = fsm_print_vmdot_complete(f, ir, fsm->opt);
 
 	free_ir(fsm, ir);
+
+	return r;
 }
 

--- a/src/libfsm/print/vmops.c
+++ b/src/libfsm/print/vmops.c
@@ -67,7 +67,7 @@ cmp_operator(int cmp)
 	}
 }
 
-static void
+static int
 print_label(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt)
 {
 	fprintf(f, "\t\t/* l%" PRIu32 " */\n", op->index);
@@ -75,38 +75,50 @@ print_label(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt
 	if (op->ir_state->example != NULL) {
 		fprintf(f, "\t\t/* e.g. \"");
 		/* Go's string escape rules are a superset of C's. */
-		escputs(f, opt, c_escputc_str, op->ir_state->example);
+		if (-1 == escputs(f, opt, c_escputc_str, op->ir_state->example)) {
+			return -1;
+		}
 		fprintf(f, "\" */\n");
 	}
+
+	return 0;
 }
 
-static void
+static int
 print_cond(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt, const char *prefix)
 {
 	fprintf(f, "\t\t{%s%s, ", prefix, cmp_operator(op->cmp));
-	c_escputcharlit(f, opt, op->cmp_arg);
+	if (-1 == c_escputcharlit(f, opt, op->cmp_arg)) {
+		return -1;
+	}
 	fprintf(f, ", ");
+
+	return 0;
 }
 
-static void
+static int
 print_end(FILE *f, const struct dfavm_op_ir *op, const char *prefix,
 	enum dfavm_op_end end_bits, const struct ir *ir)
 {
 	if (end_bits == VM_END_FAIL) {
 		fprintf(f, "%sactionRET, -1},\n", prefix);
-		return;
+		return 0;
 	}
 
 	fprintf(f, "%sactionRET, %td},\n", prefix, op->ir_state - ir->states);
+
+	return 0;
 }
 
-static void
+static int
 print_branch(FILE *f, const struct dfavm_op_ir *op, const char *prefix)
 {
 	fprintf(f, "%sactionGOTO, %" PRIu32 "},\n", prefix, op->u.br.dest_arg->index);
+
+	return 0;
 }
 
-static void
+static int
 print_fetch(FILE *f, const struct fsm_options *opt, const char *prefix)
 {
 
@@ -118,12 +130,13 @@ print_fetch(FILE *f, const struct fsm_options *opt, const char *prefix)
 	default:
 		assert(!"unreached");
 	}
+
+	return 0;
 }
 
 /* TODO: eventually to be non-static */
 static int
 fsm_print_vmopsfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt, const char *prefix,
-	const char *cp,
 	int (*leaf)(FILE *, const struct fsm_end_ids *ids, const void *leaf_opaque),
 	const void *leaf_opaque)
 {
@@ -136,7 +149,6 @@ fsm_print_vmopsfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 	assert(f != NULL);
 	assert(ir != NULL);
 	assert(opt != NULL);
-	assert(cp != NULL);
 
 	a = zero;
 
@@ -145,31 +157,42 @@ fsm_print_vmopsfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 	(void) leaf;
 	(void) leaf_opaque;
 
-	/* TODO: we'll need to heed cp for e.g. lx's codegen */
-	(void) cp;
-
 	if (!dfavm_compile_ir(&a, ir, vm_opts)) {
 		return -1;
 	}
 
 	for (op = a.linked; op != NULL; op = op->next) {
 		if (op->num_incoming > 0) {
-			print_label(f, op, opt);
+			if (-1 == print_label(f, op, opt)) {
+				return -1;
+			}
 		}
 		switch (op->instr) {
 		case VM_OP_STOP:
-			print_cond(f, op, opt, prefix);
-			print_end(f, op, prefix, op->u.stop.end_bits, ir);
+			if (-1 == print_cond(f, op, opt, prefix)) {
+				return -1;
+			}
+			if (-1 == print_end(f, op, prefix, op->u.stop.end_bits, ir)) {
+				return -1;
+			}
 			break;
 
 		case VM_OP_FETCH:
-			print_fetch(f, opt, prefix);
-			print_end(f, op, prefix, op->u.fetch.end_bits, ir);
+			if (-1 == print_fetch(f, opt, prefix)) {
+				return -1;
+			}
+			if (-1 == print_end(f, op, prefix, op->u.fetch.end_bits, ir)) {
+				return -1;
+			}
 			break;
 
 		case VM_OP_BRANCH:
-			print_cond(f, op, opt, prefix);
-			print_branch(f, op, prefix);
+			if (-1 == print_cond(f, op, opt, prefix)) {
+				return -1;
+			}
+			if (-1 == print_branch(f, op, prefix)) {
+				return -1;
+			}
 			break;
 
 		default:
@@ -183,29 +206,7 @@ fsm_print_vmopsfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 	return 0;
 }
 
-static void
-fsm_print_vmops_complete(FILE *f, const struct ir *ir, const struct fsm_options *opt, const char *prefix, enum vmops_dialect dialect)
-{
-	/* TODO: currently unused, but must be non-NULL */
-	const char *cp = "";
-
-	assert(f != NULL);
-	assert(ir != NULL);
-	assert(opt != NULL);
-
-	switch (dialect) {
-	case VMOPS_H:
-	case VMOPS_MAIN:
-		return;
-	default:
-		break;
-	}
-
-	(void) fsm_print_vmopsfrag(f, ir, opt, prefix, cp,
-		opt->leaf != NULL ? opt->leaf : leaf, opt->leaf_opaque);
-}
-
-void
+int
 fsm_print_vmops(FILE *f, const struct fsm *fsm, enum vmops_dialect dialect)
 {
 	struct ir *ir;
@@ -217,7 +218,7 @@ fsm_print_vmops(FILE *f, const struct fsm *fsm, enum vmops_dialect dialect)
 
 	ir = make_ir(fsm);
 	if (ir == NULL) {
-		return;
+		return -1;
 	}
 
 	/* henceforth, no function should be passed struct fsm *, only the ir and options */
@@ -229,172 +230,198 @@ fsm_print_vmops(FILE *f, const struct fsm *fsm, enum vmops_dialect dialect)
 	}
 
 	if (fsm->opt->fragment) {
-		fsm_print_vmops_complete(f, ir, fsm->opt, prefix, dialect);
-		return;
-	}
-
-	switch (dialect) {
-	case VMOPS_C:
-		fprintf(f, "#include <stdint.h>\n\n");
-		fprintf(f, "#ifndef %sLIBFSM_VMOPS_H\n", prefix);
-		fprintf(f, "#include \"%svmops.h\"\n", prefix);
-		fprintf(f, "#endif /* %sLIBFSM_VMOPS_H */\n", prefix);
-		fprintf(f, "struct %sop %sOps[] = {\n", prefix, prefix);
-		fsm_print_vmops_complete(f, ir, fsm->opt, prefix, dialect);
-		fprintf(f, "\t};\n");
-		break;
-
-	case VMOPS_H:
-		fprintf(f, "#ifndef %sLIBFSM_VMOPS_H\n", prefix);
-		fprintf(f, "#define %sLIBFSM_VMOPS_H\n", prefix);
-		fprintf(f, "#include <stdint.h>\n\n");
-		fprintf(f, "enum %svmOp { %sopEOF, %sopLT, %sopLE, %sopEQ, %sopNE, %sopGE, %sopGT, %sopALWAYS};\n", prefix, prefix, prefix, prefix, prefix, prefix, prefix, prefix, prefix);
-		fprintf(f, "enum %sactionOp { %sactionRET, %sactionGOTO };\n", prefix, prefix, prefix);
-		fprintf(f, "struct %sop { enum %svmOp op; unsigned char c; enum %sactionOp action; int32_t arg; };\n\n", prefix, prefix, prefix);
-		fprintf(f, "#endif /* %sLIBFSM_VMOPS_H */\n", prefix);
-		break;
-
-	case VMOPS_MAIN:
-		fprintf(f, "#include <stdio.h>\n");
-		fprintf(f, "#include <string.h>\n");
-		fprintf(f, "#include <stdlib.h>\n\n");
-		fprintf(f, "#ifndef %sLIBFSM_VMOPS_H\n", prefix);
-		fprintf(f, "#include \"%svmops.h\"\n", prefix);
-		fprintf(f, "#endif /* %sLIBFSM_VMOPS_H */\n", prefix);
-		fprintf(f, "extern struct %sop %sOps[];\n", prefix, prefix);
-		fprintf(f, "\n");
-
-		switch (fsm->opt->io) {
-		case FSM_IO_PAIR:
-			fprintf(f, "int %smatch(const char *b, const char *e)\n", prefix);
-			break;
-		case FSM_IO_STR:
-			fprintf(f, "int %smatch(const char *s)\n", prefix);
-			break;
-		case FSM_IO_GETC:
-			fprintf(stderr, "unsupported IO API\n");
-			break;
+		if (dialect == VMOPS_C) {
+			if (-1 == fsm_print_vmopsfrag(f, ir, fsm->opt, prefix,
+				fsm->opt->leaf != NULL ? fsm->opt->leaf : leaf, fsm->opt->leaf_opaque))
+			{
+				return -1;
+			}
 		}
-		fprintf(f, "{\n");
-		fprintf(f, "\tunsigned int i = 0;\n");
-		fprintf(f, "\t/* The compiler doesn't know the op stream will have fetch before the first comparison. */\n");
-		fprintf(f, "\t/* Initialize to zero to prevent maybe-uninitialized warning. */\n");
-		fprintf(f, "\tunsigned char c = 0;\n");
-		fprintf(f, "\tint ok;\n");
-		fprintf(f, "\tstruct %sop *ops = %sOps;\n", prefix, prefix);
-
-
-		switch (fsm->opt->io) {
-		case FSM_IO_PAIR:
-			fprintf(f, "\tconst char *p = b;\n");
+	} else {
+		switch (dialect) {
+		case VMOPS_C:
+			fprintf(f, "#include <stdint.h>\n\n");
+			fprintf(f, "#ifndef %sLIBFSM_VMOPS_H\n", prefix);
+			fprintf(f, "#include \"%svmops.h\"\n", prefix);
+			fprintf(f, "#endif /* %sLIBFSM_VMOPS_H */\n", prefix);
+			fprintf(f, "struct %sop %sOps[] = {\n", prefix, prefix);
+			if (-1 == fsm_print_vmopsfrag(f, ir, fsm->opt, prefix,
+				fsm->opt->leaf != NULL ? fsm->opt->leaf : leaf, fsm->opt->leaf_opaque))
+			{
+				return -1;
+			}
+			fprintf(f, "\t};\n");
 			break;
-		case FSM_IO_STR:
-			fprintf(f, "\tconst char *p = s;\n");
-			break;
-		case FSM_IO_GETC:
-			fprintf(stderr, "unsupported IO API\n");
-			break;
-		}
 
-		fprintf(f, "\n");
-		fprintf(f, "\tfor (;;) {\n");
-		fprintf(f, "\t\tok = 0;\n");
-		fprintf(f, "\t\tswitch (ops[i].op) {\n");
-		fprintf(f, "\t\tcase %sopEOF:\n", prefix);
+		case VMOPS_H:
+			fprintf(f, "#ifndef %sLIBFSM_VMOPS_H\n", prefix);
+			fprintf(f, "#define %sLIBFSM_VMOPS_H\n", prefix);
+			fprintf(f, "#include <stdint.h>\n\n");
+			fprintf(f, "enum %svmOp { %sopEOF, %sopLT, %sopLE, %sopEQ, %sopNE, %sopGE, %sopGT, %sopALWAYS};\n",
+				prefix, prefix, prefix, prefix, prefix, prefix, prefix, prefix, prefix);
+			fprintf(f, "enum %sactionOp { %sactionRET, %sactionGOTO };\n", prefix, prefix, prefix);
+			fprintf(f, "struct %sop { enum %svmOp op; unsigned char c; enum %sactionOp action; int32_t arg; };\n\n",
+				prefix, prefix, prefix);
+			fprintf(f, "#endif /* %sLIBFSM_VMOPS_H */\n", prefix);
+			break;
 
-		switch (fsm->opt->io) {
-		case FSM_IO_PAIR:
-			fprintf(f, "\t\t\tif (p < e) {\n");
-			fprintf(f, "\t\t\t\t/* not at EOF */\n");
-			fprintf(f, "\t\t\t\tc = *p++;\n");
-			fprintf(f, "\t\t\t\ti++;\n");
-			fprintf(f, "\t\t\t\tcontinue;\n");
+		case VMOPS_MAIN:
+			fprintf(f, "#include <stdio.h>\n");
+			fprintf(f, "#include <string.h>\n");
+			fprintf(f, "#include <stdlib.h>\n\n");
+			fprintf(f, "#ifndef %sLIBFSM_VMOPS_H\n", prefix);
+			fprintf(f, "#include \"%svmops.h\"\n", prefix);
+			fprintf(f, "#endif /* %sLIBFSM_VMOPS_H */\n", prefix);
+			fprintf(f, "extern struct %sop %sOps[];\n", prefix, prefix);
+			fprintf(f, "\n");
+
+			switch (fsm->opt->io) {
+			case FSM_IO_PAIR:
+				fprintf(f, "int %smatch(const char *b, const char *e)\n", prefix);
+				break;
+
+			case FSM_IO_STR:
+				fprintf(f, "int %smatch(const char *s)\n", prefix);
+				break;
+
+			case FSM_IO_GETC:
+				errno = ENOTSUP;
+				return -1;
+			}
+			fprintf(f, "{\n");
+			fprintf(f, "\tunsigned int i = 0;\n");
+			fprintf(f, "\t/* The compiler doesn't know the op stream will have fetch before the first comparison. */\n");
+			fprintf(f, "\t/* Initialize to zero to prevent maybe-uninitialized warning. */\n");
+			fprintf(f, "\tunsigned char c = 0;\n");
+			fprintf(f, "\tint ok;\n");
+			fprintf(f, "\tstruct %sop *ops = %sOps;\n", prefix, prefix);
+
+			switch (fsm->opt->io) {
+			case FSM_IO_PAIR:
+				fprintf(f, "\tconst char *p = b;\n");
+				break;
+
+			case FSM_IO_STR:
+				fprintf(f, "\tconst char *p = s;\n");
+				break;
+
+			case FSM_IO_GETC:
+				errno = ENOTSUP;
+				return -1;
+			}
+
+			fprintf(f, "\n");
+			fprintf(f, "\tfor (;;) {\n");
+			fprintf(f, "\t\tok = 0;\n");
+			fprintf(f, "\t\tswitch (ops[i].op) {\n");
+			fprintf(f, "\t\tcase %sopEOF:\n", prefix);
+
+			switch (fsm->opt->io) {
+			case FSM_IO_PAIR:
+				fprintf(f, "\t\t\tif (p < e) {\n");
+				fprintf(f, "\t\t\t\t/* not at EOF */\n");
+				fprintf(f, "\t\t\t\tc = *p++;\n");
+				fprintf(f, "\t\t\t\ti++;\n");
+				fprintf(f, "\t\t\t\tcontinue;\n");
+				fprintf(f, "\t\t\t}\n");
+				break;
+
+			case FSM_IO_STR:
+				fprintf(f, "\t\t\tc = *p++;\n");
+				fprintf(f, "\t\t\tif (c != '\\0') {\n");
+				fprintf(f, "\t\t\t\t/* not at EOF */\n");
+				fprintf(f, "\t\t\t\ti++;\n");
+				fprintf(f, "\t\t\t\tcontinue;\n");
+				fprintf(f, "\t\t\t}\n");
+				break;
+
+			case FSM_IO_GETC:
+				errno = ENOTSUP;
+				return -1;
+			}
+
+			fprintf(f, "\t\t\tok = 1;\n");
+			fprintf(f, "\t\t\tbreak;\n");
+			fprintf(f, "\t\tcase %sopLT: ok = c < ops[i].c; break;\n", prefix);
+			fprintf(f, "\t\tcase %sopLE: ok = c <= ops[i].c; break;\n", prefix);
+			fprintf(f, "\t\tcase %sopEQ: ok = c == ops[i].c; break;\n", prefix);
+			fprintf(f, "\t\tcase %sopNE: ok = c != ops[i].c; break;\n", prefix);
+			fprintf(f, "\t\tcase %sopGE: ok = c >= ops[i].c; break;\n", prefix);
+			fprintf(f, "\t\tcase %sopGT: ok = c > ops[i].c; break;\n", prefix);
+			fprintf(f, "\t\tcase %sopALWAYS: ok = 1; break;\n", prefix);
+			fprintf(f, "\t\t}\n");
+			fprintf(f, "\t\tif (ok) {\n");
+			fprintf(f, "\t\t\tif (ops[i].action == %sactionRET) {\n", prefix);
+			fprintf(f, "\t\t\t\treturn (int) (ops[i].arg);\n");
 			fprintf(f, "\t\t\t}\n");
-			break;
-		case FSM_IO_STR:
-			fprintf(f, "\t\t\tc = *p++;\n");
-			fprintf(f, "\t\t\tif (c != '\\0') {\n");
-			fprintf(f, "\t\t\t\t/* not at EOF */\n");
-			fprintf(f, "\t\t\t\ti++;\n");
-			fprintf(f, "\t\t\t\tcontinue;\n");
-			fprintf(f, "\t\t\t}\n");
-			break;
-		case FSM_IO_GETC:
-			fprintf(stderr, "unsupported IO API\n");
+			fprintf(f, "\t\t\ti = ops[i].arg;\n");
+			fprintf(f, "\t\t\tcontinue;\n");
+			fprintf(f, "\t\t}\n");
+			fprintf(f, "\t\ti++;\n");
+			fprintf(f, "\t}\n");
+			fprintf(f, "}\n");
+			fprintf(f, "\n");
+			fprintf(f, "#define %sBUFFER_SIZE (1024)\n", prefix);
+			fprintf(f, "\n");
+			fprintf(f, "int main(void)\n");
+			fprintf(f, "{\n");
+			fprintf(f, "\tchar *buf, *p;\n");
+			fprintf(f, "\tint r;\n");
+			fprintf(f, "\n");
+			fprintf(f, "\tbuf = malloc(%sBUFFER_SIZE);\n", prefix);
+			fprintf(f, "\tif (!buf) {\n");
+			fprintf(f, "\t\tperror(\"malloc\");\n");
+			fprintf(f, "\t\texit(1);\n");
+			fprintf(f, "\t}\n\n");
+			fprintf(f, "\tfor (;;) {\n");
+			fprintf(f, "\t\tp = fgets(buf, %sBUFFER_SIZE, stdin);\n", prefix);
+			fprintf(f, "\t\tif (!p) {\n");
+			fprintf(f, "\t\t\tbreak;\n");
+			fprintf(f, "\t\t}\n");
+
+			switch (fsm->opt->io) {
+			case FSM_IO_PAIR:
+				fprintf(f, "\t\tr = %smatch(p, p + strlen(p));\n", prefix);
+				break;
+			case FSM_IO_STR:
+				fprintf(f, "\t\tr = %smatch(p);\n", prefix);
+				break;
+			case FSM_IO_GETC:
+				errno = ENOTSUP;
+				return -1;
+			}
+			fprintf(f, "\t\tprintf(\"%%smatch\\n\", (r == -1) ? \"no \" : \"\");\n");
+			fprintf(f, "\t}\n");
+			fprintf(f, "\treturn 0;\n");
+			fprintf(f, "}\n");
 			break;
 		}
-
-		fprintf(f, "\t\t\tok = 1;\n");
-		fprintf(f, "\t\t\tbreak;\n");
-		fprintf(f, "\t\tcase %sopLT: ok = c < ops[i].c; break;\n", prefix);
-		fprintf(f, "\t\tcase %sopLE: ok = c <= ops[i].c; break;\n", prefix);
-		fprintf(f, "\t\tcase %sopEQ: ok = c == ops[i].c; break;\n", prefix);
-		fprintf(f, "\t\tcase %sopNE: ok = c != ops[i].c; break;\n", prefix);
-		fprintf(f, "\t\tcase %sopGE: ok = c >= ops[i].c; break;\n", prefix);
-		fprintf(f, "\t\tcase %sopGT: ok = c > ops[i].c; break;\n", prefix);
-		fprintf(f, "\t\tcase %sopALWAYS: ok = 1; break;\n", prefix);
-		fprintf(f, "\t\t}\n");
-		fprintf(f, "\t\tif (ok) {\n");
-		fprintf(f, "\t\t\tif (ops[i].action == %sactionRET) {\n", prefix);
-		fprintf(f, "\t\t\t\treturn (int) (ops[i].arg);\n");
-		fprintf(f, "\t\t\t}\n");
-		fprintf(f, "\t\t\ti = ops[i].arg;\n");
-		fprintf(f, "\t\t\tcontinue;\n");
-		fprintf(f, "\t\t}\n");
-		fprintf(f, "\t\ti++;\n");
-		fprintf(f, "\t}\n");
-		fprintf(f, "}\n");
-		fprintf(f, "\n");
-		fprintf(f, "#define %sBUFFER_SIZE (1024)\n", prefix);
-		fprintf(f, "\n");
-		fprintf(f, "int main(void)\n");
-		fprintf(f, "{\n");
-		fprintf(f, "\tchar *buf, *p;\n");
-		fprintf(f, "\tint r;\n");
-		fprintf(f, "\n");
-		fprintf(f, "\tbuf = malloc(%sBUFFER_SIZE);\n", prefix);
-		fprintf(f, "\tif (!buf) {\n");
-		fprintf(f, "\t\tperror(\"malloc\");\n");
-		fprintf(f, "\t\texit(1);\n");
-		fprintf(f, "\t}\n\n");
-		fprintf(f, "\tfor (;;) {\n");
-		fprintf(f, "\t\tp = fgets(buf, %sBUFFER_SIZE, stdin);\n", prefix);
-		fprintf(f, "\t\tif (!p) {\n");
-		fprintf(f, "\t\t\tbreak;\n");
-		fprintf(f, "\t\t}\n");
-
-		switch (fsm->opt->io) {
-		case FSM_IO_PAIR:
-			fprintf(f, "\t\tr = %smatch(p, p + strlen(p));\n", prefix);
-			break;
-		case FSM_IO_STR:
-			fprintf(f, "\t\tr = %smatch(p);\n", prefix);
-			break;
-		case FSM_IO_GETC:
-			fprintf(stderr, "unsupported IO API\n");
-			break;
-		}
-		fprintf(f, "\t\tprintf(\"%%smatch\\n\", (r == -1) ? \"no \" : \"\");\n");
-		fprintf(f, "\t}\n");
-		fprintf(f, "\treturn 0;\n");
-		fprintf(f, "}\n");
-		break;
 	}
 
 	free_ir(fsm, ir);
+
+	if (ferror(f)) {
+		return -1;
+	}
+
+	return 0;
 }
 
-void
-fsm_print_vmops_c(FILE *f, const struct fsm *fsm) {
-	fsm_print_vmops(f, fsm, VMOPS_C);
+int
+fsm_print_vmops_c(FILE *f, const struct fsm *fsm)
+{
+	return fsm_print_vmops(f, fsm, VMOPS_C);
 }
 
-void
-fsm_print_vmops_h(FILE *f, const struct fsm *fsm) {
-	fsm_print_vmops(f, fsm, VMOPS_H);
+int
+fsm_print_vmops_h(FILE *f, const struct fsm *fsm)
+{
+	return fsm_print_vmops(f, fsm, VMOPS_H);
 }
 
-void
-fsm_print_vmops_main(FILE *f, const struct fsm *fsm) {
-	fsm_print_vmops(f, fsm, VMOPS_MAIN);
+int
+fsm_print_vmops_main(FILE *f, const struct fsm *fsm)
+{
+	return fsm_print_vmops(f, fsm, VMOPS_MAIN);
 }
+

--- a/src/print/awk.c
+++ b/src/print/awk.c
@@ -48,19 +48,24 @@ awk_escputc_char(FILE *f, const struct fsm_options *opt, char c)
 	return fprintf(f, "%c", c);
 }
 
-void
+int
 awk_escputcharlit(FILE *f, const struct fsm_options *opt, char c)
 {
 	assert(f != NULL);
 	assert(opt != NULL);
 
 	if (opt->always_hex || (unsigned char) c > SCHAR_MAX) {
-		fprintf(f, "0x%02x", (unsigned char) c);
-		return;
+		return fprintf(f, "0x%02x", (unsigned char) c);
 	}
 
 	fprintf(f, "\"");
 	awk_escputc_char(f, opt, c);
 	fprintf(f, "\"");
+
+	if (ferror(f)) {
+		return -1;
+	}
+
+	return 0;
 }
 

--- a/src/print/c.c
+++ b/src/print/c.c
@@ -89,19 +89,24 @@ c_escputc_str(FILE *f, const struct fsm_options *opt, char c)
 	return fprintf(f, "%c", c);
 }
 
-void
+int
 c_escputcharlit(FILE *f, const struct fsm_options *opt, char c)
 {
 	assert(f != NULL);
 	assert(opt != NULL);
 
 	if (opt->always_hex || (unsigned char) c > SCHAR_MAX) {
-		fprintf(f, "0x%02x", (unsigned char) c);
-		return;
+		return fprintf(f, "0x%02x", (unsigned char) c);
 	}
 
 	fprintf(f, "'");
 	c_escputc_char(f, opt, c);
 	fprintf(f, "'");
+
+	if (ferror(f)) {
+		return -1;
+	}
+
+	return 0;
 }
 

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -1200,7 +1200,14 @@ main(int argc, char *argv[])
 			opt.endleaf = patterns ? endleaf_json : NULL;
 		}
 
-		print_fsm(stdout, fsm);
+		if (-1 == print_fsm(stdout, fsm)) {
+			if (errno == ENOTSUP) {
+				fprintf(stderr, "unsupported IO API\n");
+			} else {
+				perror("print_fsm");
+			}
+			exit(EXIT_FAILURE);
+		}
 
 /* XXX: free fsm */
 

--- a/src/retest/runner.c
+++ b/src/retest/runner.c
@@ -163,6 +163,12 @@ runner_init_compiled(struct fsm *fsm, struct fsm_runner *r, enum implementation 
 		(void) snprintf(cmd, sizeof cmd, "%s %s -shared %s -o %s",
 				cc ? cc : "gcc", cflags ? cflags : "",
 				tmp_o2, tmp_so);
+
+		if (0 != system(cmd)) {
+			perror(cmd);
+			return ERROR_FILE_IO;
+		}
+
 		break;
 
 	case IMPL_VMASM:
@@ -183,16 +189,16 @@ runner_init_compiled(struct fsm *fsm, struct fsm_runner *r, enum implementation 
 				cc ? cc : "gcc", cflags ? cflags : "",
 				tmp_o, tmp_so);
 
+		if (0 != system(cmd)) {
+			perror(cmd);
+			return ERROR_FILE_IO;
+		}
+
 		break;
 
 	case IMPL_INTERPRET:
 		assert(!"should not reach!");
 		break;
-	}
-
-	if (0 != system(cmd)) {
-		perror(cmd);
-		return ERROR_FILE_IO;
 	}
 
 	if (EOF == fclose(f)) {

--- a/tests/aho_corasick/actest.c
+++ b/tests/aho_corasick/actest.c
@@ -102,7 +102,7 @@ void wordlist_finalize(struct word_list *words)
 int main(int argc, char *argv[]) {
 	struct fsm *fsm;
 	char s[BUFSIZ];
-	void (*print)(FILE *, const struct fsm *);
+	fsm_print *print;
 
 	const char *pname = argv[0];
 


### PR DESCRIPTION
The crux of this is that we `fprintf()` a whole bunch and then check `ferror()`. And then if there was an error, return -1 from `fsm_print_*()`.

This allows returning -1 for other reasons, in particular ENOTSUP for unsupported IO APIs, which is what the fuzzer was hitting.

From the commit history:

> The API here is questionable. I wanted to return -1 on error to follow the model for IO, where e.g. fprintf is specified to return "a negative value" on error. So I'm returning 0 on success. This feels a little awkward, but it does mean this interface is similar to fprintf.
>
> Internally, rather than bubbling up errors from every call, I'm just calling ferror() on every return path. Also nothing in libfsm should call perror!


I also cleaned up retest's runner a bit, around the printing and compilation. We used to accidentally run `system()` twice in some places, which is harmless but cost us CI time. And I rewrote some awkward stuff about constructing strings into fixed-size arrays.