### PR TITLE
Add fsm_intersect_charset(), fsm -U

### DIFF
--- a/include/fsm/bool.h
+++ b/include/fsm/bool.h
@@ -56,6 +56,14 @@ struct fsm *
 fsm_intersect(struct fsm *a, struct fsm *b);
 
 /*
+ * A convenience to intersect against a character set, rather than
+ * a pre-existing FSM. Unlike fsm_intersect(), the FSM is required
+ * to be a DFA.
+ */
+struct fsm *
+fsm_intersect_charset(struct fsm *a, size_t n, const char *charset);
+
+/*
  * Subtract b from a. This is not commutative.
  */
 struct fsm *

--- a/man/fsm.1/fsm.1.xml
+++ b/man/fsm.1/fsm.1.xml
@@ -22,6 +22,7 @@
 	<!ENTITY io.arg "<replaceable>io</replaceable>">
 	<!ENTITY iterations.arg "<replaceable>iterations</replaceable>">
 	<!ENTITY length.arg "<replaceable>length</replaceable>">
+	<!ENTITY charset.arg "<replaceable>charset</replaceable>">
 
 	<!ENTITY a.opt "<option>-a</option>">
 	<!ENTITY w.opt "<option>-w</option>">
@@ -32,6 +33,7 @@
 	<!ENTITY G.opt "<option>-G</option>&nbsp;&length.arg;">
 	<!ENTITY k.opt "<option>-k</option>&nbsp;&io.arg;">
 	<!ENTITY i.opt "<option>-i</option>&nbsp;&iterations.arg;">
+	<!ENTITY U.opt "<option>-U</option>&nbsp;&charset.arg;">
 	<!ENTITY X.opt "<option>-X</option>">
 
 	<!ENTITY d.opt "<option>-d</option>">
@@ -75,6 +77,7 @@
 			<command>fsm</command>
 
 			<arg choice="opt">&x.opt;</arg>
+			<arg choice="opt">&U.opt;</arg>
 
 			<arg choice="plain" rep="repeat">&str.arg;</arg>
 		</cmdsynopsis>
@@ -83,6 +86,7 @@
 			<command>fsm</command>
 
 			<arg choice="plain">&p.opt;</arg>
+			<arg choice="opt">&U.opt;</arg>
 
 			<arg choice="opt">&l.opt;</arg>
 			<arg choice="opt">&a.opt;</arg>
@@ -103,6 +107,7 @@
 				<arg choice="plain">&r.opt;</arg>
 				<arg choice="plain">&t.opt;</arg>
 			</group>
+			<arg choice="opt">&U.opt;</arg>
 
 			<arg choice="opt">&i.opt;</arg>
 		</cmdsynopsis>
@@ -111,6 +116,7 @@
 			<command>fsm</command>
 
 			<arg choice="req" rep="repeat">&q.opt;</arg>
+			<arg choice="opt">&U.opt;</arg>
 
 			<arg choice="plain" rep="repeat">&file.arg;</arg>
 		</cmdsynopsis>
@@ -187,6 +193,21 @@
 						per the <code>consolidate_edges</code> option for &fsm_print.3;.
 						The default is to output edges independently,
 						which is the opposite to the equivalent &c.opt; option for &re.1;.</para>
+				</listitem>
+			</varlistentry>
+
+			<varlistentry>
+				<term>&U.opt;</term>
+
+				<listitem>
+					<para>Intersect the resulting state machine down to a
+						given character set.
+						This is done after any transformations are applied
+						(e.g. by <option>t</option>).</para>
+
+					<para>The default character set is a byte.
+						It is not possible to specify a particular character set
+						that includes a literal <literal>\0</literal>.</para>
 				</listitem>
 			</varlistentry>
 

--- a/src/libfsm/Makefile
+++ b/src/libfsm/Makefile
@@ -1,6 +1,7 @@
 .include "../../share/mk/top.mk"
 
 SRC += src/libfsm/capture.c
+SRC += src/libfsm/charset.c
 SRC += src/libfsm/collate.c
 SRC += src/libfsm/complete.c
 SRC += src/libfsm/consolidate.c

--- a/src/libfsm/charset.c
+++ b/src/libfsm/charset.c
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+#include <fsm/fsm.h>
+#include <fsm/bool.h>
+#include <fsm/pred.h>
+#include <fsm/walk.h>
+
+#include "internal.h"
+#include "walk2.h"
+
+/* ^[abc..]*$ */
+struct fsm *
+fsm_intersect_charset(struct fsm *a, size_t n, const char *charset)
+{
+	struct fsm *b, *q;
+
+	assert(a != NULL);
+
+	if (charset == NULL) {
+		return a;
+	}
+
+	/*
+	 * Since intersection is destructive, there's no point in making
+	 * the charset FSM in advance and then fsm_clone()ing it.
+	 * We may as well just make a new one each time.
+	 */
+	{
+		fsm_state_t state;
+
+		// TODO: pass .statealloc explicitly, we know it's 1. the default is overkill
+		b = fsm_new(a->opt);
+		if (b == NULL) {
+			return NULL;
+		}
+
+		if (!fsm_addstate(b, &state)) {
+			goto error;
+		}
+
+		for (size_t i = 0; i < n; i++) {
+			if (!fsm_addedge_literal(b, state, state, charset[i])) {
+				goto error;
+			}
+		}
+
+		fsm_setend(b, state, true);
+		fsm_setstart(b, state);
+	}
+
+	assert(fsm_all(a, fsm_isdfa));
+	assert(fsm_all(b, fsm_isdfa));
+
+	/*
+	 * This is equivalent to fsm_intersect(). fsm_intersect() asserts that
+	 * both operands are DFA at runtime. But we know this empirically from
+	 * our callers. So we call fsm_walk2() directly to avoid needlessly
+	 * running the DFA predicate in DNDEBUG builds.
+	 *
+	 * This is intersection implemented by walking sets of states through
+	 * both FSM simultaneously, as described by Hopcroft, Motwani and Ullman
+	 * (2001, 2nd ed.) 4.2, Closure under Intersection.
+	 *
+	 * The intersection of two FSM consists of only those items which
+	 * are present in _BOTH.
+	 */
+	q = fsm_walk2(a, b, FSM_WALK2_BOTH, FSM_WALK2_BOTH);
+	if (q == NULL) {
+		return NULL;
+	}
+
+	fsm_free(a);
+	fsm_free(b);
+
+	/* walking two DFA produces a DFA */
+	assert(fsm_all(q, fsm_isdfa));
+
+	return q;
+
+error:
+
+	fsm_free(b);
+
+	return NULL;
+}
+

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -3,6 +3,7 @@ fsm_complement
 fsm_union
 fsm_union_array
 fsm_intersect
+fsm_intersect_charset
 
 # <fsm/cost.h>
 fsm_cost_legible


### PR DESCRIPTION
Add `fsm_intersect_charset()`, a convenience to intersect an fsm against a given character set. I pulled this out of the forthcoming rx(1) tool.

Unlike `fsm_intersect()`, this doesn't automatically determinise its operands. I'm not convinced `fsm_intersect()` should do that, either. In most cases we care enough about performance to do this (or rather to avoid doing it unnecessarily) in the caller.

I've exposed this as `fsm -U <charset>`:

![image](https://github.com/katef/libfsm/assets/1371085/4a60b9c5-b774-442e-8acc-afba0a9db414)