### PR TITLE
A simple attempt to identify runs of characters and generate memcmp()

### DIFF
--- a/include/print/esc.h
+++ b/include/print/esc.h
@@ -36,6 +36,10 @@ int
 escputs(FILE *f, const struct fsm_options *opt, escputc *escputc,
 	const char *s);
 
+int
+escputbuf(FILE *f, const struct fsm_options *opt, escputc *escputc,
+	const char *buf, size_t len);
+
 void
 esctok(FILE *f, const char *s);
 

--- a/src/print/puts.c
+++ b/src/print/puts.c
@@ -40,3 +40,29 @@ escputs(FILE *f, const struct fsm_options *opt, escputc *escputc,
 	return n;
 }
 
+int
+escputbuf(FILE *f, const struct fsm_options *opt, escputc *escputc,
+	const char *buf, size_t len)
+{
+	const char *p;
+	int r, n;
+
+	assert(f != NULL);
+	assert(opt != NULL);
+	assert(escputc != NULL);
+	assert(buf != NULL);
+
+	n = 0;
+
+	for (p = buf; p < buf + len; p++) {
+		r = escputc(f, opt, *p);
+		if (r == -1) {
+			return -1;
+		}
+
+		n += r;
+	}
+
+	return n;
+}
+


### PR DESCRIPTION
I hope this code doesn't stick around, it's a simplistic approach and it's in the wrong place. But I want to find out if it actually helps or not.

From the code:

This catches situations like the "abc" and "xyz" in /^abc[01]xyz/, but not for runs in unanchored regexes. For those, we'd be better off adding VM instructions for sets of strings, and producing those from the various types of enum ir_strategy.

You can see these in the generated `-l vmc` code:
```
; ./build/bin/re -r pcre -k pair -pl vmc '^[01]abc[23]xyz'
#include <string.h>

int
fsm_main(const char *b, const char *e)
{
	const char *p;
	int c;

	p = b;
	if (p == e) return -1;

	c = (unsigned char) *p++;
	if (c <= '/') return -1;
	if (c > '1') return -1;
	if (e - p < 3 || 0 != memcmp(p, "abc", 3)) return -1;
	p += 3;

	if (p == e) return -1;

	c = (unsigned char) *p++;
	if (c <= '1') return -1;
	if (c > '3') return -1;
	if (e - p < 3 || 0 != memcmp(p, "xyz", 3)) return -1;
	p += 3;

	return 0x1; /* "^[01]abc[23]xyz" */
}
```

But this doesn't help for unanchored strings, we still have lots of `goto`s here:
```
; ./build/bin/re -r pcre -k pair -pl vmc 'abc'            
#include <string.h>

int
fsm_main(const char *b, const char *e)
{
	const char *p;
	int c;

	p = b;

l0:
	if (p == e) return -1;

	c = (unsigned char) *p++;
	if (c != 'a') goto l0;

l1: /* e.g. "a" */
	if (p == e) return -1;

	c = (unsigned char) *p++;
	if (c == 'a') goto l1;
	if (c != 'b') goto l0;
	if (p == e) return -1;

	c = (unsigned char) *p++;
	if (c == 'a') goto l1;
	if (c != 'c') goto l0;
	return 0x1; /* "abc" */
}
```