### PR TITLE
Run Rust codegen and fuzzing in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on: [ push, pull_request ]
 env:
   pcre2: pcre2-10.40
   wc: wc
+  seeds: seeds
   build: build
   cvtpcre: build/test/retest
   prefix: prefix
@@ -377,6 +378,18 @@ jobs:
         path: ${{ env.build }}
         key: build-${{ matrix.make }}-${{ matrix.os }}-${{ matrix.cc }}-${{ matrix.debug }}-${{ matrix.san }}-${{ github.sha }}
 
+    # note we do the fuzzing unconditionally; each run adds to the corpus
+    - name: Cache seeds (mode ${{ matrix.mode }})
+      uses: actions/cache@v3
+      id: cache-seeds
+      with:
+        path: ${{ env.seeds }}-${{ matrix.mode }}
+        key: seeds-${{ matrix.mode }}
+
+    - name: mkdir seeds
+      if: steps.cache-seeds.outputs.cache-hit != 'true'
+      run: mkdir -p ${{ env.seeds }}-${{ matrix.mode }}
+
     - name: Get number of CPU cores
       uses: SimenB/github-actions-cpu-cores@v1
       id: cpu-cores
@@ -386,9 +399,14 @@ jobs:
         MODE: ${{ env.mode }}
         ASAN_OPTIONS: detect_leaks=0:halt_on_error=1
         UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
-      run: |
-        mkdir -p seeds
-        ./${{ env.build }}/fuzz/fuzzer -jobs=$((${{ steps.cpu-cores.outputs.count }} + 1)) -max_total_time=60 seeds
+      run: ./${{ env.build }}/fuzz/fuzzer -jobs=$((${{ steps.cpu-cores.outputs.count }} + 1)) -max_total_time=60 ${{ env.seeds }}-${{ matrix.mode }}
+
+    # nothing to do with the caching, I'm uploading the seeds so a developer can grab them to fuzz locally
+    - name: Upload seeds (mode ${{ matrix.mode }})
+      uses: actions/upload-artifact@v3
+      with:
+        name: seeds-${{ matrix.mode }}
+        path: ${{ env.seeds }}-${{ matrix.mode }}
 
   test_pcre:
     name: "Test (PCRE suite) ${{ matrix.lang }} ${{ matrix.san }} ${{ matrix.cc }} ${{ matrix.os }} ${{ matrix.debug }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,7 +328,7 @@ jobs:
         cc: [ clang, gcc ]
         make: [ bmake ]
         debug: [ DEBUG, EXPENSIVE_CHECKS, RELEASE ] # RELEASE=1 is a no-op
-        lang: [ "vm -x v1", "vm -x v2", asm, c, vmc, vmops, go, goasm ]
+        lang: [ "vm -x v1", "vm -x v2", asm, c, rust, vmc, vmops, go, goasm ]
         exclude:
           - os: macos
             cc: gcc # it's clang anyway

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,8 +397,7 @@ jobs:
     - name: Fuzz
       env:
         MODE: ${{ env.mode }}
-        ASAN_OPTIONS: detect_leaks=0:halt_on_error=1
-        UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+        UBSAN_OPTIONS: ASAN_OPTIONS=detect_leaks=0:halt_on_error=1 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1
       run: ./${{ env.build }}/fuzz/fuzzer -fork=$((${{ steps.cpu-cores.outputs.count }} + 1)) -max_total_time=60 ${{ env.seeds }}-${{ matrix.mode }}
 
     # nothing to do with the caching, I'm uploading the seeds so a developer can grab them to fuzz locally

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,6 +333,7 @@ jobs:
   test_fuzz:
     name: "Fuzz (mode ${{ matrix.mode }}) ${{ matrix.cc }} ${{ matrix.os }} ${{ matrix.debug }}"
     runs-on: ${{ matrix.os }}-latest
+    timeout-minutes: 5 # this should never be reached, it's a safeguard for bugs in the fuzzer itself
     needs: [ build ]
 
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -399,7 +399,7 @@ jobs:
         MODE: ${{ env.mode }}
         ASAN_OPTIONS: detect_leaks=0:halt_on_error=1
         UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
-      run: ./${{ env.build }}/fuzz/fuzzer -jobs=$((${{ steps.cpu-cores.outputs.count }} + 1)) -max_total_time=60 ${{ env.seeds }}-${{ matrix.mode }}
+      run: ./${{ env.build }}/fuzz/fuzzer -fork=$((${{ steps.cpu-cores.outputs.count }} + 1)) -max_total_time=60 ${{ env.seeds }}-${{ matrix.mode }}
 
     # nothing to do with the caching, I'm uploading the seeds so a developer can grab them to fuzz locally
     - name: Upload seeds (mode ${{ matrix.mode }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -410,12 +410,12 @@ jobs:
         key: build-${{ matrix.make }}-${{ matrix.os }}-${{ matrix.cc }}-${{ matrix.debug }}-${{ matrix.san }}-${{ github.sha }}
 
     # note we do the fuzzing unconditionally; each run adds to the corpus
-    - name: Cache seeds (mode ${{ matrix.mode }})
-      uses: actions/cache@v3
+    - name: Restore seeds (mode ${{ matrix.mode }})
+      uses: actions/cache/restore@v3
       id: cache-seeds
       with:
         path: ${{ env.seeds }}-${{ matrix.mode }}
-        key: seeds-${{ matrix.mode }}
+        key: seeds-${{ matrix.mode }}-${{ matrix.debug }}
 
     - name: mkdir seeds
       if: steps.cache-seeds.outputs.cache-hit != 'true'
@@ -431,11 +431,34 @@ jobs:
         UBSAN_OPTIONS: ASAN_OPTIONS=detect_leaks=0:halt_on_error=1 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1
       run: ./${{ env.build }}/fuzz/fuzzer -fork=$((${{ steps.cpu-cores.outputs.count }} + 1)) -max_total_time=60 ${{ env.seeds }}-${{ matrix.mode }}
 
+    # saving the cache would fail because this key already exists,
+    # so I'm just explicitly purging by key here.
+    # the key contains "-${{ matrix.debug }}" so we don't lose seeds
+    # found from another instance in the matrix when purging.
+    - name: Purge cached seeds (mode ${{ matrix.mode }}-${{ matrix.debug }})
+      if: steps.cache-seeds.outputs.cache-hit == 'true'
+      run: |
+        set +e
+        gh extension install actions/gh-actions-cache
+        gh actions-cache delete ${{ steps.cache-seeds.outputs.cache-primary-key }} -R ${{ github.repository }} --confirm
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # if: always() means we keep these even on error, so we don't need to re-find
+    # the same seeds for a given bug.
+    # The explicit cache/restore and cache/save actions are just for that.
+    - name: Save seeds (mode ${{ matrix.mode }}-${{ matrix.debug }})
+      uses: actions/cache/save@v3
+      if: always()
+      with:
+        path: ${{ env.seeds }}-${{ matrix.mode }}
+        key: ${{ steps.cache-seeds.outputs.cache-primary-key }}
+
     # nothing to do with the caching, I'm uploading the seeds so a developer can grab them to fuzz locally
-    - name: Upload seeds (mode ${{ matrix.mode }})
+    - name: Upload seeds (mode ${{ matrix.mode }}-${{ matrix.debug }})
       uses: actions/upload-artifact@v3
       with:
-        name: seeds-${{ matrix.mode }}
+        name: seeds-${{ matrix.mode }}-${{ matrix.debug }}
         path: ${{ env.seeds }}-${{ matrix.mode }}
 
   test_pcre:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        san: [ NO_SANITIZER, ASAN, UBSAN, MSAN, EFENCE ] # NO_SANITIZER=1 is a no-op
+        san: [ NO_SANITIZER, ASAN, UBSAN, MSAN, EFENCE, FUZZER ] # NO_SANITIZER=1 is a no-op
         os: [ ubuntu ]
         cc: [ clang, gcc ]
         make: [ bmake ] # we test makefiles separately
@@ -149,6 +149,8 @@ jobs:
             san: MSAN # not supported
           - os: macos
             make: pmake # not packaged
+          - san: FUZZER
+            cc: gcc # -fsanitize=fuzzer is clang-only
 
     steps:
     - name: Fetch checkout
@@ -186,12 +188,24 @@ jobs:
       id: cpu-cores
 
     - name: Make
-      if: steps.cache-build.outputs.cache-hit != 'true'
+      if: matrix.san != 'FUZZER' && steps.cache-build.outputs.cache-hit != 'true'
       run: |
         # note: lexer.h first, because parser.? depends on it
         find . -name 'lexer.?' -exec touch '{}' \; # workaround for git checkout timestamps
         find . -name 'parser.?' -exec touch '{}' \; # workaround for git checkout timestamps
         ${{ matrix.make }} -r -j $((${{ steps.cpu-cores.outputs.count }} + 1)) -C ${{ env.wc }} BUILD=../${{ env.build }} ${{ matrix.san }}=1 ${{ matrix.debug }}=1 PKGCONF=pkg-config CC=${{ matrix.cc }} NODOC=1
+
+    # We aren't building the CLI executables here, just the fuzzer
+    # matrix.san=FUZZER implies UBSAN and ASAN (but not MSAN, MSAN is incompatible with ASAN)
+    # XXX: needing to explicitly mkdir here is a makefile bug
+    - name: Make (Fuzzer)
+      if: matrix.san == 'FUZZER' && steps.cache-build.outputs.cache-hit != 'true'
+      run: |
+        # note: lexer.h first, because parser.? depends on it
+        find . -name 'lexer.?' -exec touch '{}' \; # workaround for git checkout timestamps
+        find . -name 'parser.?' -exec touch '{}' \; # workaround for git checkout timestamps
+        ${{ matrix.make }} -r -j $((${{ steps.cpu-cores.outputs.count }} + 1)) -C ${{ env.wc }} BUILD=../${{ env.build }} ${{ matrix.san }}=1 ${{ matrix.debug }}=1 UBSAN=1 ASAN=1 PKGCONF=pkg-config CC=${{ matrix.cc }} NODOC=1 mkdir
+        ${{ matrix.make }} -r -j $((${{ steps.cpu-cores.outputs.count }} + 1)) -C ${{ env.wc }} BUILD=../${{ env.build }} ${{ matrix.san }}=1 ${{ matrix.debug }}=1 UBSAN=1 ASAN=1 PKGCONF=pkg-config CC=${{ matrix.cc }} NODOC=1 fuzz
 
   # testing different bmake dialects
   # the goal here is to excercise the build system, not the code
@@ -314,6 +328,67 @@ jobs:
         EF_DISABLE_BANNER: 1
       # I don't want to build SID just for sake of its -l test
       run: ${{ matrix.make }} -r -j $((${{ steps.cpu-cores.outputs.count }} + 1)) -C ${{ env.wc }} BUILD=../${{ env.build }} ${{ matrix.san }}=1 ${{ matrix.debug }}=1 PKGCONF=pkg-config SID='true; echo sid' CC=${{ matrix.cc }} NODOC=1 LX=../${{ env.build }}/bin/lx test
+
+  test_fuzz:
+    name: "Fuzz (mode ${{ matrix.mode }}) ${{ matrix.cc }} ${{ matrix.os }} ${{ matrix.debug }}"
+    runs-on: ${{ matrix.os }}-latest
+    needs: [ build ]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        san: [ FUZZER ]
+        os: [ ubuntu ]
+        cc: [ clang ]
+        make: [ bmake ]
+        debug: [ DEBUG, EXPENSIVE_CHECKS, RELEASE ] # RELEASE=1 is a no-op
+        mode: [ p, m ]
+        exclude:
+          - os: macos
+            cc: gcc # it's clang anyway
+
+    steps:
+    - name: Fetch checkout
+      uses: actions/cache@v3
+      id: cache-checkout
+      with:
+        path: ${{ env.wc }}
+        key: checkout-${{ github.sha }}
+
+    - name: Dependencies (Ubuntu)
+      if: matrix.os == 'ubuntu'
+      run: |
+        uname -a
+        sudo apt-get install bmake
+        ${{ matrix.cc }} --version
+
+    - name: Dependencies (MacOS)
+      if: matrix.os == 'macos'
+      run: |
+        uname -a
+        brew update
+        brew install bmake
+        ${{ matrix.cc }} --version
+
+    - name: Fetch build
+      uses: actions/cache@v3
+      id: cache-build
+      with:
+        path: ${{ env.build }}
+        key: build-${{ matrix.make }}-${{ matrix.os }}-${{ matrix.cc }}-${{ matrix.debug }}-${{ matrix.san }}-${{ github.sha }}
+
+    - name: Get number of CPU cores
+      uses: SimenB/github-actions-cpu-cores@v1
+      id: cpu-cores
+
+    - name: Fuzz
+      env:
+        MODE: ${{ env.mode }}
+        ASAN_OPTIONS: detect_leaks=0:halt_on_error=1
+        UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+      run: |
+        mkdir -p seeds
+        ./${{ env.build }}/fuzz/fuzzer -jobs=$((${{ steps.cpu-cores.outputs.count }} + 1)) -max_total_time=60 seeds
 
   test_pcre:
     name: "Test (PCRE suite) ${{ matrix.lang }} ${{ matrix.san }} ${{ matrix.cc }} ${{ matrix.os }} ${{ matrix.debug }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,8 +266,16 @@ jobs:
       # Same for lx
       run: ${{ matrix.make }} -r -j $((${{ steps.cpu-cores.outputs.count }} + 1)) -C ${{ env.wc }} BUILD=../${{ env.build }} ${{ matrix.debug }}=1 PKGCONF=pkg-config SID='true; echo sid' LX='true; echo lx' CC=${{ matrix.cc }} NODOC=1 test
 
+    # there's an unfixed intermittent makefile bug under -j for
+    # kmkf duplicate install targets, it's not interesting for libfsm's CI,
+    # so I'm retrying on error here. # github.com/katef/kmkf/issues/14
     - name: Install
-      run: ${{ matrix.make }} -r -j $((${{ steps.cpu-cores.outputs.count }} + 1)) -C ${{ env.wc }} BUILD=../${{ env.build }} ${{ matrix.debug }}=1 PKGCONF=pkg-config PREFIX=../${{ env.prefix }} NODOC=1 install
+      uses: nick-fields/retry@v2.8.3
+      with:
+        timeout_seconds: 10 # required, but not a problem for the kmkf bug
+        max_attempts: 3
+        retry_on: error
+        command: ${{ matrix.make }} -r -j $((${{ steps.cpu-cores.outputs.count }} + 1)) -C ${{ env.wc }} BUILD=../${{ env.build }} ${{ matrix.debug }}=1 PKGCONF=pkg-config PREFIX=../${{ env.prefix }} NODOC=1 install
 
   test_san:
     name: "Test (Sanitizers) ${{ matrix.san }} ${{ matrix.cc }} ${{ matrix.os }} ${{ matrix.debug }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       id: cache-cvtpcre
       with:
         path: ${{ env.cvtpcre }}
-        key: cvtpcre-bmake-ubuntu-gcc-DEBUG-ASAN-${{ github.sha }}-${{ env.pcre2 }}
+        key: cvtpcre-bmake-ubuntu-gcc-EXPENSIVE_CHECKS-ASAN-${{ github.sha }}-${{ env.pcre2 }}
 
     - name: Fetch build
       if: steps.cache-cvtpcre.outputs.cache-hit != 'true'
@@ -79,7 +79,7 @@ jobs:
       id: cache-build
       with:
         path: ${{ env.build }}
-        key: build-bmake-ubuntu-gcc-DEBUG-ASAN-${{ github.sha }} # arbitary build, just for cvtpcre
+        key: build-bmake-ubuntu-gcc-EXPENSIVE_CHECKS-ASAN-${{ github.sha }} # arbitary build, just for cvtpcre
 
     - name: Convert PCRE suite
       if: steps.cache-cvtpcre.outputs.cache-hit != 'true'
@@ -140,7 +140,7 @@ jobs:
         os: [ ubuntu ]
         cc: [ clang, gcc ]
         make: [ bmake ] # we test makefiles separately
-        debug: [ DEBUG, EXPENSIVE_CHECKS, RELEASE ] # RELEASE=1 is a no-op
+        debug: [ EXPENSIVE_CHECKS, RELEASE ] # RELEASE=1 is a no-op, EXPENSIVE_CHECKS implies DEBUG
         exclude:
           - os: macos
             cc: gcc # it's clang anyway
@@ -281,7 +281,7 @@ jobs:
         os: [ ubuntu ]
         cc: [ clang, gcc ]
         make: [ bmake ]
-        debug: [ DEBUG, EXPENSIVE_CHECKS, RELEASE ] # RELEASE=1 is a no-op
+        debug: [ EXPENSIVE_CHECKS, RELEASE ] # RELEASE=1 is a no-op, EXPENSIVE_CHECKS implies DEBUG
         exclude:
           - os: macos
             cc: gcc # it's clang anyway
@@ -342,7 +342,7 @@ jobs:
         os: [ ubuntu ]
         cc: [ clang ]
         make: [ bmake ]
-        debug: [ DEBUG, EXPENSIVE_CHECKS, RELEASE ] # RELEASE=1 is a no-op
+        debug: [ EXPENSIVE_CHECKS, RELEASE ] # RELEASE=1 is a no-op, EXPENSIVE_CHECKS implies DEBUG
         mode: [ m, p, d ]
         exclude:
           - os: macos
@@ -420,7 +420,7 @@ jobs:
         os: [ ubuntu ]
         cc: [ clang, gcc ]
         make: [ bmake ]
-        debug: [ DEBUG, EXPENSIVE_CHECKS, RELEASE ] # RELEASE=1 is a no-op
+        debug: [ EXPENSIVE_CHECKS, RELEASE ] # RELEASE=1 is a no-op, EXPENSIVE_CHECKS implies DEBUG
         lang: [ "vm -x v1", "vm -x v2", asm, c, rust, vmc, vmops, go, goasm ]
         exclude:
           - os: macos
@@ -464,7 +464,7 @@ jobs:
       id: cache-cvtpcre
       with:
         path: ${{ env.cvtpcre }}
-        key: cvtpcre-bmake-ubuntu-gcc-DEBUG-ASAN-${{ github.sha }}-${{ env.pcre2 }}
+        key: cvtpcre-bmake-ubuntu-gcc-EXPENSIVE_CHECKS-ASAN-${{ github.sha }}-${{ env.pcre2 }}
 
     - name: Run PCRE suite (${{ matrix.lang }})
       run: CC=${{ matrix.cc }} ./${{ env.build }}/bin/retest -O1 -l ${{ matrix.lang }} ${{ env.cvtpcre }}/*.tst

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,7 +342,7 @@ jobs:
         cc: [ clang ]
         make: [ bmake ]
         debug: [ DEBUG, EXPENSIVE_CHECKS, RELEASE ] # RELEASE=1 is a no-op
-        mode: [ p, m ]
+        mode: [ m, p, d ]
         exclude:
           - os: macos
             cc: gcc # it's clang anyway

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,15 +214,16 @@ jobs:
   test_makefiles:
     name: "Test (Makefiles) ${{ matrix.make }} ${{ matrix.os }} ${{ matrix.debug }}"
     runs-on: ${{ matrix.os }}-latest
-    needs: [ checkout ]
+    needs: [ checkout, build ]
 
     strategy:
       fail-fast: false
       matrix:
+        san: [ NO_SANITIZER ] # NO_SANITIZER=1 is a no-op
         os: [ ubuntu ]
         cc: [ clang ]
         make: [ bmake, pmake ]
-        debug: [ DEBUG, RELEASE ] # RELEASE=1 is a no-op
+        debug: [ EXPENSIVE_CHECKS, RELEASE ] # RELEASE=1 is a no-op
         exclude:
           - os: macos
             make: pmake # not packaged
@@ -234,6 +235,24 @@ jobs:
       with:
         path: ${{ env.wc }}
         key: checkout-${{ github.sha }}
+
+    # An arbitary build.
+    - name: Fetch build
+      uses: actions/cache@v3
+      id: cache-build
+      with:
+        path: ${{ env.build }}
+        key: build-${{ matrix.make }}-${{ matrix.os }}-${{ matrix.cc }}-${{ matrix.debug }}-${{ matrix.san }}-${{ github.sha }}
+
+    # We don't need to build the entire repo to know that the makefiles work,
+    # I'm just deleting a couple of .o files and rebuilding those instead.
+    - name: Delete something
+      if: steps.cache-build.outputs.cache-hit == 'true'
+      run: find ${{ env.build }} -type f -name '*.o' | sort -r | head -5 | xargs rm
+
+    - name: Outdate something
+      if: steps.cache-build.outputs.cache-hit == 'true'
+      run: find ${{ env.wc }} -type f -name '*.c' | sort -r | head -5 | xargs touch
 
     - name: Dependencies (Ubuntu)
       if: matrix.os == 'ubuntu'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       id: cache-cvtpcre
       with:
         path: ${{ env.cvtpcre }}
-        key: cvtpcre-bmake-ubuntu-gcc-EXPENSIVE_CHECKS-AUSAN-${{ github.sha }}-${{ env.pcre2 }}
+        key: cvtpcre-bmake-ubuntu-gcc-DEBUG-AUSAN-${{ github.sha }}-${{ env.pcre2 }}
 
     - name: Fetch build
       if: steps.cache-cvtpcre.outputs.cache-hit != 'true'
@@ -79,7 +79,7 @@ jobs:
       id: cache-build
       with:
         path: ${{ env.build }}
-        key: build-bmake-ubuntu-gcc-EXPENSIVE_CHECKS-AUSAN-${{ github.sha }} # arbitary build, just for cvtpcre
+        key: build-bmake-ubuntu-gcc-DEBUG-AUSAN-${{ github.sha }} # arbitary build, just for cvtpcre
 
     - name: Convert PCRE suite
       if: steps.cache-cvtpcre.outputs.cache-hit != 'true'
@@ -140,7 +140,7 @@ jobs:
         os: [ ubuntu ]
         cc: [ clang, gcc ]
         make: [ bmake ] # we test makefiles separately
-        debug: [ EXPENSIVE_CHECKS, RELEASE ] # RELEASE=1 is a no-op, EXPENSIVE_CHECKS implies DEBUG
+        debug: [ DEBUG, RELEASE ] # RELEASE=1 is a no-op
         exclude:
           - os: macos
             cc: gcc # it's clang anyway
@@ -211,6 +211,9 @@ jobs:
   # testing different bmake dialects
   # the goal here is to excercise the build system, not the code
   # we don't care about e.g. different compilers here
+  #
+  # I'm including EXPENSIVE_CHECKS here just so we have some coverage
+  # of the build during CI, even if we don't run that during tests.
   test_makefiles:
     name: "Test (Makefiles) ${{ matrix.make }} ${{ matrix.os }} ${{ matrix.debug }}"
     runs-on: ${{ matrix.os }}-latest
@@ -223,7 +226,7 @@ jobs:
         os: [ ubuntu ]
         cc: [ clang ]
         make: [ bmake, pmake ]
-        debug: [ EXPENSIVE_CHECKS, RELEASE ] # RELEASE=1 is a no-op
+        debug: [ EXPENSIVE_CHECKS, DEBUG, RELEASE ] # RELEASE=1 is a no-op
         exclude:
           - os: macos
             make: pmake # not packaged
@@ -308,7 +311,7 @@ jobs:
         os: [ ubuntu ]
         cc: [ clang, gcc ]
         make: [ bmake ]
-        debug: [ EXPENSIVE_CHECKS, RELEASE ] # RELEASE=1 is a no-op, EXPENSIVE_CHECKS implies DEBUG
+        debug: [ DEBUG, RELEASE ] # RELEASE=1 is a no-op
         exclude:
           - os: macos
             cc: gcc # it's clang anyway
@@ -370,7 +373,7 @@ jobs:
         os: [ ubuntu ]
         cc: [ clang ]
         make: [ bmake ]
-        debug: [ EXPENSIVE_CHECKS, RELEASE ] # RELEASE=1 is a no-op, EXPENSIVE_CHECKS implies DEBUG
+        debug: [ DEBUG, RELEASE ] # RELEASE=1 is a no-op
         mode: [ m, p, d ]
         exclude:
           - os: macos
@@ -447,7 +450,7 @@ jobs:
         os: [ ubuntu ]
         cc: [ clang, gcc ]
         make: [ bmake ]
-        debug: [ EXPENSIVE_CHECKS, RELEASE ] # RELEASE=1 is a no-op, EXPENSIVE_CHECKS implies DEBUG
+        debug: [ DEBUG, RELEASE ] # RELEASE=1 is a no-op
         lang: [ "vm -x v1", "vm -x v2", asm, c, rust, vmc, vmops, go, goasm ]
         exclude:
           - os: macos
@@ -491,7 +494,7 @@ jobs:
       id: cache-cvtpcre
       with:
         path: ${{ env.cvtpcre }}
-        key: cvtpcre-bmake-ubuntu-gcc-EXPENSIVE_CHECKS-AUSAN-${{ github.sha }}-${{ env.pcre2 }}
+        key: cvtpcre-bmake-ubuntu-gcc-DEBUG-AUSAN-${{ github.sha }}-${{ env.pcre2 }}
 
     - name: Run PCRE suite (${{ matrix.lang }})
       run: CC=${{ matrix.cc }} ./${{ env.build }}/bin/retest -O1 -l ${{ matrix.lang }} ${{ env.cvtpcre }}/*.tst

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       id: cache-cvtpcre
       with:
         path: ${{ env.cvtpcre }}
-        key: cvtpcre-bmake-ubuntu-gcc-EXPENSIVE_CHECKS-ASAN-${{ github.sha }}-${{ env.pcre2 }}
+        key: cvtpcre-bmake-ubuntu-gcc-EXPENSIVE_CHECKS-AUSAN-${{ github.sha }}-${{ env.pcre2 }}
 
     - name: Fetch build
       if: steps.cache-cvtpcre.outputs.cache-hit != 'true'
@@ -79,7 +79,7 @@ jobs:
       id: cache-build
       with:
         path: ${{ env.build }}
-        key: build-bmake-ubuntu-gcc-EXPENSIVE_CHECKS-ASAN-${{ github.sha }} # arbitary build, just for cvtpcre
+        key: build-bmake-ubuntu-gcc-EXPENSIVE_CHECKS-AUSAN-${{ github.sha }} # arbitary build, just for cvtpcre
 
     - name: Convert PCRE suite
       if: steps.cache-cvtpcre.outputs.cache-hit != 'true'
@@ -136,7 +136,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        san: [ NO_SANITIZER, ASAN, UBSAN, MSAN, EFENCE, FUZZER ] # NO_SANITIZER=1 is a no-op
+        san: [ NO_SANITIZER, AUSAN, MSAN, EFENCE, FUZZER ] # NO_SANITIZER=1 is a no-op
         os: [ ubuntu ]
         cc: [ clang, gcc ]
         make: [ bmake ] # we test makefiles separately
@@ -205,8 +205,8 @@ jobs:
         # note: lexer.h first, because parser.? depends on it
         find . -name 'lexer.?' -exec touch '{}' \; # workaround for git checkout timestamps
         find . -name 'parser.?' -exec touch '{}' \; # workaround for git checkout timestamps
-        ${{ matrix.make }} -r -j $((${{ steps.cpu-cores.outputs.count }} + 1)) -C ${{ env.wc }} BUILD=../${{ env.build }} ${{ matrix.san }}=1 ${{ matrix.debug }}=1 UBSAN=1 ASAN=1 PKGCONF=pkg-config CC=${{ matrix.cc }} NODOC=1 mkdir
-        ${{ matrix.make }} -r -j $((${{ steps.cpu-cores.outputs.count }} + 1)) -C ${{ env.wc }} BUILD=../${{ env.build }} ${{ matrix.san }}=1 ${{ matrix.debug }}=1 UBSAN=1 ASAN=1 PKGCONF=pkg-config CC=${{ matrix.cc }} NODOC=1 fuzz
+        ${{ matrix.make }} -r -j $((${{ steps.cpu-cores.outputs.count }} + 1)) -C ${{ env.wc }} BUILD=../${{ env.build }} ${{ matrix.san }}=1 ${{ matrix.debug }}=1 AUSAN=1 PKGCONF=pkg-config CC=${{ matrix.cc }} NODOC=1 mkdir
+        ${{ matrix.make }} -r -j $((${{ steps.cpu-cores.outputs.count }} + 1)) -C ${{ env.wc }} BUILD=../${{ env.build }} ${{ matrix.san }}=1 ${{ matrix.debug }}=1 AUSAN=1 PKGCONF=pkg-config CC=${{ matrix.cc }} NODOC=1 fuzz
 
   # testing different bmake dialects
   # the goal here is to excercise the build system, not the code
@@ -285,7 +285,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        san: [ ASAN, UBSAN, MSAN, EFENCE ]
+        san: [ AUSAN, MSAN, EFENCE ]
         os: [ ubuntu ]
         cc: [ clang, gcc ]
         make: [ bmake ]
@@ -424,7 +424,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        san: [ ASAN, UBSAN, MSAN, EFENCE ]
+        san: [ AUSAN, MSAN, EFENCE ]
         os: [ ubuntu ]
         cc: [ clang, gcc ]
         make: [ bmake ]
@@ -472,7 +472,7 @@ jobs:
       id: cache-cvtpcre
       with:
         path: ${{ env.cvtpcre }}
-        key: cvtpcre-bmake-ubuntu-gcc-EXPENSIVE_CHECKS-ASAN-${{ github.sha }}-${{ env.pcre2 }}
+        key: cvtpcre-bmake-ubuntu-gcc-EXPENSIVE_CHECKS-AUSAN-${{ github.sha }}-${{ env.pcre2 }}
 
     - name: Run PCRE suite (${{ matrix.lang }})
       run: CC=${{ matrix.cc }} ./${{ env.build }}/bin/retest -O1 -l ${{ matrix.lang }} ${{ env.cvtpcre }}/*.tst

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ BUILD_IMPOSSIBLE="attempting to use .OBJDIR other than .CURDIR"
 
 # targets
 all::  mkdir .WAIT dep .WAIT lib prog
+.if make(fuzz)
+fuzz:: mkdir
+.endif
 doc::  mkdir
 dep::
 gen::
@@ -151,6 +154,11 @@ INCDIR += include
 .include <prog.mk>
 .include <man.mk>
 .include <mkdir.mk>
+.endif
+
+# XXX: workaround for CI in github where the linker doesn't support dwarf-5?
+.if defined(FUZZER)
+CFLAGS += -gdwarf-4
 .endif
 
 # these are internal tools for development; we don't install them to $PREFIX

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,13 @@ RE     ?= re
 BUILD  ?= build
 PREFIX ?= /usr/local
 
+# libfsm has EXPENSIVE_CHECKS which are a superset of assertions;
+# this is here just so CI can only set one flag at a time.
+.if defined(EXPENSIVE_CHECKS)
+CFLAGS += -DEXPENSIVE_CHECKS
+DEBUG ?= 1
+.endif
+
 # ${unix} is an arbitrary variable set by sys.mk
 .if defined(unix)
 .BEGIN::

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,12 @@ CFLAGS += -DEXPENSIVE_CHECKS
 DEBUG ?= 1
 .endif
 
+# combined just to save time in CI
+.if defined(AUSAN)
+ASAN  ?= 1
+UBSAN ?= 1
+.endif
+
 # ${unix} is an arbitrary variable set by sys.mk
 .if defined(unix)
 .BEGIN::

--- a/Makefile
+++ b/Makefile
@@ -163,11 +163,6 @@ INCDIR += include
 .include <mkdir.mk>
 .endif
 
-# XXX: workaround for CI in github where the linker doesn't support dwarf-5?
-.if defined(FUZZER)
-CFLAGS += -gdwarf-4
-.endif
-
 # these are internal tools for development; we don't install them to $PREFIX
 STAGE_BUILD := ${STAGE_BUILD:Nbin/retest}
 STAGE_BUILD := ${STAGE_BUILD:Nbin/reperf}

--- a/fuzz/target.c
+++ b/fuzz/target.c
@@ -337,16 +337,17 @@ static enum run_mode
 get_run_mode(void)
 {
 	const char *mode = getenv("MODE");
-	if (mode != NULL) {
-		switch (mode[0]) {
-		case 'm': return MODE_SHUFFLE_MINIMISE;
-		case 'p': return MODE_ALL_PRINT_FUNCTIONS;
-		default:
-			break;
-		}
+	if (mode == NULL) {
+		return MODE_DEFAULT;
 	}
 
-	return MODE_DEFAULT;
+	switch (mode[0]) {
+	case 'm': return MODE_SHUFFLE_MINIMISE;
+	case 'p': return MODE_ALL_PRINT_FUNCTIONS;
+	case 'd':
+	default:
+		return MODE_DEFAULT;
+	}
 }
 
 static FILE *dev_null = NULL;
@@ -354,8 +355,6 @@ static FILE *dev_null = NULL;
 int
 harness_fuzzer_target(const uint8_t *data, size_t size)
 {
-	enum run_mode run_mode = get_run_mode();
-
 	if (size < 1) {
 		return EXIT_SUCCESS;
 	}
@@ -368,7 +367,7 @@ harness_fuzzer_target(const uint8_t *data, size_t size)
 
 	const char *pattern = (const char *)data_buf;
 
-	switch (run_mode) {
+	switch (get_run_mode()) {
 	case MODE_DEFAULT:
 		return build_and_codegen(pattern);
 

--- a/fuzz/target.c
+++ b/fuzz/target.c
@@ -123,6 +123,9 @@ build(const char *pattern)
 	if (total_usec > TIMEOUT_USEC) {
 #ifndef EXPENSIVE_CHECKS
 		assert(!"timeout");
+#else
+		fprintf(stderr, "exiting zero due to timeout under EXPENSIVE_CHECKS\n");
+		exit(0);
 #endif
 	}
 

--- a/fuzz/target.c
+++ b/fuzz/target.c
@@ -1,11 +1,11 @@
 #include <sys/time.h>
 #include <unistd.h>
 
+#include <assert.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h>
-#include <assert.h>
 #include <string.h>
 #include <inttypes.h>
 #include <ctype.h>
@@ -390,4 +390,6 @@ harness_fuzzer_target(const uint8_t *data, size_t size)
 		return res;
 	}
 	}
+
+	assert(!"unreached");
 }

--- a/fuzz/target.c
+++ b/fuzz/target.c
@@ -121,7 +121,9 @@ build(const char *pattern)
 	total_usec += delta_usec;
 
 	if (total_usec > TIMEOUT_USEC) {
+#ifndef EXPENSIVE_CHECKS
 		assert(!"timeout");
+#endif
 	}
 
 	return fsm;

--- a/fuzz/target.c
+++ b/fuzz/target.c
@@ -283,7 +283,6 @@ fuzz_all_print_functions(FILE *f, const char *pattern, bool det, bool min, const
 	};
 
 	fsm = re_comp(RE_PCRE, scanner_next, &s, &options, RE_MULTI, &err);
-
 	if (fsm == NULL) {
 		/* ignore invalid regexp syntax, etc. */
 		return EXIT_SUCCESS;
@@ -302,6 +301,9 @@ fuzz_all_print_functions(FILE *f, const char *pattern, bool det, bool min, const
 			}
 		}
 	}
+
+	/* if errno isn't zero already, I want to know why */
+	assert(errno == 0);
 
 	/* see if this triggers any asserts */
 	int r = 0;

--- a/include/adt/common.h
+++ b/include/adt/common.h
@@ -20,6 +20,10 @@
 #define EXPENSIVE_CHECKS 0
 #endif
 
+#if EXPENSIVE_CHECKS && NDEBUG
+#error NDEBUG with EXPENSIVE_CHECKS
+#endif
+
 /* If set to non-zero, this build should reject inputs as unsupported
  * that lead to uninteresting failures while fuzzing -- for example,
  * it's not surprising that `(some regex){1000000}` can hit the

--- a/include/fsm/print.h
+++ b/include/fsm/print.h
@@ -15,23 +15,24 @@ struct fsm;
  * Print an FSM to the given file stream. The output is written in the format
  * specified. The available formats are:
  *
- *  fsm_print_api    - C code which calls the fsm(3) API
- *  fsm_print_awk    - awk code (gawk dialect)
- *  fsm_print_c      - ISO C90 code
- *  fsm_print_dot    - Graphviz Dot format, intended for rendering graphically
- *  fsm_print_fsm    - fsm(5) .fsm format, suitable for parsing by fsm(1)
- *  fsm_print_ir     - Codegen IR as Dot
- *  fsm_print_irjson - Codegen IR as JSON
- *  fsm_print_json   - JavaScript Object Notation
- *  fsm_print_vmc    - ISO C90 code, VM style
- *  fsm_print_vmdot  - Graphviz Dot format, showing VM opcodes
- *  fsm_print_rust   - Rust code
- *  fsm_print_sh     - Shell script (bash dialect)
- *  fsm_print_go     - Go code
+ *  fsm_print_api           - C code which calls the fsm(3) API
+ *  fsm_print_awk           - awk code (gawk dialect)
+ *  fsm_print_c             - ISO C90 code
+ *  fsm_print_dot           - Graphviz Dot format, intended for rendering graphically
+ *  fsm_print_fsm           - fsm(5) .fsm format, suitable for parsing by fsm(1)
+ *  fsm_print_ir            - Codegen IR as Dot
+ *  fsm_print_irjson        - Codegen IR as JSON
+ *  fsm_print_json          - JavaScript Object Notation
+ *  fsm_print_vmc           - ISO C90 code, VM style
+ *  fsm_print_vmdot         - Graphviz Dot format, showing VM opcodes
+ *  fsm_print_rust          - Rust code
+ *  fsm_print_sh            - Shell script (bash dialect)
+ *  fsm_print_go            - Go code
+ *  fsm_print_goasm/vmasm_* - Assembly in various dialects
+ *  fsm_print_vmops_*       - VM opcodes as a datastructure
  *
  * The output options may be NULL, indicating to use defaults.
  *
- * TODO: what to return?
  * TODO: explain constraints
  *
  * Returns 0, or -1 on error and errno will be set. An errno of ENOTSUP means

--- a/src/libfsm/minimise.c
+++ b/src/libfsm/minimise.c
@@ -17,6 +17,10 @@
 #include <fsm/walk.h>
 #include <fsm/alloc.h>
 
+#if EXPENSIVE_CHECKS
+#include <fsm/print.h>
+#endif
+
 #include <adt/edgeset.h>
 #include <adt/pv.h>
 #include <adt/set.h>

--- a/src/libfsm/print/rust.c
+++ b/src/libfsm/print/rust.c
@@ -216,8 +216,19 @@ fsm_print_rustfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 	fprintf(f, "    }\n");
 	fprintf(f, "\n");
 
-	fprintf(f, "    let mut l = Ls;\n");
-	fprintf(f, "\n");
+	{
+		int has_branch = 0;
+
+		for (op = a.linked; op != NULL; op = op->next) {
+			if (op->instr == VM_OP_BRANCH) {
+				has_branch = 1;
+				break;
+			}
+		}
+
+		fprintf(f, "    let %sl = Ls;\n", has_branch ? "mut " : "");
+		fprintf(f, "\n");
+	}
 
 	fprintf(f, "    loop {\n");
 	fprintf(f, "        match l {\n");

--- a/src/libfsm/print/rust.c
+++ b/src/libfsm/print/rust.c
@@ -65,6 +65,18 @@ cmp_operator(int cmp)
 	}
 }
 
+static int
+has_op(const struct dfavm_op_ir *op, enum dfavm_op_instr instr)
+{
+	for ( ; op != NULL; op = op->next) {
+		if (op->instr == instr) {
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
 static void
 print_label(FILE *f, const struct dfavm_op_ir *op)
 {
@@ -129,24 +141,19 @@ print_fetch(FILE *f)
 
 /* TODO: eventually to be non-static */
 static int
-fsm_print_rustfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
+fsm_print_rustfrag(FILE *f, const struct dfavm_assembler_ir *a,
+	const struct ir *ir, const struct fsm_options *opt,
 	const char *cp,
 	int (*leaf)(FILE *, const struct fsm_end_ids *ids, const void *leaf_opaque),
 	const void *leaf_opaque)
 {
-	static const struct dfavm_assembler_ir zero;
-	struct dfavm_assembler_ir a;
 	struct dfavm_op_ir *op;
 	bool fallthrough;
 
-	static const struct fsm_vm_compile_opts vm_opts = { FSM_VM_COMPILE_DEFAULT_FLAGS, FSM_VM_COMPILE_VM_V1, NULL };
-
 	assert(f != NULL);
-	assert(ir != NULL);
+	assert(a != NULL);
 	assert(opt != NULL);
 	assert(cp != NULL);
-
-	a = zero;
 
 	/* TODO: we don't currently have .opaque information attached to struct dfavm_op_ir.
 	 * We'll need that in order to be able to use the leaf callback here. */
@@ -155,10 +162,6 @@ fsm_print_rustfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 
 	/* TODO: we'll need to heed cp for e.g. lx's codegen */
 	(void) cp;
-
-	if (!dfavm_compile_ir(&a, ir, vm_opts)) {
-		return -1;
-	}
 
 	/*
 	 * We only output labels for ops which are branched to. This gives
@@ -170,8 +173,8 @@ fsm_print_rustfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 
 		l = START;
 
-		for (op = a.linked; op != NULL; op = op->next) {
-			if (op == a.linked || op->num_incoming > 0) {
+		for (op = a->linked; op != NULL; op = op->next) {
+			if (op == a->linked || op->num_incoming > 0) {
 				op->index = l++;
 			}
 		}
@@ -180,8 +183,8 @@ fsm_print_rustfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 	/*
 	 * Only declare variables if we're actually going to use them.
 	 */
-	if (a.linked->cmp == VM_CMP_ALWAYS && a.linked->instr == VM_OP_STOP) {
-		assert(a.linked->next == NULL);
+	if (a->linked->cmp == VM_CMP_ALWAYS && a->linked->instr == VM_OP_STOP) {
+		assert(a->linked->next == NULL);
 		fprintf(f, "\n");
 	} else {
 		switch (opt->io) {
@@ -205,8 +208,8 @@ fsm_print_rustfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 	}
 
 	fprintf(f, "    pub enum Label {\n       ");
-	for (op = a.linked; op != NULL; op = op->next) {
-		if (op == a.linked || op->num_incoming > 0) {
+	for (op = a->linked; op != NULL; op = op->next) {
+		if (op == a->linked || op->num_incoming > 0) {
 			fprintf(f, " ");
 			print_label(f, op);
 			fprintf(f, ",");
@@ -216,28 +219,17 @@ fsm_print_rustfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 	fprintf(f, "    }\n");
 	fprintf(f, "\n");
 
-	{
-		int has_branch = 0;
-
-		for (op = a.linked; op != NULL; op = op->next) {
-			if (op->instr == VM_OP_BRANCH) {
-				has_branch = 1;
-				break;
-			}
-		}
-
-		fprintf(f, "    let %sl = Ls;\n", has_branch ? "mut " : "");
-		fprintf(f, "\n");
-	}
+	fprintf(f, "    let %sl = Ls;\n", has_op(a->linked, VM_OP_BRANCH) ? "mut " : "");
+	fprintf(f, "\n");
 
 	fprintf(f, "    loop {\n");
 	fprintf(f, "        match l {\n");
 
 	fallthrough = true;
 
-	for (op = a.linked; op != NULL; op = op->next) {
-		if (op == a.linked || op->num_incoming > 0) {
-			if (op != a.linked) {
+	for (op = a->linked; op != NULL; op = op->next) {
+		if (op == a->linked || op->num_incoming > 0) {
+			if (op != a->linked) {
 				if (fallthrough) {
 					fprintf(f, "                ");
 					print_jump(f, op);
@@ -362,8 +354,6 @@ fsm_print_rustfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 	fprintf(f, "        }\n");
 	fprintf(f, "    }\n");
 
-	dfavm_opasm_finalize_op(&a);
-
 	return 0;
 }
 
@@ -371,14 +361,24 @@ static int
 fsm_print_rust_complete(FILE *f, const struct ir *ir,
 	const struct fsm_options *opt, const char *prefix, const char *cp)
 {
+	static const struct dfavm_assembler_ir zero;
+	static const struct fsm_vm_compile_opts vm_opts = { FSM_VM_COMPILE_DEFAULT_FLAGS, FSM_VM_COMPILE_VM_V1, NULL };
+	struct dfavm_assembler_ir a;
+
 	assert(f != NULL);
 	assert(ir != NULL);
 	assert(opt != NULL);
 
-	if (opt->fragment) {
-		fsm_print_rustfrag(f, ir, opt, cp,
-			opt->leaf != NULL ? opt->leaf : leaf, opt->leaf_opaque);
+	a = zero;
+
+	if (!dfavm_compile_ir(&a, ir, vm_opts)) {
 		return -1;
+	}
+
+	if (opt->fragment) {
+		fsm_print_rustfrag(f, &a, ir, opt, cp,
+			opt->leaf != NULL ? opt->leaf : leaf, opt->leaf_opaque);
+		goto error;
 	}
 
 	fprintf(f, "\n");
@@ -394,13 +394,15 @@ fsm_print_rust_complete(FILE *f, const struct ir *ir,
 
 	case FSM_IO_STR:
 		/* e.g. dbg!(fsm_main("xabces")); */
-		fprintf(f, "(input: &str) -> Option<usize> {\n");
+		fprintf(f, "(%sinput: &str) -> Option<usize> {\n",
+			has_op(a.linked, VM_OP_FETCH) ? "" : "_");
 		fprintf(f, "    use Label::*;\n");
 		break;
 
 	case FSM_IO_PAIR:
 		/* e.g. dbg!(fsm_main("xabces".as_bytes())); */
-		fprintf(f, "(input: &[u8]) -> Option<usize> {\n");
+		fprintf(f, "(%sinput: &[u8]) -> Option<usize> {\n",
+			has_op(a.linked, VM_OP_FETCH) ? "" : "_");
 		fprintf(f, "    use Label::*;\n");
 		break;
 
@@ -409,17 +411,25 @@ fsm_print_rust_complete(FILE *f, const struct ir *ir,
 		exit(EXIT_FAILURE);
 	}
 
-	fsm_print_rustfrag(f, ir, opt, cp,
+	fsm_print_rustfrag(f, &a, ir, opt, cp,
 		opt->leaf != NULL ? opt->leaf : leaf, opt->leaf_opaque);
 
 	fprintf(f, "}\n");
 	fprintf(f, "\n");
+
+	dfavm_opasm_finalize_op(&a);
 
 	if (ferror(f)) {
 		return -1;
 	}
 
 	return 0;
+
+error:
+
+	dfavm_opasm_finalize_op(&a);
+
+	return -1;
 }
 
 int

--- a/src/lx/main.c
+++ b/src/lx/main.c
@@ -966,4 +966,4 @@ main(int argc, char *argv[])
 /* XXX: we're not interested in leaks in lx for the moment; ASAN is applied
  * for the libraries only. cleanup for lx's own structures should be addressed
  * at some point; excluding this is sloppy, but it's less important right now. */
-const char * __asan_default_options() { return "detect_leaks=0"; }
+const char * __asan_default_options(void) { return "detect_leaks=0"; }

--- a/src/print/rust.c
+++ b/src/print/rust.c
@@ -29,13 +29,9 @@ rust_escputc_char(FILE *f, const struct fsm_options *opt, char c)
 	case '\\': return fputs("\\\\", f);
 	case '\'': return fputs("\\\'", f);
 
-	case '\a': return fputs("\\a", f);
-	case '\b': return fputs("\\b", f);
-	case '\f': return fputs("\\f", f);
 	case '\n': return fputs("\\n", f);
 	case '\r': return fputs("\\r", f);
 	case '\t': return fputs("\\t", f);
-	case '\v': return fputs("\\v", f);
 
 	default:
 		break;

--- a/src/retest/main.c
+++ b/src/retest/main.c
@@ -172,9 +172,11 @@ usage(void)
 	fprintf(stderr, "        -l <implementation>\n");
 	fprintf(stderr, "             sets implementation type:\n");
 	fprintf(stderr, "                 vm        interpret vm instructions (default)\n");
-	fprintf(stderr, "                 asm       generate assembly and assemble\n");
+	fprintf(stderr, "                 asm/goasm generate assembly and assemble\n");
 	fprintf(stderr, "                 c         compile as per fsm_print_c()\n");
 	fprintf(stderr, "                 vmc       compile as per fsm_print_vmc()\n");
+	fprintf(stderr, "                 vmops     compile as per fsm_print_vmops_{c,h,main}()\n");
+	fprintf(stderr, "                 rust      compile as per fsm_print_rust()\n");
 
 	fprintf(stderr, "\n");
 	fprintf(stderr, "        -x <encoding>\n");
@@ -1264,6 +1266,8 @@ main(int argc, char *argv[])
 					impl = IMPL_GO;
 				} else if (strcmp(optarg, "goasm") == 0) {
 					impl = IMPL_GOASM;
+				} else if (strcmp(optarg, "rust") == 0) {
+					impl = IMPL_RUST;
 				} else {
 					fprintf(stderr, "unknown argument to -l: %s\n", optarg);
 					usage();

--- a/src/retest/runner.c
+++ b/src/retest/runner.c
@@ -114,10 +114,14 @@ print(const struct fsm *fsm, enum implementation impl,
 		fprintf(f, "use std::slice;\n");
 		fprintf(f, "\n");
 
+		// XXX: fsm_main shouldn't return Option<usize>, Option<u64> or a bitfield type
 		fprintf(f, "#[no_mangle]\n");
 		fprintf(f, "pub extern \"C\" fn retest_trampoline(ptr: *const c_uchar, len: usize) -> i64 {\n");
 		fprintf(f, "    let a: &[u8] = unsafe { slice::from_raw_parts(ptr, len as usize) };\n");
-		fprintf(f, "    fsm_main(a).unwrap_or(-1)\n");
+		fprintf(f, "    match fsm_main(a) {\n");
+		fprintf(f, "    Some(u) => u as i64,\n"); // XXX: we lose info for the i64 ABI
+		fprintf(f, "    None => -1,\n");
+		fprintf(f, "    }\n");
 		fprintf(f, "}\n");
 	}
 
@@ -152,7 +156,7 @@ compile(enum implementation impl,
 
 	case IMPL_RUST:
 		if (0 != systemf("%s %s --crate-type dylib %s -o %s",
-				"rustc", "--edition 2018",
+				"rustc", "--edition 2021",
 				tmp_src, tmp_so))
 		{
 			return 0;

--- a/src/retest/runner.c
+++ b/src/retest/runner.c
@@ -99,7 +99,7 @@ print(const struct fsm *fsm, enum implementation impl,
 
 		case IMPL_INTERPRET:
 			assert(!"unreached");
-			break;
+			abort();
 		}
 
 		if (e == -1) {
@@ -297,7 +297,7 @@ runner_init_compiled(struct fsm *fsm, struct fsm_runner *r, enum implementation 
 
 	case IMPL_INTERPRET:
 		assert(!"unreached");
-		break;
+		abort();
 	}
 
 	if (!print(fsm, r->impl, tmp_src)) {


### PR DESCRIPTION
The Rust codegen has warnings for a few cases, which I haven't addressed here. I'd like to do that before I merge this PR.

I'm not sure if the way i'm running fuzzing is good. I'm building with UBSAN and ASAN (but not MSAN), and I'm essentially recreating the same work the `run_fuzzer` script does, but in CI. Breaking that up a bit allows caching a build between stages. The fuzzer itself runs for all modes (currently just `p` and `m`).

I fixed a couple of unrelated small things while I was here.