### PR TITLE
Emit inline strncmp() for str IO vmc codegen

### DIFF
--- a/src/libfsm/print/vmc.c
+++ b/src/libfsm/print/vmc.c
@@ -392,6 +392,19 @@ fsm_print_cfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 				fprintf(f, "p += %zu;\n", n);
 
 				op = tail;
+			} else if (n > 1 && opt->io == FSM_IO_STR) {
+				fprintf(f, "if (0 != strncmp(p, \"");
+				escputbuf(f, opt, c_escputc_str, buf, n);
+				fprintf(f, "\", %zu)) ", n);
+				if (-1 == print_end(f, NULL, opt, end_bits, ir)) {
+					return -1;
+				}
+				fprintf(f, "\n");
+
+				fprintf(f, "\t");
+				fprintf(f, "p += %zu;\n", n);
+
+				op = tail;
 			} else {
 				print_fetch(f, opt);
 				if (-1 == print_end(f, op, opt, op->u.fetch.end_bits, ir)) {

--- a/src/libfsm/print/vmc.c
+++ b/src/libfsm/print/vmc.c
@@ -403,6 +403,14 @@ fsm_print_cfrag(FILE *f, const struct ir *ir, const struct fsm_options *opt,
 					fprintf(f, "c = (unsigned char) *p++;");
 				}
 			}
+
+			/*
+			 * If the following instruction is an unconditional return,
+			 * we won't be using this value.
+			 */
+			if (op->next != NULL && op->next->instr == VM_OP_STOP && op->next->cmp == VM_CMP_ALWAYS) {
+				fprintf(f, "\n\t(void) c;\n");
+			}
 			break;
 		}
 

--- a/src/retest/main.c
+++ b/src/retest/main.c
@@ -165,6 +165,10 @@ usage(void)
 	fprintf(stderr, "                 enc       logs VM encoding instructions\n");
 
 	fprintf(stderr, "\n");
+	fprintf(stderr, "        -k <io>\n");
+	fprintf(stderr, "             sets IO API:  getc, str, pair (default)\n");
+
+	fprintf(stderr, "\n");
 	fprintf(stderr, "        -l <implementation>\n");
 	fprintf(stderr, "             sets implementation type:\n");
 	fprintf(stderr, "                 vm        interpret vm instructions (default)\n");
@@ -1167,6 +1171,39 @@ finish:
 	return num_errors;
 }
 
+static enum fsm_io
+io(const char *name)
+{
+	size_t i;
+
+	struct {
+		const char *name;
+		enum fsm_io io;
+	} a[] = {
+		{ "getc", FSM_IO_GETC },
+		{ "str",  FSM_IO_STR  },
+		{ "pair", FSM_IO_PAIR }
+	};
+
+	assert(name != NULL);
+
+	for (i = 0; i < sizeof a / sizeof *a; i++) {
+		if (0 == strcmp(a[i].name, name)) {
+			return a[i].io;
+		}
+	}
+
+	fprintf(stderr, "unrecognised IO API; valid IO APIs are: ");
+
+	for (i = 0; i < sizeof a / sizeof *a; i++) {
+		fprintf(stderr, "%s%s",
+			a[i].name,
+			i + 1 < sizeof a / sizeof *a ? ", " : "\n");
+	}
+
+	exit(EXIT_FAILURE);
+}
+
 int
 main(int argc, char *argv[])
 {
@@ -1194,7 +1231,7 @@ main(int argc, char *argv[])
 	{
 		int c;
 
-		while (c = getopt(argc, argv, "h" "O:L:l:x:" "e:E:" "r:" "tw:"), c != -1) {
+		while (c = getopt(argc, argv, "h" "k:O:L:l:x:" "e:E:" "r:" "tw:"), c != -1) {
 			switch (c) {
 			case 'O':
 				optlevel = strtoul(optarg, NULL, 10);
@@ -1232,6 +1269,10 @@ main(int argc, char *argv[])
 					usage();
 					exit(1);
 				}
+				break;
+
+			case 'k':
+				opt.io = io(optarg);
 				break;
 
 			case 'x':

--- a/src/retest/runner.c
+++ b/src/retest/runner.c
@@ -75,8 +75,8 @@ print(const struct fsm *fsm, enum implementation impl,
 		return 0;
 	}
 
-	/* the vmc codegen can emit memcmp() calls */
-	if (impl == IMPL_VMC && fsm_getoptions(fsm)->io == FSM_IO_PAIR) {
+	/* the vmc codegen can emit memcmp() or strncmp() calls */
+	if (impl == IMPL_VMC && (fsm_getoptions(fsm)->io == FSM_IO_PAIR || fsm_getoptions(fsm)->io == FSM_IO_STR)) {
 		fprintf(f, "#include <string.h>\n\n");
 	}
 

--- a/tests/retest/Makefile
+++ b/tests/retest/Makefile
@@ -8,11 +8,18 @@ DIR += ${TEST_OUTDIR.tests/retest}
 
 RETEST=${BUILD}/bin/retest
 
+.for io in pair str
+
 .for n in ${TEST.tests/retest:T:R:C/^tests_//}
 
-${TEST_OUTDIR.tests/retest}/res${n}: ${TEST_SRCDIR.tests/retest}/tests_${n}.tst
-	( ${RETEST} ${.ALLSRC:M*.tst} > ${TEST_OUTDIR.tests/retest}/got${n} && echo PASS || echo FAIL ) > ${TEST_OUTDIR.tests/retest}/res${n}
+${TEST_OUTDIR.tests/retest}/res-${io}${n}: ${TEST_SRCDIR.tests/retest}/tests_${n}.tst
+	( ${RETEST} -k ${io} ${.ALLSRC:M*.tst} \
+		> ${TEST_OUTDIR.tests/retest}/got-${io}${n} && echo PASS || echo FAIL ) \
+	> ${TEST_OUTDIR.tests/retest}/res-${io}${n}
 
-test:: ${TEST_OUTDIR.tests/retest}/res${n}
+test:: ${TEST_OUTDIR.tests/retest}/res-${io}${n}
 
 .endfor
+
+.endfor
+

--- a/tests/retest/Makefile
+++ b/tests/retest/Makefile
@@ -8,18 +8,20 @@ DIR += ${TEST_OUTDIR.tests/retest}
 
 RETEST=${BUILD}/bin/retest
 
+.for lang in vm asm c vmc
 .for io in pair str
 
 .for n in ${TEST.tests/retest:T:R:C/^tests_//}
 
-${TEST_OUTDIR.tests/retest}/res-${io}${n}: ${TEST_SRCDIR.tests/retest}/tests_${n}.tst
-	( ${RETEST} -k ${io} ${.ALLSRC:M*.tst} \
-		> ${TEST_OUTDIR.tests/retest}/got-${io}${n} && echo PASS || echo FAIL ) \
-	> ${TEST_OUTDIR.tests/retest}/res-${io}${n}
+${TEST_OUTDIR.tests/retest}/res-${lang}-${io}${n}: ${TEST_SRCDIR.tests/retest}/tests_${n}.tst
+	( ${RETEST} -l ${lang} -k ${io} ${.ALLSRC:M*.tst} \
+		> ${TEST_OUTDIR.tests/retest}/got-${lang}-${io}${n} && echo PASS || echo FAIL ) \
+	> ${TEST_OUTDIR.tests/retest}/res-${lang}-${io}${n}
 
-test:: ${TEST_OUTDIR.tests/retest}/res-${io}${n}
+test:: ${TEST_OUTDIR.tests/retest}/res-${lang}-${io}${n}
 
 .endfor
 
+.endfor
 .endfor
 


### PR DESCRIPTION
This is equivalent to #430 but with `strncmp()` for `FSM_IO_STR`.

Coverage for the string API is poor. I don't want to try to run the pcre suite for that, because `FSM_IO_STR` has no provision for binary data, being a \0-terminated string. So I've extended how we run retest for a few handwritten test cases instead.

The generated code looks like this:
```
; ./build/bin/re -k str -l vmc '^abc[xy]'
int
fsm_main(const char *s)
{
	const char *p;
	int c;

	p = s;
	if (0 != strncmp(p, "abc", 3)) return -1;
	p += 3;

	if (c = (unsigned char) *p++, c == '\0') return -1;
	if (c <= 'w') return -1;
	if (c > 'y') return -1;
	return 0x1; /* "^abc[xy]" */
}
```