### PR TITLE
Break a dependency on group #0 for re_is_literal()

### DIFF
--- a/include/fsm/bool.h
+++ b/include/fsm/bool.h
@@ -44,7 +44,7 @@ fsm_union(struct fsm *a, struct fsm *b,
  * starting states and (if used) capture bases.
  *
  * bases[] is expected to have the same count as fsms[], and
- * will be initialized by the function.
+ * will be initialized by the function. May be NULL.
  *
  * On success, returns the unioned fsm and updates bases[].
  * On failure, returns NULL; all fsms are freed. */

--- a/src/libfsm/union.c
+++ b/src/libfsm/union.c
@@ -101,7 +101,9 @@ fsm_union_array(size_t fsm_count,
 	struct fsm *res = fsms[0];
 
 	fsms[0] = NULL;
-	memset(bases, 0x00, fsm_count * sizeof(bases[0]));
+	if (bases != NULL) {
+		memset(bases, 0x00, fsm_count * sizeof(bases[0]));
+	}
 
 	for (i = 1; i < fsm_count; i++) {
 		struct fsm_combine_info ci;
@@ -117,9 +119,14 @@ fsm_union_array(size_t fsm_count,
 			return NULL;
 		}
 
+		res = combined;
+
+		if (bases == NULL) {
+			continue;
+		}
+
 		bases[i].state = ci.base_b;
 		bases[i].capture = ci.capture_base_b;
-		res = combined;
 
 		/* If the first argument didn't get its states put first
 		 * in the union, then shift the bases for everything
@@ -134,9 +141,11 @@ fsm_union_array(size_t fsm_count,
 	}
 
 #if LOG_UNION_ARRAY
-	for (i = 0; i < fsm_count; i++) {
-		fprintf(stderr, "union_array: bases %u: %zu, %zu\n",
-		    i, bases[i].state, bases[i].capture);
+	if (bases != NULL) {
+		for (i = 0; i < fsm_count; i++) {
+			fprintf(stderr, "union_array: bases %u: %zu, %zu\n",
+				i, bases[i].state, bases[i].capture);
+		}
 	}
 #endif
 

--- a/src/libre/dialect/glob/parser.c
+++ b/src/libre/dialect/glob/parser.c
@@ -537,7 +537,19 @@ p_re__glob(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 119 */
+		t_group__id ZIid;
+		t_ast__expr ZIe;
+
+		/* BEGINNING OF ACTION: make-group-id */
+		{
+#line 915 "src/libre/parser.act"
+
+		(ZIid) = act_state->group_id++;
+	
+#line 550 "src/libre/dialect/glob/parser.c"
+		}
+		/* END OF ACTION: make-group-id */
+		/* BEGINNING OF INLINE: 120 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_MANY): case (TOK_CHAR):
@@ -546,15 +558,15 @@ p_re__glob(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 					{
 #line 894 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_concat(act_state->poolp, *flags);
-		if ((ZInode) == NULL) {
+		(ZIe) = ast_make_expr_concat(act_state->poolp, *flags);
+		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 555 "src/libre/dialect/glob/parser.c"
+#line 567 "src/libre/dialect/glob/parser.c"
 					}
 					/* END OF ACTION: ast-make-concat */
-					p_list_Hof_Hatoms (flags, lex_state, act_state, err, ZInode);
+					p_list_Hof_Hatoms (flags, lex_state, act_state, err, ZIe);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL1;
@@ -567,20 +579,32 @@ p_re__glob(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 					{
 #line 887 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
-		if ((ZInode) == NULL) {
+		(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
+		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 576 "src/libre/dialect/glob/parser.c"
+#line 588 "src/libre/dialect/glob/parser.c"
 					}
 					/* END OF ACTION: ast-make-empty */
 				}
 				break;
 			}
 		}
-		/* END OF INLINE: 119 */
-		/* BEGINNING OF INLINE: 120 */
+		/* END OF INLINE: 120 */
+		/* BEGINNING OF ACTION: ast-make-group */
+		{
+#line 945 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_group(act_state->poolp, *flags, (ZIe), (ZIid));
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 605 "src/libre/dialect/glob/parser.c"
+		}
+		/* END OF ACTION: ast-make-group */
+		/* BEGINNING OF INLINE: 121 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -603,13 +627,13 @@ p_re__glob(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 		}
 		goto ZL1;
 	
-#line 607 "src/libre/dialect/glob/parser.c"
+#line 631 "src/libre/dialect/glob/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 120 */
+		/* END OF INLINE: 121 */
 	}
 	goto ZL0;
 ZL1:;
@@ -779,6 +803,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 783 "src/libre/dialect/glob/parser.c"
+#line 807 "src/libre/dialect/glob/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/glob/parser.sid
+++ b/src/libre/dialect/glob/parser.sid
@@ -15,7 +15,7 @@
 	ast_count;
 	ast_class_id;
 	!endpoint;
-	!group_id;
+	group_id;
 
 %terminals%
 
@@ -84,7 +84,7 @@
 	!<count-one>:         () -> (:ast_count);
 	!<count-range>: (:unsigned, :pos, :unsigned, :pos) -> (:ast_count);
 
-	!<make-group-id>:      () -> (:group_id);
+	<make-group-id>:       () -> (:group_id);
 	!<make-literal-cbrak>: () -> (:char);
 	!<make-literal-cr>:    () -> (:char);
 	!<make-literal-nl>:    () -> (:char);
@@ -97,7 +97,7 @@
 	<ast-make-concat>:        ()                       -> (:ast_expr);
 	!<ast-make-alt>:          ()                       -> (:ast_expr);
 	<ast-make-piece>:         (:ast_expr, :ast_count)  -> (:ast_expr);
-	!<ast-make-group>:        (:ast_expr, :group_id)   -> (:ast_expr);
+	<ast-make-group>:         (:ast_expr, :group_id)   -> (:ast_expr);
 	!<ast-get-re-flags>:      ()                       -> (:re_flags);
 	!<ast-set-re-flags>:      (:re_flags)              -> ();
 	!<ast-mask-re-flags>:     (:re_flags, :re_flags)   -> ();
@@ -165,12 +165,14 @@
 	};
 
 	re_glob: () -> (node :ast_expr) = {
+		id = <make-group-id>;
 		{
-			node = <ast-make-concat>;
-			list-of-atoms(node);
+			e = <ast-make-concat>;
+			list-of-atoms(e);
 		||
-			node = <ast-make-empty>;
+			e = <ast-make-empty>;
 		};
+		node = <ast-make-group>(e, id);
 
 		{
 			EOF;

--- a/src/libre/dialect/like/parser.c
+++ b/src/libre/dialect/like/parser.c
@@ -537,7 +537,19 @@ p_re__like(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 119 */
+		t_group__id ZIid;
+		t_ast__expr ZIe;
+
+		/* BEGINNING OF ACTION: make-group-id */
+		{
+#line 915 "src/libre/parser.act"
+
+		(ZIid) = act_state->group_id++;
+	
+#line 550 "src/libre/dialect/like/parser.c"
+		}
+		/* END OF ACTION: make-group-id */
+		/* BEGINNING OF INLINE: 120 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_ANY): case (TOK_MANY): case (TOK_CHAR):
@@ -546,15 +558,15 @@ p_re__like(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 					{
 #line 894 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_concat(act_state->poolp, *flags);
-		if ((ZInode) == NULL) {
+		(ZIe) = ast_make_expr_concat(act_state->poolp, *flags);
+		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 555 "src/libre/dialect/like/parser.c"
+#line 567 "src/libre/dialect/like/parser.c"
 					}
 					/* END OF ACTION: ast-make-concat */
-					p_list_Hof_Hatoms (flags, lex_state, act_state, err, ZInode);
+					p_list_Hof_Hatoms (flags, lex_state, act_state, err, ZIe);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL1;
@@ -567,20 +579,32 @@ p_re__like(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 					{
 #line 887 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
-		if ((ZInode) == NULL) {
+		(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
+		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 576 "src/libre/dialect/like/parser.c"
+#line 588 "src/libre/dialect/like/parser.c"
 					}
 					/* END OF ACTION: ast-make-empty */
 				}
 				break;
 			}
 		}
-		/* END OF INLINE: 119 */
-		/* BEGINNING OF INLINE: 120 */
+		/* END OF INLINE: 120 */
+		/* BEGINNING OF ACTION: ast-make-group */
+		{
+#line 945 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_group(act_state->poolp, *flags, (ZIe), (ZIid));
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 605 "src/libre/dialect/like/parser.c"
+		}
+		/* END OF ACTION: ast-make-group */
+		/* BEGINNING OF INLINE: 121 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -603,13 +627,13 @@ p_re__like(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 		}
 		goto ZL1;
 	
-#line 607 "src/libre/dialect/like/parser.c"
+#line 631 "src/libre/dialect/like/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 120 */
+		/* END OF INLINE: 121 */
 	}
 	goto ZL0;
 ZL1:;
@@ -779,6 +803,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 783 "src/libre/dialect/like/parser.c"
+#line 807 "src/libre/dialect/like/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/like/parser.sid
+++ b/src/libre/dialect/like/parser.sid
@@ -15,7 +15,7 @@
 	ast_count;
 	ast_class_id;
 	!endpoint;
-	!group_id;
+	group_id;
 
 %terminals%
 
@@ -84,7 +84,7 @@
 	!<count-one>:         () -> (:ast_count);
 	!<count-range>: (:unsigned, :pos, :unsigned, :pos) -> (:ast_count);
 
-	!<make-group-id>:      () -> (:group_id);
+	<make-group-id>:       () -> (:group_id);
 	!<make-literal-cbrak>: () -> (:char);
 	!<make-literal-cr>:    () -> (:char);
 	!<make-literal-nl>:    () -> (:char);
@@ -97,7 +97,7 @@
 	<ast-make-concat>:        ()                       -> (:ast_expr);
 	!<ast-make-alt>:          ()                       -> (:ast_expr);
 	<ast-make-piece>:         (:ast_expr, :ast_count)  -> (:ast_expr);
-	!<ast-make-group>:        (:ast_expr, :group_id)   -> (:ast_expr);
+	<ast-make-group>:         (:ast_expr, :group_id)   -> (:ast_expr);
 	!<ast-get-re-flags>:      ()                       -> (:re_flags);
 	!<ast-set-re-flags>:      (:re_flags)              -> ();
 	!<ast-mask-re-flags>:     (:re_flags, :re_flags)   -> ();
@@ -165,12 +165,14 @@
 	};
 
 	re_like: () -> (node :ast_expr) = {
+		id = <make-group-id>;
 		{
-			node = <ast-make-concat>;
-			list-of-atoms(node);
+			e = <ast-make-concat>;
+			list-of-atoms(e);
 		||
-			node = <ast-make-empty>;
+			e = <ast-make-empty>;
 		};
+		node = <ast-make-group>(e, id);
 
 		{
 			EOF;

--- a/src/libre/dialect/literal/parser.c
+++ b/src/libre/dialect/literal/parser.c
@@ -363,7 +363,19 @@ p_re__literal(flags flags, lex_state lex_state, act_state act_state, err err, t_
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 117 */
+		t_group__id ZIid;
+		t_ast__expr ZIe;
+
+		/* BEGINNING OF ACTION: make-group-id */
+		{
+#line 915 "src/libre/parser.act"
+
+		(ZIid) = act_state->group_id++;
+	
+#line 376 "src/libre/dialect/literal/parser.c"
+		}
+		/* END OF ACTION: make-group-id */
+		/* BEGINNING OF INLINE: 118 */
 		{
 			switch (CURRENT_TERMINAL) {
 			case (TOK_CHAR):
@@ -372,15 +384,15 @@ p_re__literal(flags flags, lex_state lex_state, act_state act_state, err err, t_
 					{
 #line 894 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_concat(act_state->poolp, *flags);
-		if ((ZInode) == NULL) {
+		(ZIe) = ast_make_expr_concat(act_state->poolp, *flags);
+		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 381 "src/libre/dialect/literal/parser.c"
+#line 393 "src/libre/dialect/literal/parser.c"
 					}
 					/* END OF ACTION: ast-make-concat */
-					p_list_Hof_Hatoms (flags, lex_state, act_state, err, ZInode);
+					p_list_Hof_Hatoms (flags, lex_state, act_state, err, ZIe);
 					if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 						RESTORE_LEXER;
 						goto ZL1;
@@ -393,20 +405,32 @@ p_re__literal(flags flags, lex_state lex_state, act_state act_state, err err, t_
 					{
 #line 887 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_empty(act_state->poolp, *flags);
-		if ((ZInode) == NULL) {
+		(ZIe) = ast_make_expr_empty(act_state->poolp, *flags);
+		if ((ZIe) == NULL) {
 			goto ZL1;
 		}
 	
-#line 402 "src/libre/dialect/literal/parser.c"
+#line 414 "src/libre/dialect/literal/parser.c"
 					}
 					/* END OF ACTION: ast-make-empty */
 				}
 				break;
 			}
 		}
-		/* END OF INLINE: 117 */
-		/* BEGINNING OF INLINE: 118 */
+		/* END OF INLINE: 118 */
+		/* BEGINNING OF ACTION: ast-make-group */
+		{
+#line 945 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_group(act_state->poolp, *flags, (ZIe), (ZIid));
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 431 "src/libre/dialect/literal/parser.c"
+		}
+		/* END OF ACTION: ast-make-group */
+		/* BEGINNING OF INLINE: 120 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
@@ -429,13 +453,13 @@ p_re__literal(flags flags, lex_state lex_state, act_state act_state, err err, t_
 		}
 		goto ZL1;
 	
-#line 433 "src/libre/dialect/literal/parser.c"
+#line 457 "src/libre/dialect/literal/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
 		ZL3:;
 		}
-		/* END OF INLINE: 118 */
+		/* END OF INLINE: 120 */
 	}
 	goto ZL0;
 ZL1:;
@@ -475,7 +499,7 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 
 		ZIc = lex_state->buf.a[0];
 	
-#line 479 "src/libre/dialect/literal/parser.c"
+#line 503 "src/libre/dialect/literal/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			break;
@@ -492,7 +516,7 @@ p_list_Hof_Hatoms_C_Catom(flags flags, lex_state lex_state, act_state act_state,
 			goto ZL1;
 		}
 	
-#line 496 "src/libre/dialect/literal/parser.c"
+#line 520 "src/libre/dialect/literal/parser.c"
 		}
 		/* END OF ACTION: ast-make-literal */
 	}
@@ -508,7 +532,7 @@ ZL1:;
 		}
 		goto ZL2;
 	
-#line 512 "src/libre/dialect/literal/parser.c"
+#line 536 "src/libre/dialect/literal/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-empty */
@@ -520,7 +544,7 @@ ZL1:;
 			goto ZL2;
 		}
 	
-#line 524 "src/libre/dialect/literal/parser.c"
+#line 548 "src/libre/dialect/literal/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -692,6 +716,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 696 "src/libre/dialect/literal/parser.c"
+#line 720 "src/libre/dialect/literal/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/literal/parser.sid
+++ b/src/libre/dialect/literal/parser.sid
@@ -15,7 +15,7 @@
 	!ast_count;
 	!ast_class_id;
 	!endpoint;
-	!group_id;
+	group_id;
 
 %terminals%
 
@@ -84,7 +84,7 @@
 	!<count-one>:          () -> (:ast_count);
 	!<count-range>: (:unsigned, :pos, :unsigned, :pos) -> (:ast_count);
 
-	!<make-group-id>:      () -> (:group_id);
+	<make-group-id>:       () -> (:group_id);
 	!<make-literal-cbrak>: () -> (:char);
 	!<make-literal-cr>:    () -> (:char);
 	!<make-literal-nl>:    () -> (:char);
@@ -97,7 +97,7 @@
 	<ast-make-concat>:        ()                       -> (:ast_expr);
 	!<ast-make-alt>:          ()                       -> (:ast_expr);
 	!<ast-make-piece>:        (:ast_expr, :ast_count)  -> (:ast_expr);
-	!<ast-make-group>:        (:ast_expr, :group_id)   -> (:ast_expr);
+	<ast-make-group>:         (:ast_expr, :group_id)   -> (:ast_expr);
 	!<ast-get-re-flags>:      ()                       -> (:re_flags);
 	!<ast-set-re-flags>:      (:re_flags)              -> ();
 	!<ast-mask-re-flags>:     (:re_flags, :re_flags)   -> ();
@@ -155,12 +155,14 @@
 	};
 
 	re_literal: () -> (node :ast_expr) = {
+		id = <make-group-id>;
 		{
-			node = <ast-make-concat>;
-			list-of-atoms(node);
+			e = <ast-make-concat>;
+			list-of-atoms(e);
 		||
-			node = <ast-make-empty>;
+			e = <ast-make-empty>;
 		};
+		node = <ast-make-group>(e, id);
 	
 		{
 			EOF;

--- a/src/libre/dialect/native/parser.c
+++ b/src/libre/dialect/native/parser.c
@@ -298,7 +298,7 @@
 /* BEGINNING OF FUNCTION DECLARATIONS */
 
 static void p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags, lex_state, act_state, err, t_endpoint *, t_pos *, t_pos *);
-static void p_268(flags, lex_state, act_state, err, t_pos *, t_unsigned *, t_ast__count *);
+static void p_267(flags, lex_state, act_state, err, t_pos *, t_unsigned *, t_ast__count *);
 static void p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms(flags, lex_state, act_state, err, t_ast__expr);
 static void p_155(flags, lex_state, act_state, err);
 static void p_expr_C_Clist_Hof_Hpieces(flags, lex_state, act_state, err, t_ast__expr);
@@ -316,9 +316,9 @@ static void p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint(flags, lex_state, act_
 static void p_expr_C_Clist_Hof_Halts(flags, lex_state, act_state, err, t_ast__expr);
 static void p_expr_C_Cpiece_C_Ccount(flags, lex_state, act_state, err, t_ast__count *);
 static void p_expr_C_Cpiece_C_Catom(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_249(flags, lex_state, act_state, err, t_ast__class__id *, t_pos *, t_ast__expr *);
+static void p_248(flags, lex_state, act_state, err, t_ast__class__id *, t_pos *, t_ast__expr *);
 static void p_expr_C_Calt(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_253(flags, lex_state, act_state, err, t_char *, t_pos *, t_ast__expr *);
+static void p_252(flags, lex_state, act_state, err, t_char *, t_pos *, t_ast__expr *);
 
 /* BEGINNING OF STATIC VARIABLES */
 
@@ -538,7 +538,7 @@ ZL0:;
 }
 
 static void
-p_268(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI266, t_unsigned *ZIm, t_ast__count *ZOc)
+p_267(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI265, t_unsigned *ZIm, t_ast__count *ZOc)
 {
 	t_ast__count ZIc;
 
@@ -566,7 +566,7 @@ p_268(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			{
 #line 791 "src/libre/parser.act"
 
-		mark(&act_state->countstart, &(*ZI266));
+		mark(&act_state->countstart, &(*ZI265));
 		mark(&act_state->countend,   &(ZIend));
 	
 #line 573 "src/libre/dialect/native/parser.c"
@@ -583,13 +583,13 @@ p_268(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			err->m = (*ZIm);
 			err->n = (*ZIm);
 
-			mark(&act_state->countstart, &(*ZI266));
+			mark(&act_state->countstart, &(*ZI265));
 			mark(&act_state->countend,   &(ZIend));
 
 			goto ZL1;
 		}
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI266));
+		AST_POS_OF_LX_POS(ast_start, (*ZI265));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (*ZIm), &ast_end);
@@ -662,7 +662,7 @@ p_268(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			{
 #line 791 "src/libre/parser.act"
 
-		mark(&act_state->countstart, &(*ZI266));
+		mark(&act_state->countstart, &(*ZI265));
 		mark(&act_state->countend,   &(ZIend));
 	
 #line 669 "src/libre/dialect/native/parser.c"
@@ -679,13 +679,13 @@ p_268(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			err->m = (*ZIm);
 			err->n = (ZIn);
 
-			mark(&act_state->countstart, &(*ZI266));
+			mark(&act_state->countstart, &(*ZI265));
 			mark(&act_state->countend,   &(ZIend));
 
 			goto ZL1;
 		}
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI266));
+		AST_POS_OF_LX_POS(ast_start, (*ZI265));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (ZIn), &ast_end);
@@ -1087,9 +1087,9 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CHAR):
 		{
-			t_char ZI262;
+			t_char ZI261;
+			t_pos ZI262;
 			t_pos ZI263;
-			t_pos ZI264;
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
@@ -1098,19 +1098,19 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI263 = lex_state->lx.start;
-		ZI264   = lex_state->lx.end;
+		ZI262 = lex_state->lx.start;
+		ZI263   = lex_state->lx.end;
 
+		(void) ZI262;
 		(void) ZI263;
-		(void) ZI264;
 
-		ZI262 = lex_state->buf.a[0];
+		ZI261 = lex_state->buf.a[0];
 	
 #line 1110 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
-			p_253 (flags, lex_state, act_state, err, &ZI262, &ZI263, &ZInode);
+			p_252 (flags, lex_state, act_state, err, &ZI261, &ZI262, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1119,9 +1119,9 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		break;
 	case (TOK_ESC):
 		{
-			t_char ZI250;
+			t_char ZI249;
+			t_pos ZI250;
 			t_pos ZI251;
-			t_pos ZI252;
 
 			/* BEGINNING OF EXTRACT: ESC */
 			{
@@ -1131,31 +1131,31 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		assert(lex_state->buf.a[1] != '\0');
 		assert(lex_state->buf.a[2] == '\0');
 
-		ZI250 = lex_state->buf.a[1];
+		ZI249 = lex_state->buf.a[1];
 
-		switch (ZI250) {
-		case 'a': ZI250 = '\a'; break;
-		case 'b': ZI250 = '\b'; break;
-		case 'e': ZI250 = '\033'; break;
-		case 'f': ZI250 = '\f'; break;
-		case 'n': ZI250 = '\n'; break;
-		case 'r': ZI250 = '\r'; break;
-		case 't': ZI250 = '\t'; break;
-		case 'v': ZI250 = '\v'; break;
+		switch (ZI249) {
+		case 'a': ZI249 = '\a'; break;
+		case 'b': ZI249 = '\b'; break;
+		case 'e': ZI249 = '\033'; break;
+		case 'f': ZI249 = '\f'; break;
+		case 'n': ZI249 = '\n'; break;
+		case 'r': ZI249 = '\r'; break;
+		case 't': ZI249 = '\t'; break;
+		case 'v': ZI249 = '\v'; break;
 		default:             break;
 		}
 
-		ZI251 = lex_state->lx.start;
-		ZI252   = lex_state->lx.end;
+		ZI250 = lex_state->lx.start;
+		ZI251   = lex_state->lx.end;
 
+		(void) ZI250;
 		(void) ZI251;
-		(void) ZI252;
 	
 #line 1155 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: ESC */
 			ADVANCE_LEXER;
-			p_253 (flags, lex_state, act_state, err, &ZI250, &ZI251, &ZInode);
+			p_252 (flags, lex_state, act_state, err, &ZI249, &ZI250, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1164,9 +1164,9 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		break;
 	case (TOK_HEX):
 		{
-			t_char ZI258;
+			t_char ZI257;
+			t_pos ZI258;
 			t_pos ZI259;
-			t_pos ZI260;
 
 			/* BEGINNING OF EXTRACT: HEX */
 			{
@@ -1179,11 +1179,11 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		assert(0 == strncmp(lex_state->buf.a, "\\x", 2));
 		assert(strlen(lex_state->buf.a) >= 2);  /* pcre allows \x without a suffix */
 
-		ZI259 = lex_state->lx.start;
-		ZI260   = lex_state->lx.end;
+		ZI258 = lex_state->lx.start;
+		ZI259   = lex_state->lx.end;
 
+		(void) ZI258;
 		(void) ZI259;
-		(void) ZI260;
 
 		errno = 0;
 
@@ -1216,13 +1216,13 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 			goto ZL1;
 		}
 
-		ZI258 = (char) (unsigned char) u;
+		ZI257 = (char) (unsigned char) u;
 	
 #line 1222 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: HEX */
 			ADVANCE_LEXER;
-			p_253 (flags, lex_state, act_state, err, &ZI258, &ZI259, &ZInode);
+			p_252 (flags, lex_state, act_state, err, &ZI257, &ZI258, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1231,31 +1231,31 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		break;
 	case (TOK_NAMED__CLASS):
 		{
-			t_ast__class__id ZI246;
+			t_ast__class__id ZI245;
+			t_pos ZI246;
 			t_pos ZI247;
-			t_pos ZI248;
 
 			/* BEGINNING OF EXTRACT: NAMED_CLASS */
 			{
 #line 661 "src/libre/parser.act"
 
-		ZI246 = DIALECT_CLASS(lex_state->buf.a);
-		if (ZI246 == NULL) {
+		ZI245 = DIALECT_CLASS(lex_state->buf.a);
+		if (ZI245 == NULL) {
 			/* syntax error -- unrecognized class */
 			goto ZL1;
 		}
 
-		ZI247 = lex_state->lx.start;
-		ZI248   = lex_state->lx.end;
+		ZI246 = lex_state->lx.start;
+		ZI247   = lex_state->lx.end;
 
+		(void) ZI246;
 		(void) ZI247;
-		(void) ZI248;
 	
 #line 1255 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			ADVANCE_LEXER;
-			p_249 (flags, lex_state, act_state, err, &ZI246, &ZI247, &ZInode);
+			p_248 (flags, lex_state, act_state, err, &ZI245, &ZI246, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1264,9 +1264,9 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		break;
 	case (TOK_OCT):
 		{
-			t_char ZI254;
+			t_char ZI253;
+			t_pos ZI254;
 			t_pos ZI255;
-			t_pos ZI256;
 
 			/* BEGINNING OF EXTRACT: OCT */
 			{
@@ -1279,11 +1279,11 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
 		assert(strlen(lex_state->buf.a) >= 2);
 
-		ZI255 = lex_state->lx.start;
-		ZI256   = lex_state->lx.end;
+		ZI254 = lex_state->lx.start;
+		ZI255   = lex_state->lx.end;
 
+		(void) ZI254;
 		(void) ZI255;
-		(void) ZI256;
 
 		errno = 0;
 
@@ -1311,13 +1311,13 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 			goto ZL1;
 		}
 
-		ZI254 = (char) (unsigned char) u;
+		ZI253 = (char) (unsigned char) u;
 	
 #line 1317 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: OCT */
 			ADVANCE_LEXER;
-			p_253 (flags, lex_state, act_state, err, &ZI254, &ZI255, &ZInode);
+			p_252 (flags, lex_state, act_state, err, &ZI253, &ZI254, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -2222,30 +2222,48 @@ p_re__native(flags flags, lex_state lex_state, act_state act_state, err err, t_a
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 233 */
+		t_group__id ZIid;
+		t_ast__expr ZIe;
+
+		/* BEGINNING OF ACTION: make-group-id */
 		{
-			{
-				p_expr (flags, lex_state, act_state, err, &ZInode);
-				if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-					RESTORE_LEXER;
-					goto ZL1;
-				}
-			}
+#line 915 "src/libre/parser.act"
+
+		(ZIid) = act_state->group_id++;
+	
+#line 2235 "src/libre/dialect/native/parser.c"
 		}
-		/* END OF INLINE: 233 */
-		/* BEGINNING OF INLINE: 234 */
+		/* END OF ACTION: make-group-id */
+		p_expr (flags, lex_state, act_state, err, &ZIe);
+		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+			RESTORE_LEXER;
+			goto ZL1;
+		}
+		/* BEGINNING OF ACTION: ast-make-group */
+		{
+#line 945 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_group(act_state->poolp, *flags, (ZIe), (ZIid));
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 2252 "src/libre/dialect/native/parser.c"
+		}
+		/* END OF ACTION: ast-make-group */
+		/* BEGINNING OF INLINE: 233 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
 				case (TOK_EOF):
 					break;
 				default:
-					goto ZL4;
+					goto ZL3;
 				}
 				ADVANCE_LEXER;
 			}
-			goto ZL3;
-		ZL4:;
+			goto ZL2;
+		ZL3:;
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
@@ -2256,13 +2274,13 @@ p_re__native(flags flags, lex_state lex_state, act_state act_state, err err, t_a
 		}
 		goto ZL1;
 	
-#line 2260 "src/libre/dialect/native/parser.c"
+#line 2278 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
-		ZL3:;
+		ZL2:;
 		}
-		/* END OF INLINE: 234 */
+		/* END OF INLINE: 233 */
 	}
 	goto ZL0;
 ZL1:;
@@ -2289,7 +2307,7 @@ p_196(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 			goto ZL1;
 		}
 	
-#line 2293 "src/libre/dialect/native/parser.c"
+#line 2311 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -2311,7 +2329,7 @@ p_196(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 		(ZIr).type = AST_ENDPOINT_LITERAL;
 		(ZIr).u.literal.c = (unsigned char)(*ZIcbrak);
 	
-#line 2315 "src/libre/dialect/native/parser.c"
+#line 2333 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF EXTRACT: RANGE */
@@ -2326,7 +2344,7 @@ p_196(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 		(void) ZI198;
 		(void) ZI199;
 	
-#line 2330 "src/libre/dialect/native/parser.c"
+#line 2348 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
@@ -2342,7 +2360,7 @@ p_196(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 		(ZIlower).type = AST_ENDPOINT_LITERAL;
 		(ZIlower).u.literal.c = (unsigned char)(*ZIcbrak);
 	
-#line 2346 "src/libre/dialect/native/parser.c"
+#line 2364 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF ACTION: ast-make-range */
@@ -2380,7 +2398,7 @@ p_196(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZIs
 			goto ZL1;
 		}
 	
-#line 2384 "src/libre/dialect/native/parser.c"
+#line 2402 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -2467,7 +2485,7 @@ ZL2_expr_C_Clist_Hof_Halts:;
 			goto ZL1;
 		}
 	
-#line 2471 "src/libre/dialect/native/parser.c"
+#line 2489 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-add-alt */
 		/* BEGINNING OF INLINE: 231 */
@@ -2499,7 +2517,7 @@ ZL1:;
 		}
 		goto ZL4;
 	
-#line 2503 "src/libre/dialect/native/parser.c"
+#line 2521 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
 	}
@@ -2518,21 +2536,21 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 	switch (CURRENT_TERMINAL) {
 	case (TOK_OPENCOUNT):
 		{
+			t_pos ZI265;
 			t_pos ZI266;
-			t_pos ZI267;
 			t_unsigned ZIm;
 
 			/* BEGINNING OF EXTRACT: OPENCOUNT */
 			{
 #line 389 "src/libre/parser.act"
 
-		ZI266 = lex_state->lx.start;
-		ZI267   = lex_state->lx.end;
+		ZI265 = lex_state->lx.start;
+		ZI266   = lex_state->lx.end;
 
+		(void) ZI265;
 		(void) ZI266;
-		(void) ZI267;
 	
-#line 2536 "src/libre/dialect/native/parser.c"
+#line 2554 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF EXTRACT: OPENCOUNT */
 			ADVANCE_LEXER;
@@ -2560,7 +2578,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		ZIm = (unsigned int) u;
 	
-#line 2564 "src/libre/dialect/native/parser.c"
+#line 2582 "src/libre/dialect/native/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -2568,7 +2586,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 				goto ZL1;
 			}
 			ADVANCE_LEXER;
-			p_268 (flags, lex_state, act_state, err, &ZI266, &ZIm, &ZIc);
+			p_267 (flags, lex_state, act_state, err, &ZI265, &ZIm, &ZIc);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -2584,7 +2602,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		(ZIc) = ast_make_count(0, NULL, 1, NULL);
 	
-#line 2588 "src/libre/dialect/native/parser.c"
+#line 2606 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-one */
 		}
@@ -2598,7 +2616,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		(ZIc) = ast_make_count(1, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 2602 "src/libre/dialect/native/parser.c"
+#line 2620 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: count-one-or-more */
 		}
@@ -2612,7 +2630,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 2616 "src/libre/dialect/native/parser.c"
+#line 2634 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 		}
@@ -2625,7 +2643,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 2629 "src/libre/dialect/native/parser.c"
+#line 2647 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: count-one */
 		}
@@ -2645,7 +2663,7 @@ ZL1:;
 		}
 		goto ZL2;
 	
-#line 2649 "src/libre/dialect/native/parser.c"
+#line 2667 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: err-expected-count */
 		/* BEGINNING OF ACTION: count-one */
@@ -2654,7 +2672,7 @@ ZL1:;
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 2658 "src/libre/dialect/native/parser.c"
+#line 2676 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: count-one */
 	}
@@ -2684,7 +2702,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 		/* TODO: or the unicode equivalent */
 		(ZIa) = (*flags & RE_SINGLE) ? &class_any : &class_notnl;
 	
-#line 2688 "src/libre/dialect/native/parser.c"
+#line 2706 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
@@ -2696,7 +2714,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 2700 "src/libre/dialect/native/parser.c"
+#line 2718 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 		}
@@ -2713,7 +2731,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 2717 "src/libre/dialect/native/parser.c"
+#line 2735 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-end */
 		}
@@ -2730,7 +2748,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 
 		(ZIid) = act_state->group_id++;
 	
-#line 2734 "src/libre/dialect/native/parser.c"
+#line 2752 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: make-group-id */
 			p_expr (flags, lex_state, act_state, err, &ZIg);
@@ -2747,7 +2765,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 2751 "src/libre/dialect/native/parser.c"
+#line 2769 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-group */
 			switch (CURRENT_TERMINAL) {
@@ -2771,7 +2789,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 2775 "src/libre/dialect/native/parser.c"
+#line 2793 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-start */
 		}
@@ -2811,7 +2829,7 @@ ZL1:;
 		}
 		goto ZL2;
 	
-#line 2815 "src/libre/dialect/native/parser.c"
+#line 2833 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-empty */
@@ -2823,7 +2841,7 @@ ZL1:;
 			goto ZL2;
 		}
 	
-#line 2827 "src/libre/dialect/native/parser.c"
+#line 2845 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -2836,7 +2854,7 @@ ZL0:;
 }
 
 static void
-p_249(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class__id *ZI246, t_pos *ZI247, t_ast__expr *ZOnode)
+p_248(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class__id *ZI245, t_pos *ZI246, t_ast__expr *ZOnode)
 {
 	t_ast__expr ZInode;
 
@@ -2847,12 +2865,12 @@ p_249(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 			{
 #line 1071 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_named(act_state->poolp, *flags, (*ZI246));
+		(ZInode) = ast_make_expr_named(act_state->poolp, *flags, (*ZI245));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2856 "src/libre/dialect/native/parser.c"
+#line 2874 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 		}
@@ -2868,9 +2886,9 @@ p_249(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 #line 878 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_NAMED;
-		(ZIlower).u.named.class = (*ZI246);
+		(ZIlower).u.named.class = (*ZI245);
 	
-#line 2874 "src/libre/dialect/native/parser.c"
+#line 2892 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-class */
 			p_155 (flags, lex_state, act_state, err);
@@ -2883,10 +2901,10 @@ p_249(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 			{
 #line 786 "src/libre/parser.act"
 
-		mark(&act_state->rangestart, &(*ZI247));
+		mark(&act_state->rangestart, &(*ZI246));
 		mark(&act_state->rangeend,   &(ZIend));
 	
-#line 2890 "src/libre/dialect/native/parser.c"
+#line 2908 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-make-range */
@@ -2896,7 +2914,7 @@ p_249(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI247));
+		AST_POS_OF_LX_POS(ast_start, (*ZI246));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		if ((ZIlower).type != AST_ENDPOINT_LITERAL ||
@@ -2924,7 +2942,7 @@ p_249(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 			goto ZL1;
 		}
 	
-#line 2928 "src/libre/dialect/native/parser.c"
+#line 2946 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -2958,7 +2976,7 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 			goto ZL1;
 		}
 	
-#line 2962 "src/libre/dialect/native/parser.c"
+#line 2980 "src/libre/dialect/native/parser.c"
 		}
 		/* END OF ACTION: ast-make-concat */
 		p_expr_C_Clist_Hof_Hpieces (flags, lex_state, act_state, err, ZInode);
@@ -2976,7 +2994,7 @@ ZL0:;
 }
 
 static void
-p_253(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI250, t_pos *ZI251, t_ast__expr *ZOnode)
+p_252(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI249, t_pos *ZI250, t_ast__expr *ZOnode)
 {
 	t_ast__expr ZInode;
 
@@ -2987,12 +3005,12 @@ p_253(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			{
 #line 908 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (*ZI250));
+		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (*ZI249));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 2996 "src/libre/dialect/native/parser.c"
+#line 3014 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -3008,9 +3026,9 @@ p_253(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 #line 873 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_LITERAL;
-		(ZIlower).u.literal.c = (unsigned char)(*ZI250);
+		(ZIlower).u.literal.c = (unsigned char)(*ZI249);
 	
-#line 3014 "src/libre/dialect/native/parser.c"
+#line 3032 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			p_155 (flags, lex_state, act_state, err);
@@ -3023,10 +3041,10 @@ p_253(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			{
 #line 786 "src/libre/parser.act"
 
-		mark(&act_state->rangestart, &(*ZI251));
+		mark(&act_state->rangestart, &(*ZI250));
 		mark(&act_state->rangeend,   &(ZIend));
 	
-#line 3030 "src/libre/dialect/native/parser.c"
+#line 3048 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-make-range */
@@ -3036,7 +3054,7 @@ p_253(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI251));
+		AST_POS_OF_LX_POS(ast_start, (*ZI250));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		if ((ZIlower).type != AST_ENDPOINT_LITERAL ||
@@ -3064,7 +3082,7 @@ p_253(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			goto ZL1;
 		}
 	
-#line 3068 "src/libre/dialect/native/parser.c"
+#line 3086 "src/libre/dialect/native/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -3240,6 +3258,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 3244 "src/libre/dialect/native/parser.c"
+#line 3262 "src/libre/dialect/native/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/native/parser.sid
+++ b/src/libre/dialect/native/parser.sid
@@ -466,9 +466,9 @@
 	};
 
 	re_native: () -> (node :ast_expr) = {
-		{
-			node = expr;
-		};
+		id = <make-group-id>;
+		e = expr;
+		node = <ast-make-group>(e, id);
 
 		{
 			EOF;

--- a/src/libre/dialect/pcre/parser.c
+++ b/src/libre/dialect/pcre/parser.c
@@ -301,7 +301,7 @@ static void p_expr_C_Cflags_C_Cflag__set(flags, lex_state, act_state, err, t_re_
 static void p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hliteral(flags, lex_state, act_state, err, t_endpoint *, t_pos *, t_pos *);
 static void p_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms(flags, lex_state, act_state, err, t_ast__expr);
 static void p_expr_C_Clist_Hof_Hpieces(flags, lex_state, act_state, err, t_ast__expr);
-static void p_296(flags, lex_state, act_state, err, t_ast__class__id *, t_pos *, t_ast__expr *);
+static void p_295(flags, lex_state, act_state, err, t_ast__class__id *, t_pos *, t_ast__expr *);
 static void p_169(flags, lex_state, act_state, err);
 static void p_expr_C_Cliteral(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags, lex_state, act_state, err, t_ast__expr *);
@@ -309,12 +309,12 @@ static void p_expr_C_Ccomment(flags, lex_state, act_state, err);
 static void p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_C_Crange_Hendpoint_Hclass(flags, lex_state, act_state, err, t_endpoint *, t_pos *, t_pos *);
 static void p_expr_C_Ccharacter_Hclass(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_Hend(flags, lex_state, act_state, err, t_endpoint *, t_pos *);
+static void p_319(flags, lex_state, act_state, err, t_char *, t_pos *, t_ast__expr *);
 static void p_expr_C_Cpiece(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_320(flags, lex_state, act_state, err, t_char *, t_pos *, t_ast__expr *);
 static void p_expr(flags, lex_state, act_state, err, t_ast__expr *);
+static void p_322(flags, lex_state, act_state, err, t_pos *, t_unsigned *, t_ast__count *);
 static void p_195(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_323(flags, lex_state, act_state, err, t_pos *, t_unsigned *, t_ast__count *);
-static void p_324(flags, lex_state, act_state, err, t_pos *, t_unsigned *, t_ast__count *);
 static void p_expr_C_Cflags(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Cpiece_C_Clist_Hof_Hcounts(flags, lex_state, act_state, err, t_ast__expr, t_ast__expr *);
 static void p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint(flags, lex_state, act_state, err, t_endpoint *, t_pos *, t_pos *);
@@ -879,7 +879,7 @@ ZL1:;
 }
 
 static void
-p_296(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class__id *ZI293, t_pos *ZI294, t_ast__expr *ZOnode)
+p_295(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__class__id *ZI292, t_pos *ZI293, t_ast__expr *ZOnode)
 {
 	t_ast__expr ZInode;
 
@@ -890,7 +890,7 @@ p_296(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 			{
 #line 1071 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_named(act_state->poolp, *flags, (*ZI293));
+		(ZInode) = ast_make_expr_named(act_state->poolp, *flags, (*ZI292));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
@@ -911,7 +911,7 @@ p_296(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 #line 878 "src/libre/parser.act"
 
 		(ZIlower).type = AST_ENDPOINT_NAMED;
-		(ZIlower).u.named.class = (*ZI293);
+		(ZIlower).u.named.class = (*ZI292);
 	
 #line 917 "src/libre/dialect/pcre/parser.c"
 			}
@@ -926,7 +926,7 @@ p_296(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 			{
 #line 786 "src/libre/parser.act"
 
-		mark(&act_state->rangestart, &(*ZI294));
+		mark(&act_state->rangestart, &(*ZI293));
 		mark(&act_state->rangeend,   &(ZIend));
 	
 #line 933 "src/libre/dialect/pcre/parser.c"
@@ -939,7 +939,7 @@ p_296(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__cla
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI294));
+		AST_POS_OF_LX_POS(ast_start, (*ZI293));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		if ((ZIlower).type != AST_ENDPOINT_LITERAL ||
@@ -1388,9 +1388,9 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CHAR):
 		{
-			t_char ZI309;
+			t_char ZI308;
+			t_pos ZI309;
 			t_pos ZI310;
-			t_pos ZI311;
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
@@ -1399,19 +1399,19 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI310 = lex_state->lx.start;
-		ZI311   = lex_state->lx.end;
+		ZI309 = lex_state->lx.start;
+		ZI310   = lex_state->lx.end;
 
+		(void) ZI309;
 		(void) ZI310;
-		(void) ZI311;
 
-		ZI309 = lex_state->buf.a[0];
+		ZI308 = lex_state->buf.a[0];
 	
 #line 1411 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
-			p_320 (flags, lex_state, act_state, err, &ZI309, &ZI310, &ZInode);
+			p_319 (flags, lex_state, act_state, err, &ZI308, &ZI309, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1420,9 +1420,9 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		break;
 	case (TOK_CONTROL):
 		{
-			t_char ZI313;
+			t_char ZI312;
+			t_pos ZI313;
 			t_pos ZI314;
-			t_pos ZI315;
 
 			/* BEGINNING OF EXTRACT: CONTROL */
 			{
@@ -1433,7 +1433,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		assert(lex_state->buf.a[2] != '\0');
 		assert(lex_state->buf.a[3] == '\0');
 
-		ZI313 = lex_state->buf.a[2];
+		ZI312 = lex_state->buf.a[2];
 		/* from http://www.pcre.org/current/doc/html/pcre2pattern.html#SEC5
 		 * 
 		 *  The precise effect of \cx on ASCII characters is as follows: if x is a lower case letter, it is converted to
@@ -1443,7 +1443,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		 */
 
 		{
-			unsigned char cc = (unsigned char)ZI313;
+			unsigned char cc = (unsigned char)ZI312;
 			if (cc > 126 || cc < 32) {
 				goto ZL1;
 			}
@@ -1454,14 +1454,14 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 			cc ^= 0x40;
 
-			ZI313 = cc;
+			ZI312 = cc;
 		}
 
-		ZI314 = lex_state->lx.start;
-		ZI315   = lex_state->lx.end;
+		ZI313 = lex_state->lx.start;
+		ZI314   = lex_state->lx.end;
 
+		(void) ZI313;
 		(void) ZI314;
-		(void) ZI315;
 	
 #line 1467 "src/libre/dialect/pcre/parser.c"
 			}
@@ -1479,7 +1479,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 #line 1480 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: err-unsupported */
-			p_320 (flags, lex_state, act_state, err, &ZI313, &ZI314, &ZInode);
+			p_319 (flags, lex_state, act_state, err, &ZI312, &ZI313, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1488,9 +1488,9 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		break;
 	case (TOK_ESC):
 		{
-			t_char ZI297;
+			t_char ZI296;
+			t_pos ZI297;
 			t_pos ZI298;
-			t_pos ZI299;
 
 			/* BEGINNING OF EXTRACT: ESC */
 			{
@@ -1500,31 +1500,31 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		assert(lex_state->buf.a[1] != '\0');
 		assert(lex_state->buf.a[2] == '\0');
 
-		ZI297 = lex_state->buf.a[1];
+		ZI296 = lex_state->buf.a[1];
 
-		switch (ZI297) {
-		case 'a': ZI297 = '\a'; break;
-		case 'b': ZI297 = '\b'; break;
-		case 'e': ZI297 = '\033'; break;
-		case 'f': ZI297 = '\f'; break;
-		case 'n': ZI297 = '\n'; break;
-		case 'r': ZI297 = '\r'; break;
-		case 't': ZI297 = '\t'; break;
-		case 'v': ZI297 = '\v'; break;
+		switch (ZI296) {
+		case 'a': ZI296 = '\a'; break;
+		case 'b': ZI296 = '\b'; break;
+		case 'e': ZI296 = '\033'; break;
+		case 'f': ZI296 = '\f'; break;
+		case 'n': ZI296 = '\n'; break;
+		case 'r': ZI296 = '\r'; break;
+		case 't': ZI296 = '\t'; break;
+		case 'v': ZI296 = '\v'; break;
 		default:             break;
 		}
 
-		ZI298 = lex_state->lx.start;
-		ZI299   = lex_state->lx.end;
+		ZI297 = lex_state->lx.start;
+		ZI298   = lex_state->lx.end;
 
+		(void) ZI297;
 		(void) ZI298;
-		(void) ZI299;
 	
 #line 1524 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: ESC */
 			ADVANCE_LEXER;
-			p_320 (flags, lex_state, act_state, err, &ZI297, &ZI298, &ZInode);
+			p_319 (flags, lex_state, act_state, err, &ZI296, &ZI297, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1533,9 +1533,9 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		break;
 	case (TOK_HEX):
 		{
-			t_char ZI305;
+			t_char ZI304;
+			t_pos ZI305;
 			t_pos ZI306;
-			t_pos ZI307;
 
 			/* BEGINNING OF EXTRACT: HEX */
 			{
@@ -1548,11 +1548,11 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		assert(0 == strncmp(lex_state->buf.a, "\\x", 2));
 		assert(strlen(lex_state->buf.a) >= 2);  /* pcre allows \x without a suffix */
 
-		ZI306 = lex_state->lx.start;
-		ZI307   = lex_state->lx.end;
+		ZI305 = lex_state->lx.start;
+		ZI306   = lex_state->lx.end;
 
+		(void) ZI305;
 		(void) ZI306;
-		(void) ZI307;
 
 		errno = 0;
 
@@ -1585,13 +1585,13 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 			goto ZL1;
 		}
 
-		ZI305 = (char) (unsigned char) u;
+		ZI304 = (char) (unsigned char) u;
 	
 #line 1591 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: HEX */
 			ADVANCE_LEXER;
-			p_320 (flags, lex_state, act_state, err, &ZI305, &ZI306, &ZInode);
+			p_319 (flags, lex_state, act_state, err, &ZI304, &ZI305, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1600,31 +1600,31 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		break;
 	case (TOK_NAMED__CLASS):
 		{
-			t_ast__class__id ZI293;
+			t_ast__class__id ZI292;
+			t_pos ZI293;
 			t_pos ZI294;
-			t_pos ZI295;
 
 			/* BEGINNING OF EXTRACT: NAMED_CLASS */
 			{
 #line 661 "src/libre/parser.act"
 
-		ZI293 = DIALECT_CLASS(lex_state->buf.a);
-		if (ZI293 == NULL) {
+		ZI292 = DIALECT_CLASS(lex_state->buf.a);
+		if (ZI292 == NULL) {
 			/* syntax error -- unrecognized class */
 			goto ZL1;
 		}
 
-		ZI294 = lex_state->lx.start;
-		ZI295   = lex_state->lx.end;
+		ZI293 = lex_state->lx.start;
+		ZI294   = lex_state->lx.end;
 
+		(void) ZI293;
 		(void) ZI294;
-		(void) ZI295;
 	
 #line 1624 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			ADVANCE_LEXER;
-			p_296 (flags, lex_state, act_state, err, &ZI293, &ZI294, &ZInode);
+			p_295 (flags, lex_state, act_state, err, &ZI292, &ZI293, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1673,9 +1673,9 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		break;
 	case (TOK_OCT):
 		{
-			t_char ZI301;
+			t_char ZI300;
+			t_pos ZI301;
 			t_pos ZI302;
-			t_pos ZI303;
 
 			/* BEGINNING OF EXTRACT: OCT */
 			{
@@ -1688,11 +1688,11 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		assert(0 == strncmp(lex_state->buf.a, "\\", 1));
 		assert(strlen(lex_state->buf.a) >= 2);
 
-		ZI302 = lex_state->lx.start;
-		ZI303   = lex_state->lx.end;
+		ZI301 = lex_state->lx.start;
+		ZI302   = lex_state->lx.end;
 
+		(void) ZI301;
 		(void) ZI302;
-		(void) ZI303;
 
 		errno = 0;
 
@@ -1720,13 +1720,13 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 			goto ZL1;
 		}
 
-		ZI301 = (char) (unsigned char) u;
+		ZI300 = (char) (unsigned char) u;
 	
 #line 1726 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: OCT */
 			ADVANCE_LEXER;
-			p_320 (flags, lex_state, act_state, err, &ZI301, &ZI302, &ZInode);
+			p_319 (flags, lex_state, act_state, err, &ZI300, &ZI301, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1735,9 +1735,9 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		break;
 	case (TOK_UNSUPPORTED):
 		{
-			t_char ZI317;
+			t_char ZI316;
+			t_pos ZI317;
 			t_pos ZI318;
-			t_pos ZI319;
 
 			/* BEGINNING OF EXTRACT: UNSUPPORTED */
 			{
@@ -1745,17 +1745,17 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 
 		/* handle \1-\9 back references */
 		if (lex_state->buf.a[0] == '\\' && lex_state->buf.a[1] != '\0' && lex_state->buf.a[2] == '\0') {
-			ZI317 = lex_state->buf.a[1];
+			ZI316 = lex_state->buf.a[1];
 		}
 		else {
-			ZI317 = lex_state->buf.a[0];
+			ZI316 = lex_state->buf.a[0];
 		}
 
-		ZI318 = lex_state->lx.start;
-		ZI319   = lex_state->lx.end;
+		ZI317 = lex_state->lx.start;
+		ZI318   = lex_state->lx.end;
 
+		(void) ZI317;
 		(void) ZI318;
-		(void) ZI319;
 	
 #line 1761 "src/libre/dialect/pcre/parser.c"
 			}
@@ -1773,7 +1773,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 #line 1774 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: err-unsupported */
-			p_320 (flags, lex_state, act_state, err, &ZI317, &ZI318, &ZInode);
+			p_319 (flags, lex_state, act_state, err, &ZI316, &ZI317, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -2420,6 +2420,111 @@ ZL0:;
 }
 
 static void
+p_319(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI316, t_pos *ZI317, t_ast__expr *ZOnode)
+{
+	t_ast__expr ZInode;
+
+	switch (CURRENT_TERMINAL) {
+	default:
+		{
+			/* BEGINNING OF ACTION: ast-make-literal */
+			{
+#line 908 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (*ZI316));
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 2440 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: ast-make-literal */
+		}
+		break;
+	case (TOK_RANGE):
+		{
+			t_endpoint ZIlower;
+			t_endpoint ZIupper;
+			t_pos ZIend;
+
+			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
+			{
+#line 873 "src/libre/parser.act"
+
+		(ZIlower).type = AST_ENDPOINT_LITERAL;
+		(ZIlower).u.literal.c = (unsigned char)(*ZI316);
+	
+#line 2458 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: ast-range-endpoint-literal */
+			p_169 (flags, lex_state, act_state, err);
+			p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_Hend (flags, lex_state, act_state, err, &ZIupper, &ZIend);
+			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+				RESTORE_LEXER;
+				goto ZL1;
+			}
+			/* BEGINNING OF ACTION: mark-range */
+			{
+#line 786 "src/libre/parser.act"
+
+		mark(&act_state->rangestart, &(*ZI317));
+		mark(&act_state->rangeend,   &(ZIend));
+	
+#line 2474 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: mark-range */
+			/* BEGINNING OF ACTION: ast-make-range */
+			{
+#line 1038 "src/libre/parser.act"
+
+		struct ast_pos ast_start, ast_end;
+		unsigned char lower, upper;
+
+		AST_POS_OF_LX_POS(ast_start, (*ZI317));
+		AST_POS_OF_LX_POS(ast_end, (ZIend));
+
+		if ((ZIlower).type != AST_ENDPOINT_LITERAL ||
+			(ZIupper).type != AST_ENDPOINT_LITERAL) {
+			err->e = RE_EUNSUPPORTED;
+			goto ZL1;
+		}
+
+		lower = (ZIlower).u.literal.c;
+		upper = (ZIupper).u.literal.c;
+
+		if (lower > upper) {
+			char a[5], b[5];
+			
+			assert(sizeof err->set >= 1 + sizeof a + 1 + sizeof b + 1 + 1);
+			
+			sprintf(err->set, "%s-%s",
+				escchar(a, sizeof a, lower), escchar(b, sizeof b, upper));
+			err->e = RE_ENEGRANGE;
+			goto ZL1;
+		}
+
+		(ZInode) = ast_make_expr_range(act_state->poolp, *flags, &(ZIlower), ast_start, &(ZIupper), ast_end);
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 2512 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: ast-make-range */
+		}
+		break;
+	case (ERROR_TERMINAL):
+		return;
+	}
+	goto ZL0;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+ZL0:;
+	*ZOnode = ZInode;
+}
+
+static void
 p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZOnode)
 {
 	t_ast__expr ZInode;
@@ -2453,7 +2558,7 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 2457 "src/libre/dialect/pcre/parser.c"
+#line 2562 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: count-one */
 					/* BEGINNING OF ACTION: ast-make-piece */
@@ -2472,7 +2577,7 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 			goto ZL1;
 		}
 	
-#line 2476 "src/libre/dialect/pcre/parser.c"
+#line 2581 "src/libre/dialect/pcre/parser.c"
 					}
 					/* END OF ACTION: ast-make-piece */
 				}
@@ -2483,111 +2588,6 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 			}
 		}
 		/* END OF INLINE: 267 */
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOnode = ZInode;
-}
-
-static void
-p_320(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI317, t_pos *ZI318, t_ast__expr *ZOnode)
-{
-	t_ast__expr ZInode;
-
-	switch (CURRENT_TERMINAL) {
-	default:
-		{
-			/* BEGINNING OF ACTION: ast-make-literal */
-			{
-#line 908 "src/libre/parser.act"
-
-		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (*ZI317));
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 2513 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: ast-make-literal */
-		}
-		break;
-	case (TOK_RANGE):
-		{
-			t_endpoint ZIlower;
-			t_endpoint ZIupper;
-			t_pos ZIend;
-
-			/* BEGINNING OF ACTION: ast-range-endpoint-literal */
-			{
-#line 873 "src/libre/parser.act"
-
-		(ZIlower).type = AST_ENDPOINT_LITERAL;
-		(ZIlower).u.literal.c = (unsigned char)(*ZI317);
-	
-#line 2531 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: ast-range-endpoint-literal */
-			p_169 (flags, lex_state, act_state, err);
-			p_expr_C_Ccharacter_Hclass_C_Crange_Hendpoint_Hend (flags, lex_state, act_state, err, &ZIupper, &ZIend);
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-			/* BEGINNING OF ACTION: mark-range */
-			{
-#line 786 "src/libre/parser.act"
-
-		mark(&act_state->rangestart, &(*ZI318));
-		mark(&act_state->rangeend,   &(ZIend));
-	
-#line 2547 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: mark-range */
-			/* BEGINNING OF ACTION: ast-make-range */
-			{
-#line 1038 "src/libre/parser.act"
-
-		struct ast_pos ast_start, ast_end;
-		unsigned char lower, upper;
-
-		AST_POS_OF_LX_POS(ast_start, (*ZI318));
-		AST_POS_OF_LX_POS(ast_end, (ZIend));
-
-		if ((ZIlower).type != AST_ENDPOINT_LITERAL ||
-			(ZIupper).type != AST_ENDPOINT_LITERAL) {
-			err->e = RE_EUNSUPPORTED;
-			goto ZL1;
-		}
-
-		lower = (ZIlower).u.literal.c;
-		upper = (ZIupper).u.literal.c;
-
-		if (lower > upper) {
-			char a[5], b[5];
-			
-			assert(sizeof err->set >= 1 + sizeof a + 1 + sizeof b + 1 + 1);
-			
-			sprintf(err->set, "%s-%s",
-				escchar(a, sizeof a, lower), escchar(b, sizeof b, upper));
-			err->e = RE_ENEGRANGE;
-			goto ZL1;
-		}
-
-		(ZInode) = ast_make_expr_range(act_state->poolp, *flags, &(ZIlower), ast_start, &(ZIupper), ast_end);
-		if ((ZInode) == NULL) {
-			goto ZL1;
-		}
-	
-#line 2585 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: ast-make-range */
-		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
 	}
 	goto ZL0;
 ZL1:;
@@ -2661,6 +2661,91 @@ ZL0:;
 }
 
 static void
+p_322(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI320, t_unsigned *ZIm, t_ast__count *ZOc)
+{
+	t_ast__count ZIc;
+
+	switch (CURRENT_TERMINAL) {
+	case (TOK_CLOSECOUNT):
+		{
+			t_pos ZI258;
+			t_pos ZIend;
+
+			/* BEGINNING OF EXTRACT: CLOSECOUNT */
+			{
+#line 397 "src/libre/parser.act"
+
+		ZI258 = lex_state->lx.start;
+		ZIend   = lex_state->lx.end;
+
+		(void) ZI258;
+		(void) ZIend;
+	
+#line 2685 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF EXTRACT: CLOSECOUNT */
+			ADVANCE_LEXER;
+			/* BEGINNING OF ACTION: mark-count */
+			{
+#line 791 "src/libre/parser.act"
+
+		mark(&act_state->countstart, &(*ZI320));
+		mark(&act_state->countend,   &(ZIend));
+	
+#line 2696 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: mark-count */
+			/* BEGINNING OF ACTION: count-range */
+			{
+#line 853 "src/libre/parser.act"
+
+		struct ast_pos ast_start, ast_end;
+
+		if ((*ZIm) < (*ZIm)) {
+			err->e = RE_ENEGCOUNT;
+			err->m = (*ZIm);
+			err->n = (*ZIm);
+
+			mark(&act_state->countstart, &(*ZI320));
+			mark(&act_state->countend,   &(ZIend));
+
+			goto ZL1;
+		}
+
+		AST_POS_OF_LX_POS(ast_start, (*ZI320));
+		AST_POS_OF_LX_POS(ast_end, (ZIend));
+
+		(ZIc) = ast_make_count((*ZIm), &ast_start, (*ZIm), &ast_end);
+	
+#line 2721 "src/libre/dialect/pcre/parser.c"
+			}
+			/* END OF ACTION: count-range */
+		}
+		break;
+	case (TOK_SEP):
+		{
+			ADVANCE_LEXER;
+			p_323 (flags, lex_state, act_state, err, ZI320, ZIm, &ZIc);
+			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+				RESTORE_LEXER;
+				goto ZL1;
+			}
+		}
+		break;
+	case (ERROR_TERMINAL):
+		return;
+	default:
+		goto ZL1;
+	}
+	goto ZL0;
+ZL1:;
+	SAVE_LEXER ((ERROR_TERMINAL));
+	return;
+ZL0:;
+	*ZOc = ZIc;
+}
+
+static void
 p_195(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZItmp)
 {
 	switch (CURRENT_TERMINAL) {
@@ -2683,7 +2768,7 @@ p_195(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 		(void) ZIrstart;
 		(void) ZI196;
 	
-#line 2687 "src/libre/dialect/pcre/parser.c"
+#line 2772 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
@@ -2701,7 +2786,7 @@ p_195(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			goto ZL1;
 		}
 	
-#line 2705 "src/libre/dialect/pcre/parser.c"
+#line 2790 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF ACTION: ast-make-literal */
 					}
@@ -2722,7 +2807,7 @@ p_195(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 		(ZIlower).type = AST_ENDPOINT_LITERAL;
 		(ZIlower).u.literal.c = (unsigned char)(ZIc);
 	
-#line 2726 "src/libre/dialect/pcre/parser.c"
+#line 2811 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF ACTION: ast-range-endpoint-literal */
 						/* BEGINNING OF EXTRACT: RANGE */
@@ -2737,7 +2822,7 @@ p_195(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 		(void) ZI199;
 		(void) ZI200;
 	
-#line 2741 "src/libre/dialect/pcre/parser.c"
+#line 2826 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF EXTRACT: RANGE */
 						ADVANCE_LEXER;
@@ -2781,7 +2866,7 @@ p_195(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			goto ZL1;
 		}
 	
-#line 2785 "src/libre/dialect/pcre/parser.c"
+#line 2870 "src/libre/dialect/pcre/parser.c"
 						}
 						/* END OF ACTION: ast-make-range */
 					}
@@ -2797,7 +2882,7 @@ p_195(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			goto ZL1;
 		}
 	
-#line 2801 "src/libre/dialect/pcre/parser.c"
+#line 2886 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 		}
@@ -2814,92 +2899,7 @@ ZL1:;
 }
 
 static void
-p_323(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI321, t_unsigned *ZIm, t_ast__count *ZOc)
-{
-	t_ast__count ZIc;
-
-	switch (CURRENT_TERMINAL) {
-	case (TOK_CLOSECOUNT):
-		{
-			t_pos ZI258;
-			t_pos ZIend;
-
-			/* BEGINNING OF EXTRACT: CLOSECOUNT */
-			{
-#line 397 "src/libre/parser.act"
-
-		ZI258 = lex_state->lx.start;
-		ZIend   = lex_state->lx.end;
-
-		(void) ZI258;
-		(void) ZIend;
-	
-#line 2838 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF EXTRACT: CLOSECOUNT */
-			ADVANCE_LEXER;
-			/* BEGINNING OF ACTION: mark-count */
-			{
-#line 791 "src/libre/parser.act"
-
-		mark(&act_state->countstart, &(*ZI321));
-		mark(&act_state->countend,   &(ZIend));
-	
-#line 2849 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: mark-count */
-			/* BEGINNING OF ACTION: count-range */
-			{
-#line 853 "src/libre/parser.act"
-
-		struct ast_pos ast_start, ast_end;
-
-		if ((*ZIm) < (*ZIm)) {
-			err->e = RE_ENEGCOUNT;
-			err->m = (*ZIm);
-			err->n = (*ZIm);
-
-			mark(&act_state->countstart, &(*ZI321));
-			mark(&act_state->countend,   &(ZIend));
-
-			goto ZL1;
-		}
-
-		AST_POS_OF_LX_POS(ast_start, (*ZI321));
-		AST_POS_OF_LX_POS(ast_end, (ZIend));
-
-		(ZIc) = ast_make_count((*ZIm), &ast_start, (*ZIm), &ast_end);
-	
-#line 2874 "src/libre/dialect/pcre/parser.c"
-			}
-			/* END OF ACTION: count-range */
-		}
-		break;
-	case (TOK_SEP):
-		{
-			ADVANCE_LEXER;
-			p_324 (flags, lex_state, act_state, err, ZI321, ZIm, &ZIc);
-			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-				RESTORE_LEXER;
-				goto ZL1;
-			}
-		}
-		break;
-	case (ERROR_TERMINAL):
-		return;
-	default:
-		goto ZL1;
-	}
-	goto ZL0;
-ZL1:;
-	SAVE_LEXER ((ERROR_TERMINAL));
-	return;
-ZL0:;
-	*ZOc = ZIc;
-}
-
-static void
-p_324(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI321, t_unsigned *ZIm, t_ast__count *ZOc)
+p_323(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI320, t_unsigned *ZIm, t_ast__count *ZOc)
 {
 	t_ast__count ZIc;
 
@@ -2928,7 +2928,7 @@ p_324(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI3
 			{
 #line 791 "src/libre/parser.act"
 
-		mark(&act_state->countstart, &(*ZI321));
+		mark(&act_state->countstart, &(*ZI320));
 		mark(&act_state->countend,   &(ZIend));
 	
 #line 2935 "src/libre/dialect/pcre/parser.c"
@@ -2954,13 +2954,13 @@ p_324(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI3
 			err->m = (*ZIm);
 			err->n = (ZIn);
 
-			mark(&act_state->countstart, &(*ZI321));
+			mark(&act_state->countstart, &(*ZI320));
 			mark(&act_state->countend,   &(ZIend));
 
 			goto ZL1;
 		}
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI321));
+		AST_POS_OF_LX_POS(ast_start, (*ZI320));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (ZIn), &ast_end);
@@ -3026,7 +3026,7 @@ p_324(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI3
 			{
 #line 791 "src/libre/parser.act"
 
-		mark(&act_state->countstart, &(*ZI321));
+		mark(&act_state->countstart, &(*ZI320));
 		mark(&act_state->countend,   &(ZIend));
 	
 #line 3033 "src/libre/dialect/pcre/parser.c"
@@ -3043,13 +3043,13 @@ p_324(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI3
 			err->m = (*ZIm);
 			err->n = (ZIn);
 
-			mark(&act_state->countstart, &(*ZI321));
+			mark(&act_state->countstart, &(*ZI320));
 			mark(&act_state->countend,   &(ZIend));
 
 			goto ZL1;
 		}
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI321));
+		AST_POS_OF_LX_POS(ast_start, (*ZI320));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (ZIn), &ast_end);
@@ -3678,19 +3678,19 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 	switch (CURRENT_TERMINAL) {
 	case (TOK_OPENCOUNT):
 		{
+			t_pos ZI320;
 			t_pos ZI321;
-			t_pos ZI322;
 			t_unsigned ZIm;
 
 			/* BEGINNING OF EXTRACT: OPENCOUNT */
 			{
 #line 389 "src/libre/parser.act"
 
-		ZI321 = lex_state->lx.start;
-		ZI322   = lex_state->lx.end;
+		ZI320 = lex_state->lx.start;
+		ZI321   = lex_state->lx.end;
 
+		(void) ZI320;
 		(void) ZI321;
-		(void) ZI322;
 	
 #line 3696 "src/libre/dialect/pcre/parser.c"
 			}
@@ -3728,7 +3728,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 				goto ZL1;
 			}
 			ADVANCE_LEXER;
-			p_323 (flags, lex_state, act_state, err, &ZI321, &ZIm, &ZIc);
+			p_322 (flags, lex_state, act_state, err, &ZI320, &ZIm, &ZIc);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -3824,28 +3824,25 @@ p_re__pcre(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 282 */
-		{
-			{
-				t_group__id ZIid;
-				t_ast__expr ZIe;
+		t_group__id ZIid;
+		t_ast__expr ZIe;
 
-				/* BEGINNING OF ACTION: make-group-id */
-				{
+		/* BEGINNING OF ACTION: make-group-id */
+		{
 #line 915 "src/libre/parser.act"
 
 		(ZIid) = act_state->group_id++;
 	
-#line 3840 "src/libre/dialect/pcre/parser.c"
-				}
-				/* END OF ACTION: make-group-id */
-				p_expr (flags, lex_state, act_state, err, &ZIe);
-				if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-					RESTORE_LEXER;
-					goto ZL1;
-				}
-				/* BEGINNING OF ACTION: ast-make-group */
-				{
+#line 3837 "src/libre/dialect/pcre/parser.c"
+		}
+		/* END OF ACTION: make-group-id */
+		p_expr (flags, lex_state, act_state, err, &ZIe);
+		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+			RESTORE_LEXER;
+			goto ZL1;
+		}
+		/* BEGINNING OF ACTION: ast-make-group */
+		{
 #line 945 "src/libre/parser.act"
 
 		(ZInode) = ast_make_expr_group(act_state->poolp, *flags, (ZIe), (ZIid));
@@ -3853,25 +3850,22 @@ p_re__pcre(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 			goto ZL1;
 		}
 	
-#line 3857 "src/libre/dialect/pcre/parser.c"
-				}
-				/* END OF ACTION: ast-make-group */
-			}
+#line 3854 "src/libre/dialect/pcre/parser.c"
 		}
-		/* END OF INLINE: 282 */
-		/* BEGINNING OF INLINE: 283 */
+		/* END OF ACTION: ast-make-group */
+		/* BEGINNING OF INLINE: 282 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
 				case (TOK_EOF):
 					break;
 				default:
-					goto ZL4;
+					goto ZL3;
 				}
 				ADVANCE_LEXER;
 			}
-			goto ZL3;
-		ZL4:;
+			goto ZL2;
+		ZL3:;
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
@@ -3882,13 +3876,13 @@ p_re__pcre(flags flags, lex_state lex_state, act_state act_state, err err, t_ast
 		}
 		goto ZL1;
 	
-#line 3886 "src/libre/dialect/pcre/parser.c"
+#line 3880 "src/libre/dialect/pcre/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
-		ZL3:;
+		ZL2:;
 		}
-		/* END OF INLINE: 283 */
+		/* END OF INLINE: 282 */
 	}
 	goto ZL0;
 ZL1:;
@@ -3916,7 +3910,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 		/* TODO: or the unicode equivalent */
 		(ZIa) = (*flags & RE_SINGLE) ? &class_any : &class_notnl;
 	
-#line 3920 "src/libre/dialect/pcre/parser.c"
+#line 3914 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
@@ -3928,7 +3922,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 3932 "src/libre/dialect/pcre/parser.c"
+#line 3926 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 		}
@@ -3945,7 +3939,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 3949 "src/libre/dialect/pcre/parser.c"
+#line 3943 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-end */
 		}
@@ -3965,7 +3959,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			(ZIe)->u.anchor.is_end_nl = 1;
 		}
 	
-#line 3969 "src/libre/dialect/pcre/parser.c"
+#line 3963 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-end-nl */
 		}
@@ -3988,7 +3982,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 		/* TODO: or the unicode equivalent */
 		(ZIclass__bsr) = &class_bsr;
 	
-#line 3992 "src/libre/dialect/pcre/parser.c"
+#line 3986 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: class-bsr */
 			/* BEGINNING OF ACTION: ast-make-named */
@@ -4000,7 +3994,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 4004 "src/libre/dialect/pcre/parser.c"
+#line 3998 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 			/* BEGINNING OF ACTION: ast-make-concat */
@@ -4012,7 +4006,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 4016 "src/libre/dialect/pcre/parser.c"
+#line 4010 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-concat */
 			/* BEGINNING OF ACTION: make-literal-cr */
@@ -4021,7 +4015,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 
 		(ZIcr) = '\r';
 	
-#line 4025 "src/libre/dialect/pcre/parser.c"
+#line 4019 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: make-literal-cr */
 			/* BEGINNING OF ACTION: ast-make-literal */
@@ -4033,7 +4027,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 4037 "src/libre/dialect/pcre/parser.c"
+#line 4031 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 			/* BEGINNING OF ACTION: make-literal-nl */
@@ -4042,7 +4036,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 
 		(ZInl) = '\n';
 	
-#line 4046 "src/libre/dialect/pcre/parser.c"
+#line 4040 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: make-literal-nl */
 			/* BEGINNING OF ACTION: ast-make-literal */
@@ -4054,7 +4048,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 4058 "src/libre/dialect/pcre/parser.c"
+#line 4052 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 			/* BEGINNING OF ACTION: ast-add-concat */
@@ -4065,7 +4059,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 4069 "src/libre/dialect/pcre/parser.c"
+#line 4063 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-concat */
 			/* BEGINNING OF ACTION: ast-add-concat */
@@ -4076,7 +4070,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 4080 "src/libre/dialect/pcre/parser.c"
+#line 4074 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-concat */
 			/* BEGINNING OF ACTION: ast-make-alt */
@@ -4088,7 +4082,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 4092 "src/libre/dialect/pcre/parser.c"
+#line 4086 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-alt */
 			/* BEGINNING OF ACTION: ast-add-alt */
@@ -4099,7 +4093,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 4103 "src/libre/dialect/pcre/parser.c"
+#line 4097 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 			/* BEGINNING OF ACTION: ast-add-alt */
@@ -4110,7 +4104,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 4114 "src/libre/dialect/pcre/parser.c"
+#line 4108 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 		}
@@ -4128,7 +4122,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 
 		(ZIflags) = *flags;
 	
-#line 4132 "src/libre/dialect/pcre/parser.c"
+#line 4126 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-get-re-flags */
 			/* BEGINNING OF ACTION: make-group-id */
@@ -4137,7 +4131,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 
 		(ZIid) = act_state->group_id++;
 	
-#line 4141 "src/libre/dialect/pcre/parser.c"
+#line 4135 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: make-group-id */
 			p_expr (flags, lex_state, act_state, err, &ZIg);
@@ -4151,7 +4145,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 
 		*flags = (ZIflags);
 	
-#line 4155 "src/libre/dialect/pcre/parser.c"
+#line 4149 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-set-re-flags */
 			/* BEGINNING OF ACTION: ast-make-group */
@@ -4163,7 +4157,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 4167 "src/libre/dialect/pcre/parser.c"
+#line 4161 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-group */
 			switch (CURRENT_TERMINAL) {
@@ -4187,7 +4181,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 4191 "src/libre/dialect/pcre/parser.c"
+#line 4185 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-anchor-start */
 		}
@@ -4246,7 +4240,7 @@ ZL1:;
 		}
 		goto ZL2;
 	
-#line 4250 "src/libre/dialect/pcre/parser.c"
+#line 4244 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-empty */
@@ -4258,7 +4252,7 @@ ZL1:;
 			goto ZL2;
 		}
 	
-#line 4262 "src/libre/dialect/pcre/parser.c"
+#line 4256 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -4291,7 +4285,7 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 			goto ZL1;
 		}
 	
-#line 4295 "src/libre/dialect/pcre/parser.c"
+#line 4289 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-concat */
 			p_expr_C_Clist_Hof_Hpieces (flags, lex_state, act_state, err, ZInode);
@@ -4312,7 +4306,7 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 			goto ZL1;
 		}
 	
-#line 4316 "src/libre/dialect/pcre/parser.c"
+#line 4310 "src/libre/dialect/pcre/parser.c"
 			}
 			/* END OF ACTION: ast-make-empty */
 		}
@@ -4355,7 +4349,7 @@ p_expr_C_Ctype(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL1;
 		}
 	
-#line 4359 "src/libre/dialect/pcre/parser.c"
+#line 4353 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-make-alt */
 		/* BEGINNING OF ACTION: ast-add-alt */
@@ -4366,7 +4360,7 @@ p_expr_C_Ctype(flags flags, lex_state lex_state, act_state act_state, err err, t
 			goto ZL1;
 		}
 	
-#line 4370 "src/libre/dialect/pcre/parser.c"
+#line 4364 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: ast-add-alt */
 		/* BEGINNING OF ACTION: mark-expr */
@@ -4386,7 +4380,7 @@ p_expr_C_Ctype(flags flags, lex_state lex_state, act_state act_state, err err, t
 		(ZInode)->u.class.end   = ast_end;
 */
 	
-#line 4390 "src/libre/dialect/pcre/parser.c"
+#line 4384 "src/libre/dialect/pcre/parser.c"
 		}
 		/* END OF ACTION: mark-expr */
 	}
@@ -4558,6 +4552,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 4562 "src/libre/dialect/pcre/parser.c"
+#line 4556 "src/libre/dialect/pcre/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/pcre/parser.sid
+++ b/src/libre/dialect/pcre/parser.sid
@@ -465,7 +465,7 @@
 				e = <ast-make-anchor-end>;
 			||
 				END_NL;
-                                e = <ast-make-anchor-end-nl>;
+				e = <ast-make-anchor-end-nl>;
 			||
 				ANY;
 				a = <class-any>;
@@ -644,11 +644,9 @@
 	};
 
 	re_pcre: () -> (node :ast_expr) = {
-		{
-			id = <make-group-id>;
-			e = expr;
-			node = <ast-make-group>(e, id);
-		};
+		id = <make-group-id>;
+		e = expr;
+		node = <ast-make-group>(e, id);
 
 		{
 			EOF;

--- a/src/libre/dialect/sql/parser.c
+++ b/src/libre/dialect/sql/parser.c
@@ -306,9 +306,9 @@ static void p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags, lex_state, act_stat
 static void p_expr_C_Ccharacter_Hclass(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr_C_Cpiece(flags, lex_state, act_state, err, t_ast__expr *);
 static void p_expr(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_206(flags, lex_state, act_state, err, t_ast__expr *);
-static void p_210(flags, lex_state, act_state, err, t_char *, t_pos *, t_ast__expr *);
-static void p_213(flags, lex_state, act_state, err, t_pos *, t_unsigned *, t_ast__count *);
+static void p_205(flags, lex_state, act_state, err, t_ast__expr *);
+static void p_209(flags, lex_state, act_state, err, t_char *, t_pos *, t_ast__expr *);
+static void p_212(flags, lex_state, act_state, err, t_pos *, t_unsigned *, t_ast__count *);
 static void p_expr_C_Clist_Hof_Halts(flags, lex_state, act_state, err, t_ast__expr);
 static void p_expr_C_Cpiece_C_Ccount(flags, lex_state, act_state, err, t_ast__count *);
 static void p_expr_C_Cpiece_C_Catom(flags, lex_state, act_state, err, t_ast__expr *);
@@ -326,21 +326,21 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hhead(flags flags, lex_state lex_state, act_
 	switch (CURRENT_TERMINAL) {
 	case (TOK_INVERT):
 		{
-			t_char ZI205;
+			t_char ZI204;
 
 			/* BEGINNING OF EXTRACT: INVERT */
 			{
 #line 321 "src/libre/parser.act"
 
-		ZI205 = '^';
+		ZI204 = '^';
 
-		(void) ZI205;
+		(void) ZI204;
 	
 #line 340 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: INVERT */
 			ADVANCE_LEXER;
-			p_206 (flags, lex_state, act_state, err, ZIclass);
+			p_205 (flags, lex_state, act_state, err, ZIclass);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -415,30 +415,48 @@ p_re__sql(flags flags, lex_state lex_state, act_state act_state, err err, t_ast_
 		return;
 	}
 	{
-		/* BEGINNING OF INLINE: 192 */
+		t_group__id ZIid;
+		t_ast__expr ZIe;
+
+		/* BEGINNING OF ACTION: make-group-id */
 		{
-			{
-				p_expr (flags, lex_state, act_state, err, &ZInode);
-				if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
-					RESTORE_LEXER;
-					goto ZL1;
-				}
-			}
+#line 915 "src/libre/parser.act"
+
+		(ZIid) = act_state->group_id++;
+	
+#line 428 "src/libre/dialect/sql/parser.c"
 		}
-		/* END OF INLINE: 192 */
-		/* BEGINNING OF INLINE: 193 */
+		/* END OF ACTION: make-group-id */
+		p_expr (flags, lex_state, act_state, err, &ZIe);
+		if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
+			RESTORE_LEXER;
+			goto ZL1;
+		}
+		/* BEGINNING OF ACTION: ast-make-group */
+		{
+#line 945 "src/libre/parser.act"
+
+		(ZInode) = ast_make_expr_group(act_state->poolp, *flags, (ZIe), (ZIid));
+		if ((ZInode) == NULL) {
+			goto ZL1;
+		}
+	
+#line 445 "src/libre/dialect/sql/parser.c"
+		}
+		/* END OF ACTION: ast-make-group */
+		/* BEGINNING OF INLINE: 192 */
 		{
 			{
 				switch (CURRENT_TERMINAL) {
 				case (TOK_EOF):
 					break;
 				default:
-					goto ZL4;
+					goto ZL3;
 				}
 				ADVANCE_LEXER;
 			}
-			goto ZL3;
-		ZL4:;
+			goto ZL2;
+		ZL3:;
 			{
 				/* BEGINNING OF ACTION: err-expected-eof */
 				{
@@ -449,13 +467,13 @@ p_re__sql(flags flags, lex_state lex_state, act_state act_state, err err, t_ast_
 		}
 		goto ZL1;
 	
-#line 453 "src/libre/dialect/sql/parser.c"
+#line 471 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: err-expected-eof */
 			}
-		ZL3:;
+		ZL2:;
 		}
-		/* END OF INLINE: 193 */
+		/* END OF INLINE: 192 */
 	}
 	goto ZL0;
 ZL1:;
@@ -491,7 +509,7 @@ ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 			goto ZL4;
 		}
 	
-#line 495 "src/libre/dialect/sql/parser.c"
+#line 513 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: ast-add-alt */
 			}
@@ -507,7 +525,7 @@ ZL2_expr_C_Ccharacter_Hclass_C_Clist_Hof_Hclass_Hterms:;
 		}
 		goto ZL1;
 	
-#line 511 "src/libre/dialect/sql/parser.c"
+#line 529 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: err-expected-term */
 			}
@@ -567,7 +585,7 @@ ZL2_expr_C_Clist_Hof_Hpieces:;
 			goto ZL1;
 		}
 	
-#line 571 "src/libre/dialect/sql/parser.c"
+#line 589 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-add-concat */
 		/* BEGINNING OF INLINE: 184 */
@@ -601,9 +619,9 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 	switch (CURRENT_TERMINAL) {
 	case (TOK_CHAR):
 		{
-			t_char ZI207;
+			t_char ZI206;
+			t_pos ZI207;
 			t_pos ZI208;
-			t_pos ZI209;
 
 			/* BEGINNING OF EXTRACT: CHAR */
 			{
@@ -612,19 +630,19 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hterm(flags flags, lex_state lex_state, act_
 		/* the first byte may be '\x00' */
 		assert(lex_state->buf.a[1] == '\0');
 
-		ZI208 = lex_state->lx.start;
-		ZI209   = lex_state->lx.end;
+		ZI207 = lex_state->lx.start;
+		ZI208   = lex_state->lx.end;
 
+		(void) ZI207;
 		(void) ZI208;
-		(void) ZI209;
 
-		ZI207 = lex_state->buf.a[0];
+		ZI206 = lex_state->buf.a[0];
 	
-#line 624 "src/libre/dialect/sql/parser.c"
+#line 642 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
-			p_210 (flags, lex_state, act_state, err, &ZI207, &ZI208, &ZInode);
+			p_209 (flags, lex_state, act_state, err, &ZI206, &ZI207, &ZInode);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -679,7 +697,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		(void) ZIopen__start;
 		(void) ZIopen__end;
 	
-#line 683 "src/libre/dialect/sql/parser.c"
+#line 701 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: OPENGROUP */
 			break;
@@ -696,7 +714,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			goto ZL1;
 		}
 	
-#line 700 "src/libre/dialect/sql/parser.c"
+#line 718 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-alt */
 		ZItmp = ZIclass;
@@ -724,7 +742,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		(void) ZIclose__start;
 		(void) ZIclose__end;
 	
-#line 728 "src/libre/dialect/sql/parser.c"
+#line 746 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF EXTRACT: CLOSEGROUP */
 					ADVANCE_LEXER;
@@ -735,7 +753,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		mark(&act_state->groupstart, &(ZIopen__start));
 		mark(&act_state->groupend,   &(ZIopen__end));
 	
-#line 739 "src/libre/dialect/sql/parser.c"
+#line 757 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: mark-group */
 					/* BEGINNING OF ACTION: mark-expr */
@@ -755,7 +773,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		(ZItmp)->u.class.end   = ast_end;
 */
 	
-#line 759 "src/libre/dialect/sql/parser.c"
+#line 777 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: mark-expr */
 					ZInode = ZIclass;
@@ -775,7 +793,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 
 		(void) ZI159;
 	
-#line 779 "src/libre/dialect/sql/parser.c"
+#line 797 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF EXTRACT: INVERT */
 					ADVANCE_LEXER;
@@ -788,7 +806,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			goto ZL3;
 		}
 	
-#line 792 "src/libre/dialect/sql/parser.c"
+#line 810 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: ast-make-alt */
 					ZImask__tmp = ZImask;
@@ -820,7 +838,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		(void) ZIclose__start;
 		(void) ZIclose__end;
 	
-#line 824 "src/libre/dialect/sql/parser.c"
+#line 842 "src/libre/dialect/sql/parser.c"
 								}
 								/* END OF EXTRACT: CLOSEGROUP */
 								break;
@@ -835,7 +853,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		mark(&act_state->groupstart, &(ZIclose__start));
 		mark(&act_state->groupend,   &(ZIclose__end));
 	
-#line 839 "src/libre/dialect/sql/parser.c"
+#line 857 "src/libre/dialect/sql/parser.c"
 							}
 							/* END OF ACTION: mark-group */
 							/* BEGINNING OF ACTION: mark-expr */
@@ -855,7 +873,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		(ZItmp)->u.class.end   = ast_end;
 */
 	
-#line 859 "src/libre/dialect/sql/parser.c"
+#line 877 "src/libre/dialect/sql/parser.c"
 							}
 							/* END OF ACTION: mark-expr */
 							/* BEGINNING OF ACTION: mark-expr */
@@ -875,7 +893,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		(ZImask__tmp)->u.class.end   = ast_end;
 */
 	
-#line 879 "src/libre/dialect/sql/parser.c"
+#line 897 "src/libre/dialect/sql/parser.c"
 							}
 							/* END OF ACTION: mark-expr */
 						}
@@ -891,7 +909,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		}
 		goto ZL3;
 	
-#line 895 "src/libre/dialect/sql/parser.c"
+#line 913 "src/libre/dialect/sql/parser.c"
 							}
 							/* END OF ACTION: err-expected-closegroup */
 						}
@@ -907,7 +925,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			goto ZL3;
 		}
 	
-#line 911 "src/libre/dialect/sql/parser.c"
+#line 929 "src/libre/dialect/sql/parser.c"
 					}
 					/* END OF ACTION: ast-make-subtract */
 				}
@@ -930,7 +948,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 		}
 		goto ZL1;
 	
-#line 934 "src/libre/dialect/sql/parser.c"
+#line 952 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: err-expected-closegroup */
 				/* BEGINNING OF ACTION: ast-make-empty */
@@ -942,7 +960,7 @@ p_expr_C_Ccharacter_Hclass(flags flags, lex_state lex_state, act_state act_state
 			goto ZL1;
 		}
 	
-#line 946 "src/libre/dialect/sql/parser.c"
+#line 964 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF ACTION: ast-make-empty */
 			}
@@ -992,7 +1010,7 @@ p_expr_C_Cpiece(flags flags, lex_state lex_state, act_state act_state, err err, 
 			goto ZL1;
 		}
 	
-#line 996 "src/libre/dialect/sql/parser.c"
+#line 1014 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-piece */
 	}
@@ -1022,7 +1040,7 @@ p_expr(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__ex
 			goto ZL1;
 		}
 	
-#line 1026 "src/libre/dialect/sql/parser.c"
+#line 1044 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-alt */
 		p_expr_C_Clist_Hof_Halts (flags, lex_state, act_state, err, ZInode);
@@ -1043,7 +1061,7 @@ ZL1:;
 		}
 		goto ZL2;
 	
-#line 1047 "src/libre/dialect/sql/parser.c"
+#line 1065 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
 		/* BEGINNING OF ACTION: ast-make-empty */
@@ -1055,7 +1073,7 @@ ZL1:;
 			goto ZL2;
 		}
 	
-#line 1059 "src/libre/dialect/sql/parser.c"
+#line 1077 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -1068,7 +1086,7 @@ ZL0:;
 }
 
 static void
-p_206(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZIclass)
+p_205(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__expr *ZIclass)
 {
 	switch (CURRENT_TERMINAL) {
 	case (TOK_RANGE):
@@ -1090,7 +1108,7 @@ p_206(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 		(void) ZI118;
 		(void) ZI119;
 	
-#line 1094 "src/libre/dialect/sql/parser.c"
+#line 1112 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
@@ -1103,7 +1121,7 @@ p_206(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			goto ZL1;
 		}
 	
-#line 1107 "src/libre/dialect/sql/parser.c"
+#line 1125 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 			/* BEGINNING OF ACTION: ast-add-alt */
@@ -1114,7 +1132,7 @@ p_206(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			goto ZL1;
 		}
 	
-#line 1118 "src/libre/dialect/sql/parser.c"
+#line 1136 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-add-alt */
 			/* BEGINNING OF ACTION: ast-make-invert */
@@ -1157,7 +1175,7 @@ p_206(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			goto ZL1;
 		}
 	
-#line 1161 "src/libre/dialect/sql/parser.c"
+#line 1179 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-invert */
 		}
@@ -1204,7 +1222,7 @@ p_206(flags flags, lex_state lex_state, act_state act_state, err err, t_ast__exp
 			goto ZL1;
 		}
 	
-#line 1208 "src/libre/dialect/sql/parser.c"
+#line 1226 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-invert */
 		}
@@ -1219,7 +1237,7 @@ ZL1:;
 }
 
 static void
-p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI207, t_pos *ZI208, t_ast__expr *ZOnode)
+p_209(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI206, t_pos *ZI207, t_ast__expr *ZOnode)
 {
 	t_ast__expr ZInode;
 
@@ -1230,12 +1248,12 @@ p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			{
 #line 908 "src/libre/parser.act"
 
-		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (*ZI207));
+		(ZInode) = ast_make_expr_literal(act_state->poolp, *flags, (*ZI206));
 		if ((ZInode) == NULL) {
 			goto ZL1;
 		}
 	
-#line 1239 "src/libre/dialect/sql/parser.c"
+#line 1257 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -1256,9 +1274,9 @@ p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 #line 873 "src/libre/parser.act"
 
 		(ZIa).type = AST_ENDPOINT_LITERAL;
-		(ZIa).u.literal.c = (unsigned char)(*ZI207);
+		(ZIa).u.literal.c = (unsigned char)(*ZI206);
 	
-#line 1262 "src/libre/dialect/sql/parser.c"
+#line 1280 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF EXTRACT: RANGE */
@@ -1273,7 +1291,7 @@ p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		(void) ZI138;
 		(void) ZI139;
 	
-#line 1277 "src/libre/dialect/sql/parser.c"
+#line 1295 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: RANGE */
 			ADVANCE_LEXER;
@@ -1294,7 +1312,7 @@ p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 
 		ZIcz = lex_state->buf.a[0];
 	
-#line 1298 "src/libre/dialect/sql/parser.c"
+#line 1316 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: CHAR */
 				break;
@@ -1309,17 +1327,17 @@ p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		(ZIz).type = AST_ENDPOINT_LITERAL;
 		(ZIz).u.literal.c = (unsigned char)(ZIcz);
 	
-#line 1313 "src/libre/dialect/sql/parser.c"
+#line 1331 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-range-endpoint-literal */
 			/* BEGINNING OF ACTION: mark-range */
 			{
 #line 786 "src/libre/parser.act"
 
-		mark(&act_state->rangestart, &(*ZI208));
+		mark(&act_state->rangestart, &(*ZI207));
 		mark(&act_state->rangeend,   &(ZIend));
 	
-#line 1323 "src/libre/dialect/sql/parser.c"
+#line 1341 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: mark-range */
 			/* BEGINNING OF ACTION: ast-make-range */
@@ -1329,7 +1347,7 @@ p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 		struct ast_pos ast_start, ast_end;
 		unsigned char lower, upper;
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI208));
+		AST_POS_OF_LX_POS(ast_start, (*ZI207));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		if ((ZIa).type != AST_ENDPOINT_LITERAL ||
@@ -1357,7 +1375,7 @@ p_210(flags flags, lex_state lex_state, act_state act_state, err err, t_char *ZI
 			goto ZL1;
 		}
 	
-#line 1361 "src/libre/dialect/sql/parser.c"
+#line 1379 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-range */
 		}
@@ -1374,7 +1392,7 @@ ZL0:;
 }
 
 static void
-p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI211, t_unsigned *ZIm, t_ast__count *ZOc)
+p_212(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI210, t_unsigned *ZIm, t_ast__count *ZOc)
 {
 	t_ast__count ZIc;
 
@@ -1394,7 +1412,7 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 		(void) ZI177;
 		(void) ZIend;
 	
-#line 1398 "src/libre/dialect/sql/parser.c"
+#line 1416 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: CLOSECOUNT */
 			ADVANCE_LEXER;
@@ -1402,10 +1420,10 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			{
 #line 791 "src/libre/parser.act"
 
-		mark(&act_state->countstart, &(*ZI211));
+		mark(&act_state->countstart, &(*ZI210));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 1409 "src/libre/dialect/sql/parser.c"
+#line 1427 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
@@ -1419,18 +1437,18 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			err->m = (*ZIm);
 			err->n = (*ZIm);
 
-			mark(&act_state->countstart, &(*ZI211));
+			mark(&act_state->countstart, &(*ZI210));
 			mark(&act_state->countend,   &(ZIend));
 
 			goto ZL1;
 		}
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI211));
+		AST_POS_OF_LX_POS(ast_start, (*ZI210));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (*ZIm), &ast_end);
 	
-#line 1434 "src/libre/dialect/sql/parser.c"
+#line 1452 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-range */
 		}
@@ -1466,7 +1484,7 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 
 		ZIn = (unsigned int) u;
 	
-#line 1470 "src/libre/dialect/sql/parser.c"
+#line 1488 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -1486,7 +1504,7 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 		(void) ZI180;
 		(void) ZIend;
 	
-#line 1490 "src/libre/dialect/sql/parser.c"
+#line 1508 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: CLOSECOUNT */
 				break;
@@ -1498,10 +1516,10 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			{
 #line 791 "src/libre/parser.act"
 
-		mark(&act_state->countstart, &(*ZI211));
+		mark(&act_state->countstart, &(*ZI210));
 		mark(&act_state->countend,   &(ZIend));
 	
-#line 1505 "src/libre/dialect/sql/parser.c"
+#line 1523 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: mark-count */
 			/* BEGINNING OF ACTION: count-range */
@@ -1515,18 +1533,18 @@ p_213(flags flags, lex_state lex_state, act_state act_state, err err, t_pos *ZI2
 			err->m = (*ZIm);
 			err->n = (ZIn);
 
-			mark(&act_state->countstart, &(*ZI211));
+			mark(&act_state->countstart, &(*ZI210));
 			mark(&act_state->countend,   &(ZIend));
 
 			goto ZL1;
 		}
 
-		AST_POS_OF_LX_POS(ast_start, (*ZI211));
+		AST_POS_OF_LX_POS(ast_start, (*ZI210));
 		AST_POS_OF_LX_POS(ast_end, (ZIend));
 
 		(ZIc) = ast_make_count((*ZIm), &ast_start, (ZIn), &ast_end);
 	
-#line 1530 "src/libre/dialect/sql/parser.c"
+#line 1548 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-range */
 		}
@@ -1567,7 +1585,7 @@ ZL2_expr_C_Clist_Hof_Halts:;
 			goto ZL1;
 		}
 	
-#line 1571 "src/libre/dialect/sql/parser.c"
+#line 1589 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-add-alt */
 		/* BEGINNING OF INLINE: 190 */
@@ -1599,7 +1617,7 @@ ZL1:;
 		}
 		goto ZL4;
 	
-#line 1603 "src/libre/dialect/sql/parser.c"
+#line 1621 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: err-expected-alts */
 	}
@@ -1618,21 +1636,21 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 	switch (CURRENT_TERMINAL) {
 	case (TOK_OPENCOUNT):
 		{
+			t_pos ZI210;
 			t_pos ZI211;
-			t_pos ZI212;
 			t_unsigned ZIm;
 
 			/* BEGINNING OF EXTRACT: OPENCOUNT */
 			{
 #line 389 "src/libre/parser.act"
 
-		ZI211 = lex_state->lx.start;
-		ZI212   = lex_state->lx.end;
+		ZI210 = lex_state->lx.start;
+		ZI211   = lex_state->lx.end;
 
+		(void) ZI210;
 		(void) ZI211;
-		(void) ZI212;
 	
-#line 1636 "src/libre/dialect/sql/parser.c"
+#line 1654 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: OPENCOUNT */
 			ADVANCE_LEXER;
@@ -1660,7 +1678,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		ZIm = (unsigned int) u;
 	
-#line 1664 "src/libre/dialect/sql/parser.c"
+#line 1682 "src/libre/dialect/sql/parser.c"
 				}
 				/* END OF EXTRACT: COUNT */
 				break;
@@ -1668,7 +1686,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 				goto ZL1;
 			}
 			ADVANCE_LEXER;
-			p_213 (flags, lex_state, act_state, err, &ZI211, &ZIm, &ZIc);
+			p_212 (flags, lex_state, act_state, err, &ZI210, &ZIm, &ZIc);
 			if ((CURRENT_TERMINAL) == (ERROR_TERMINAL)) {
 				RESTORE_LEXER;
 				goto ZL1;
@@ -1684,7 +1702,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		(ZIc) = ast_make_count(0, NULL, 1, NULL);
 	
-#line 1688 "src/libre/dialect/sql/parser.c"
+#line 1706 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-one */
 		}
@@ -1698,7 +1716,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		(ZIc) = ast_make_count(1, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 1702 "src/libre/dialect/sql/parser.c"
+#line 1720 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-one-or-more */
 		}
@@ -1712,7 +1730,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 1716 "src/libre/dialect/sql/parser.c"
+#line 1734 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 		}
@@ -1725,7 +1743,7 @@ p_expr_C_Cpiece_C_Ccount(flags flags, lex_state lex_state, act_state act_state, 
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 1729 "src/libre/dialect/sql/parser.c"
+#line 1747 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-one */
 		}
@@ -1745,7 +1763,7 @@ ZL1:;
 		}
 		goto ZL2;
 	
-#line 1749 "src/libre/dialect/sql/parser.c"
+#line 1767 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: err-expected-count */
 		/* BEGINNING OF ACTION: count-one */
@@ -1754,7 +1772,7 @@ ZL1:;
 
 		(ZIc) = ast_make_count(1, NULL, 1, NULL);
 	
-#line 1758 "src/libre/dialect/sql/parser.c"
+#line 1776 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: count-one */
 	}
@@ -1784,7 +1802,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 		/* TODO: or the unicode equivalent */
 		(ZIa) = (*flags & RE_SINGLE) ? &class_any : &class_notnl;
 	
-#line 1788 "src/libre/dialect/sql/parser.c"
+#line 1806 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
@@ -1796,7 +1814,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 1800 "src/libre/dialect/sql/parser.c"
+#line 1818 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 		}
@@ -1822,7 +1840,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 
 		ZIa = lex_state->buf.a[0];
 	
-#line 1826 "src/libre/dialect/sql/parser.c"
+#line 1844 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: CHAR */
 			ADVANCE_LEXER;
@@ -1835,7 +1853,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 1839 "src/libre/dialect/sql/parser.c"
+#line 1857 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-literal */
 		}
@@ -1854,7 +1872,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 		/* TODO: or the unicode equivalent */
 		(ZIa) = (*flags & RE_SINGLE) ? &class_any : &class_notnl;
 	
-#line 1858 "src/libre/dialect/sql/parser.c"
+#line 1876 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: class-any */
 			/* BEGINNING OF ACTION: ast-make-named */
@@ -1866,7 +1884,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 1870 "src/libre/dialect/sql/parser.c"
+#line 1888 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-named */
 			/* BEGINNING OF ACTION: count-zero-or-more */
@@ -1875,7 +1893,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 
 		(ZIc) = ast_make_count(0, NULL, AST_COUNT_UNBOUNDED, NULL);
 	
-#line 1879 "src/libre/dialect/sql/parser.c"
+#line 1897 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: count-zero-or-more */
 			/* BEGINNING OF ACTION: ast-make-piece */
@@ -1894,7 +1912,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 1898 "src/libre/dialect/sql/parser.c"
+#line 1916 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-piece */
 		}
@@ -1911,7 +1929,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 
 		(ZIid) = act_state->group_id++;
 	
-#line 1915 "src/libre/dialect/sql/parser.c"
+#line 1933 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: make-group-id */
 			p_expr (flags, lex_state, act_state, err, &ZIg);
@@ -1928,7 +1946,7 @@ p_expr_C_Cpiece_C_Catom(flags flags, lex_state lex_state, act_state act_state, e
 			goto ZL1;
 		}
 	
-#line 1932 "src/libre/dialect/sql/parser.c"
+#line 1950 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-group */
 			switch (CURRENT_TERMINAL) {
@@ -1966,7 +1984,7 @@ ZL1:;
 		}
 		goto ZL2;
 	
-#line 1970 "src/libre/dialect/sql/parser.c"
+#line 1988 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: err-expected-atom */
 		/* BEGINNING OF ACTION: ast-make-empty */
@@ -1978,7 +1996,7 @@ ZL1:;
 			goto ZL2;
 		}
 	
-#line 1982 "src/libre/dialect/sql/parser.c"
+#line 2000 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-empty */
 	}
@@ -2021,7 +2039,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed(flags flags, lex_state lex_state, act
 		(void) ZI129;
 		(void) ZI130;
 	
-#line 2025 "src/libre/dialect/sql/parser.c"
+#line 2043 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF EXTRACT: NAMED_CLASS */
 			break;
@@ -2038,7 +2056,7 @@ p_expr_C_Ccharacter_Hclass_C_Cclass_Hnamed(flags flags, lex_state lex_state, act
 			goto ZL1;
 		}
 	
-#line 2042 "src/libre/dialect/sql/parser.c"
+#line 2060 "src/libre/dialect/sql/parser.c"
 		}
 		/* END OF ACTION: ast-make-named */
 	}
@@ -2068,7 +2086,7 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 			goto ZL1;
 		}
 	
-#line 2072 "src/libre/dialect/sql/parser.c"
+#line 2090 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-concat */
 			p_expr_C_Clist_Hof_Hpieces (flags, lex_state, act_state, err, ZInode);
@@ -2089,7 +2107,7 @@ p_expr_C_Calt(flags flags, lex_state lex_state, act_state act_state, err err, t_
 			goto ZL1;
 		}
 	
-#line 2093 "src/libre/dialect/sql/parser.c"
+#line 2111 "src/libre/dialect/sql/parser.c"
 			}
 			/* END OF ACTION: ast-make-empty */
 		}
@@ -2265,6 +2283,6 @@ ZL0:;
 		return NULL;
 	}
 
-#line 2269 "src/libre/dialect/sql/parser.c"
+#line 2287 "src/libre/dialect/sql/parser.c"
 
 /* END OF FILE */

--- a/src/libre/dialect/sql/parser.sid
+++ b/src/libre/dialect/sql/parser.sid
@@ -412,9 +412,9 @@
 	};
 
 	re_sql: () -> (node :ast_expr) = {
-		{
-			node = expr;
-		};
+		id = <make-group-id>;
+		e = expr;
+		node = <ast-make-group>(e, id);
 
 		{
 			EOF;

--- a/src/libre/re.c
+++ b/src/libre/re.c
@@ -223,6 +223,7 @@ re_is_literal(enum re_dialect dialect, int (*getc)(void *opaque), void *opaque,
 	enum re_literal_category *category, char **s, size_t *n)
 {
 	struct ast *ast;
+	struct ast_expr *root;
 	const struct dialect *m;
 	int unsatisfiable;
 	int r;
@@ -262,8 +263,10 @@ re_is_literal(enum re_dialect dialect, int (*getc)(void *opaque), void *opaque,
 
 	/*
 	 * Literals have an enclosing group #0, and we skip it for our purposes.
-	 * Parsing a satisfiable expression is required to produce group #0.
-	 * If this doesn't exist, whatever we parsed, it's not a literal.
+	 * Parsing a satisfiable expression is required to produce group #0,
+	 * so we grab the root node from inside #0. But this is only true for
+	 * dialects with group capture, and I dont want to explicitly handle
+	 * all those dialects here. So this is conditional on group #0.
 	 *
 	 * I'm not doing this as an assertion because AST rewriting is free to
 	 * transform as it wishes, and I don't want to assume a particular
@@ -272,14 +275,15 @@ re_is_literal(enum re_dialect dialect, int (*getc)(void *opaque), void *opaque,
 	 * This is outside of ast_expr_is_literal() because that function may
 	 * apply to sub-trees within a larger AST.
 	 */
-	if (ast->expr->type != AST_EXPR_GROUP || ast->expr->u.group.id != 0) {
-		r = 0;
-		goto done;
+	if (ast->expr->type == AST_EXPR_GROUP && ast->expr->u.group.id == 0) {
+		root = ast->expr->u.group.e;
+	} else {
+		root = ast->expr;
 	}
 
 	int anchor_start, anchor_end;
 
-	r = ast_expr_is_literal(ast->expr->u.group.e, &anchor_start, &anchor_end, s, n);
+	r = ast_expr_is_literal(root, &anchor_start, &anchor_end, s, n);
 	if (r == -1) {
 		goto error;
 	}


### PR DESCRIPTION
Two small things here:
 * Allow bases=NULL for `fsm_union_array()`
 * A bugfix for `re_is_literal()` where I'd assumed the root of the AST is always group #0, but that's only the case for dialects providing group capture.
 
 Now that I'm writing that out, I actually think it makes more sense to have all dialects construct #0. hm