### PR TITLE
Minimisation should not combine end states with distinct sets of endids.

### DIFF
--- a/src/libfsm/minimise.c
+++ b/src/libfsm/minimise.c
@@ -25,6 +25,7 @@
 #include <adt/pv.h>
 #include <adt/set.h>
 #include <adt/u64bitset.h>
+#include <adt/hash.h>
 
 #include "internal.h"
 #include "capture.h"
@@ -37,6 +38,21 @@
 
 #include "minimise_internal.h"
 #include "minimise_test_oracle.h"
+
+static int
+split_ecs_by_end_metadata(struct min_env *env, const struct fsm *fsm);
+
+#define DEF_CAPTURE_ID_CEIL 4
+struct end_metadata {
+	struct end_metadata_end {
+		unsigned count;
+		fsm_end_id_t *ids;
+	} end;
+};
+
+static int
+collect_end_ids(const struct fsm *fsm, fsm_state_t s,
+	struct end_metadata_end *e);
 
 int
 fsm_minimise(struct fsm *fsm)
@@ -250,6 +266,12 @@ build_minimised_mapping(const struct fsm *fsm,
 	env.done_ec_offset = env.ec_count;
 
 	if (!populate_initial_ecs(&env, fsm, shortest_end_distance)) {
+		goto cleanup;
+	}
+
+	/* This only needs to be run once, but must run before the main
+	 * fixpoint loop below, because it potentially refines ECs. */
+	if (!split_ecs_by_end_metadata(&env, fsm)) {
 		goto cleanup;
 	}
 
@@ -644,6 +666,307 @@ cleanup:
 	res = 1;
 	return res;
 #endif
+}
+
+SUPPRESS_EXPECTED_UNSIGNED_INTEGER_OVERFLOW()
+static void
+incremental_hash_of_ids(uint64_t *accum, fsm_end_id_t id)
+{
+	(*accum) += hash_id(id);
+}
+
+static int
+same_end_metadata(const struct end_metadata *a, const struct end_metadata *b)
+{
+	if (a->end.count != b->end.count) {
+		return 0;
+	}
+
+	/* compare -- these must be sorted */
+
+	for (size_t i = 0; i < a->end.count; i++) {
+		if (a->end.ids[i] != b->end.ids[i]) {
+			return 0;
+		}
+	}
+
+	return 1;
+}
+
+static int
+split_ecs_by_end_metadata(struct min_env *env, const struct fsm *fsm)
+{
+	int res = 0;
+
+	struct end_metadata *end_md;
+	fsm_state_t *htab = NULL;
+
+	const size_t state_count = fsm_countstates(fsm);
+
+#if EXPENSIVE_INTEGRITY_CHECKS
+	/* Invariant: For each EC, either all or none of the states
+	 * are end states. We only partition the set(s) of end states
+	 * here. */
+	all_end_states_are_currently_together(env);
+#endif
+
+	/* Use the hash table to assign to new groups. */
+
+	end_md = f_calloc(fsm->opt->alloc,
+	    state_count, sizeof(end_md[0]));
+	if (end_md == NULL) {
+		goto cleanup;
+	}
+
+	size_t bucket_count = 1;
+	while (bucket_count < state_count) {
+		bucket_count *= 2; /* power of 2 ceiling */
+	}
+	const size_t mask = bucket_count - 1;
+
+	htab = f_malloc(fsm->opt->alloc,
+	    bucket_count * sizeof(htab[0]));
+	if (htab == NULL) {
+		goto cleanup;
+	}
+
+	/* First pass: collect end state metadata */
+	for (size_t ec_i = 0; ec_i < env->ec_count; ec_i++) {
+		fsm_state_t s = MASK_EC_HEAD(env->ecs[ec_i]);
+#if LOG_ECS
+		fprintf(stderr, "## EC %zu\n", ec_i);
+#endif
+		while (s != NO_ID) {
+			struct end_metadata *e = &end_md[s];
+			if (!fsm_isend(fsm, s)) {
+				break; /* this EC has non-end states, skip */
+			}
+
+			if (!collect_end_ids(fsm, s, &e->end)) {
+				goto cleanup;
+			}
+
+			s = env->jump[s];
+		}
+	}
+
+#if LOG_ECS
+	fprintf(stderr, "==== BEFORE PARTITIONING BY END METADATA\n");
+	dump_ecs(stderr, env);
+	fprintf(stderr, "====\n");
+#endif
+
+	/* Second pass: partition ECs into groups with identical end IDs.
+	 * for each group with different end IDs, unlink them. */
+	const size_t max_ec = env->ec_count;
+	for (size_t ec_i = 0; ec_i < max_ec; ec_i++) {
+		fsm_state_t s = MASK_EC_HEAD(env->ecs[ec_i]);
+		fsm_state_t prev = NO_ID;
+
+		for (size_t i = 0; i < bucket_count; i++) {
+			htab[i] = NO_ID; /* reset hash table */
+		}
+
+		while (s != NO_ID) {
+			const struct end_metadata *s_md = &end_md[s];
+
+			uint64_t hash = 0;
+			const fsm_state_t next = env->jump[s];
+
+			for (size_t eid_i = 0; eid_i < s_md->end.count; eid_i++) {
+				incremental_hash_of_ids(&hash, s_md->end.ids[eid_i]);
+			}
+
+			for (size_t b_i = 0; b_i < bucket_count; b_i++) {
+				fsm_state_t *b = &htab[(b_i + hash) & mask];
+				const fsm_state_t other = *b;
+				const struct end_metadata *other_md = &end_md[other];
+
+				if (other == NO_ID) { /* empty hash bucket */
+					*b = s;
+					if (prev == NO_ID) {
+						/* keep the first state, along with other states
+						 * with matching end IDs, in this EC. no-op. */
+#if LOG_ECS
+						fprintf(stderr, " -- keeping state s %d in EC %u\n",
+						    s, env->state_ecs[s]);
+#endif
+						prev = s;
+					} else { /* not first (prev is set), so it landed somewhere else */
+						/* unlink and assign new EC */
+#if LOG_ECS
+						fprintf(stderr, " -- moving state s %d from EC %u to EC %u\n",
+						    s, env->state_ecs[s], env->ec_count);
+#endif
+						env->jump[prev] = env->jump[s]; /* unlink */
+						env->ecs[env->ec_count] = s;    /* head of new EC */
+						env->state_ecs[s] = env->ec_count;
+						env->jump[s] = NO_ID;
+						env->ec_count++;
+					}
+					break;
+				} else if (same_end_metadata(s_md, other_md)) {
+					if (env->state_ecs[other] == ec_i) {
+						/* keep in the current EC -- no-op */
+#if LOG_ECS
+						fprintf(stderr, " -- keeping state s %d in EC %u\n",
+						    s, env->state_ecs[s]);
+#endif
+						prev = s;
+					} else {
+						/* unlink and link to other state's EC */
+#if LOG_ECS
+						fprintf(stderr, " -- appending s %d to EC %u, after state %d, before %d\n",
+						    s, env->state_ecs[other], other, env->jump[other]);
+#endif
+						assert(prev != NO_ID);
+						env->jump[prev] = env->jump[s]; /* unlink */
+						env->state_ecs[s] = env->state_ecs[other];
+						env->jump[s] = env->jump[other];
+						env->jump[other] = s; /* link after other */
+					}
+					break;
+				} else {
+					continue; /* collision */
+				}
+			}
+
+			s = next;
+		}
+
+		/* If this EC only has one entry and it's before the
+		 * done_ec_offset, then set that here so that invariants
+		 * will be restored while sweeping forward after this loop. */
+
+		if (env->jump[MASK_EC_HEAD(env->ecs[ec_i])] == NO_ID && ec_i < env->done_ec_offset) {
+			env->done_ec_offset = ec_i; /* will be readjusted later */
+		}
+
+#if LOG_ECS
+		fprintf(stderr, "==== AFTER PARTITIONING BY END METADATA -- EC %zu\n", ec_i);
+		dump_ecs(stderr, env);
+		fprintf(stderr, "==== (done_ec_offset: %d)\n", env->done_ec_offset);
+#endif
+	}
+
+#if LOG_ECS
+	fprintf(stderr, "==== AFTER PARTITIONING BY END IDs\n");
+	dump_ecs(stderr, env);
+	fprintf(stderr, "==== (done_ec_offset: %d)\n", env->done_ec_offset);
+#endif
+
+	/* Sweep forward and swap ECs as necessary so all single-entry
+	 * ECs are at the end -- they're done. */
+	size_t ec_i = env->done_ec_offset;
+
+	while (ec_i < env->ec_count) {
+		const fsm_state_t head = MASK_EC_HEAD(env->ecs[ec_i]);
+		if (env->jump[head] == NO_ID) {
+			/* offset stays where it is */
+#if LOG_ECS
+			fprintf(stderr, "ec_i: %zu / %u -- branch a\n", ec_i, env->ec_count);
+#endif
+			env->ecs[ec_i] = SET_SMALL_EC_FLAG(head);
+		} else {
+			/* this EC has more than one state, but is after
+			 * the done_ec_offset, so swap it with an EC at
+			 * the boundary. */
+			const fsm_state_t n_ec_i = env->done_ec_offset;
+#if LOG_ECS
+			fprintf(stderr, "ec_i: %zu / %u -- branch b -- swap %ld and %d\n",
+			    ec_i, env->ec_count, ec_i, n_ec_i);
+#endif
+
+			/* swap ec[n_ec_i] and ec[ec_i] */
+			const fsm_state_t tmp = env->ecs[ec_i];
+			env->ecs[ec_i] = env->ecs[n_ec_i];
+			env->ecs[n_ec_i] = tmp;
+			/* note: this may set the SMALL_EC_FLAG. */
+			update_ec_links(env, ec_i);
+			update_ec_links(env, n_ec_i);
+			env->done_ec_offset++;
+		}
+		ec_i++;
+	}
+
+#if LOG_ECS
+	fprintf(stderr, "==== (done_ec_offset is now: %d, ec_count %u)\n", env->done_ec_offset, env->ec_count);
+	dump_ecs(stderr, env);
+#endif
+
+	/* check that all ECs are before/after done_ec_offset */
+	for (size_t ec_i = 0; ec_i < env->ec_count; ec_i++) {
+		const fsm_state_t s = MASK_EC_HEAD(env->ecs[ec_i]);
+#if LOG_ECS
+		fprintf(stderr, "  -- ec_i %zu: s %d\n", ec_i, s);
+#endif
+		if (ec_i < env->done_ec_offset) {
+			assert(env->jump[s] != NO_ID);
+		} else {
+			assert(env->jump[s] == NO_ID);
+		}
+	}
+
+	res = 1;
+
+cleanup:
+	if (htab != NULL) {
+		f_free(fsm->opt->alloc, htab);
+	}
+	if (end_md != NULL) {
+		size_t i;
+		for (i = 0; i < state_count; i++) {
+			struct end_metadata *e = &end_md[i];
+			if (e->end.ids != NULL) {
+				f_free(fsm->opt->alloc, e->end.ids);
+			}
+		}
+		f_free(fsm->opt->alloc, end_md);
+	}
+
+	return res;
+}
+
+static int
+cmp_end_ids(const void *pa, const void *pb)
+{
+	const fsm_end_id_t a = *(fsm_end_id_t *)pa;
+	const fsm_end_id_t b = *(fsm_end_id_t *)pb;
+	return a < b ? -1 : a > b ? 1 : 0;
+}
+
+static int
+collect_end_ids(const struct fsm *fsm, fsm_state_t s,
+	struct end_metadata_end *e)
+{
+	e->count = fsm_getendidcount(fsm, s);
+
+	if (e->count > 0) {
+		e->ids = f_malloc(fsm->opt->alloc,
+		    e->count * sizeof(e->ids[0]));
+		if (e->ids == NULL) {
+			return 0;
+		}
+
+		size_t written;
+		enum fsm_getendids_res res = fsm_getendids(fsm, s,
+		    e->count, e->ids, &written);
+		assert(res == FSM_GETENDIDS_FOUND);
+		assert(written == e->count);
+
+		/* sort, to make comparison easier later */
+		qsort(e->ids, e->count,
+		    sizeof(e->ids[0]), cmp_end_ids);
+
+#if LOG_ECS
+		fprintf(stderr, "%d:", s);
+		for (size_t i = 0; i < written; i++) {
+			fprintf(stderr, " %u", e->ids[i]);
+		}
+		fprintf(stderr, "\n");
+#endif
+	}
+	return 1;
 }
 
 #if EXPENSIVE_INTEGRITY_CHECKS

--- a/src/libfsm/minimise_internal.h
+++ b/src/libfsm/minimise_internal.h
@@ -3,10 +3,6 @@
 
 #define NO_ID ((fsm_state_t)-1)
 
-/* If set to non-zero, do extra intensive
- * integrity checks inside some inner loops. */
-#define EXPENSIVE_INTEGRITY_CHECKS 0
-
 #define DEF_INITIAL_COUNT_CEIL 8
 
 struct min_env {

--- a/src/libfsm/minimise_test_oracle.c
+++ b/src/libfsm/minimise_test_oracle.c
@@ -353,6 +353,10 @@ fsm_minimise_test_oracle(const struct fsm *fsm)
 	free(table);
 	free(tmp_map);
 	free(mapping);
+	free(endid_group_assignments);
+	free(endid_group_leaders);
+	free(endid_buf_a);
+	free(endid_buf_b);
 
 	return res;
 

--- a/src/libfsm/minimise_test_oracle.c
+++ b/src/libfsm/minimise_test_oracle.c
@@ -7,6 +7,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <string.h>
 
 #include <fsm/fsm.h>
 #include <fsm/capture.h>
@@ -107,6 +108,14 @@ fsm_minimise_test_oracle(const struct fsm *fsm)
 	fsm_state_t *tmp_map = NULL;
 	fsm_state_t *mapping = NULL;
 
+	/* endid_group_assignments[X] = Y: state X is in endid group Y
+	 * endid_group_leaders[X] = Y: see end state Y for endid group X */
+	unsigned *endid_group_assignments = NULL;
+	size_t endid_group_count = 1; /* group 0 is the empty set */
+	unsigned *endid_group_leaders = NULL;
+	fsm_end_id_t *endid_buf_a = NULL;
+	fsm_end_id_t *endid_buf_b = NULL;
+
 	table = calloc(row_words * table_states, sizeof(table[0]));
 	if (table == NULL) { goto cleanup; }
 
@@ -116,15 +125,30 @@ fsm_minimise_test_oracle(const struct fsm *fsm)
 	mapping = malloc(state_count * sizeof(mapping[0]));
 	if (mapping == NULL) { goto cleanup; }
 
+	endid_group_assignments = calloc(state_count, sizeof(tmp_map[0]));
+	if (endid_group_assignments == NULL) { goto cleanup; }
+
+	endid_group_leaders = calloc(state_count, sizeof(tmp_map[0]));
+	if (endid_group_leaders == NULL) { goto cleanup; }
+
 	/* macros for NxN bit table */
 #define POS(X,Y) ((X*table_states) + Y)
 #define MARK(X,Y)  u64bitset_set(table, POS(X,Y))
 #define CLEAR(X,Y) u64bitset_clear(table, POS(X,Y))
 #define CHECK(X,Y) u64bitset_get(table, POS(X,Y))
 
+	size_t max_endid_count = 0;
+
 	/* Mark all pairs of states where one is final and one is not.
 	 * This includes the dead state. */
 	for (size_t i = 0; i < table_states; i++) {
+		if (i < state_count && fsm_isend(fsm, i)) {
+			const size_t count = fsm_getendidcount(fsm, i);
+			if (count > max_endid_count) {
+				max_endid_count = count;
+			}
+		}
+
 		for (size_t j = 0; j < i; j++) {
 			const bool end_i = i == dead_state
 			    ? false : fsm_isend(fsm, i);
@@ -137,6 +161,69 @@ fsm_minimise_test_oracle(const struct fsm *fsm)
 					    i, j);
 				}
 				MARK(i, j);
+			}
+		}
+	}
+
+	endid_buf_a = malloc(max_endid_count * sizeof(endid_buf_a[0]));
+	if (endid_buf_a == NULL) { goto cleanup; }
+	endid_buf_b = malloc(max_endid_count * sizeof(endid_buf_b[0]));
+	if (endid_buf_b == NULL) { goto cleanup; }
+
+	/* For every end state, check if it has endids. If not, assign it
+	 * to endid group 0 (none). Otherwise, check if its endids match
+	 * any of the other end states. If so, assign it to the same endid
+	 * group, otherwise assign a new one and mark it as the leader. */
+	for (size_t i = 0; i < state_count; i++) {
+		if (fsm_isend(fsm, i)) {
+			size_t written_a;
+			enum fsm_getendids_res eres = fsm_getendids(fsm, i,
+			    max_endid_count, endid_buf_a, &written_a);
+			assert(eres != FSM_GETENDIDS_ERROR_INSUFFICIENT_SPACE);
+			if (eres == FSM_GETENDIDS_NOT_FOUND) {
+				assert(written_a == 0);
+			} else {
+				assert(written_a > 0);
+				bool found = false;
+				/* note: skipping eg 0 here since that's the empty set */
+				for (size_t eg_i = 1; eg_i < endid_group_count; eg_i++) {
+					size_t written_b;
+					eres = fsm_getendids(fsm, endid_group_leaders[eg_i],
+					    max_endid_count, endid_buf_b, &written_b);
+					assert(eres != FSM_GETENDIDS_ERROR_INSUFFICIENT_SPACE);
+					if (written_b != written_a) { continue; }
+					if (0 == memcmp(endid_buf_a, endid_buf_b, written_a * sizeof(endid_buf_a[0]))) {
+						found = true;
+						endid_group_assignments[i] = eg_i;
+						break;
+					} else {
+						continue;
+					}
+				}
+
+				if (!found) {
+					endid_group_assignments[i] = endid_group_count;
+					endid_group_leaders[endid_group_count] = i;
+					endid_group_count++;
+				}
+			}
+		} else {
+			endid_group_assignments[i] = 0; /* none */
+		}
+	}
+
+	/* Any end states that have not been assigned the same endid
+	 * group must be distinguishable. */
+	for (size_t i = 0; i < state_count; i++) {
+		if (fsm_isend(fsm, i)) {
+			const unsigned i_group = endid_group_assignments[i];
+			for (size_t j = 0; j < i; j++) {
+				if (fsm_isend(fsm, j)) {
+					const unsigned j_group = endid_group_assignments[j];
+					if (i_group != j_group) {
+						MARK(i, j);
+					}
+				}
 			}
 		}
 	}
@@ -273,6 +360,10 @@ cleanup:
 	if (table != NULL) { free(table); }
 	if (tmp_map != NULL) { free(tmp_map); }
 	if (mapping != NULL) { free(mapping); }
+	if (endid_group_assignments != NULL) { free(endid_group_assignments); }
+	if (endid_group_leaders != NULL) { free(endid_group_leaders); }
+	if (endid_buf_a != NULL) { free(endid_buf_a); }
+	if (endid_buf_b != NULL) { free(endid_buf_b); }
 	if (res != NULL) { fsm_free(res); }
 	return NULL;
 }

--- a/tests/endids/endids10_minimise_partial_overlap.c
+++ b/tests/endids/endids10_minimise_partial_overlap.c
@@ -63,6 +63,7 @@ int main(void)
 	}
 	assert(written == 1);
 	assert(endids[0] == ENDID_AB_STAR_C);
+	free(endids);
 
 	if (match_string(combined, "abc", NULL, &endids, &written) != 1) {
 		assert(!"'abc' should match");
@@ -71,12 +72,14 @@ int main(void)
 	/* result is not sorted */
 	assert((endids[0] == ENDID_AB_STAR_C && endids[1] == ENDID_ABC) ||
 	    (endids[1] == ENDID_AB_STAR_C && endids[0] == ENDID_ABC));
+	free(endids);
 
 	if (match_string(combined, "abbc", NULL, &endids, &written) != 1) {
 		assert(!"'abbc' should match");
 	}
 	assert(written == 1);
 	assert(endids[0] == ENDID_AB_STAR_C);
+	free(endids);
 
 	fsm_free(combined);
 }

--- a/tests/endids/endids10_minimise_partial_overlap.c
+++ b/tests/endids/endids10_minimise_partial_overlap.c
@@ -1,0 +1,82 @@
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#include <errno.h>
+
+#include <assert.h>
+
+#include <re/re.h>
+
+#include <fsm/fsm.h>
+#include <fsm/bool.h>
+#include <fsm/pred.h>
+#include <fsm/print.h>
+#include <fsm/walk.h>
+
+#include "endids_utils.h"
+
+#define ENDID_AB_STAR_C 1
+#define ENDID_ABC 2
+
+int main(void)
+{
+	/* Union /^ab*c$/ and /^abc$/ with distinct endids set on each
+	 * and verify that inputs of "ac", "abc", "abbc" get the endids
+	 * associated with only the regexes that match.
+	 *
+	 * In other words, check that minimisation does not merge them
+	 * and cause false positives. */
+
+	const char *regex_ab_star_c = "^ab*c$";
+	const char *regex_abc = "^abc$";
+
+	struct fsm *fsm_ab_star_c = re_comp(RE_NATIVE, fsm_sgetc, (void *)&regex_ab_star_c, NULL, 0, NULL);
+	assert(fsm_ab_star_c != NULL);
+	if (!fsm_setendid(fsm_ab_star_c, ENDID_AB_STAR_C)) { assert(!"setendid"); }
+
+	if (!fsm_determinise(fsm_ab_star_c)) { assert(!"determinise"); }
+	if (!fsm_minimise(fsm_ab_star_c)) { assert(!"minimise"); }
+
+	struct fsm *fsm_abc = re_comp(RE_NATIVE, fsm_sgetc, (void *)&regex_abc, NULL, 0, NULL);
+	assert(fsm_abc != NULL);
+	if (!fsm_setendid(fsm_abc, ENDID_ABC)) { assert(!"setendid"); }
+
+	if (!fsm_determinise(fsm_abc)) { assert(!"determinise"); }
+	if (!fsm_minimise(fsm_abc)) { assert(!"minimise"); }
+
+	struct fsm *combined = fsm_union(fsm_ab_star_c, fsm_abc, NULL);
+	assert(combined != NULL);
+
+	int ret = fsm_determinise(combined);
+	assert(ret != 0);
+
+	ret = fsm_minimise(combined);
+	assert(ret != 0);
+
+	size_t written;
+	fsm_end_id_t *endids = NULL;
+	if (match_string(combined, "ac", NULL, &endids, &written) != 1) {
+		assert(!"'ac' should match");
+	}
+	assert(written == 1);
+	assert(endids[0] == ENDID_AB_STAR_C);
+
+	if (match_string(combined, "abc", NULL, &endids, &written) != 1) {
+		assert(!"'abc' should match");
+	}
+	assert(written == 2);
+	/* result is not sorted */
+	assert((endids[0] == ENDID_AB_STAR_C && endids[1] == ENDID_ABC) ||
+	    (endids[1] == ENDID_AB_STAR_C && endids[0] == ENDID_ABC));
+
+	if (match_string(combined, "abbc", NULL, &endids, &written) != 1) {
+		assert(!"'abbc' should match");
+	}
+	assert(written == 1);
+	assert(endids[0] == ENDID_AB_STAR_C);
+
+	fsm_free(combined);
+}


### PR DESCRIPTION
This was adapted from the group capture integration branch. It isn't specific to group capture.

Currently, metadata on end states will not prohibit merging, which can lead to false positives when using endids to detect which of the original regexes are matching when several regexes are compiled and then unioned into a single DFA. This adds a pass before the main minimisation loop that splits the ECs of end states with distinct sets of end IDs, which is sufficient to prevent them from merging later.

I reworked the test tests/endids/endids2_union_many_endids.c somewhat, since it was previously checking that the end states WERE merged. Unfortunately the other checks are somewhat weakened -- I removed the part checking that `endids[j] == j+1` because that ordering isn't guaranteed anymore: the patterns aren't anchored, so some examples will match more than one of them, and the endids collected can be nonconsecutive.

I added a separate test, endids10_minimise_partial_overlap.c, which checks the minimal case that when the two regexes /^abc$/ and /^ab*c$/ are combined and a distinct endid is set on each, matching "ac" "abc" "abbc" gets one or both endids as appropriate. Ideally, we'd have a property test that checks that any arbitrary set of regex patterns has the same set of inputs matching -> endids when they are run individually vs. when combined into a single FSM, determinised, and minimised.