### PR TITLE
Add fsm_vacuum, which reduces the state array when over-allocated.

### DIFF
--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -15,6 +15,8 @@
  * be atomic.
  */
 
+#include <stdbool.h>
+
 struct fsm;
 struct fsm_options;
 struct path; /* XXX */
@@ -494,12 +496,9 @@ int
 fsm_shuffle(struct fsm *fsm, unsigned seed);
 
 /* Attempt to reclaim memory if an FSM has significantly reduced its
- * state count. Returns 1 if */
-enum fsm_vacuum_res {
-	FSM_VACUUM_NO_CHANGE,
-	FSM_VACUUM_REDUCED_MEMORY,
-	FSM_VACUUM_ERROC_REALLOC = -1,
-}
+ * state count. Returns true if the vacuuming attempt succeeded (including
+ * deciding not to do anything), false if realloc failed. */
+bool
 fsm_vacuum(struct fsm *fsm);
 
 #endif

--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -493,5 +493,14 @@ int fsm_fgetc(void *opaque); /* expects opaque to be FILE *  */
 int
 fsm_shuffle(struct fsm *fsm, unsigned seed);
 
+/* Attempt to reclaim memory if an FSM has significantly reduced its
+ * state count. Returns 1 if */
+enum fsm_vacuum_res {
+	FSM_VACUUM_NO_CHANGE,
+	FSM_VACUUM_REDUCED_MEMORY,
+	FSM_VACUUM_ERROC_REALLOC = -1,
+}
+fsm_vacuum(struct fsm *fsm);
+
 #endif
 

--- a/src/libfsm/Makefile
+++ b/src/libfsm/Makefile
@@ -22,6 +22,7 @@ SRC += src/libfsm/trim.c
 SRC += src/libfsm/example.c
 SRC += src/libfsm/getc.c
 SRC += src/libfsm/shuffle.c
+SRC += src/libfsm/vacuum.c
 SRC += src/libfsm/vm.c
 
 # graph things

--- a/src/libfsm/fsm.c
+++ b/src/libfsm/fsm.c
@@ -22,6 +22,9 @@
 #include "capture.h"
 #include "endids.h"
 
+/* guess for default state allocation */
+#define FSM_DEFAULT_STATEALLOC 128
+
 void
 free_contents(struct fsm *fsm)
 {

--- a/src/libfsm/fsm.c
+++ b/src/libfsm/fsm.c
@@ -57,7 +57,7 @@ fsm_new(const struct fsm_options *opt)
 		return NULL;
 	}
 
-	new->statealloc = 128; /* guess */
+	new->statealloc = FSM_DEFAULT_STATEALLOC;
 	new->statecount = 0;
 	new->endcount   = 0;
 	new->capture_info = NULL;

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -44,9 +44,6 @@ struct state_array;
 
 #define FSM_CAPTURE_MAX INT_MAX
 
-/* guess for default state allocation */
-#define FSM_DEFAULT_STATEALLOC 128
-
 struct fsm_edge {
 	fsm_state_t state; /* destination */
 	unsigned char symbol;

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -44,6 +44,9 @@ struct state_array;
 
 #define FSM_CAPTURE_MAX INT_MAX
 
+/* guess for default state allocation */
+#define FSM_DEFAULT_STATEALLOC 128
+
 struct fsm_edge {
 	fsm_state_t state; /* destination */
 	unsigned char symbol;

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -68,6 +68,7 @@ fsm_addstate
 fsm_addstate_bulk
 fsm_removestate
 fsm_shuffle
+fsm_vacuum
 
 fsm_addedge_any
 fsm_addedge_epsilon

--- a/src/libfsm/minimise.c
+++ b/src/libfsm/minimise.c
@@ -157,6 +157,12 @@ fsm_minimise(struct fsm *fsm)
 
 	fsm_move(fsm, dst);
 
+	/* The FSM state count should be settled now, so if the state
+	 * allocation is unnecessarily large move to a smaller one. */
+	if (!fsm_vacuum(fsm)) {	/* realloc failure */
+		r = 0;
+	}
+
 cleanup:
 	if (mapping != NULL) {
 		f_free(fsm->opt->alloc, mapping);

--- a/src/libfsm/vacuum.c
+++ b/src/libfsm/vacuum.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 Scott Vokes
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <stdlib.h>
+#include <fsm/fsm.h>
+#include <fsm/alloc.h>
+
+#include <assert.h>
+
+#include "internal.h"
+
+enum fsm_vacuum_res
+fsm_vacuum(struct fsm *fsm)
+{
+	assert(fsm != NULL);
+	assert(fsm->statecount <= fsm->statealloc);
+	size_t nceil = fsm->statealloc;
+
+	while ((fsm->statecount < nceil/2) && nceil > 1) {
+		nceil /= 2;
+	}
+
+	if (nceil == fsm->statealloc) {
+		return FSM_VACUUM_NO_CHANGE;
+	}
+
+	struct fsm_state *nstates = f_realloc(fsm->opt->alloc,
+	    fsm->states, nceil * sizeof(nstates[0]));
+	if (nstates == NULL) {
+		return FSM_VACUUM_ERROC_REALLOC;
+	}
+
+	fsm->states = nstates;
+	fsm->statealloc = nceil;
+
+	return FSM_VACUUM_REDUCED_MEMORY;
+}

--- a/src/libfsm/vacuum.c
+++ b/src/libfsm/vacuum.c
@@ -12,7 +12,7 @@
 
 #include "internal.h"
 
-enum fsm_vacuum_res
+bool
 fsm_vacuum(struct fsm *fsm)
 {
 	assert(fsm != NULL);
@@ -24,17 +24,17 @@ fsm_vacuum(struct fsm *fsm)
 	}
 
 	if (nceil == fsm->statealloc) {
-		return FSM_VACUUM_NO_CHANGE;
+		return true;
 	}
 
 	struct fsm_state *nstates = f_realloc(fsm->opt->alloc,
 	    fsm->states, nceil * sizeof(nstates[0]));
 	if (nstates == NULL) {
-		return FSM_VACUUM_ERROC_REALLOC;
+		return false;
 	}
 
 	fsm->states = nstates;
 	fsm->statealloc = nceil;
 
-	return FSM_VACUUM_REDUCED_MEMORY;
+	return true;
 }


### PR DESCRIPTION
This doesn't have any tests, but it's just optionally calling realloc and `fsm->statealloc` isn't publicly exposed. I could test it via the alloc hooks (checking that realloc is called) or add a parameter to report how many states were freed from the backing array, but testing the direct amounts is likely to be brittle. Thoughts?