### PR TITLE
Missing error handling for retest(1)

### DIFF
--- a/src/retest/main.c
+++ b/src/retest/main.c
@@ -1181,7 +1181,7 @@ finish:
 		exit(EXIT_FAILURE);
 	}
 
-	return num_errors;
+	return num_errors + num_re_errors;
 }
 
 static enum fsm_io

--- a/src/retest/runner.c
+++ b/src/retest/runner.c
@@ -242,8 +242,12 @@ compile(enum implementation impl,
 			return 0;
 		}
 
-		if (0 != systemf("%s %s -shared %s -o %s",
+		if (0 != systemf("%s %s -shared %s %s -o %s",
 				cc ? cc : "gcc", cflags ? cflags : "",
+
+				// for "missing .note.GNU-stack section implies executable stack"
+				"-Wl,-z,noexecstack",
+
 				tmp_o, tmp_so))
 		{
 			return 0;

--- a/tests/retest/Makefile
+++ b/tests/retest/Makefile
@@ -11,6 +11,9 @@ RETEST=${BUILD}/bin/retest
 .for lang in vm asm c vmc
 .for io in pair str
 
+# XXX: we don't have FSM_IO_STR for asm yet
+.if ${lang} != asm || ${io} != str
+
 .for n in ${TEST.tests/retest:T:R:C/^tests_//}
 
 ${TEST_OUTDIR.tests/retest}/res-${lang}-${io}${n}: ${TEST_SRCDIR.tests/retest}/tests_${n}.tst
@@ -21,6 +24,8 @@ ${TEST_OUTDIR.tests/retest}/res-${lang}-${io}${n}: ${TEST_SRCDIR.tests/retest}/t
 test:: ${TEST_OUTDIR.tests/retest}/res-${lang}-${io}${n}
 
 .endfor
+
+.endif
 
 .endfor
 .endfor


### PR DESCRIPTION
Here I'm including `re_test_errors` in the count towards total text failures. This includes compilation failures as well as match errors at runtime. The difference is visible for tests which don't actually match anything.

This gives a place to catch warnings with `-Werror`, and I've addressed a few more outstanding situations.

I think this error count was just missed by accident. It's the reason warnings like the ones addressed by #475 kept slipping through, and I didn't understand why.