### PR TITLE
Don't purge the seed cache for PRs syncing clones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -409,8 +409,15 @@ jobs:
         path: ${{ env.build }}
         key: build-${{ matrix.make }}-${{ matrix.os }}-${{ matrix.cc }}-${{ matrix.debug }}-${{ matrix.san }}-${{ github.sha }}
 
-    # note we do the fuzzing unconditionally; each run adds to the corpus
+    # note we do the fuzzing unconditionally; each run adds to the corpus.
+    #
+    # We only run fuzzing for PRs in the base repo, this prevents attempting
+    # to purge the seed cache from a PR syncing a forked repo, which fails
+    # due to a permissions error (I'm unsure why, I think PRs from clones can't
+    # purge a cache in CI presumably for security/DoS reasons). PRs from clones
+    # still run fuzzing, just from empty, and do not save their seeds.
     - name: Restore seeds (mode ${{ matrix.mode }})
+      if: github.repository == 'katef/libfsm'
       uses: actions/cache/restore@v3
       id: cache-seeds
       with:


### PR DESCRIPTION
As of #429, sync PRs to forks fail with a permissions error for purging the seed cache:
```
Fuzz
Purge cached seeds (mode m-RELEASE)
Run set +e
  set +e
  gh extension install actions/gh-actions-cache
  gh actions-cache delete seeds-m-RELEASE -R <org>/libfsm --confirm
  shell: /usr/bin/bash -e {0}
  env:
    pcre2: pcre2-10.40
    wc: wc
    seeds: seeds
    build: build
    cvtpcre: build/test/retest
    prefix: prefix
    maintainer: kate@elide.org
    GH_TOKEN: ***

Error: Resource not accessible by integration
Error: Process completed with exit code 1.
```

This PR is a simple fix that just skips using the cache for PRs where the repo isn't mine.

So fuzzing still runs, just with empty seeds. I think that's a good balance between serving as a smoke test and, well, working.