### PR TITLE
Handling for the initial token being TOK_UNKNOWN in lx syntax

### DIFF
--- a/src/lx/parser.act
+++ b/src/lx/parser.act
@@ -869,7 +869,19 @@
 
 		lx->free(lx->buf_opaque);
 
-		assert(ast != NULL);
+		/*
+		 * This can happen when the first token is TOK_UNKNOWN.
+		 * SID's generated parser bails out immediately.
+		 * So we never reach <make-ast>, and never <err-syntax> about it.
+		 *
+		 * Really I wanted this handled along with the usual syntax error
+		 * case, from ## alts inside parser.sid, instead of reproducing
+		 * the same error here.
+		 */
+		if (ast == NULL) {
+			err(lex_state, "Syntax error");
+			exit(EXIT_FAILURE);
+		}
 
 		return ast;
 	}

--- a/src/lx/parser.c
+++ b/src/lx/parser.c
@@ -3364,11 +3364,23 @@ ZL1:;
 
 		lx->free(lx->buf_opaque);
 
-		assert(ast != NULL);
+		/*
+		 * This can happen when the first token is TOK_UNKNOWN.
+		 * SID's generated parser bails out immediately.
+		 * So we never reach <make-ast>, and never <err-syntax> about it.
+		 *
+		 * Really I wanted this handled along with the usual syntax error
+		 * case, from ## alts inside parser.sid, instead of reproducing
+		 * the same error here.
+		 */
+		if (ast == NULL) {
+			err(lex_state, "Syntax error");
+			exit(EXIT_FAILURE);
+		}
 
 		return ast;
 	}
 
-#line 3373 "src/lx/parser.c"
+#line 3385 "src/lx/parser.c"
 
 /* END OF FILE */

--- a/src/lx/parser.h
+++ b/src/lx/parser.h
@@ -29,7 +29,7 @@
 extern void p_lx(lex_state, act_state, ast *);
 /* BEGINNING OF TRAILER */
 
-#line 877 "src/lx/parser.act"
+#line 889 "src/lx/parser.act"
 
 
 #line 36 "src/lx/parser.h"


### PR DESCRIPTION
My intended idea was to have all syntax errors go through the same actions driven by parser.sid. But in this case SID's generated parser bails out immediately on TOK_UNKNOWN, and we never reach an `##` alt. So we never reach `<make-ast>`, and thus never `<err-syntax>` about it.

That's what the assertion was about; the generated parser should never return with a `NULL` AST.

My workaround for this is just to recreate the equivalent syntax error at the top-level, which isn't very satisfying at all. But it does what we need here.

Spotted by @cinco-de-mayonnaise, thank you.

This resolves #451.