### PR TITLE
lx: Add a guard for referencing `lx->end.col`, may not be in the struct.

### DIFF
--- a/src/lx/print/c.c
+++ b/src/lx/print/c.c
@@ -1118,7 +1118,9 @@ lx_print_c(FILE *f, const struct ast *ast)
 		fprintf(f, "{\n");
 		fprintf(f, "\tassert(lx != NULL);\n");
 		fprintf(f, "\tassert(p != NULL);\n");
-		fprintf(f, "\tlx->end.col = 1;\n");
+		if (~api_exclude & API_POS) {
+			fprintf(f, "\tlx->end.col = 1;\n");
+		}
 		fprintf(f, "\tlx->p = p;\n");
 		fprintf(f, "}\n");
         }


### PR DESCRIPTION
This field doesn't exist when lx is called with `-x pos`, so don't include references to it the generated code.