### PR TITLE
Performance improvements for epsilon removal and determinisation

### DIFF
--- a/src/adt/edgeset.c
+++ b/src/adt/edgeset.c
@@ -223,9 +223,9 @@ edge_set_add_bulk(struct edge_set **pset, const struct fsm_alloc *alloc,
 	assert(set->count <= set->ceil);
 
 #if LOG_BITSET
-		fprintf(stderr, " -- edge_set_add: symbols [0x%lx, 0x%lx, 0x%lx, 0x%lx] -> state %d on %p\n",
-		    symbols[0], symbols[1], symbols[2], symbols[3],
-		    state, (void *)set);
+	fprintf(stderr, " -- edge_set_add: symbols [0x%lx, 0x%lx, 0x%lx, 0x%lx] -> state %d on %p\n",
+	    symbols[0], symbols[1], symbols[2], symbols[3],
+	    state, (void *)set);
 #endif
 
 	/* Linear search for a group with the same destination

--- a/src/adt/edgeset.c
+++ b/src/adt/edgeset.c
@@ -326,8 +326,6 @@ edge_set_add_bulk(struct edge_set **pset, const struct fsm_alloc *alloc,
 	switch (find_state_position(set, state, &i)) {
 	case FSP_FOUND_VALUE_PRESENT:
 		assert(i < set->count);
-		/* This API does not indicate whether that
-		 * symbol -> to edge was already present. */
 		eg = &set->groups[i];
 		for (i = 0; i < 256/64; i++) {
 			eg->symbols[i] |= symbols[i];

--- a/src/adt/stateset.c
+++ b/src/adt/stateset.c
@@ -273,8 +273,7 @@ state_set_add(struct state_set **setp, const struct fsm_alloc *alloc,
 			set->n *= 2;
 		}
 
-
-		if (i <= set->i) {
+		if (i < set->i) {
 			memmove(&set->a[i + 1], &set->a[i], (set->i - i) * (sizeof *set->a));
 		}
 

--- a/src/adt/stateset.c
+++ b/src/adt/stateset.c
@@ -284,6 +284,8 @@ state_set_add(struct state_set **setp, const struct fsm_alloc *alloc,
 		set->i = 1;
 	}
 
+	/* This assert can be pretty expensive in -O0 but in -O3 it has very
+	 * little impact on the overall runtime. */
 	assert(state_set_contains(set, state));
 
 	return 1;

--- a/src/adt/stateset.c
+++ b/src/adt/stateset.c
@@ -44,8 +44,8 @@
 struct state_set {
 	const struct fsm_alloc *alloc;
 	fsm_state_t *a;
-	size_t i;
-	size_t n;
+	size_t i;		/* used */
+	size_t n;		/* ceil */
 };
 
 int

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -2016,28 +2016,87 @@ static void
 sort_and_dedup_dst_buf(fsm_state_t *buf, size_t *used)
 {
 	const size_t orig_used = *used;
-	qsort(buf, orig_used, sizeof(buf[0]), cmp_fsm_state_t);
 
-	/* squash out duplicates */
-	size_t rd = 1;
-	size_t wr = 1;
-	while (rd < orig_used) {
-		if (buf[rd - 1] == buf[rd]) {
-			rd++;	/* skip */
-		} else {
-			buf[wr] = buf[rd];
-			rd++;
-			wr++;
+	if (orig_used <= 1) {
+		return;		/* no change */
+	}
+
+	/* Figure out what the min and max values are, because
+	 * when the difference between them is not too large it
+	 * can be significantly faster to avoid qsort here. */
+	fsm_state_t min = (fsm_state_t)-1;
+	fsm_state_t max = 0;
+	for (size_t i = 0; i < orig_used; i++) {
+		const fsm_state_t cur = buf[i];
+		if (cur < min) { min = cur; }
+		if (cur > max) { max = cur; }
+	}
+
+	/* If there's only one unique value, then we're done. */
+	if (min == max) {
+		buf[0] = min;
+		*used = 1;
+		return;
+	}
+
+/* 81920 = 10 KB buffer on the stack. This must be divisible by 64.
+ * Set to 0 to disable. */
+#define QSORT_CUTOFF 81920
+
+	if (QSORT_CUTOFF == 0 || max - min > QSORT_CUTOFF) {
+		/* If the bitset would be very large but sparse due to
+		 * extreme values, then fall back on using qsort and
+		 * then sweeping over the array to squash out
+		 * duplicates. */
+		qsort(buf, orig_used, sizeof(buf[0]), cmp_fsm_state_t);
+
+		/* squash out duplicates */
+		size_t rd = 1;
+		size_t wr = 1;
+		while (rd < orig_used) {
+			if (buf[rd - 1] == buf[rd]) {
+				rd++;	/* skip */
+			} else {
+				buf[wr] = buf[rd];
+				rd++;
+				wr++;
+			}
 		}
-	}
 
-	*used = wr;
+		*used = wr;
 #if EXPENSIVE_CHECKS
-	assert(wr <= orig_used);
-	for (size_t i = 1; i < *used; i++) {
-		assert(buf[i - 1] < buf[i]);
-	}
+		assert(wr <= orig_used);
+		for (size_t i = 1; i < *used; i++) {
+			assert(buf[i - 1] < buf[i]);
+		}
 #endif
+	} else {
+		/* Convert the array into a bitset and back, which sorts
+		 * and deduplicates in the process. Add 1 to avoid a zero-
+		 * zero-length array error if QSORT_CUTOFF is 0. */
+		uint64_t bitset[QSORT_CUTOFF/64 + 1];
+		const size_t words = u64bitset_words(max - min);
+		memset(bitset, 0x00, words * sizeof(bitset[0]));
+
+		for (size_t i = 0; i < orig_used; i++) {
+			u64bitset_set(bitset, buf[i] - min);
+		}
+
+		size_t dst = 0;
+		for (size_t i = 0; i < words; i++) {
+			const uint64_t w = bitset[i];
+			if (w != 0) { /* skip empty words */
+				uint64_t bit = 0x1;
+				for (size_t b_i = 0; b_i < 64; b_i++, bit <<= 1) {
+					if (w & bit) {
+						buf[dst] = 64*i + b_i + min;
+						dst++;
+					}
+				}
+			}
+		}
+		*used = dst;
+	}
 }
 
 static int

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -2075,7 +2075,7 @@ sort_and_dedup_dst_buf(fsm_state_t *buf, size_t *used)
 		 * and deduplicates in the process. Add 1 to avoid a zero-
 		 * zero-length array error if QSORT_CUTOFF is 0. */
 		uint64_t bitset[QSORT_CUTOFF/64 + 1];
-		const size_t words = u64bitset_words(max - min);
+		const size_t words = u64bitset_words(max - min + 1);
 		memset(bitset, 0x00, words * sizeof(bitset[0]));
 
 		for (size_t i = 0; i < orig_used; i++) {

--- a/src/libre/ast_compile.c
+++ b/src/libre/ast_compile.c
@@ -208,11 +208,11 @@ addedge_literal(struct comp_env *env, enum re_flags re_flags,
 	assert(to < env->fsm->statecount);
 
 	if (re_flags & RE_ICASE) {
-		if (!fsm_addedge_literal(fsm, from, to, tolower((unsigned char) c))) {
+		if (!fsm_addedge_literal(fsm, from, to, (char)tolower((unsigned char) c))) {
 			return 0;
 		}
 		
-		if (!fsm_addedge_literal(fsm, from, to, toupper((unsigned char) c))) {
+		if (!fsm_addedge_literal(fsm, from, to, (char)toupper((unsigned char) c))) {
 			return 0;
 		}
 	} else {

--- a/src/retest/main.c
+++ b/src/retest/main.c
@@ -393,7 +393,7 @@ hexdigit:
 
 					ndig++;
 				} else {
-					s[j++] = ccode;
+					s[j++] = (char)ccode;
 					st = ST_BARE;
 
 					if (!hexcurly) {


### PR DESCRIPTION
This PR improves performance for a couple code paths in epsilon removal and determinisation that become hotspots with large `{}` repeated groups:

- Add a fast path upfront for when `state_set_search` would return the position after the array (appending), since this is very common.
- Switch from linear to binary searching in `edge_set_add_bulk`.
- Avoid unnecessary calls to `qsort`, when working space would be small (also very common) build a bitset on the stack instead.

I did some other experimentation with reworking the algorithm for `epsilon_closure` to avoid populating the closure with intermediate states on the transitive path to the epsilon closure endpoints, but in the end it didn't have anywhere near as much impact as the other changes, and it makes the epsilon closure function less general-purpose, so it's probably not worth the extra complexity. For epsilon removal we only need to add states to the closures that either have labeled edges or are an end state. Filtering anything else (potentially including states being in their own epsilon closure) reduces the state set sizes for further processing. Otherwise they get filtered out in a later step.

On my laptop, building with `-O3`, the difference between `main` and this PR's `HEAD` for `time ./re_main -rpcre -C '^[ab]{0,5000}$'`:
- `main`: `real	0m41.328s`
- `HEAD`: `real	0m5.167s`

I chose that regex for benchmarking because it produces a very long chain of epsilon closures and a big edge set pileup.