### PR TITLE
ast_compile: If errno != 0, and err->e is unset, set it to `RE_EERRNO`.

### DIFF
--- a/src/libre/ast_compile.c
+++ b/src/libre/ast_compile.c
@@ -975,6 +975,10 @@ ast_compile(const struct ast *ast,
 
 error:
 
+	if (err != NULL && err->e == RE_ESUCCESS && errno != 0) {
+		err->e = RE_EERRNO;
+	}
+
 	fsm_free(fsm);
 
 	return NULL;


### PR DESCRIPTION
It's possible to trigger this assert in re.c's re_comp:

    assert(err == NULL || err->e != RE_ESUCCESS);

if using a very tightly limited custom allocator for libfsm.

Is this the right location to update `err->e` if unset?