### PR TITLE
Improve performance when hashing sets of state IDs.

### DIFF
--- a/src/adt/internedstateset.c
+++ b/src/adt/internedstateset.c
@@ -203,7 +203,7 @@ hash_state_ids(size_t count, const fsm_state_t *ids)
 {
 	uint64_t h = 0;
 	for (size_t i = 0; i < count; i++) {
-		h = hash_id(ids[i]) + (FSM_PHI_64 * h);
+		h ^= hash_id(ids[i]);
 	}
 	return h;
 }


### PR DESCRIPTION
Add probe count logging to `to_set_htab_check`.

Switch from adding each PHI_64*(id+1) to xor-ing, it has better collision behavior.

This change makes

    time ./re -rpcre 'a[^bz][^bz][^bz][^b][^bz][^bz][^bz][^bz][^bz][^bz][^b][^bz][^bz][^bz][^bz][^bz]'

go from taking ~14 seconds to ~6 when I run it locally, because adding leads to much higher probe counts on average.