### PR TITLE
Add fsm_new_statealloc()

### DIFF
--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -61,6 +61,15 @@ struct fsm *
 fsm_new(const struct fsm_options *opt);
 
 /*
+ * As fsm_new(), but with an explicit number of pre-allocated states.
+ * This is intended to save on internal reallocations for situations
+ * where it's known in advance exactly how many states an FSM will have.
+ * You can still add more states per usual.
+ */
+struct fsm *
+fsm_new_statealloc(const struct fsm_options *opt, size_t statealloc);
+
+/*
  * Free a structure created by fsm_new(), and all of its contents.
  * No other pointers returned by this API are to be freed individually.
  */

--- a/src/libfsm/charset.c
+++ b/src/libfsm/charset.c
@@ -36,8 +36,7 @@ fsm_intersect_charset(struct fsm *a, size_t n, const char *charset)
 	{
 		fsm_state_t state;
 
-		// TODO: pass .statealloc explicitly, we know it's 1. the default is overkill
-		b = fsm_new(a->opt);
+		b = fsm_new_statealloc(a->opt, 1);
 		if (b == NULL) {
 			return NULL;
 		}

--- a/src/libfsm/clone.c
+++ b/src/libfsm/clone.c
@@ -35,7 +35,7 @@ fsm_clone(const struct fsm *fsm)
 	assert(fsm != NULL);
 	assert(fsm->opt != NULL);
 
-	new = fsm_new(fsm->opt);
+	new = fsm_new_statealloc(fsm->opt, fsm->statecount);
 	if (new == NULL) {
 		return NULL;
 	}

--- a/src/libfsm/fsm.c
+++ b/src/libfsm/fsm.c
@@ -44,10 +44,14 @@ free_contents(struct fsm *fsm)
 }
 
 struct fsm *
-fsm_new(const struct fsm_options *opt)
+fsm_new_statealloc(const struct fsm_options *opt, size_t statealloc)
 {
 	static const struct fsm_options defaults;
 	struct fsm *new, f;
+
+	if (statealloc == 0) {
+		return fsm_new(opt);
+	}
 
 	if (opt == NULL) {
 		opt = &defaults;
@@ -60,7 +64,7 @@ fsm_new(const struct fsm_options *opt)
 		return NULL;
 	}
 
-	new->statealloc = FSM_DEFAULT_STATEALLOC;
+	new->statealloc = statealloc;
 	new->statecount = 0;
 	new->endcount   = 0;
 	new->capture_info = NULL;
@@ -90,6 +94,12 @@ fsm_new(const struct fsm_options *opt)
 	}
 
 	return new;
+}
+
+struct fsm *
+fsm_new(const struct fsm_options *opt)
+{
+	return fsm_new_statealloc(opt, FSM_DEFAULT_STATEALLOC);
 }
 
 void

--- a/src/libfsm/reverse.c
+++ b/src/libfsm/reverse.c
@@ -54,7 +54,7 @@ fsm_reverse(struct fsm *fsm)
 	if (fsm->endcount == 0 || !fsm_getstart(fsm, &prevstart)) {
 		struct fsm *new;
 
-		new = fsm_new(fsm->opt);
+		new = fsm_new_statealloc(fsm->opt, 1);
 		if (new == NULL) {
 			return 0;
 		}

--- a/src/libre/re_strings.c
+++ b/src/libre/re_strings.c
@@ -96,6 +96,7 @@ re_strings_build(struct re_strings *g,
 		}
 	}
 
+	/* TODO: count trie nodes and fsm_new_statealloc() */
 	fsm = fsm_new(opt);
 	if (fsm == NULL) {
 		goto error;


### PR DESCRIPTION
This allows pre-allocation where the number of states is known empirically by the caller. I added calls in a couple of places where over-allocating has been bugging me.

Based on #472, I'll rebase before this goes in.