### PR TITLE
Further hash function cleanup.

### DIFF
--- a/include/adt/hash.h
+++ b/include/adt/hash.h
@@ -17,7 +17,7 @@
 
 SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
 static __inline__ uint64_t
-hash_id(unsigned id)
+hash_id(uint64_t id)
 {
 	/* xorshift* A1(12,25,27),
 	 * from http://vigna.di.unimi.it/ftp/papers/xorshift.pdf */

--- a/include/adt/hash.h
+++ b/include/adt/hash.h
@@ -12,6 +12,10 @@
 #include "adt/common.h"
 #include "fsm/fsm.h"
 
+#if EXPENSIVE_CHECKS
+#include <assert.h>
+#endif
+
 #define HASH_LOG_PROBES 0
 /* #define HASH_PROBE_LIMIT 100 */
 
@@ -35,6 +39,11 @@ hash_ids(size_t count, const fsm_state_t *ids)
 	uint64_t h = 0;
 	for (size_t i = 0; i < count; i++) {
 		h = hash_id(h ^ ids[i]);
+#if EXPENSIVE_CHECKS
+		if (i > 0) {
+			assert(ids[i-1] <= ids[i]);
+		}
+#endif
 	}
 	return h;
 }

--- a/include/adt/hash.h
+++ b/include/adt/hash.h
@@ -10,10 +10,10 @@
 #include <stdint.h>
 
 #include "adt/common.h"
+#include "fsm/fsm.h"
 
-/* 32 and 64-bit approximations of the golden ratio. */
-#define FSM_PHI_32 0x9e3779b9UL
-#define FSM_PHI_64 (uint64_t)0x9e3779b97f4a7c15UL
+#define HASH_LOG_PROBES 0
+/* #define HASH_PROBE_LIMIT 100 */
 
 SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
 static __inline__ uint64_t
@@ -28,38 +28,13 @@ hash_id(uint64_t id)
 	return x * 2685821657736338717LLU;
 }
 
-/* FNV-1a hash function, 32 and 64 bit versions. This is in the public
- * domain. For details, see:
- *
- *     http://www.isthe.com/chongo/tech/comp/fnv/index.html
- */
-
-SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
-static __inline__ uint32_t
-hash_fnv1a_32(const uint8_t *buf, size_t length)
-{
-#define FNV1a_32_OFFSET_BASIS 	0x811c9dc5UL
-#define FNV1a_32_PRIME		0x01000193UL
-	uint32_t h = FNV1a_32_OFFSET_BASIS;
-	size_t i;
-	for (i = 0; i < length; i++) {
-		h ^= buf[i];
-		h *= FNV1a_32_PRIME;
-	}
-	return h;
-}
-
 SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
 static __inline__ uint64_t
-hash_fnv1a_64(const uint8_t *buf, size_t length)
+hash_ids(size_t count, const fsm_state_t *ids)
 {
-#define FNV1a_64_OFFSET_BASIS   0xcbf29ce484222325UL
-#define FNV1a_64_PRIME		0x100000001b3UL
-	uint64_t h = FNV1a_64_OFFSET_BASIS;
-	size_t i;
-	for (i = 0; i < length; i++) {
-		h ^= buf[i];
-		h *= FNV1a_64_PRIME;
+	uint64_t h = 0;
+	for (size_t i = 0; i < count; i++) {
+		h = hash_id(h ^ ids[i]);
 	}
 	return h;
 }

--- a/include/adt/stateset.h
+++ b/include/adt/stateset.h
@@ -72,8 +72,5 @@ state_set_rebase(struct state_set **set, fsm_state_t base);
 void
 state_set_replace(struct state_set **set, fsm_state_t old, fsm_state_t new);
 
-unsigned long
-state_set_hash(const struct state_set *set);
-
 #endif
 

--- a/src/adt/stateset.c
+++ b/src/adt/stateset.c
@@ -668,19 +668,3 @@ state_set_replace(struct state_set **setp, fsm_state_t old, fsm_state_t new)
 		}
 	}
 }
-
-unsigned long
-state_set_hash(const struct state_set *set)
-{
-	if (set == NULL) {
-		return 0;	/* empty */
-	}
-
-	if (IS_SINGLETON(set)) {
-		fsm_state_t state;
-		state = SINGLETON_DECODE(set);
-		return hashrec(&state, sizeof state);
-	}
-
-	return hashrec(set->a, set->i * sizeof *set->a);
-}

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -1659,10 +1659,14 @@ hash_pair(fsm_state_t a, fsm_state_t b)
 	assert(a != b);
 	assert(a & RESULT_BIT);
 	assert(b & RESULT_BIT);
-	a &=~ RESULT_BIT;
-	b &=~ RESULT_BIT;
-	assert(a != b);
-	const uint64_t ab = ((uint64_t)a << 32) | (uint64_t)b;
+	const uint64_t ma = (uint64_t)(a & ~RESULT_BIT); /* m: masked */
+	const uint64_t mb = (uint64_t)(b & ~RESULT_BIT);
+	assert(ma != mb);
+
+	/* Left-shift the smaller ID, so the pair order is consistent for hashing. */
+	const uint64_t ab = (ma < mb)
+	    ? ((ma << 32) | mb)
+	    : ((mb << 32) | ma);
 	const uint64_t res = hash_id(ab);
 	/* fprintf(stderr, "%s: a %d, b %d -> %016lx\n", __func__, a, b, res); */
 	return res;

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -1645,16 +1645,9 @@ hash_pair(fsm_state_t a, fsm_state_t b)
 	assert(b & RESULT_BIT);
 	a &=~ RESULT_BIT;
 	b &=~ RESULT_BIT;
-
-	/* Don't hash a and b separately and combine them with
-	 * hash_id, because it's common to have adjacent pairs of
-	 * result IDs, and with how hash_id works that leads to
-	 * multiples of similar hash values bunching up.
-	 *
-	 * This could be replaced with a better hash function later,
-	 * but use LOG_CACHE_HTAB to ensure there aren't visually obvious
-	 * runs of collisions appearing in the tables. */
-	const uint64_t res = hash_id(a + b);
+	assert(a != b);
+	const uint64_t ab = ((uint64_t)a << 32) | (uint64_t)b;
+	const uint64_t res = hash_id(ab);
 	/* fprintf(stderr, "%s: a %d, b %d -> %016lx\n", __func__, a, b, res); */
 	return res;
 }


### PR DESCRIPTION
- hash_id should take a `uint64_t` argument, rather than `unsigned`.

- Instead of adding the IDs or hashing them separately and combining, pack both into the uint64_t argument for hash_id, since each is a 32-bit ID. Further experimentation supports that this has better collision behavior.

- Add `hash_ids` to `hash.h`, so hashing a series of IDs is handled in one place. Chain the hashing, so difference from individual bits propagate bette

- Remove fnv1a and `FSM_PHI_*`, now unused.

- Add #defines for logging and asserting probe counts.