### PR TITLE
src/libfsm/print/c.c: Add opaque argument to generated DFA functions.

### DIFF
--- a/src/libfsm/print/c.c
+++ b/src/libfsm/print/c.c
@@ -434,7 +434,7 @@ fsm_print_c_complete(FILE *f, const struct ir *ir,
 			break;
 
 		case FSM_IO_STR:
-			fprintf(f, "(const char *s)\n");
+			fprintf(f, "(const char *s, void *opaque)\n");
 			fprintf(f, "{\n");
 			if (ir->n > 0) {
 				fprintf(f, "\tconst char *p;\n");
@@ -443,7 +443,7 @@ fsm_print_c_complete(FILE *f, const struct ir *ir,
 			break;
 
 		case FSM_IO_PAIR:
-			fprintf(f, "(const char *b, const char *e)\n");
+			fprintf(f, "(const char *b, const char *e, void *opaque)\n");
 			fprintf(f, "{\n");
 			if (ir->n > 0) {
 				fprintf(f, "\tconst char *p;\n");


### PR DESCRIPTION
The generated functions for FSM_IO_STR and FSM_IO_PAIR didn't include a `void *opaque` to pass other state, so add it. For example, this could be used to pass info about which endids matched.