### PR TITLE
Sort endids written out by fsm_endid_get()

### DIFF
--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -222,8 +222,7 @@ fsm_endid_set(struct fsm *fsm, fsm_state_t end_state, fsm_end_id_t id);
  * id_buf is expected to have enough cells (according to id_buf_count)
  * to store all the end IDs. You can find this with fsm_endid_count().
  *
- * The end IDs in the buffer may appear in any order,
- * but will not have duplicates.
+ * The end IDs in the buffer are sorted and do not have duplicates.
  *
  * A state with no end IDs set is considered equivalent to a state
  * that has the empty set, this API does not distinguish these cases.

--- a/src/libfsm/endids.c
+++ b/src/libfsm/endids.c
@@ -734,7 +734,9 @@ fsm_endid_get(const struct fsm *fsm, fsm_state_t end_state,
 				ids[id_i] = b->ids->ids[id_i];
 			}
 
-			/* todo: could sort them here, if it matters. */
+			/* sorting for caller convenience */
+			qsort(ids, count, sizeof *ids, cmp_endids);
+
 			return 1;
 		} else {	/* collision */
 #if LOG_ENDIDS > 4

--- a/src/libfsm/minimise.c
+++ b/src/libfsm/minimise.c
@@ -940,14 +940,6 @@ cleanup:
 }
 
 static int
-cmp_end_ids(const void *pa, const void *pb)
-{
-	const fsm_end_id_t a = *(fsm_end_id_t *)pa;
-	const fsm_end_id_t b = *(fsm_end_id_t *)pb;
-	return a < b ? -1 : a > b ? 1 : 0;
-}
-
-static int
 collect_end_ids(const struct fsm *fsm, fsm_state_t s,
 	struct end_metadata_end *e)
 {
@@ -964,10 +956,6 @@ collect_end_ids(const struct fsm *fsm, fsm_state_t s,
 
 	int res = fsm_endid_get(fsm, s, e->count, e->ids);
 	assert(res == 1);
-
-	/* sort, to make comparison easier later */
-	qsort(e->ids, e->count,
-		sizeof(e->ids[0]), cmp_end_ids);
 
 #if LOG_ECS
 	fprintf(stderr, "%d:", s);

--- a/src/libfsm/minimise_test_oracle.c
+++ b/src/libfsm/minimise_test_oracle.c
@@ -186,8 +186,7 @@ fsm_minimise_test_oracle(const struct fsm *fsm)
 			continue;
 		}
 
-		int eres = fsm_endid_get(fsm, i,
-		    count_a, ids_a);
+		int eres = fsm_endid_get(fsm, i, count_a, ids_a);
 		assert(eres == 1);
 
 		bool found = false;

--- a/src/libfsm/print/api.c
+++ b/src/libfsm/print/api.c
@@ -27,19 +27,6 @@
 #include <fsm/print.h>
 #include <fsm/options.h>
 
-/* TODO: centralise */
-static int
-comp_end_id(const void *a, const void *b)
-{
-	assert(a != NULL);
-	assert(b != NULL);
-
-	if (* (fsm_end_id_t *) a < * (fsm_end_id_t *) b) { return -1; }
-	if (* (fsm_end_id_t *) a > * (fsm_end_id_t *) b) { return +1; }
-
-	return 0;
-}
-
 static int
 rangeclass(unsigned char x, unsigned char y)
 {
@@ -160,8 +147,6 @@ fsm_print_api(FILE *f, const struct fsm *fsm_orig)
 
 			res = fsm_endid_get(fsm, end, count, ids);
 			assert(res == 1);
-
-			qsort(ids, count, sizeof *ids, comp_end_id);
 
 			fprintf(f, "\tif (fsm_isend(fsm, s[%u])) {\n", end);
 			for (size_t id = 0; id < count; id++) {

--- a/src/libfsm/print/fsm.c
+++ b/src/libfsm/print/fsm.c
@@ -26,19 +26,6 @@
 
 /* TODO: centralise */
 static int
-comp_end_id(const void *a, const void *b)
-{
-	assert(a != NULL);
-	assert(b != NULL);
-
-	if (* (fsm_end_id_t *) a < * (fsm_end_id_t *) b) { return -1; }
-	if (* (fsm_end_id_t *) a > * (fsm_end_id_t *) b) { return +1; }
-
-	return 0;
-}
-
-/* TODO: centralise */
-static int
 findany(const struct fsm *fsm, fsm_state_t state, fsm_state_t *a)
 {
 	struct fsm_edge e;
@@ -325,8 +312,6 @@ fsm_print_fsm(FILE *f, const struct fsm *fsm)
 		}
 
 		if (count > 0) {
-			qsort(ids, count, sizeof *ids, comp_end_id);
-
 			fprintf(f, " = [");
 
 			for (size_t id = 0; id < count; id++) {

--- a/tests/capture/capture4.c
+++ b/tests/capture/capture4.c
@@ -223,7 +223,7 @@ check(const struct fsm *fsm, const char *string,
 		int gres;
 		fsm_end_id_t ids[2];
 
-		gres = fsm_endid_get(fsm, end, 2, ids);
+		gres = fsm_endid_get(fsm, end, fsm_endid_count(fsm, end), ids);
 		if (gres != 1) {
 			assert(!"fsm_getendids failed");
 		}

--- a/tests/endids/endids0.c
+++ b/tests/endids/endids0.c
@@ -48,12 +48,7 @@ int main(void)
 
 			assert( fsm_endid_count(fsm, state_ind) == 1);
 
-			ret = fsm_endid_get(
-				fsm,
-				state_ind,
-				1,
-				&id);
-
+			ret = fsm_endid_get(fsm, state_ind, 1, &id);
 			assert(ret == 1);
 			assert(id == 1);
 

--- a/tests/endids/endids0_many_endids.c
+++ b/tests/endids/endids0_many_endids.c
@@ -100,20 +100,14 @@ int main(void)
 
 			assert(ret == 1);
 
-			/* sort endids and compare */
-			qsort(&endids[0],
-				sizeof endids / sizeof endids[0], sizeof endids[0],
-				cmp_endids);
-			for (i=0; i < fsm_endid_count(fsm, state_ind); i++) {
+			for (i=0; i < sizeof all_ids / sizeof all_ids[0]; i++) {
 				assert(endids[i] == sorted_all_ids[i]);
 			}
 
-#if 0
 			/* endids should be sorted */
-			for (i=0; i < nwritten; i++) {
+			for (i=0; i < sizeof all_ids / sizeof all_ids[0]; i++) {
 				assert(endids[i] == sorted_all_ids[i]);
 			}
-#endif /* 0 */
 
 			nend++;
 		}
@@ -159,9 +153,6 @@ int main(void)
 			assert( ids[0] == 1 );
 			assert( ids[0] == matches[i].endid );
 #endif /* 0 */
-
-                        /* sort endids and compare */
-                        qsort(&ids[0], count, sizeof ids[0], cmp_endids);
 
 			for (j=0; j < count; j++) {
 				assert(ids[j] == sorted_all_ids[j]);

--- a/tests/endids/endids1_determinise.c
+++ b/tests/endids/endids1_determinise.c
@@ -44,12 +44,7 @@ int main(void)
 
 			assert( fsm_endid_count(fsm, state_ind) == 1);
 
-			ret = fsm_endid_get(
-				fsm,
-				state_ind,
-				1,
-				&endid);
-
+			ret = fsm_endid_get(fsm, state_ind, 1, &endid);
 			assert(ret == 1);
 			assert( endid == 1 );
 		}

--- a/tests/endids/endids1_determinise_and_minimise.c
+++ b/tests/endids/endids1_determinise_and_minimise.c
@@ -49,12 +49,7 @@ int main(void)
 
 			assert(fsm_endid_count(fsm, state_ind) == 1);
 
-			ret = fsm_endid_get(
-				fsm,
-				state_ind,
-				1,
-				&endid);
-
+			ret = fsm_endid_get(fsm, state_ind, 1, &endid);
 			assert(ret == 1);
 			assert( endid == 1 );
 		}

--- a/tests/endids/endids2_union.c
+++ b/tests/endids/endids2_union.c
@@ -60,15 +60,9 @@ int main(void)
 
 			count = fsm_endid_count(comb, state_ind);
 			// fprintf(stderr, "state %u, count = %zu\n", state_ind, count);
+			assert(count > 0 && count <= 2);
 
-			assert( count > 0 && count <= 2);
-
-			ret = fsm_endid_get(
-				comb,
-				state_ind,
-				2,
-				&endids[0]);
-
+			ret = fsm_endid_get( comb, state_ind, count, &endids[0]);
 			assert(ret == 1);
 
 			if (count == 1) {
@@ -157,8 +151,6 @@ int main(void)
 				assert( ids != NULL );
 
 				assert( count == matches[i].count );
-
-				qsort(&ids[0], count, sizeof ids[0], cmp_endids);
 
 				for (j=0; j < count; j++) {
 					assert( ids[j] == matches[i].endid[j] );

--- a/tests/endids/endids2_union_many_endids.c
+++ b/tests/endids/endids2_union_many_endids.c
@@ -189,15 +189,9 @@ int main(void)
 			memset(&ids[0], 0, sizeof ids);
 
 			count = fsm_endid_count(fsm, state_ind);
-
 			assert(count > 0 && count <= sizeof ids/sizeof ids[0]);
 
-			ret = fsm_endid_get(
-				fsm,
-				state_ind,
-				sizeof ids/sizeof ids[0],
-				&ids[0]);
-
+			ret = fsm_endid_get(fsm, state_ind, count, &ids[0]);
 			assert(ret == 1);
 
 			memset(&tested_pattern[0], 0, sizeof tested_pattern);
@@ -253,15 +247,9 @@ int main(void)
 			memset(&ids[0], 0, sizeof ids);
 
 			count = fsm_endid_count(fsm, state_ind);
-
 			assert(count <= NUM_ENDIDS_TOTAL);
 
-			ret = fsm_endid_get(
-				fsm,
-				state_ind,
-				sizeof ids/sizeof ids[0],
-				&ids[0]);
-
+			ret = fsm_endid_get(fsm, state_ind, count, &ids[0]);
 			assert(ret == 1);
 		}
 	}

--- a/tests/endids/endids4.c
+++ b/tests/endids/endids4.c
@@ -71,20 +71,12 @@ int main(void)
 			int ret;
 
 			count = fsm_endid_count(comb, state_ind);
-
 			printf("state %u count = %zu\n", state_ind, count);
-
 			assert(count == 2);
 
-			ret = fsm_endid_get(
-				comb,
-				state_ind,
-				2,
-				&endids[0]);
-
+			ret = fsm_endid_get(comb, state_ind, count, &endids[0]);
 			assert(ret == 1);
 
-			qsort(&endids[0], count, sizeof endids[0], cmp_endids);
 			assert(endids[0] == 1 && endids[1] == 2);
 		}
 	}
@@ -148,8 +140,6 @@ int main(void)
 				assert( ids != NULL );
 
 				assert( count == matches[i].count );
-
-				qsort(&ids[0], count, sizeof ids[0], cmp_endids);
 
 				for (j=0; j < count; j++) {
 					assert( ids[j] == matches[i].endid[j] );

--- a/tests/endids/endids5.c
+++ b/tests/endids/endids5.c
@@ -72,17 +72,10 @@ int main(void)
 			int ret;
 
 			count = fsm_endid_count(comb, state_ind);
-
 			printf("state %u count = %zu\n", state_ind, count);
-
 			assert(count == 1);
 
-			ret = fsm_endid_get(
-				comb,
-				state_ind,
-				2,
-				&endids[0]);
-
+			ret = fsm_endid_get(comb, state_ind, count, &endids[0]);
 			assert(ret == 1);
 
 			assert(endids[0] == 1);
@@ -152,8 +145,6 @@ int main(void)
 				assert( ids != NULL );
 
 				assert( count == matches[i].count );
-
-				qsort(&ids[0], count, sizeof ids[0], cmp_endids);
 
 				for (j=0; j < count; j++) {
 					assert( ids[j] == matches[i].endid[j] );

--- a/tests/endids/endids6.c
+++ b/tests/endids/endids6.c
@@ -96,15 +96,9 @@ int main(void)
 			int ret;
 
 			count = fsm_endid_count(fsm, state_ind);
+			assert(count > 0 && count <= 2);
 
-			assert( count > 0 && count <= 2);
-
-			ret = fsm_endid_get(
-				fsm,
-				state_ind,
-				sizeof ids / sizeof ids[0],
-				&ids[0]);
-
+			ret = fsm_endid_get(fsm, state_ind, count, &ids[0]);
 			assert(ret == 1);
 
 			info[ninfo].state = state_ind;
@@ -114,7 +108,6 @@ int main(void)
 				assert(ids[0] == 1 || ids[0] == 2);
 				info[ninfo].ids[0] = ids[0];
 			} else if (count == 2) {
-				qsort(&ids[0], count, sizeof ids[0], cmp_endids);
 				assert(ids[0] == 1 && ids[1] == 2);
 				info[ninfo].ids[0] = ids[0];
 				info[ninfo].ids[1] = ids[1];
@@ -139,21 +132,11 @@ int main(void)
 			assert( state_ind == info[info_ind].state );
 
 			count = fsm_endid_count(fsm, state_ind);
-
 			assert(count > 0 && count <= 2);
+			assert(count == info[info_ind].count);
 
-			assert( count == info[info_ind].count );
-			ret = fsm_endid_get(
-				fsm,
-				state_ind,
-				sizeof ids / sizeof ids[0],
-				&ids[0]);
-
+			ret = fsm_endid_get(fsm, state_ind, count, &ids[0]);
 			assert(ret == 1);
-
-			if (count > 1) {
-				qsort(&ids[0], count, sizeof ids[0], cmp_endids);
-			}
 
 			for (ind=0; ind < count; ind++) {
 				fsm_end_id_t expected = info[info_ind].ids[ind];

--- a/tests/endids/endids7.c
+++ b/tests/endids/endids7.c
@@ -108,15 +108,9 @@ int main(void)
 			int ret;
 
 			count = fsm_endid_count(fsm, state_ind);
-
 			assert( count > 0 && count <= 2);
 
-			ret = fsm_endid_get(
-				fsm,
-				state_ind,
-				sizeof ids / sizeof ids[0],
-				&ids[0]);
-
+			ret = fsm_endid_get(fsm, state_ind, count, &ids[0]);
 			assert(ret == 1);
 
 			info[ninfo].state = state_ind;
@@ -126,7 +120,6 @@ int main(void)
 				assert(ids[0] == 1 || ids[0] == 2);
 				info[ninfo].ids[0] = ids[0];
 			} else if (count == 2) {
-				qsort(&ids[0], count, sizeof ids[0], cmp_endids);
 				assert(ids[0] == 1 && ids[1] == 2);
 				info[ninfo].ids[0] = ids[0];
 				info[ninfo].ids[1] = ids[1];
@@ -152,14 +145,9 @@ int main(void)
 			assert( state_ind == info[info_ind].state );
 
 			count = fsm_endid_count(fsm, state_ind);
-
 			assert(count == 1);
-			ret = fsm_endid_get(
-				fsm,
-				state_ind,
-				1,
-				&id);
 
+			ret = fsm_endid_get(fsm, state_ind, 1, &id);
 			assert(ret == 1);
 
 			if (info[info_ind].count == 2) {

--- a/tests/endids/endids7_with_duplicates.c
+++ b/tests/endids/endids7_with_duplicates.c
@@ -112,15 +112,9 @@ int main(void)
 			int ret;
 
 			count = fsm_endid_count(fsm, state_ind);
-
 			assert( count > 0 && count <= 2);
 
-			ret = fsm_endid_get(
-				fsm,
-				state_ind,
-				sizeof ids / sizeof ids[0],
-				&ids[0]);
-
+			ret = fsm_endid_get(fsm, state_ind, count, &ids[0]);
 			assert(ret == 1);
 
 			info[ninfo].state = state_ind;
@@ -130,7 +124,6 @@ int main(void)
 				assert(ids[0] == 1 || ids[0] == 2);
 				info[ninfo].ids[0] = ids[0];
 			} else if (count == 2) {
-				qsort(&ids[0], count, sizeof ids[0], cmp_endids);
 				assert(ids[0] == 1 && ids[1] == 2);
 				info[ninfo].ids[0] = ids[0];
 				info[ninfo].ids[1] = ids[1];
@@ -156,14 +149,9 @@ int main(void)
 			assert( state_ind == info[info_ind].state );
 
 			count = fsm_endid_count(fsm, state_ind);
-
 			assert(count == 1);
-			ret = fsm_endid_get(
-				fsm,
-				state_ind,
-				1,
-				&endid);
 
+			ret = fsm_endid_get( fsm, state_ind, 1, &endid);
 			assert(ret == 1);
 
 			if (info[info_ind].count == 2) {

--- a/tests/endids/endids8.c
+++ b/tests/endids/endids8.c
@@ -77,20 +77,12 @@ int main(void)
 			int ret;
 
 			count = fsm_endid_count(comb, state_ind);
-
 			printf("state %u count = %zu\n", state_ind, count);
-
 			assert(count == 3);
 
-			ret = fsm_endid_get(
-				comb,
-				state_ind,
-				sizeof ids / sizeof ids[0],
-				&ids[0]);
-
+			ret = fsm_endid_get(comb, state_ind, count, &ids[0]);
 			assert(ret == 1);
 
-			qsort(&ids[0], count, sizeof ids[0], cmp_endids);
 			assert(ids[0] == 1 && ids[1] == 2 && ids[2] == 4);
 		}
 	}

--- a/tests/endids/endids9.c
+++ b/tests/endids/endids9.c
@@ -76,15 +76,9 @@ int main(void)
 			int ret;
 
 			count = fsm_endid_count(fsm, state_ind);
-
 			assert( count > 0 && count <= 2);
 
-			ret = fsm_endid_get(
-				fsm,
-				state_ind,
-				sizeof ids / sizeof ids[0],
-				&ids[0]);
-
+			ret = fsm_endid_get(fsm, state_ind, count, &ids[0]);
 			assert(ret == 1);
 
 			info[ninfo].state = state_ind;
@@ -94,7 +88,6 @@ int main(void)
 				assert(ids[0] == 11 || ids[0] == 12);
 				info[ninfo].ids[0] = ids[0];
 			} else if (count == 2) {
-				qsort(&ids[0], count, sizeof ids[0], cmp_endids);
 				assert(ids[0] == 11 && ids[1] == 12);
 				info[ninfo].ids[0] = ids[0];
 				info[ninfo].ids[1] = ids[1];

--- a/tests/endids/endids_utils.h
+++ b/tests/endids/endids_utils.h
@@ -7,8 +7,5 @@
 int
 match_string(const struct fsm *fsm, const char *s, fsm_state_t *end_ptr, fsm_end_id_t **endids_ptr, size_t *num_endids_ptr);
 
-int
-cmp_endids(const void *pa, const void *pb);
-
 #endif /* ENDIDS_UTILS_H */
 

--- a/tests/endids/utils.c
+++ b/tests/endids/utils.c
@@ -47,14 +47,3 @@ match_string(const struct fsm *fsm, const char *s, fsm_state_t *end_ptr, fsm_end
 	return ret;
 }
 
-int
-cmp_endids(const void *pa, const void *pb) {
-	const fsm_end_id_t *a = pa;
-	const fsm_end_id_t *b = pb;
-
-	if (*a < *b) { return -1; }
-	if (*a > *b) { return  1; }
-	return 0;
-}
-
-

--- a/tests/gen/gtest.c
+++ b/tests/gen/gtest.c
@@ -60,7 +60,7 @@ gtest_matches_cb(const struct fsm *fsm,
 #define ID_BUF_COUNT 1
 			fsm_end_id_t ids[ID_BUF_COUNT];
 			int gres = fsm_endid_get(fsm,
-			    end_state, ID_BUF_COUNT, ids);
+			    end_state, fsm_endid_count(fsm, end_state), ids);
 
 			if (gres != 1) {
 				fprintf(stderr,

--- a/tests/re_strings/testutil.c
+++ b/tests/re_strings/testutil.c
@@ -47,11 +47,13 @@ run_test(const char **strings)
 		const int res = fsm_exec(fsm, fsm_sgetc, string, &end, NULL);
 		assert(res > 0); /* match */
 
-		int eres = fsm_endid_get(fsm, end,
-		    MAX_INPUTS, ids);
+		size_t count = fsm_endid_count(fsm, end);
+		assert(count <= MAX_INPUTS);
+
+		int eres = fsm_endid_get(fsm, end, count, ids);
 		assert(eres == 1);
 		bool found = false;
-		for (size_t i = 0; i < fsm_endid_count(fsm, end); i++) {
+		for (size_t i = 0; i < count; i++) {
 			if (ids[i] == id) {
 				found = true;
 				break;


### PR DESCRIPTION
This is for caller convenience, I keep calling qsort for various reasons whenever I call this function, for example to use memcmp on ids.

But the final motivation here was that I wanted to memcmp a const-qualified pointer to an id set stored elsewhere, and I can't do that without allocating for a local copy. And that seems silly when we can just qsort here.