### PR TITLE
Add `void* opaque` to vmc codegen too, disable unused warning.

### DIFF
--- a/src/libfsm/print/c.c
+++ b/src/libfsm/print/c.c
@@ -427,6 +427,7 @@ fsm_print_c_complete(FILE *f, const struct ir *ir,
 		case FSM_IO_GETC:
 			fprintf(f, "(int (*fsm_getc)(void *opaque), void *opaque)\n");
 			fprintf(f, "{\n");
+			fprintf(f, "\t(void)opaque;\n");
 			if (ir->n > 0) {
 				fprintf(f, "\tint c;\n");
 				fprintf(f, "\n");
@@ -436,6 +437,7 @@ fsm_print_c_complete(FILE *f, const struct ir *ir,
 		case FSM_IO_STR:
 			fprintf(f, "(const char *s, void *opaque)\n");
 			fprintf(f, "{\n");
+			fprintf(f, "\t(void)opaque;\n");
 			if (ir->n > 0) {
 				fprintf(f, "\tconst char *p;\n");
 				fprintf(f, "\n");
@@ -445,6 +447,7 @@ fsm_print_c_complete(FILE *f, const struct ir *ir,
 		case FSM_IO_PAIR:
 			fprintf(f, "(const char *b, const char *e, void *opaque)\n");
 			fprintf(f, "{\n");
+			fprintf(f, "\t(void)opaque;\n");
 			if (ir->n > 0) {
 				fprintf(f, "\tconst char *p;\n");
 				fprintf(f, "\n");

--- a/src/libfsm/print/vmc.c
+++ b/src/libfsm/print/vmc.c
@@ -472,13 +472,15 @@ fsm_print_c_complete(FILE *f, const struct ir *ir, const struct fsm_options *opt
 			break;
 
 		case FSM_IO_STR:
-			fprintf(f, "(const char *s)\n");
+			fprintf(f, "(const char *s, void *opaque)\n");
 			fprintf(f, "{\n");
+			fprintf(f, "\t(void)opaque;\n");
 			break;
 
 		case FSM_IO_PAIR:
-			fprintf(f, "(const char *b, const char *e)\n");
+			fprintf(f, "(const char *b, const char *e, void *opaque)\n");
 			fprintf(f, "{\n");
+			fprintf(f, "\t(void)opaque;\n");
 			break;
 		}
 


### PR DESCRIPTION
This is a follow-up to #465:

- Also add the extra `void *opaque` to vmc's codegen.

- Add a `(void)` cast to suppress warnings if the extra opaque void pointer isn't used by the generated code.