### PR TITLE
Add llvm codegen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -481,7 +481,7 @@ jobs:
         cc: [ clang, gcc ]
         make: [ bmake ]
         debug: [ DEBUG, RELEASE ] # RELEASE=1 is a no-op
-        lang: [ "vm -x v1", "vm -x v2", asm, c, rust, vmc, vmops, go, goasm ]
+        lang: [ "vm -x v1", "vm -x v2", asm, c, rust, vmc, vmops, go, goasm, llvm ]
         exclude:
           - os: macos
             cc: gcc # it's clang anyway

--- a/fuzz/target.c
+++ b/fuzz/target.c
@@ -329,6 +329,7 @@ fuzz_all_print_functions(FILE *f, const char *pattern, bool det, bool min, const
 	r |= fsm_print_sh(f, fsm);
 	r |= fsm_print_go(f, fsm);
 	r |= fsm_print_rust(f, fsm);
+	r |= fsm_print_llvm(f, fsm);
 	assert(r == 0 || errno != 0);
 
 	fsm_free(fsm);

--- a/include/fsm/print.h
+++ b/include/fsm/print.h
@@ -26,6 +26,7 @@ struct fsm;
  *  fsm_print_vmc           - ISO C90 code, VM style
  *  fsm_print_vmdot         - Graphviz Dot format, showing VM opcodes
  *  fsm_print_rust          - Rust code
+ *  fsm_print_llvm          - Live Laugh Virtual Machine
  *  fsm_print_sh            - Shell script (bash dialect)
  *  fsm_print_go            - Go code
  *  fsm_print_goasm/vmasm_* - Assembly in various dialects
@@ -58,6 +59,7 @@ fsm_print fsm_print_vmasm_amd64_go;   /* output amd64 assembler in Go format */
 fsm_print fsm_print_sh;
 fsm_print fsm_print_go;
 fsm_print fsm_print_rust;
+fsm_print fsm_print_llvm;
 fsm_print fsm_print_vmops_c;
 fsm_print fsm_print_vmops_h;
 fsm_print fsm_print_vmops_main;

--- a/include/print/esc.h
+++ b/include/print/esc.h
@@ -22,12 +22,16 @@ escputc json_escputc;
 escputc pcre_escputc;
 escputc rust_escputc_char;
 escputc rust_escputc_str;
+escputc llvm_escputc_char;
 
 int
 awk_escputcharlit(FILE *f, const struct fsm_options *opt, char c);
 
 int
 c_escputcharlit(FILE *f, const struct fsm_options *opt, char c);
+
+void
+llvm_escputcharlit(FILE *f, const struct fsm_options *opt, char c);
 
 void
 rust_escputcharlit(FILE *f, const struct fsm_options *opt, char c);

--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -167,6 +167,7 @@ print_name(const char *name)
 		{ "vmc",   fsm_print_vmc   },
 		{ "vmdot", fsm_print_vmdot },
 		{ "rust",  fsm_print_rust  },
+		{ "llvm",  fsm_print_llvm  },
 		{ "sh",    fsm_print_sh    },
 		{ "go",    fsm_print_go    },
 

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -50,6 +50,7 @@ fsm_print_vmasm_amd64_att
 fsm_print_vmasm_amd64_nasm
 fsm_print_vmasm_amd64_go
 fsm_print_rust
+fsm_print_llvm
 fsm_print_sh
 fsm_print_go
 fsm_print_vmops_c

--- a/src/libfsm/print/Makefile
+++ b/src/libfsm/print/Makefile
@@ -11,6 +11,7 @@ SRC += src/libfsm/print/irdot.c
 SRC += src/libfsm/print/irjson.c
 SRC += src/libfsm/print/json.c
 SRC += src/libfsm/print/rust.c
+SRC += src/libfsm/print/llvm.c
 SRC += src/libfsm/print/sh.c
 SRC += src/libfsm/print/go.c
 SRC += src/libfsm/print/vmc.c

--- a/src/libfsm/print/llvm.c
+++ b/src/libfsm/print/llvm.c
@@ -565,7 +565,7 @@ fsm_print_llvmfrag(FILE *f, const struct dfavm_assembler_ir *a,
 			if (opt->endleaf != NULL) {
 				if (-1 == opt->endleaf(f,
 					retlist.a[i].ids, retlist.a[i].count,
-					&i)) // XXX: passing &i rather than opt->endleaf_opaque is a hack
+					opt->endleaf_opaque))
 				{
 					return -1;
 				}

--- a/src/libfsm/print/llvm.c
+++ b/src/libfsm/print/llvm.c
@@ -464,7 +464,7 @@ fsm_print_llvm_complete(FILE *f, const struct ir *ir,
 
 	fprintf(f, " local_unnamed_addr");
 	fprintf(f, " hot nosync nounwind norecurse willreturn");
-	fprintf(f, "#0 {\n");
+	fprintf(f, " #0 {\n");
 
 	switch (opt->io) {
 	case FSM_IO_GETC:

--- a/src/libfsm/print/llvm.c
+++ b/src/libfsm/print/llvm.c
@@ -1,0 +1,527 @@
+/*
+ * Copyright 2008-2024 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdint.h>
+#include <errno.h>
+#include <stdio.h>
+#include <inttypes.h>
+
+#include <print/esc.h>
+
+#include <adt/set.h>
+
+#include <fsm/fsm.h>
+#include <fsm/pred.h>
+#include <fsm/walk.h>
+#include <fsm/print.h>
+#include <fsm/options.h>
+#include <fsm/vm.h>
+
+#include "libfsm/internal.h"
+
+#include "libfsm/vm/vm.h"
+
+#include "ir.h"
+
+#define OPAQUE_POINTERS 1
+
+#ifdef OPAQUE_POINTERS // llvm >= 15
+static const char *ptr_i8   = "ptr";
+static const char *ptr_i32  = "ptr";
+static const char *ptr_void = "ptr";
+#else
+static const char *ptr_i8   = "i8*";
+static const char *ptr_i32  = "i32*";
+static const char *ptr_void = "i8*";
+#endif
+
+/*
+ * If we had a stack, the current set of live values would be a frame.
+ * We're a DFA, so we don't have a stack. But I still think of them as a frame.
+ */
+struct frame {
+	unsigned r;
+	unsigned b;
+	unsigned c;
+};
+
+static unsigned
+use(const unsigned *n)
+{
+	assert(*n > 0);
+	return *n - 1;
+}
+
+static unsigned
+decl(unsigned *n)
+{
+	return (*n)++;
+}
+
+static int
+leaf(FILE *f, const fsm_end_id_t *ids, size_t count, const void *leaf_opaque)
+{
+	assert(f != NULL);
+	assert(leaf_opaque == NULL);
+
+	(void) ids;
+	(void) count;
+	(void) leaf_opaque;
+
+	/* XXX: this should be FSM_UNKNOWN or something non-EOF,
+	 * maybe user defined */
+	fprintf(f, "return TOK_UNKNOWN;");
+
+	return 0;
+}
+
+static const char *
+cmp_operator(int cmp)
+{
+	switch (cmp) {
+	case VM_CMP_LT: return "ult";
+	case VM_CMP_LE: return "ule";
+	case VM_CMP_EQ: return "eq";
+	case VM_CMP_GE: return "uge";
+	case VM_CMP_GT: return "ugt";
+	case VM_CMP_NE: return "ne";
+
+	case VM_CMP_ALWAYS:
+	default:
+		assert("unreached");
+		return NULL;
+	}
+}
+
+static void
+print_decl(FILE *f, const char *name, unsigned n)
+{
+	fprintf(f, "\t%%%s%u = ", name, n);
+}
+
+static void
+print_ret(FILE *f, long l)
+{
+	fprintf(f, "\tret i32 %ld\n", l);
+}
+
+// TODO: variadic
+static void
+print_label(FILE *f, const struct dfavm_op_ir *op, bool decl)
+{
+	if (!decl) {
+		fprintf(f, "%%");
+	}
+
+	fprintf(f, "l%" PRIu32, op->index);
+
+	if (decl) {
+		fprintf(f, ":\n");
+	}
+}
+
+static void
+print_cond(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt,
+	struct frame *frame)
+{
+	assert(frame != NULL);
+	assert(op->cmp != VM_CMP_ALWAYS);
+
+	print_decl(f, "r", decl(&frame->r));
+	fprintf(f, "icmp %s i8 %%c%u, ",
+		cmp_operator(op->cmp), use(&frame->c));
+	llvm_escputcharlit(f, opt, op->cmp_arg);
+	fprintf(f, " ; ");
+	c_escputcharlit(f, opt, op->cmp_arg); // C escaping for a comment
+	fprintf(f, "\n");
+}
+
+static int
+print_end(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt,
+	const struct ir *ir, enum dfavm_op_end end_bits)
+{
+	if (end_bits == VM_END_FAIL) {
+		print_ret(f, -1);
+	} else {
+		if (opt->endleaf != NULL) {
+			if (-1 == opt->endleaf(f,
+				op->ir_state->endids.ids, op->ir_state->endids.count,
+				opt->endleaf_opaque))
+			{
+				return -1;
+			}
+		} else {
+			print_ret(f, op->ir_state - ir->states);
+		}
+	}
+
+	return 0;
+}
+
+static void
+print_jump(FILE *f, const struct dfavm_op_ir *dest)
+{
+	fprintf(f, "\tbr label ");
+	print_label(f, dest, false);
+	fprintf(f, "\n");
+}
+
+static void
+print_fetch(FILE *f, const struct fsm_options *opt,
+	struct frame *frame, const struct dfavm_op_ir *next)
+{
+	unsigned n = decl(&frame->c);
+	unsigned b = decl(&frame->b);
+
+	assert(frame != NULL);
+	assert(next != NULL);
+
+	/*
+	 * Emitting phi here would mean we'd need to keep track of the
+	 * basic blocks that jump to the current block. That's entirely
+	 * possible with our IR, but seems like a lot of work when we
+	 * can just alloca and let llvm do it for us.
+	 */
+
+	// TODO: consider emitting fetch(%s, %n)
+
+	switch (opt->io) {
+	case FSM_IO_GETC: {
+		print_decl(f, "i", n);
+		fprintf(f, "tail call i32 %%fsm_getc(%s noundef %%getc_opaque) #1\n",
+			ptr_i8);
+
+		print_decl(f, "r", decl(&frame->r));
+		fprintf(f, "icmp eq i32 %%i%u, -1 ; EOF\n", n);
+
+		fprintf(f, "\tbr i1 %%r%u, label %%t%u, label %%f%u\n",
+			use(&frame->r), b, b);
+		fprintf(f, "f%u:\n", b);
+
+		print_decl(f, "c", n);
+		fprintf(f, "trunc i32 %%i%u to i8\n", n);
+
+		print_jump(f, next);
+		break;
+	}
+
+	case FSM_IO_STR: {
+		/*
+		 * If we increment %s instead of maintaining %n, we'd need to
+		 * do it post-EOS check. Otherwise we'd skip the first character
+		 * (or start with the pointer out of bounds).
+		 */
+		print_decl(f, "n", n);
+		fprintf(f, "load i32, %s %%n\n", ptr_i32);
+
+		print_decl(f, "n.new", n);
+		fprintf(f, "add i32 1, %%n%u\n", n);
+
+		fprintf(f, "\tstore i32 %%n.new%u, %s %%n\n", n, ptr_i32);
+
+		print_decl(f, "p", n);
+		fprintf(f, "getelementptr inbounds i8, %s %%s, i32 %%n%u\n",
+			ptr_i8, n);
+
+		print_decl(f, "c", n);
+		fprintf(f, "load i8, %s %%p%u\n",
+			ptr_i8, n);
+
+		print_decl(f, "r", decl(&frame->r));
+	  	fprintf(f, "icmp eq i8 %%c%u, 0 ; EOT\n",
+			n);
+
+		// TODO: skip t%u: if the next instruction is ret -1, centralise it to fail:
+		fprintf(f, "\tbr i1 %%r%u, label %%t%u, label %%l%u\n",
+			use(&frame->r), b, next->index);
+		break;
+	 }
+
+	case FSM_IO_PAIR: {
+		print_decl(f, "n", n);
+		fprintf(f, "load i32, %s %%n\n", ptr_i32);
+
+		print_decl(f, "n.new", n);
+		fprintf(f, "add i32 1, %%n%u\n", n);
+
+		fprintf(f, "\tstore i32 %%n.new%u, %s %%n\n", n, ptr_i32);
+
+		print_decl(f, "p", n);
+		fprintf(f, "getelementptr inbounds i8, %s %%b, i32 %%n%u\n",
+			ptr_i8, n);
+
+		print_decl(f, "r", decl(&frame->r));
+	  	fprintf(f, "icmp eq %s %%p%u, %%e ; EOF\n",
+			ptr_i8, n);
+
+		fprintf(f, "\tbr i1 %%r%u, label %%t%u, label %%f%u\n",
+			use(&frame->r), b, b);
+		fprintf(f, "f%u:\n", b);
+
+		print_decl(f, "c", n);
+		fprintf(f, "load i8, %s %%p%u\n",
+			ptr_i8, n);
+
+		print_jump(f, next);
+		break;
+	}
+
+	default:
+		fprintf(stderr, "unsupported IO API\n");
+		exit(EXIT_FAILURE);
+	}
+
+	// TODO: skip t%u: if the next instruction is ret -1, centralise it to fail:
+	fprintf(f, "t%u:\n", use(&frame->b));
+}
+
+/* TODO: eventually to be non-static */
+static int
+fsm_print_llvmfrag(FILE *f, const struct dfavm_assembler_ir *a,
+	const struct fsm_options *opt, const struct ir *ir,
+	const char *cp,
+	int (*leaf)(FILE *, const fsm_end_id_t *ids, size_t count, const void *leaf_opaque),
+	const void *leaf_opaque)
+{
+	struct dfavm_op_ir *op;
+
+	assert(f != NULL);
+	assert(a != NULL);
+	assert(opt != NULL);
+	assert(cp != NULL);
+
+	/* TODO: we don't currently have .opaque information attached to struct dfavm_op_ir.
+	 * We'll need that in order to be able to use the leaf callback here. */
+	(void) leaf;
+	(void) leaf_opaque;
+
+	/* TODO: we'll need to heed cp for e.g. lx's codegen */
+	(void) cp;
+
+	{
+		uint32_t l;
+
+		l = 0;
+
+		for (op = a->linked; op != NULL; op = op->next) {
+			op->index = l++;
+		}
+	}
+
+	print_jump(f, a->linked);
+
+	struct frame frame = { 0, 0, 0 };
+	for (op = a->linked; op != NULL; op = op->next) {
+		print_label(f, op, true);
+
+		if (op->ir_state != NULL && op->ir_state->example != NULL) {
+			/* C's escaping seems to be a subset of llvm's, and these are
+			 * for comments anyway. So I'm borrowing this for C here */
+			fprintf(f, "\t; e.g. \"");
+			escputs(f, opt, c_escputc_str, op->ir_state->example);
+			fprintf(f, "\"");
+
+			fprintf(f, "\n");
+		}
+
+		switch (op->instr) {
+		case VM_OP_STOP:
+			if (op->cmp != VM_CMP_ALWAYS) {
+				unsigned b = decl(&frame.b);
+				unsigned next = op->next->index;
+
+				print_cond(f, op, opt, &frame);
+
+// TODO: fold into print_cond()
+				fprintf(f, "\tbr i1 %%r%u, label %%t%u, label %%l%u\n",
+					use(&frame.r), b, next);
+				fprintf(f, "t%u:\n", b);
+			}
+
+			if (-1 == print_end(f, op, opt, ir, op->u.stop.end_bits)) {
+				return -1;
+			}
+			break;
+
+		case VM_OP_FETCH: {
+			print_fetch(f, opt, &frame, op->next);
+
+			if (-1 == print_end(f, op, opt, ir, op->u.fetch.end_bits)) {
+				return -1;
+			}
+			break;
+		}
+
+		case VM_OP_BRANCH: {
+			const struct dfavm_op_ir *dest = op->u.br.dest_arg;
+
+			if (op->cmp == VM_CMP_ALWAYS) {
+				print_jump(f, dest);
+			} else {
+				unsigned next = op->next->index;
+
+				print_cond(f, op, opt, &frame);
+
+				fprintf(f, "\tbr i1 %%r%u, label ", use(&frame.r));
+				print_label(f, dest, false);
+				fprintf(f, ", label %%l%u\n", next);
+			}
+			break;
+		}
+
+		default:
+			assert(!"unreached");
+			break;
+		}
+	}
+
+// TODO: collate ret values together at the end, keeps them out of the i-cache maybe
+// or better yet, have one ret: label and emit a phi
+
+	return 0;
+}
+
+static int
+fsm_print_llvm_complete(FILE *f, const struct ir *ir,
+	const struct fsm_options *opt, const char *prefix, const char *cp)
+{
+	static const struct dfavm_assembler_ir zero;
+	struct dfavm_assembler_ir a;
+
+	static const struct fsm_vm_compile_opts vm_opts = {
+		FSM_VM_COMPILE_DEFAULT_FLAGS,
+		FSM_VM_COMPILE_VM_V1,
+		NULL
+	};
+
+	assert(f != NULL);
+	assert(ir != NULL);
+	assert(opt != NULL);
+
+	a = zero;
+
+	if (!dfavm_compile_ir(&a, ir, vm_opts)) {
+		return -1;
+	}
+
+	if (opt->fragment) {
+		fsm_print_llvmfrag(f, &a, opt, ir, cp,
+			opt->leaf != NULL ? opt->leaf : leaf, opt->leaf_opaque);
+		goto error;
+	}
+
+	fprintf(f, "; generated\n");
+	fprintf(f, "define dso_local i32 @%smain", prefix);
+
+	switch (opt->io) {
+	case FSM_IO_GETC:
+#ifdef OPAQUE_POINTERS
+		fprintf(f, "(i32 (%s)* nocapture noundef readonly %%fsm_getc, %s noundef %%getc_opaque)",
+			ptr_i8, ptr_void);
+#else
+		fprintf(f, "(ptr nocapture noundef readonly %%fsm_getc, ptr noundef %%getc_opaque)");
+#endif
+		break;
+
+	case FSM_IO_STR:
+		fprintf(f, "(%s nocapture noundef readonly %%s)",
+			ptr_i8);
+		break;
+
+	case FSM_IO_PAIR:
+		fprintf(f, "(%s noundef readonly %%b, %s noundef readnone %%e)",
+			ptr_i8, ptr_i8);
+		break;
+
+	default:
+		fprintf(f, "(%s nocapture noundef readonly %%b, %s nocapture noundef readonly %%e)",
+			ptr_i8, ptr_i8);
+		break;
+	}
+
+	fprintf(f, " local_unnamed_addr");
+	fprintf(f, " hot nosync nounwind norecurse willreturn");
+	fprintf(f, "#0 {\n");
+
+	switch (opt->io) {
+	case FSM_IO_GETC:
+		break;
+
+	case FSM_IO_STR:
+		fprintf(f, "\t%%n = alloca i32\n");
+		fprintf(f, "\tstore i32 -1, %s %%n\n", ptr_i32);
+		break;
+
+	case FSM_IO_PAIR:
+		fprintf(f, "\t%%n = alloca i32\n");
+		fprintf(f, "\tstore i32 -1, %s %%n\n", ptr_i32);
+		break;
+
+	default:
+		fprintf(stderr, "unsupported IO API\n");
+		exit(EXIT_FAILURE);
+	}
+
+	fsm_print_llvmfrag(f, &a, opt, ir, cp,
+		opt->leaf != NULL ? opt->leaf : leaf, opt->leaf_opaque);
+
+	fprintf(f, "}\n");
+	fprintf(f, "\n");
+
+	dfavm_opasm_finalize_op(&a);
+
+	if (ferror(f)) {
+		return -1;
+	}
+
+	return 0;
+
+error:
+
+	dfavm_opasm_finalize_op(&a);
+
+	return -1;
+}
+
+int
+fsm_print_llvm(FILE *f, const struct fsm *fsm)
+{
+	struct ir *ir;
+	const char *prefix;
+	const char *cp;
+	int r;
+
+	assert(f != NULL);
+	assert(fsm != NULL);
+	assert(fsm->opt != NULL);
+
+	ir = make_ir(fsm);
+	if (ir == NULL) {
+		return -1;
+	}
+
+	if (fsm->opt->prefix != NULL) {
+		prefix = fsm->opt->prefix;
+	} else {
+		prefix = "fsm_";
+	}
+
+	if (fsm->opt->cp != NULL) {
+		cp = fsm->opt->cp;
+	} else {
+		cp = "c"; /* XXX */
+	}
+
+	r = fsm_print_llvm_complete(f, ir, fsm->opt, prefix, cp);
+
+	free_ir(fsm, ir);
+
+	return r;
+}
+

--- a/src/print/Makefile
+++ b/src/print/Makefile
@@ -6,6 +6,7 @@ SRC += src/print/dot.c
 SRC += src/print/abnf.c
 SRC += src/print/fsm.c
 SRC += src/print/json.c
+SRC += src/print/llvm.c
 SRC += src/print/pcre.c
 SRC += src/print/rust.c
 SRC += src/print/tok.c

--- a/src/print/llvm.c
+++ b/src/print/llvm.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2008-2017 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#include <ctype.h>
+#include <assert.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include <fsm/fsm.h>
+#include <fsm/options.h>
+
+#include <print/esc.h>
+
+int
+llvm_escputc_char(FILE *f, const struct fsm_options *opt, char c)
+{
+	assert(f != NULL);
+	assert(opt != NULL);
+
+	if (opt->always_hex) {
+		return fprintf(f, "u%#02x", (unsigned char) c);
+	}
+
+	return fprintf(f, "%u", (unsigned char) c);
+}
+
+void
+llvm_escputcharlit(FILE *f, const struct fsm_options *opt, char c)
+{
+	assert(f != NULL);
+	assert(opt != NULL);
+
+	if (opt->always_hex || (unsigned char) c > SCHAR_MAX) {
+		fprintf(f, "u%#02x", (unsigned char) c);
+		return;
+	}
+
+	llvm_escputc_char(f, opt, c);
+}
+

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -503,10 +503,11 @@ endleaf_llvm(FILE *f,
 	unsigned n;
 	size_t i;
 
-	assert(endleaf_opaque == NULL);
+	/* hack for llvm codegen only */
+	const size_t *ret = endleaf_opaque;
+	assert(ret != NULL);
 
 	(void) f;
-	(void) endleaf_opaque;
 
 	n = 0;
 
@@ -516,7 +517,7 @@ endleaf_llvm(FILE *f,
 		}
 	}
 
-	fprintf(f, "\tret i32 u%#x", (unsigned) n);
+	fprintf(f, "[u%#x, %%ret%zu],", (unsigned) n, *ret);
 
 	fprintf(f, " ; ");
 

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -503,11 +503,20 @@ endleaf_llvm(FILE *f,
 	unsigned n;
 	size_t i;
 
-	/* hack for llvm codegen only */
-	const size_t *ret = endleaf_opaque;
-	assert(ret != NULL);
+	/*
+	 * XXX: Hack for llvm codegen only, we don't have a way to pass this
+	 * value from fsm_print_llvm(). We're working around that by making
+	 * an assumption about the ordering for ret label numbers, that
+	 * they're output sequentially.
+	 *
+	 * And also it's not very forward-thinking to keep this in static storage.
+	 */
+	static size_t ret = 0;
+
+	assert(endleaf_opaque == NULL);
 
 	(void) f;
+	(void) endleaf_opaque;
 
 	n = 0;
 
@@ -517,7 +526,7 @@ endleaf_llvm(FILE *f,
 		}
 	}
 
-	fprintf(f, "[u%#x, %%ret%zu],", (unsigned) n, *ret);
+	fprintf(f, "[u%#x, %%ret%zu],", (unsigned) n, ret++);
 
 	fprintf(f, " ; ");
 

--- a/src/retest/main.c
+++ b/src/retest/main.c
@@ -179,6 +179,7 @@ usage(void)
 	fprintf(stderr, "                 vmc       compile as per fsm_print_vmc()\n");
 	fprintf(stderr, "                 vmops     compile as per fsm_print_vmops_{c,h,main}()\n");
 	fprintf(stderr, "                 rust      compile as per fsm_print_rust()\n");
+	fprintf(stderr, "                 llvm      compile as per fsm_print_llvm()\n");
 
 	fprintf(stderr, "\n");
 	fprintf(stderr, "        -x <encoding>\n");
@@ -1280,6 +1281,8 @@ main(int argc, char *argv[])
 					impl = IMPL_GO;
 				} else if (strcmp(optarg, "goasm") == 0) {
 					impl = IMPL_GOASM;
+				} else if (strcmp(optarg, "llvm") == 0) {
+					impl = IMPL_LLVM;
 				} else if (strcmp(optarg, "rust") == 0) {
 					impl = IMPL_RUST;
 				} else {

--- a/src/retest/reperf.c
+++ b/src/retest/reperf.c
@@ -1062,6 +1062,7 @@ usage(void)
 	fprintf(stderr, "                 c         compile as per fsm_print_c()\n");
 	fprintf(stderr, "                 vmc       compile as per fsm_print_vmc()\n");
 	fprintf(stderr, "                 rust      compile as per fsm_print_rust()\n");
+	fprintf(stderr, "                 llvm      compile as per fsm_print_llvm()\n");
 
 	fprintf(stderr, "\n");
 	fprintf(stderr, "        -x <encoding>\n");
@@ -1155,6 +1156,8 @@ main(int argc, char *argv[])
 					impl = IMPL_INTERPRET;
 				} else if (strcmp(optarg, "c") == 0) {
 					impl = IMPL_C;
+				} else if (strcmp(optarg, "llvm") == 0) {
+					impl = IMPL_LLVM;
 				} else if (strcmp(optarg, "rust") == 0) {
 					impl = IMPL_RUST;
 				} else if (strcmp(optarg, "asm") == 0) {

--- a/src/retest/runner.c
+++ b/src/retest/runner.c
@@ -166,7 +166,7 @@ compile(enum implementation impl,
 		break;
 
 	case IMPL_LLVM:
-		if (0 != systemf("clang %s -shared -fPIC -opaque-pointers %s -o %s",
+		if (0 != systemf("clang %s -shared -fPIC -mllvm -opaque-pointers %s -o %s",
 				cflags ? cflags : "-pedantic -Wall -Werror -Wno-override-module -O3",
 				tmp_src, tmp_so))
 		{

--- a/src/retest/runner.c
+++ b/src/retest/runner.c
@@ -166,7 +166,7 @@ compile(enum implementation impl,
 		break;
 
 	case IMPL_LLVM:
-		if (0 != systemf("clang %s -shared -fPIC %s -o %s",
+		if (0 != systemf("clang %s -shared -fPIC -opaque-pointers %s -o %s",
 				cflags ? cflags : "-pedantic -Wall -Werror -Wno-override-module -O3",
 				tmp_src, tmp_so))
 		{

--- a/src/retest/runner.c
+++ b/src/retest/runner.c
@@ -86,6 +86,7 @@ print(const struct fsm *fsm, enum implementation impl,
 		switch (impl) {
 		case IMPL_C:     e = fsm_print_c(f, fsm);               break;
 		case IMPL_RUST:  e = fsm_print_rust(f, fsm);            break;
+		case IMPL_LLVM:  e = fsm_print_llvm(f, fsm);            break;
 		case IMPL_VMC:   e = fsm_print_vmc(f, fsm);             break;
 		case IMPL_GOASM: e = fsm_print_vmasm_amd64_go(f, fsm);  break;
 		case IMPL_VMASM: e = fsm_print_vmasm_amd64_att(f, fsm); break;
@@ -145,7 +146,7 @@ compile(enum implementation impl,
 	case IMPL_C:
 	case IMPL_VMC:
 	case IMPL_VMOPS:
-		if (0 != systemf("%s %s -xc -shared -fPIC %s -o %s",
+		if (0 != systemf("%s %s -shared -fPIC %s -o %s",
 				cc ? cc : "gcc", cflags ? cflags : "-std=c89 -pedantic -Wall -Werror -O3",
 				tmp_src, tmp_so))
 		{
@@ -157,6 +158,16 @@ compile(enum implementation impl,
 	case IMPL_RUST:
 		if (0 != systemf("%s %s --crate-type dylib %s -o %s",
 				"rustc", "--edition 2021",
+				tmp_src, tmp_so))
+		{
+			return 0;
+		}
+
+		break;
+
+	case IMPL_LLVM:
+		if (0 != systemf("clang %s -shared -fPIC %s -o %s",
+				cflags ? cflags : "-pedantic -Wall -Werror -Wno-override-module -O3",
 				tmp_src, tmp_so))
 		{
 			return 0;
@@ -287,6 +298,7 @@ runner_init_compiled(struct fsm *fsm, struct fsm_runner *r, enum implementation 
 	char tmp_src_go[] = "/tmp/fsmcompile_src-XXXXXX.go";
 	char tmp_src_c[]  = "/tmp/fsmcompile_src-XXXXXX.c";
 	char tmp_src_rs[] = "/tmp/fsmcompile_src-XXXXXX.rs";
+	char tmp_src_ll[] = "/tmp/fsmcompile_src-XXXXXX.ll";
 	char tmp_src_s[]  = "/tmp/fsmcompile_src-XXXXXX.s";
 	char *tmp_src;
 
@@ -295,6 +307,7 @@ runner_init_compiled(struct fsm *fsm, struct fsm_runner *r, enum implementation 
 	case IMPL_C:
 	case IMPL_VMC:   tmp_src = tmp_src_c;  break;
 	case IMPL_RUST:  tmp_src = tmp_src_rs; break;
+	case IMPL_LLVM:  tmp_src = tmp_src_ll; break;
 	case IMPL_GOASM:
 	case IMPL_VMASM: tmp_src = tmp_src_s;  break;
 	case IMPL_GO:    tmp_src = tmp_src_go; break;
@@ -359,6 +372,11 @@ runner_init_compiled(struct fsm *fsm, struct fsm_runner *r, enum implementation 
 		r->u.impl_rust.func = (int64_t (*)(const unsigned char *, size_t)) (uintptr_t) dlsym(h, "retest_trampoline");
 		break;
 
+	case IMPL_LLVM:
+		r->u.impl_llvm.h = h;
+		r->u.impl_llvm.func = (int (*)(const char *, const char *)) (uintptr_t) dlsym(h, "fsm_main");
+		break;
+
 	case IMPL_GO:
 	case IMPL_GOASM:
 		r->u.impl_go.h = h;
@@ -394,6 +412,7 @@ fsm_runner_initialize(struct fsm *fsm, struct fsm_runner *r, enum implementation
 
 	switch (impl) {
 	case IMPL_C:
+	case IMPL_LLVM:
 	case IMPL_RUST:
 	case IMPL_VMASM:
 	case IMPL_VMC:
@@ -433,6 +452,12 @@ fsm_runner_finalize(struct fsm_runner *r)
 	case IMPL_RUST:
 		if (r->u.impl_rust.h != NULL) {
 			dlclose(r->u.impl_rust.h);
+		}
+		break;
+
+	case IMPL_LLVM:
+		if (r->u.impl_llvm.h != NULL) {
+			dlclose(r->u.impl_llvm.h);
 		}
 		break;
 
@@ -476,6 +501,10 @@ fsm_runner_run(const struct fsm_runner *r, const char *s, size_t n)
 	case IMPL_RUST:
 		assert(r->u.impl_rust.func != NULL);
 		return r->u.impl_rust.func((const unsigned char *)s, n) >= 0;
+
+	case IMPL_LLVM:
+		assert(r->u.impl_llvm.func != NULL);
+		return r->u.impl_llvm.func(s, s+n) >= 0;
 
 	case IMPL_GO:
 	case IMPL_GOASM:

--- a/src/retest/runner.h
+++ b/src/retest/runner.h
@@ -27,6 +27,7 @@ enum error_type {
 enum implementation {
 	IMPL_C,
 	IMPL_RUST,
+	IMPL_LLVM,
 	IMPL_GO,
 	IMPL_GOASM,
 	IMPL_VMC,
@@ -49,6 +50,11 @@ struct fsm_runner {
 			void *h;
 			int64_t (*func)(const unsigned char *, size_t);
 		} impl_rust;
+
+		struct {
+			void *h;
+			int (*func)(const char *, const char *);
+		} impl_llvm;
 
 		struct {
 			void *h;

--- a/tests/retest/Makefile
+++ b/tests/retest/Makefile
@@ -8,7 +8,7 @@ DIR += ${TEST_OUTDIR.tests/retest}
 
 RETEST=${BUILD}/bin/retest
 
-.for lang in vm asm c vmc
+.for lang in vm asm c vmc llvm
 .for io in pair str
 
 # XXX: we don't have FSM_IO_STR for asm yet


### PR DESCRIPTION
This goes via the VM opcodes.

I've made a couple of simple attempts to inline labels for branching where the target immediately jumps to something else, but not many.

There are a few optimisations I'd like to do in order to cut down the code size. In particular I'd like to emit `switch` for consolidating runs of `VM_CMP_EQ` comparisons, and `icmp` for memcmp-style runs fetched in sequence. However to do those, I'd like to rework some of the VM opcodes a bit, because attempting to do that analysis here in the output layer is the wrong place. Then every codegen could benefit.

That isn't a rabbit hole I need to go down right now, and the current llvm codegen is enough for what I'm doing. So I'm calling it here and making a PR while I can still escape.

The generated code looks like this:
```
; ./build/bin/re -pl llvm '^ab*c' 'x?'
; generated
define dso_local i32 @fsm_main(i32 (ptr)* nocapture noundef readonly %fsm_getc, ptr noundef %getc_opaque) local_unnamed_addr hot nosync nounwind norecurse willreturn #0 {
	br label %l0
stop:
	%ret = phi i32
	 [u0x2, %ret0], ; "x?"
	 [u0x3, %ret1], ; "^ab*c", "x?"
	 [-1, %fail]
	ret i32 %ret
fail:
	br label %stop
ret0:
	br label %stop
ret1:
	br label %stop
l0:
	%i0 = tail call i32 %fsm_getc(ptr noundef %getc_opaque) #1
	%r0 = icmp eq i32 %i0, -1 ; EOF
	br i1 %r0, label %t0, label %f0
f0:
	%c0 = trunc i32 %i0 to i8
	br label %l1
t0:
	br label %ret0
l1:
	%r1 = icmp eq i8 %c0, 97 ; 'a'
	br i1 %r1, label %l3, label %l2
l2:
	; e.g. "\\x00"
	br label %ret0
l3:
	; e.g. "a"
	%i1 = tail call i32 %fsm_getc(ptr noundef %getc_opaque) #1
	%r2 = icmp eq i32 %i1, -1 ; EOF
	br i1 %r2, label %t1, label %f1
f1:
	%c1 = trunc i32 %i1 to i8
	br label %l4
t1:
	br label %ret0
l4:
	; e.g. "a"
	%r3 = icmp eq i8 %c1, 98 ; 'b'
	br i1 %r3, label %l3, label %l5
l5:
	; e.g. "a"
	%r4 = icmp ne i8 %c1, 99 ; 'c'
	br i1 %r4, label %l2, label %l6
l6:
	; e.g. "ac"
	br label %ret1
}
```