### PR TITLE
Escape ? as a way to avoid emitting trigraphs.

### DIFF
--- a/src/print/c.c
+++ b/src/print/c.c
@@ -80,9 +80,11 @@ c_escputc_str(FILE *f, const struct fsm_options *opt, char c)
 	 * Escaping '/' here is a lazy way to avoid keeping state when
 	 * emitting '*', '/', since this is used to output example strings
 	 * inside comments.
+	 *
+	 * Escaping '?' is a cheap way to avoid accidentally emitting trigraphs.
 	 */
 
-	if (!isprint((unsigned char) c) || c == '/') {
+	if (!isprint((unsigned char) c) || c == '/' || c == '?') {
 		return fprintf(f, "\\%03o", (unsigned char) c);
 	}
 

--- a/tests/retest/tests_2.tst
+++ b/tests/retest/tests_2.tst
@@ -16,3 +16,10 @@ R pcre
 +
 -xyz
 
+# avoid generating trigraphs (!) in strncmp()/memcmp() for inlined strings
+~^abc\?\?-$
++abc??-
+-abc???-
+-abc~
+-abc
+


### PR DESCRIPTION
This is applicable for the inline memcmp()/strncmp() calls added recently for the vmc codegen.

Before:
```
; ./build/bin/re -k str -pl vmc '^abc\?\?-$'
int
fsm_main(const char *s)
{
	const char *p;
	int c;

	p = s;
	if (0 != strncmp(p, "abc??-", 6)) return -1;
	p += 6;

	if (c = (unsigned char) *p++, c == '\0') return 0x1; /* "^abc\?\?-$" */
	(void) c;

	return -1;
}
```

After:
```
; ./build/bin/re -k str -pl vmc '^abc\?\?-$' | grep strncmp 
	if (0 != strncmp(p, "abc\077\077-", 6)) return -1;
; ./build/bin/re -k pair -pl vmc '^abc\?\?-$' | grep memcmp 
	if (e - p < 6 || 0 != memcmp(p, "abc\077\077-", 6)) return -1;
; 
```