### PR TITLE
Implement AMBIG_MULTIPLE for llvm, Rust, go, and the vmops dump

### DIFF
--- a/include/fsm/print.h
+++ b/include/fsm/print.h
@@ -94,7 +94,7 @@ struct fsm_hooks {
  * but simply not yet implemented, where fsm_print() will print a message
  * to stderr and exit.
  *
- * The code generation for the typical case of matching input require the FSM
+ * The code generation for the typical case of matching input requires the FSM
  * to be a DFA, and will EINVAL if the FSM is not a DFA. As opposed to e.g.
  * FSM_PRINT_API, which generates code for other purposes, and does not place
  * particular expecations on the FSM.

--- a/include/fsm/print.h
+++ b/include/fsm/print.h
@@ -74,7 +74,7 @@ struct fsm_hooks {
 
 	int (*comment)(FILE *, const struct fsm_options *opt,
 		const fsm_end_id_t *ids, size_t count,
-		void *lang_opaque, void *hook_opaque);
+		void *hook_opaque);
 
 	/* only called for AMBIG_ERROR; see opt.ambig */
 	int (*conflict)(FILE *, const struct fsm_options *opt,

--- a/include/fsm/print.h
+++ b/include/fsm/print.h
@@ -87,7 +87,17 @@ struct fsm_hooks {
 
 /*
  * Print an FSM to the given file stream. The output is written in the format
- * specified.
+ * specified by the lang enum.
+ *
+ * Not all languages support all options, and fsm_print will ENOTSUP where
+ * these are not possible. This is different to when an option is possible
+ * but simply not yet implemented, where fsm_print() will print a message
+ * to stderr and exit.
+ *
+ * The code generation for the typical case of matching input require the FSM
+ * to be a DFA, and will EINVAL if the FSM is not a DFA. As opposed to e.g.
+ * FSM_PRINT_API, which generates code for other purposes, and does not place
+ * particular expecations on the FSM.
  *
  * The output options may be NULL, indicating to use defaults.
  *

--- a/include/fsm/print.h
+++ b/include/fsm/print.h
@@ -72,6 +72,10 @@ struct fsm_hooks {
 	int (*reject)(FILE *, const struct fsm_options *opt,
 		void *lang_opaque, void *hook_opaque);
 
+	int (*comment)(FILE *, const struct fsm_options *opt,
+		const fsm_end_id_t *ids, size_t count,
+		void *lang_opaque, void *hook_opaque);
+
 	/* only called for AMBIG_ERROR; see opt.ambig */
 	int (*conflict)(FILE *, const struct fsm_options *opt,
 		const fsm_end_id_t *ids, size_t count,

--- a/src/libfsm/print.c
+++ b/src/libfsm/print.c
@@ -59,6 +59,8 @@ print_hook_accept(FILE *f,
 		void *lang_opaque, void *hook_opaque),
 	void *lang_opaque)
 {
+	int r;
+
 	assert(f != NULL);
 	assert(opt != NULL);
 	assert(hooks != NULL);
@@ -72,10 +74,24 @@ print_hook_accept(FILE *f,
 	}
 
 	if (hooks->accept != NULL) {
-		return hooks->accept(f, opt, ids, count,
+		r = hooks->accept(f, opt, ids, count,
 			lang_opaque, hooks->hook_opaque);
 	} else if (default_accept != NULL) {
-		return default_accept(f, opt, ids, count,
+		r = default_accept(f, opt, ids, count,
+			lang_opaque, hooks->hook_opaque);
+	} else {
+		r = 0;
+	}
+
+	if (r != 0) {
+		return r;
+	}
+
+	if (opt->comments && hooks->comment != NULL) {
+		/* this space is a polyglot */
+		fprintf(f, " ");
+
+		r = hooks->comment(f, opt, ids, count,
 			lang_opaque, hooks->hook_opaque);
 	}
 

--- a/src/libfsm/print.c
+++ b/src/libfsm/print.c
@@ -18,6 +18,7 @@
 #include "print.h"
 #include "internal.h"
 
+#include "vm/retlist.h"
 #include "vm/vm.h"
 #include "print/ir.h"
 
@@ -179,6 +180,7 @@ print_conflicts(FILE *f, const struct fsm *fsm,
 		assert(res == 1);
 
 		// TODO: de-duplicate by ids[], so we don't call the conflict hook an unneccessary number of times
+		// TODO: now i think this is the same as calling once per retlist entry
 
 		/*
 		 * The conflict hook is called here (rather in the caller),
@@ -336,19 +338,36 @@ fsm_print(FILE *f, const struct fsm *fsm,
 		goto done;
 	}
 
+	/*
+	 * We're building the retlist here based on the ir.
+	 * I think we could build the retlist earlier instead,
+	 * and then point at the struct ret entries from the ir,
+	 * and then dfavm_compile_ir() would pick those up from there.
+	 * But for now this is good.
+	 */
+	struct ret_list retlist;
+
+	if (!build_retlist(&retlist, ir)) {
+		free_ir(fsm, ir);
+		goto error;
+	}
+
 	a = zero;
 
 	/* TODO: non-const a */
-	if (!dfavm_compile_ir(&a, ir, vm_opts)) {
+	if (!dfavm_compile_ir(&a, ir, &retlist, vm_opts)) {
+		free_retlist(&retlist);
 		free_ir(fsm, ir);
 		return -1;
 	}
 
 	if (print_vm != NULL) {
-		r = print_vm(f, opt, hooks, a.linked);
+		r = print_vm(f, opt, hooks, &retlist, a.linked);
 	}
 
 	dfavm_opasm_finalize_op(&a);
+
+	free_retlist(&retlist);
 
 done:
 

--- a/src/libfsm/print.c
+++ b/src/libfsm/print.c
@@ -59,8 +59,6 @@ print_hook_accept(FILE *f,
 		void *lang_opaque, void *hook_opaque),
 	void *lang_opaque)
 {
-	int r;
-
 	assert(f != NULL);
 	assert(opt != NULL);
 	assert(hooks != NULL);
@@ -74,25 +72,36 @@ print_hook_accept(FILE *f,
 	}
 
 	if (hooks->accept != NULL) {
-		r = hooks->accept(f, opt, ids, count,
+		return hooks->accept(f, opt, ids, count,
 			lang_opaque, hooks->hook_opaque);
 	} else if (default_accept != NULL) {
-		r = default_accept(f, opt, ids, count,
+		return default_accept(f, opt, ids, count,
 			lang_opaque, hooks->hook_opaque);
-	} else {
-		r = 0;
 	}
 
-	if (r != 0) {
-		return r;
+	return 0;
+}
+
+int
+print_hook_comment(FILE *f,
+	const struct fsm_options *opt,
+	const struct fsm_hooks *hooks,
+	const fsm_end_id_t *ids, size_t count)
+{
+	assert(f != NULL);
+	assert(opt != NULL);
+	assert(hooks != NULL);
+
+	if (opt->ambig == AMBIG_ERROR) {
+		assert(count <= 1);
 	}
 
 	if (opt->comments && hooks->comment != NULL) {
 		/* this space is a polyglot */
 		fprintf(f, " ");
 
-		r = hooks->comment(f, opt, ids, count,
-			lang_opaque, hooks->hook_opaque);
+		return hooks->comment(f, opt, ids, count,
+			hooks->hook_opaque);
 	}
 
 	return 0;

--- a/src/libfsm/print.h
+++ b/src/libfsm/print.h
@@ -12,6 +12,7 @@ struct fsm_options;
 struct fsm_hooks;
 struct ir;
 struct dfavm_op_ir;
+struct ret_list;
 
 int
 print_hook_args(FILE *f,
@@ -59,6 +60,7 @@ typedef int ir_print_f(FILE *f,
 typedef int vm_print_f(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
+	const struct ret_list *retlist,
 	struct dfavm_op_ir *ops);
 
 vm_print_f fsm_print_amd64_att;

--- a/src/libfsm/print.h
+++ b/src/libfsm/print.h
@@ -33,6 +33,12 @@ print_hook_accept(FILE *f,
 	void *lang_opaque);
 
 int
+print_hook_comment(FILE *f,
+	const struct fsm_options *opt,
+	const struct fsm_hooks *hooks,
+	const fsm_end_id_t *ids, size_t count);
+
+int
 print_hook_reject(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,

--- a/src/libfsm/print/api.c
+++ b/src/libfsm/print/api.c
@@ -217,7 +217,7 @@ fsm_print_api(FILE *f,
 				} else {
 					fprintf(f, "\tfor (i = 0x%02x; i <= 0x%02x; i++) {",
 						(unsigned int) lo, (unsigned int) hi - 1);
-					if (rangeclass(lo, hi - 1)) {
+					if (opt->comments && rangeclass(lo, hi - 1)) {
 						fprintf(f, " /* '%c' .. '%c' */", (unsigned char) lo, (unsigned char) hi - 1);
 					}
 					fprintf(f, "\n");

--- a/src/libfsm/print/awk.c
+++ b/src/libfsm/print/awk.c
@@ -157,10 +157,21 @@ print_end(FILE *f, const struct dfavm_op_ir *op,
 		return print_hook_reject(f, opt, hooks, default_reject, NULL);
 
 	case VM_END_SUCC:
-		return print_hook_accept(f, opt, hooks,
+		if (-1 == print_hook_accept(f, opt, hooks,
 			op->ret->ids, op->ret->count,
 			default_accept,
-			NULL);
+			NULL))
+		{
+			return -1;
+		}
+
+		if (-1 == print_hook_comment(f, opt, hooks,
+			op->ret->ids, op->ret->count))
+		{
+			return -1;
+		}
+
+		return 0;
 
 	default:
 		assert(!"unreached");

--- a/src/libfsm/print/awk.c
+++ b/src/libfsm/print/awk.c
@@ -26,6 +26,7 @@
 #include "libfsm/internal.h"
 #include "libfsm/print.h"
 
+#include "libfsm/vm/retlist.h"
 #include "libfsm/vm/vm.h"
 
 #define START UINT32_MAX
@@ -157,7 +158,7 @@ print_end(FILE *f, const struct dfavm_op_ir *op,
 
 	case VM_END_SUCC:
 		return print_hook_accept(f, opt, hooks,
-			op->endids.ids, op->endids.count,
+			op->ret->ids, op->ret->count,
 			default_accept,
 			NULL);
 
@@ -186,6 +187,7 @@ static int
 fsm_print_awkfrag(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
+	const struct ret_list *retlist,
 	struct dfavm_op_ir *ops,
 	const char *cp, const char *prefix)
 {
@@ -194,6 +196,7 @@ fsm_print_awkfrag(FILE *f,
 	assert(f != NULL);
 	assert(opt != NULL);
 	assert(hooks != NULL);
+	assert(retlist != NULL);
 	assert(cp != NULL);
 	assert(prefix != NULL);
 
@@ -289,6 +292,7 @@ int
 fsm_print_awk(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
+	const struct ret_list *retlist,
 	struct dfavm_op_ir *ops)
 {
 	const char *prefix;
@@ -297,6 +301,7 @@ fsm_print_awk(FILE *f,
 	assert(f != NULL);
 	assert(opt != NULL);
 	assert(hooks != NULL);
+	assert(retlist != NULL);
 
 	if (opt->prefix != NULL) {
 		prefix = opt->prefix;
@@ -311,7 +316,7 @@ fsm_print_awk(FILE *f,
 	}
 
 	if (opt->fragment) {
-		if (-1 == fsm_print_awkfrag(f, opt, hooks, ops, cp, prefix)) {
+		if (-1 == fsm_print_awkfrag(f, opt, hooks, retlist, ops, cp, prefix)) {
 			return -1;
 		}
 	} else {
@@ -333,7 +338,7 @@ fsm_print_awk(FILE *f,
 
 		fprintf(f, ",    l, c) {\n");
 
-		if (-1 == fsm_print_awkfrag(f, opt, hooks, ops, cp, prefix)) {
+		if (-1 == fsm_print_awkfrag(f, opt, hooks, retlist, ops, cp, prefix)) {
 			return -1;
 		}
 

--- a/src/libfsm/print/c.c
+++ b/src/libfsm/print/c.c
@@ -71,15 +71,17 @@ print_ids(FILE *f,
 			return -1;
 		}
 
-		fprintf(f, "return %u;", ids[0]);
-		break;
+		/* fallthrough */
 
 	case AMBIG_EARLIEST:
 		/*
 		 * The libfsm api guarentees these ids are unique,
 		 * and only appear once each, and are sorted.
 		 */
-		fprintf(f, "return %u;", ids[0]);
+		fprintf(f, "{\n");
+		fprintf(f, "\t\t*id = %u;\n", ids[0]);
+		fprintf(f, "\t\treturn 1;\n");
+		fprintf(f, "\t}");
 		break;
 
 	case AMBIG_MULTIPLE:

--- a/src/libfsm/print/c.c
+++ b/src/libfsm/print/c.c
@@ -352,12 +352,18 @@ print_endstates(FILE *f,
 
 	/* no end states */
 	if (!ir_hasend(ir)) {
-		fprintf(f, "\treturn 0; /* unexpected EOT */\n");
+		fprintf(f, "\treturn 0;");
+		if (opt->comments) {
+			fprintf(f, " /* unexpected EOT */");
+		}
+		fprintf(f, "\n");
 		return 0;
 	}
 
 	/* usual case */
-	fprintf(f, "\t/* end states */\n");
+	if (opt->comments) {
+		fprintf(f, "\t/* end states */\n");
+	}
 	fprintf(f, "\tswitch (state) {\n");
 	for (i = 0; i < ir->n; i++) {
 		if (!ir->states[i].isend) {
@@ -410,7 +416,7 @@ fsm_print_cfrag(FILE *f, const struct ir *ir,
 				fprintf(f, " /* e.g. \"");
 				escputs(f, opt, c_escputc_str, ir->states[i].example);
 				fprintf(f, "\" */");
-			} else if (i == ir->start) {
+			} else if (i == ir->start && opt->comments) {
 				fprintf(f, " /* start */");
 			}
 		}
@@ -423,7 +429,11 @@ fsm_print_cfrag(FILE *f, const struct ir *ir,
 		fprintf(f, "\n");
 	}
 	fprintf(f, "\t\tdefault:\n");
-	fprintf(f, "\t\t\t; /* unreached */\n");
+	fprintf(f, "\t\t\t;");
+	if (opt->comments) {
+		fprintf(f, " /* unreached */");
+	}
+	fprintf(f, "\n");
 	fprintf(f, "\t\t}\n");
 
 	if (ferror(f)) {
@@ -595,7 +605,11 @@ fsm_print_c(FILE *f,
 		}
 
 		if (ir->n == 0) {
-			fprintf(f, "\treturn 0; /* no matches */\n");
+			fprintf(f, "\treturn 0;");
+			if (opt->comments) {
+				fprintf(f, " /* no matches */");
+			}
+			fprintf(f, "\n");
 		} else {
 			if (-1 == fsm_print_c_body(f, ir, opt, hooks)) {
 				return -1;

--- a/src/libfsm/print/c.c
+++ b/src/libfsm/print/c.c
@@ -101,7 +101,7 @@ print_ids(FILE *f,
 		fprintf(f, " };\n");
 		fprintf(f, "\t\t*ids = a;\n");
 		fprintf(f, "\t\t*count = %zu;\n", count);
-		fprintf(f, "\t\treturn 0;\n");
+		fprintf(f, "\t\treturn 1;\n");
 		fprintf(f, "\t}");
 		break;
 

--- a/src/libfsm/print/c.c
+++ b/src/libfsm/print/c.c
@@ -382,6 +382,12 @@ print_endstates(FILE *f,
 			return -1;
 		}
 
+		if (-1 == print_hook_comment(f, opt, hooks,
+			ir->states[i].endids.ids, ir->states[i].endids.count))
+		{
+			return -1;
+		}
+
 		fprintf(f, "\n");
 	}
 

--- a/src/libfsm/print/dot.c
+++ b/src/libfsm/print/dot.c
@@ -265,6 +265,16 @@ print_dotfrag(FILE *f,
 				return -1;
 			}
 
+			if (opt->comments && hooks->comment != NULL) {
+				fprintf(f, ",");
+
+				if (-1 == print_hook_comment(f, opt, hooks,
+					ids, count))
+				{
+					return -1;
+				}
+			}
+
 			fprintf(f, " ];\n");
 
 			f_free(fsm->alloc, ids);

--- a/src/libfsm/print/dot.c
+++ b/src/libfsm/print/dot.c
@@ -270,7 +270,7 @@ print_dotfrag(FILE *f,
 			f_free(fsm->alloc, ids);
 		}
 
-		/* TODO: show example here, unless !opt->comments */
+		/* TODO: comment example per state */
 
 		if (-1 == print_state(f, opt, hooks, fsm, prefix, s)) {
 			return -1;

--- a/src/libfsm/print/fsm.c
+++ b/src/libfsm/print/fsm.c
@@ -364,7 +364,13 @@ fsm_print_fsm(FILE *f,
 		if (-1 == print_hook_accept(f, opt, hooks,
 			ids, count,    
 			default_accept,
-			NULL))    
+			NULL))
+		{
+			return -1;
+		}
+
+		if (-1 == print_hook_comment(f, opt, hooks,
+			ids, count))
 		{
 			return -1;
 		}

--- a/src/libfsm/print/go.c
+++ b/src/libfsm/print/go.c
@@ -202,6 +202,12 @@ print_end(FILE *f, const struct dfavm_op_ir *op,
 			return -1;
 		}
 
+		if (-1 == print_hook_comment(f, opt, hooks,
+			op->ret->ids, op->ret->count))
+		{
+			return -1;
+		}
+
 		fprintf(f, "\n\t}\n");
 
 		return 0;

--- a/src/libfsm/print/go.c
+++ b/src/libfsm/print/go.c
@@ -232,6 +232,21 @@ print_fetch(FILE *f, const struct fsm_options *opt)
 	}
 }
 
+static void
+print_ret(FILE *f, const unsigned *ids, size_t count)
+{
+	size_t i;
+
+	fprintf(f, "[]uint{");
+	for (i = 0; i < count; i++) {
+		fprintf(f, "%u", ids[i]);
+		if (i + 1 < count) {
+			fprintf(f, ", ");
+		}
+	}
+	fprintf(f, "}");
+}
+
 /* TODO: eventually to be non-static */
 static int
 fsm_print_gofrag(FILE *f,
@@ -372,14 +387,9 @@ fsm_print_go(FILE *f,
 
 		if (opt->ambig == AMBIG_MULTIPLE) {
 			for (size_t i = 0; i < retlist->count; i++) {
-				fprintf(f, "var ret%zu []uint = []uint{", i);
-				for (size_t j = 0; j < retlist->a[i].count; j++) {
-					fprintf(f, "%u", retlist->a[i].ids[j]);
-					if (j + 1 < retlist->a[i].count) {
-						fprintf(f, ", ");
-					}
-				}
-				fprintf(f, "}\n");
+				fprintf(f, "var ret%zu []uint = ", i);
+				print_ret(f, retlist->a[i].ids, retlist->a[i].count);
+				fprintf(f, "\n");
 			}
 			fprintf(f, "\n");
 		}

--- a/src/libfsm/print/irdot.c
+++ b/src/libfsm/print/irdot.c
@@ -215,8 +215,6 @@ print_state(FILE *f,
 		fprintf(f, "</TD></TR>\n");
 	}
 
-	/* TODO: leaf callback for dot output */
-
 	/* showing hook in addition to existing content */
 	if (cs->isend && hooks->accept != NULL) {
 		fprintf(f, "\t\t  <TR><TD COLSPAN='3' ALIGN='LEFT'>");

--- a/src/libfsm/print/llvm.c
+++ b/src/libfsm/print/llvm.c
@@ -164,7 +164,7 @@ default_reject(FILE *f, const struct fsm_options *opt,
 		break;
 
 	case AMBIG_MULTIPLE:
-		fprintf(f, "%%rt { i1 false, %s poison, i32 poison }", ptr_i32);
+		fprintf(f, "%%rt { %s poison, i64 -1 }", ptr_i32);
 		break;
 
 	default:
@@ -196,8 +196,8 @@ print_rettype(FILE *f, const char *name, enum fsm_ambig ambig)
 		break;
 
 	case AMBIG_MULTIPLE:
-		// success, ids, count
-		fprintf(f, "{ i1, %s, i32 }", ptr_i32);
+		// ids, -1/count
+		fprintf(f, "{ %s, i64 }", ptr_i32);
 		break;
 
 	default:
@@ -676,7 +676,7 @@ fsm_print_llvm(FILE *f,
 	for (size_t i = 0; i < retlist->count; i++) {
 		fprintf(f, "\t  ");
 		if (opt->ambig == AMBIG_MULTIPLE) {
-			fprintf(f, "%%rt { i1 true, %s bitcast ([%zu x i32]* @%sr%zu to %s), i32 %zu }",
+			fprintf(f, "%%rt { %s bitcast ([%zu x i32]* @%sr%zu to %s), i64 %zu }",
 				ptr_i32, retlist->a[i].count, prefix, i, ptr_i32, retlist->a[i].count);
 		} else {
 			if (-1 == print_hook_accept(f, opt, hooks,

--- a/src/libfsm/print/llvm.c
+++ b/src/libfsm/print/llvm.c
@@ -668,6 +668,13 @@ fsm_print_llvm(FILE *f,
 			{
 				return -1;
 			}
+
+			if (-1 == print_hook_comment(f, opt, hooks,
+				retlist->a[i].ids, retlist->a[i].count))
+			{
+				return -1;
+			}
+
 			fprintf(f, "\n");
 		}
 	}
@@ -678,6 +685,7 @@ fsm_print_llvm(FILE *f,
 		if (opt->ambig == AMBIG_MULTIPLE) {
 			fprintf(f, "%%rt { %s bitcast ([%zu x i32]* @%sr%zu to %s), i64 %zu }",
 				ptr_i32, retlist->a[i].count, prefix, i, ptr_i32, retlist->a[i].count);
+			fprintf(f, ",");
 		} else {
 			if (-1 == print_hook_accept(f, opt, hooks,
 				retlist->a[i].ids, retlist->a[i].count,
@@ -685,8 +693,16 @@ fsm_print_llvm(FILE *f,
 			{
 				return -1;
 			}
+
+			fprintf(f, ",");
+
+			if (-1 == print_hook_comment(f, opt, hooks,
+				retlist->a[i].ids, retlist->a[i].count))
+			{
+				return -1;
+			}
 		}
-		fprintf(f, ",\n");
+		fprintf(f, "\n");
 	}
 	fprintf(f, "\t  ");
 	if (-1 == print_hook_reject(f, opt, hooks, default_reject, NULL)) {

--- a/src/libfsm/print/llvm.c
+++ b/src/libfsm/print/llvm.c
@@ -160,11 +160,11 @@ default_reject(FILE *f, const struct fsm_options *opt,
 
 	case AMBIG_ERROR:
 	case AMBIG_EARLIEST:
-		fprintf(f, "%%rt { i1 false, i32 undef } ; fail\n");
+		fprintf(f, "%%rt { i1 false, i32 poison } ; fail\n");
 		break;
 
 	case AMBIG_MULTIPLE:
-		fprintf(f, "%%rt { i1 false, %s undef, i32 undef } ; fail\n", ptr_i32);
+		fprintf(f, "%%rt { i1 false, %s poison, i32 poison } ; fail\n", ptr_i32);
 		break;
 
 	default:

--- a/src/libfsm/print/rust.c
+++ b/src/libfsm/print/rust.c
@@ -26,6 +26,7 @@
 #include "libfsm/internal.h"
 #include "libfsm/print.h"
 
+#include "libfsm/vm/retlist.h"
 #include "libfsm/vm/vm.h"
 
 #define START UINT32_MAX
@@ -170,7 +171,7 @@ print_end(FILE *f, const struct dfavm_op_ir *op,
 
 	case VM_END_SUCC:
 		return print_hook_accept(f, opt, hooks,
-			op->endids.ids, op->endids.count,
+			op->ret->ids, op->ret->count,
 			default_accept,
 			NULL);
 
@@ -205,6 +206,7 @@ static int
 fsm_print_rustfrag(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
+	const struct ret_list *retlist,
 	struct dfavm_op_ir *ops,
 	const char *cp)
 {
@@ -213,6 +215,7 @@ fsm_print_rustfrag(FILE *f,
 
 	assert(f != NULL);
 	assert(opt != NULL);
+	assert(retlist != NULL);
 	assert(cp != NULL);
 
 	/* TODO: we'll need to heed cp for e.g. lx's codegen */
@@ -415,6 +418,7 @@ int
 fsm_print_rust(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
+	const struct ret_list *retlist,
 	struct dfavm_op_ir *ops)
 {
 	const char *prefix;
@@ -423,6 +427,7 @@ fsm_print_rust(FILE *f,
 	assert(f != NULL);
 	assert(opt != NULL);
 	assert(hooks != NULL);
+	assert(retlist != NULL);
 
 	if (opt->prefix != NULL) {
 		prefix = opt->prefix;
@@ -437,7 +442,7 @@ fsm_print_rust(FILE *f,
 	}
 
 	if (opt->fragment) {
-		fsm_print_rustfrag(f, opt, hooks, ops, cp);
+		fsm_print_rustfrag(f, opt, hooks, retlist, ops, cp);
 		goto error;
 	}
 
@@ -471,7 +476,7 @@ fsm_print_rust(FILE *f,
 		exit(EXIT_FAILURE);
 	}
 
-	fsm_print_rustfrag(f, opt, hooks, ops, cp);
+	fsm_print_rustfrag(f, opt, hooks, retlist, ops, cp);
 
 	fprintf(f, "}\n");
 	fprintf(f, "\n");

--- a/src/libfsm/print/rust.c
+++ b/src/libfsm/print/rust.c
@@ -364,6 +364,14 @@ fsm_print_rustfrag(FILE *f,
 				fprintf(f, " }");
 			}
 
+			if (op->u.stop.end_bits == VM_END_SUCC) {
+				if (-1 == print_hook_comment(f, opt, hooks,
+					op->ret->ids, op->ret->count))
+				{
+					return -1;
+				}
+			}
+
 			if (op->cmp == VM_CMP_ALWAYS) {
 				/* the code for fallthrough would be unreachable */
 				fallthrough = false;

--- a/src/libfsm/print/rust.c
+++ b/src/libfsm/print/rust.c
@@ -212,6 +212,21 @@ print_fetch(FILE *f)
 	fprintf(f, "bytes.next()");
 }
 
+static void
+print_ret(FILE *f, const unsigned *ids, size_t count)
+{
+	size_t i;
+
+	fprintf(f, "[");
+	for (i = 0; i < count; i++) {
+		fprintf(f, "%u", ids[i]);
+		if (i + 1 < count) {
+			fprintf(f, ", ");
+		}
+	}
+	fprintf(f, "];");
+}
+
 /* TODO: eventually to be non-static */
 static int
 fsm_print_rustfrag(FILE *f,
@@ -234,14 +249,9 @@ fsm_print_rustfrag(FILE *f,
 
 	if (opt->ambig == AMBIG_MULTIPLE) {
 		for (size_t i = 0; i < retlist->count; i++) {
-			fprintf(f, "    static RET%zu: [u32; %zu] = [", i, retlist->a[i].count);
-			for (size_t j = 0; j < retlist->a[i].count; j++) {
-				fprintf(f, "%u", retlist->a[i].ids[j]);
-				if (j + 1 < retlist->a[i].count) {
-					fprintf(f, ", ");
-				}
-			}
-			fprintf(f, "];\n");
+			fprintf(f, "    static RET%zu: [u32; %zu] = ", i, retlist->a[i].count);
+			print_ret(f, retlist->a[i].ids, retlist->a[i].count);
+			fprintf(f, "\n");
 		}
 		fprintf(f, "\n");
 	}

--- a/src/libfsm/print/sh.c
+++ b/src/libfsm/print/sh.c
@@ -205,10 +205,21 @@ print_end(FILE *f, const struct dfavm_op_ir *op,
 		return print_hook_reject(f, opt, hooks, default_reject, NULL);
 
 	case VM_END_SUCC:
-		return print_hook_accept(f, opt, hooks,
+		if (-1 == print_hook_accept(f, opt, hooks,
 			op->ret->ids, op->ret->count,
 			default_accept,
-			NULL);
+			NULL))
+		{
+			return -1;
+		}
+
+		if (-1 == print_hook_comment(f, opt, hooks,
+			op->ret->ids, op->ret->count))
+		{
+			return -1;
+		}
+
+		return 0;
 
 	default:
 		assert(!"unreached");

--- a/src/libfsm/print/sh.c
+++ b/src/libfsm/print/sh.c
@@ -26,6 +26,7 @@
 #include "libfsm/internal.h"
 #include "libfsm/print.h"
 
+#include "libfsm/vm/retlist.h"
 #include "libfsm/vm/vm.h"
 
 static const char *
@@ -205,7 +206,7 @@ print_end(FILE *f, const struct dfavm_op_ir *op,
 
 	case VM_END_SUCC:
 		return print_hook_accept(f, opt, hooks,
-			op->endids.ids, op->endids.count,
+			op->ret->ids, op->ret->count,
 			default_accept,
 			NULL);
 
@@ -233,6 +234,7 @@ int
 fsm_print_sh(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
+	const struct ret_list *retlist,
 	struct dfavm_op_ir *ops)
 {
 	struct dfavm_op_ir *op;
@@ -240,6 +242,7 @@ fsm_print_sh(FILE *f,
 	assert(f != NULL);
 	assert(opt != NULL);
 	assert(hooks != NULL);
+	assert(retlist != NULL);
 
 	if (opt->io != FSM_IO_STR) {
 		errno = ENOTSUP;

--- a/src/libfsm/print/vmasm.c
+++ b/src/libfsm/print/vmasm.c
@@ -153,12 +153,16 @@ print_asm_amd64(FILE *f,
 
 		switch (opt->io) {
 		case FSM_IO_STR:
-			fprintf(f, "// func %s%s(data string) int\n", prefix, "Match");
+			if (opt->comments) {
+				fprintf(f, "// func %s%s(data string) int\n", prefix, "Match");
+			}
 			fprintf(f, "TEXT    ·%s(SB), NOSPLIT, $0-24\n", "Match");
 			break;
 
 		case FSM_IO_PAIR:
-			fprintf(f, "// func %s%s(data []byte) int\n", prefix, "Match");
+			if (opt->comments) {
+				fprintf(f, "// func %s%s(data []byte) int\n", prefix, "Match");
+			}
 			fprintf(f, "TEXT    ·%s%s(SB), NOSPLIT, $0-32\n", prefix, "Match");
 			break;
 
@@ -195,7 +199,9 @@ print_asm_amd64(FILE *f,
 	for (op = ops; op != NULL; op = op->next) {
 		if (op->num_incoming > 0) {
 			fprintf(f, "%sl%u:\n", label_dot, op->index);
-		} else {
+
+			// TODO: example
+		} else if (opt->comments) {
 			fprintf(f, "%s l%u\n", comment, op->index);
 		}
 
@@ -210,7 +216,9 @@ print_asm_amd64(FILE *f,
 				}
 
 				if (op->cmp == VM_CMP_ALWAYS && op->next == NULL) {
-					fprintf(f, "\t%s elided jmp to %sfinish\n", comment, label_dot);
+					if (opt->comments) {
+						fprintf(f, "\t%s elided jmp to %sfinish\n", comment, label_dot);
+					}
 				} else {
 					const char *jmp_op;
 

--- a/src/libfsm/print/vmasm.c
+++ b/src/libfsm/print/vmasm.c
@@ -56,6 +56,11 @@ print_end(FILE *f, const struct dfavm_op_ir *op,
 		{
 			return -1;
 		}
+		if (-1 == print_hook_comment(f, opt, hooks,
+			op->ret->ids, op->ret->count))
+		{
+			return -1;
+		}
 		break;
 
 	default:

--- a/src/libfsm/print/vmasm.c
+++ b/src/libfsm/print/vmasm.c
@@ -24,6 +24,7 @@
 #include "libfsm/internal.h"
 #include "libfsm/print.h"
 
+#include "libfsm/vm/retlist.h"
 #include "libfsm/vm/vm.h"
 
 enum asm_dialect {
@@ -50,7 +51,7 @@ print_end(FILE *f, const struct dfavm_op_ir *op,
 
 	case VM_END_SUCC:
 		if (-1 == print_hook_accept(f, opt, hooks,
-			op->endids.ids, op->endids.count,
+			op->ret->ids, op->ret->count,
 			NULL, NULL))
 		{
 			return -1;
@@ -358,6 +359,7 @@ static int
 print_vmasm_encoding(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
+	const struct ret_list *retlist,
 	struct dfavm_op_ir *ops,
 	enum asm_dialect dialect)
 {
@@ -366,6 +368,7 @@ print_vmasm_encoding(FILE *f,
 	assert(f != NULL);
 	assert(opt != NULL);
 	assert(hooks != NULL);
+	assert(retlist != NULL);
 
 	if (dialect == AMD64_GO) {
 		if (opt->io != FSM_IO_STR && opt->io != FSM_IO_PAIR) {
@@ -392,26 +395,29 @@ int
 fsm_print_amd64_att(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
+	const struct ret_list *retlist,
 	struct dfavm_op_ir *ops)
 {
-	return print_vmasm_encoding(f, opt, hooks, ops, AMD64_ATT);
+	return print_vmasm_encoding(f, opt, hooks, retlist, ops, AMD64_ATT);
 }
 
 int
 fsm_print_amd64_nasm(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
+	const struct ret_list *retlist,
 	struct dfavm_op_ir *ops)
 {
-	return print_vmasm_encoding(f, opt, hooks, ops, AMD64_NASM);
+	return print_vmasm_encoding(f, opt, hooks, retlist, ops, AMD64_NASM);
 }
 
 int
 fsm_print_amd64_go(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
+	const struct ret_list *retlist,
 	struct dfavm_op_ir *ops)
 {
-	return print_vmasm_encoding(f, opt, hooks, ops, AMD64_GO);
+	return print_vmasm_encoding(f, opt, hooks, retlist, ops, AMD64_GO);
 }
 

--- a/src/libfsm/print/vmc.c
+++ b/src/libfsm/print/vmc.c
@@ -63,16 +63,18 @@ print_ids(FILE *f,
 			errno = EINVAL;
 			return -1;
 		}
-		
-		fprintf(f, "return %u;", ids[0]);
-		break;
-	
+
+		/* fallthrough */
+
 	case AMBIG_EARLIEST:
 		/*
 		 * The libfsm api guarentees these ids are unique,
 		 * and only appear once each, and are sorted.
 		 */
-		fprintf(f, "return %u;", ids[0]);
+		fprintf(f, "{\n");
+		fprintf(f, "\t\t*id = %u;\n", ids[0]);
+		fprintf(f, "\t\treturn 1;\n");
+		fprintf(f, "\t}");
 		break;
 	
 	case AMBIG_MULTIPLE:

--- a/src/libfsm/print/vmc.c
+++ b/src/libfsm/print/vmc.c
@@ -178,10 +178,21 @@ print_end(FILE *f, const struct dfavm_op_ir *op,
 		return print_hook_reject(f, opt, hooks, default_reject, NULL);
 
 	case VM_END_SUCC:
-		return print_hook_accept(f, opt, hooks,
+		if (-1 == print_hook_accept(f, opt, hooks,
 			op->ret->ids, op->ret->count,
 			default_accept,
-			NULL);
+			NULL))
+		{
+			return -1;
+		}
+
+		if (-1 == print_hook_comment(f, opt, hooks,
+			op->ret->ids, op->ret->count))
+		{
+			return -1;
+		}
+
+		return 0;
 
 	default:
 		assert(!"unreached");

--- a/src/libfsm/print/vmc.c
+++ b/src/libfsm/print/vmc.c
@@ -25,6 +25,7 @@
 #include "libfsm/internal.h"
 #include "libfsm/print.h"
 
+#include "libfsm/vm/retlist.h"
 #include "libfsm/vm/vm.h"
 
 static const char *
@@ -176,7 +177,7 @@ print_end(FILE *f, const struct dfavm_op_ir *op,
 
 	case VM_END_SUCC:
 		return print_hook_accept(f, opt, hooks,
-			op->endids.ids, op->endids.count,
+			op->ret->ids, op->ret->count,
 			default_accept,
 			NULL);
 
@@ -360,6 +361,7 @@ static int
 fsm_print_cfrag(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
+	const struct ret_list *retlist,
 	struct dfavm_op_ir *ops,
 	const char *cp)
 {
@@ -367,6 +369,7 @@ fsm_print_cfrag(FILE *f,
 
 	assert(f != NULL);
 	assert(opt != NULL);
+	assert(retlist != NULL);
 	assert(cp != NULL);
 
 	/* TODO: we'll need to heed cp for e.g. lx's codegen */
@@ -512,6 +515,7 @@ int
 fsm_print_vmc(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
+	const struct ret_list *retlist,
 	struct dfavm_op_ir *ops)
 {
 	const char *prefix;
@@ -522,6 +526,7 @@ fsm_print_vmc(FILE *f,
 	assert(f != NULL);
 	assert(opt != NULL);
 	assert(hooks != NULL);
+	assert(retlist != NULL);
 
 	if (opt->prefix != NULL) {
 		prefix = opt->prefix;
@@ -530,7 +535,7 @@ fsm_print_vmc(FILE *f,
 	}
 
 	if (opt->fragment) {
-		if (-1 == fsm_print_cfrag(f, opt, hooks, ops, cp)) {
+		if (-1 == fsm_print_cfrag(f, opt, hooks, retlist, ops, cp)) {
 			return -1;
 		}
 	} else {
@@ -591,7 +596,7 @@ fsm_print_vmc(FILE *f,
 		fprintf(f, ")\n");
 		fprintf(f, "{\n");
 
-		if (-1 == fsm_print_cfrag(f, opt, hooks, ops, cp)) {
+		if (-1 == fsm_print_cfrag(f, opt, hooks, retlist, ops, cp)) {
 			return -1;
 		}
 

--- a/src/libfsm/print/vmc.c
+++ b/src/libfsm/print/vmc.c
@@ -94,7 +94,7 @@ print_ids(FILE *f,
 		fprintf(f, " };\n");
 		fprintf(f, "\t\t*ids = a;\n");
 		fprintf(f, "\t\t*count = %zu;\n", count);
-		fprintf(f, "\t\treturn 0;\n");
+		fprintf(f, "\t\treturn 1;\n");
 		fprintf(f, "\t}");
 		break;
 	

--- a/src/libfsm/print/vmdot.c
+++ b/src/libfsm/print/vmdot.c
@@ -268,9 +268,12 @@ fsm_print_edges(FILE *f, const struct fsm_options *opt, const struct dfavm_op_ir
 		if (op->num_incoming > 0 || op == ops) {
 			if (op != ops && can_fallthrough) {
 				fprintf(f, "\t");
-				fprintf(f, "S%lu:s -> S%" PRIu32 ":n [ style = bold ]; /* fallthrough */",
+				fprintf(f, "S%lu:s -> S%" PRIu32 ":n [ style = bold ];",
 					block,
 					op->index);
+				if (opt->comments) {
+					fprintf(f, " /* fallthrough */");
+				}
 				fprintf(f, "\n");
 			}
 
@@ -306,11 +309,14 @@ fsm_print_edges(FILE *f, const struct fsm_options *opt, const struct dfavm_op_ir
 		} else {
 			/* relative branch within the same block, entry on the east */
 			/* XXX: would like to make these edges shorter, but I don't know how */
-			fprintf(f, "S%lu:b%" PRIu32 ":e -> S%lu:b%" PRIu32 ":e [ constraint = false ]; /* relative */",
+			fprintf(f, "S%lu:b%" PRIu32 ":e -> S%lu:b%" PRIu32 ":e [ constraint = false ];",
 				block,
 				op->index,
 				block,
 				op->u.br.dest_arg->index);
+			if (opt->comments) {
+				fprintf(f, " /* relative */");
+			}
 		}
 
 		fprintf(f, "\n");

--- a/src/libfsm/print/vmdot.c
+++ b/src/libfsm/print/vmdot.c
@@ -129,10 +129,17 @@ print_end(FILE *f,
 		return print_hook_reject(f, opt, hooks, default_reject, NULL);
 
 	case VM_END_SUCC:
-		return print_hook_accept(f, opt, hooks,
+		if (-1 == print_hook_accept(f, opt, hooks,
 			op->ret->ids, op->ret->count,
 			default_accept,
-			NULL);
+			NULL))
+		{
+			return -1;
+		}
+
+		/* no print_hook_comment() for dot output */
+
+		return 0;
 
 	default:
 		assert(!"unreached");

--- a/src/libfsm/print/vmdot.c
+++ b/src/libfsm/print/vmdot.c
@@ -25,6 +25,7 @@
 #include "libfsm/internal.h"
 #include "libfsm/print.h"
 
+#include "libfsm/vm/retlist.h"
 #include "libfsm/vm/vm.h"
 
 static const char *
@@ -129,7 +130,7 @@ print_end(FILE *f,
 
 	case VM_END_SUCC:
 		return print_hook_accept(f, opt, hooks,
-			op->endids.ids, op->endids.count,
+			op->ret->ids, op->ret->count,
 			default_accept,
 			NULL);
 
@@ -321,10 +322,12 @@ static int
 fsm_print_vmdotfrag(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
+	const struct ret_list *retlist,
 	struct dfavm_op_ir *ops)
 {
 	assert(f != NULL);
 	assert(opt != NULL);
+	assert(retlist != NULL);
 
 	if (-1 == fsm_print_nodes(f, opt, hooks, ops)) {
 		return -1;
@@ -340,14 +343,16 @@ int
 fsm_print_vmdot(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
+	const struct ret_list *retlist,
 	struct dfavm_op_ir *ops)
 {
 	assert(f != NULL);
 	assert(opt != NULL);
 	assert(hooks != NULL);
+	assert(retlist != NULL);
 
 	if (opt->fragment) {
-		if (-1 == fsm_print_vmdotfrag(f, opt, hooks, ops)) {
+		if (-1 == fsm_print_vmdotfrag(f, opt, hooks, retlist, ops)) {
 			return -1;
 		}
 	} else {
@@ -365,7 +370,7 @@ fsm_print_vmdot(FILE *f,
 		fprintf(f, "\tstart [ shape = none, label = \"\" ];\n");
 		fprintf(f, "\tstart -> S0:i0:w [ style = bold ];\n");
 
-		if (-1 == fsm_print_vmdotfrag(f, opt, hooks, ops)) {
+		if (-1 == fsm_print_vmdotfrag(f, opt, hooks, retlist, ops)) {
 			return -1;
 		}
 

--- a/src/libfsm/print/vmops.c
+++ b/src/libfsm/print/vmops.c
@@ -201,6 +201,21 @@ print_fetch(FILE *f, const struct fsm_options *opt, const char *prefix)
 	return 0;
 }
 
+static void
+print_ret(FILE *f, const unsigned *ids, size_t count)
+{
+	size_t i;
+
+	fprintf(f, "{ (const unsigned []) { ");
+	for (i = 0; i < count; i++) {
+		fprintf(f, "%u", ids[i]);
+		if (i + 1 < count) {
+			fprintf(f, ", ");
+		}
+	}
+	fprintf(f, " }, %zu }", count);
+}
+
 int
 fsm_print_vmops_c(FILE *f,
 	const struct fsm_options *opt,
@@ -235,14 +250,9 @@ fsm_print_vmops_c(FILE *f,
 	if (opt->ambig != AMBIG_NONE) {
 		fprintf(f, "struct %sret %sRet[] = {\n", prefix, prefix);
 		for (size_t i = 0; i < retlist->count; i++) {
-			fprintf(f, "\t{ (const unsigned []) { ");
-			for (size_t j = 0; j < retlist->a[i].count; j++) {
-				fprintf(f, "%u", retlist->a[i].ids[j]);
-				if (j + 1 < retlist->a[i].count) {
-					fprintf(f, ", ");
-				}
-			}
-			fprintf(f, " }, %zu },\n", retlist->a[i].count);
+			fprintf(f, "\t");
+			print_ret(f, retlist->a[i].ids, retlist->a[i].count);
+			fprintf(f, ",\n");
 		}
 		fprintf(f, "};\n");
 		fprintf(f, "const size_t %sRet_count = sizeof %sRet / sizeof *%sRet;\n", prefix, prefix, prefix);

--- a/src/libfsm/print/vmops.c
+++ b/src/libfsm/print/vmops.c
@@ -108,7 +108,7 @@ print_label(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt
 static int
 print_cond(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt, const char *prefix)
 {
-	fprintf(f, "\t\t{%s%s, ", prefix, cmp_operator(op->cmp));
+	fprintf(f, "%s%s, ", prefix, cmp_operator(op->cmp));
 	if (-1 == c_escputcharlit(f, opt, op->cmp_arg)) {
 		return -1;
 	}
@@ -148,15 +148,13 @@ print_end(FILE *f, const struct dfavm_op_ir *op,
 		abort();
 	}
 
-	fprintf(f, "},\n");
-
 	return 0;
 }
 
 static int
 print_branch(FILE *f, const struct dfavm_op_ir *op, const char *prefix)
 {
-	fprintf(f, "%sactionGOTO, %" PRIu32 "},\n", prefix, op->u.br.dest_arg->index);
+	fprintf(f, "%sactionGOTO, %" PRIu32, prefix, op->u.br.dest_arg->index);
 
 	return 0;
 }
@@ -165,7 +163,7 @@ static int
 print_fetch(FILE *f, const struct fsm_options *opt, const char *prefix)
 {
 
-	fprintf(f, "\t\t{%sopEOF, 0, ", prefix);
+	fprintf(f, "%sopEOF, 0, ", prefix);
 	switch (opt->io) {
 	case FSM_IO_GETC:
 	case FSM_IO_STR:
@@ -200,6 +198,9 @@ fsm_print_vmopsfrag(FILE *f,
 				return -1;
 			}
 		}
+
+		fprintf(f, "\t\t{");
+
 		switch (op->instr) {
 		case VM_OP_STOP:
 			if (-1 == print_cond(f, op, opt, prefix)) {
@@ -232,6 +233,8 @@ fsm_print_vmopsfrag(FILE *f,
 			assert(!"unreached");
 			break;
 		}
+
+		fprintf(f, "},\n");
 	}
 
 	return 0;

--- a/src/libfsm/print/vmops.c
+++ b/src/libfsm/print/vmops.c
@@ -108,7 +108,9 @@ default_reject(FILE *f, const struct fsm_options *opt,
 static int
 print_label(FILE *f, const struct dfavm_op_ir *op, const struct fsm_options *opt)
 {
-	fprintf(f, "\t\t/* l%" PRIu32 " */\n", op->index);
+	if (opt->comments) {
+		fprintf(f, "\t\t/* l%" PRIu32 " */\n", op->index);
+	}
 
 	if (op->example != NULL) {
 		fprintf(f, "\t\t/* e.g. \"");
@@ -409,8 +411,10 @@ fsm_print_vmops_main(FILE *f,
 
 	fprintf(f, "{\n");
 	fprintf(f, "\tunsigned int i = 0;\n");
-	fprintf(f, "\t/* The compiler doesn't know the op stream will have fetch before the first comparison. */\n");
-	fprintf(f, "\t/* Initialize to zero to prevent maybe-uninitialized warning. */\n");
+	if (opt->comments) {
+		fprintf(f, "\t/* The compiler doesn't know the op stream will have fetch before the first comparison. */\n");
+		fprintf(f, "\t/* Initialize to zero to prevent maybe-uninitialized warning. */\n");
+	}
 	fprintf(f, "\tunsigned char c = 0;\n");
 	fprintf(f, "\tint ok;\n");
 	fprintf(f, "\tstruct %sop *ops = %sOps;\n", prefix, prefix);
@@ -438,7 +442,9 @@ fsm_print_vmops_main(FILE *f,
 	switch (opt->io) {
 	case FSM_IO_PAIR:
 		fprintf(f, "\t\t\tif (p < e) {\n");
-		fprintf(f, "\t\t\t\t/* not at EOF */\n");
+		if (opt->comments) {
+			fprintf(f, "\t\t\t\t/* not at EOF */\n");
+		}
 		fprintf(f, "\t\t\t\tc = *p++;\n");
 		fprintf(f, "\t\t\t\ti++;\n");
 		fprintf(f, "\t\t\t\tcontinue;\n");
@@ -448,7 +454,9 @@ fsm_print_vmops_main(FILE *f,
 	case FSM_IO_STR:
 		fprintf(f, "\t\t\tc = *p++;\n");
 		fprintf(f, "\t\t\tif (c != '\\0') {\n");
-		fprintf(f, "\t\t\t\t/* not at EOF */\n");
+		if (opt->comments) {
+			fprintf(f, "\t\t\t\t/* not at EOF */\n");
+		}
 		fprintf(f, "\t\t\t\ti++;\n");
 		fprintf(f, "\t\t\t\tcontinue;\n");
 		fprintf(f, "\t\t\t}\n");

--- a/src/libfsm/print/vmops.c
+++ b/src/libfsm/print/vmops.c
@@ -51,6 +51,7 @@ default_accept(FILE *f, const struct fsm_options *opt,
 	void *lang_opaque, void *hook_opaque)
 {
 	const char *prefix;
+	size_t i;
 
 	assert(f != NULL);
 	assert(opt != NULL);
@@ -58,13 +59,21 @@ default_accept(FILE *f, const struct fsm_options *opt,
 
 	(void) hook_opaque;
 
-	prefix = lang_opaque;
+	if (opt->prefix != NULL) {
+		prefix = opt->prefix;
+	} else {
+		prefix = "fsm_";
+	}
 
-	// TODO: print ids
 	(void) ids;
 	(void) count;
 
 	fprintf(f, "%sactionRET, 1", prefix);
+	if (opt->ambig != AMBIG_NONE) {
+		i = * (const size_t *) lang_opaque;
+
+		fprintf(f, ", %zu", i);
+	}
 
 	return 0;
 }
@@ -77,13 +86,21 @@ default_reject(FILE *f, const struct fsm_options *opt,
 
 	assert(f != NULL);
 	assert(opt != NULL);
-	assert(lang_opaque != NULL);
+	assert(lang_opaque == NULL);
 
+	(void) lang_opaque;
 	(void) hook_opaque;
 
-	prefix = lang_opaque;
+	if (opt->prefix != NULL) {
+		prefix = opt->prefix;
+	} else {
+		prefix = "fsm_";
+	}
 
 	fprintf(f, "%sactionRET, 0", prefix);
+	if (opt->ambig != AMBIG_NONE) {
+		fprintf(f, ", 0");
+	}
 
 	return 0;
 }
@@ -121,23 +138,26 @@ static int
 print_end(FILE *f, const struct dfavm_op_ir *op,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
-	const char *prefix,
+	const struct ret_list *retlist,
 	enum dfavm_op_end end_bits)
 {
+	size_t i;
+
 	switch (end_bits) {
 	case VM_END_FAIL:
-		if (-1 == print_hook_reject(f, opt, hooks, default_reject,
-			(void *) prefix))
-		{
+		if (-1 == print_hook_reject(f, opt, hooks, default_reject, NULL)) {
 			return -1;
 		}
 		break;
 
 	case VM_END_SUCC:
+		assert(op->ret >= retlist->a);
+
+		i = op->ret - retlist->a;
+
 		if (-1 == print_hook_accept(f, opt, hooks,
 			op->ret->ids, op->ret->count,
-			default_accept,
-			(void *) prefix))
+			default_accept, &i))
 		{
 			return -1;
 		}
@@ -152,9 +172,12 @@ print_end(FILE *f, const struct dfavm_op_ir *op,
 }
 
 static int
-print_branch(FILE *f, const struct dfavm_op_ir *op, const char *prefix)
+print_branch(FILE *f, const struct fsm_options *opt, const struct dfavm_op_ir *op, const char *prefix)
 {
 	fprintf(f, "%sactionGOTO, %" PRIu32, prefix, op->u.br.dest_arg->index);
+	if (opt->ambig != AMBIG_NONE) {
+		fprintf(f, ", 0");
+	}
 
 	return 0;
 }
@@ -176,21 +199,55 @@ print_fetch(FILE *f, const struct fsm_options *opt, const char *prefix)
 	return 0;
 }
 
-/* TODO: eventually to be non-static */
-static int
-fsm_print_vmopsfrag(FILE *f,
+int
+fsm_print_vmops_c(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
 	const struct ret_list *retlist,
-	struct dfavm_op_ir *ops,
-	const char *prefix)
+	struct dfavm_op_ir *ops)
 {
-	struct dfavm_op_ir *op;
+	const struct dfavm_op_ir *op;
+	const char *prefix;
 
 	assert(f != NULL);
 	assert(opt != NULL);
+	assert(hooks != NULL);
 
-	(void) retlist;
+	if (opt->fragment) {
+		errno = ENOTSUP;
+		return -1;
+	}
+
+	if (opt->prefix != NULL) {
+		prefix = opt->prefix;
+	} else {
+		prefix = "fsm_";
+	}
+
+	fprintf(f, "#include <stdint.h>\n\n");
+	fprintf(f, "#ifndef %sLIBFSM_VMOPS_H\n", prefix);
+	fprintf(f, "#include \"%svmops.h\"\n", prefix);
+	fprintf(f, "#endif /* %sLIBFSM_VMOPS_H */\n", prefix);
+	fprintf(f, "\n");
+
+	if (opt->ambig != AMBIG_NONE) {
+		fprintf(f, "struct %sret %sRet[] = {\n", prefix, prefix);
+		for (size_t i = 0; i < retlist->count; i++) {
+			fprintf(f, "\t{ (const unsigned []) { ");
+			for (size_t j = 0; j < retlist->a[i].count; j++) {
+				fprintf(f, "%u", retlist->a[i].ids[j]);
+				if (j + 1 < retlist->a[i].count) {
+					fprintf(f, ", ");
+				}
+			}
+			fprintf(f, " }, %zu },\n", retlist->a[i].count);
+		}
+		fprintf(f, "};\n");
+		fprintf(f, "const size_t %sRet_count = sizeof %sRet / sizeof *%sRet;\n", prefix, prefix, prefix);
+		fprintf(f, "\n");
+	}
+
+	fprintf(f, "struct %sop %sOps[] = {\n", prefix, prefix);
 
 	for (op = ops; op != NULL; op = op->next) {
 		if (op->num_incoming > 0) {
@@ -199,14 +256,14 @@ fsm_print_vmopsfrag(FILE *f,
 			}
 		}
 
-		fprintf(f, "\t\t{");
+		fprintf(f, "\t{");
 
 		switch (op->instr) {
 		case VM_OP_STOP:
 			if (-1 == print_cond(f, op, opt, prefix)) {
 				return -1;
 			}
-			if (-1 == print_end(f, op, opt, hooks, prefix, op->u.stop.end_bits)) {
+			if (-1 == print_end(f, op, opt, hooks, retlist, op->u.stop.end_bits)) {
 				return -1;
 			}
 			break;
@@ -215,7 +272,7 @@ fsm_print_vmopsfrag(FILE *f,
 			if (-1 == print_fetch(f, opt, prefix)) {
 				return -1;
 			}
-			if (-1 == print_end(f, op, opt, hooks, prefix, op->u.fetch.end_bits)) {
+			if (-1 == print_end(f, op, opt, hooks, retlist, op->u.fetch.end_bits)) {
 				return -1;
 			}
 			break;
@@ -224,7 +281,7 @@ fsm_print_vmopsfrag(FILE *f,
 			if (-1 == print_cond(f, op, opt, prefix)) {
 				return -1;
 			}
-			if (-1 == print_branch(f, op, prefix)) {
+			if (-1 == print_branch(f, opt, op, prefix)) {
 				return -1;
 			}
 			break;
@@ -237,43 +294,7 @@ fsm_print_vmopsfrag(FILE *f,
 		fprintf(f, "},\n");
 	}
 
-	return 0;
-}
-
-int
-fsm_print_vmops_c(FILE *f,
-	const struct fsm_options *opt,
-	const struct fsm_hooks *hooks,
-	const struct ret_list *retlist,
-	struct dfavm_op_ir *ops)
-{
-	const char *prefix;
-
-	assert(f != NULL);
-	assert(opt != NULL);
-	assert(hooks != NULL);
-
-	if (opt->prefix != NULL) {
-		prefix = opt->prefix;
-	} else {
-		prefix = "fsm_";
-	}
-
-	if (opt->fragment) {
-		if (-1 == fsm_print_vmopsfrag(f, opt, hooks, retlist, ops, prefix)) {
-			return -1;
-		}
-	} else {
-		fprintf(f, "#include <stdint.h>\n\n");
-		fprintf(f, "#ifndef %sLIBFSM_VMOPS_H\n", prefix);
-		fprintf(f, "#include \"%svmops.h\"\n", prefix);
-		fprintf(f, "#endif /* %sLIBFSM_VMOPS_H */\n", prefix);
-		fprintf(f, "struct %sop %sOps[] = {\n", prefix, prefix);
-		if (-1 == fsm_print_vmopsfrag(f, opt, hooks, retlist, ops, prefix)) {
-			return -1;
-		}
-		fprintf(f, "\t};\n");
-	}
+	fprintf(f, "\t};\n");
 
 	return 0;
 }
@@ -294,6 +315,11 @@ fsm_print_vmops_h(FILE *f,
 	(void) retlist;
 	(void) ops;
 
+	if (opt->fragment) {
+		errno = ENOTSUP;
+		return -1;
+	}
+
 	if (opt->prefix != NULL) {
 		prefix = opt->prefix;
 	} else {
@@ -303,11 +329,19 @@ fsm_print_vmops_h(FILE *f,
 	fprintf(f, "#ifndef %sLIBFSM_VMOPS_H\n", prefix);
 	fprintf(f, "#define %sLIBFSM_VMOPS_H\n", prefix);
 	fprintf(f, "#include <stdint.h>\n\n");
+	fprintf(f, "#include <stddef.h>\n\n");
 	fprintf(f, "enum %svmOp { %sopEOF, %sopLT, %sopLE, %sopEQ, %sopNE, %sopGE, %sopGT, %sopALWAYS};\n",
 		prefix, prefix, prefix, prefix, prefix, prefix, prefix, prefix, prefix);
 	fprintf(f, "enum %sactionOp { %sactionRET, %sactionGOTO };\n", prefix, prefix, prefix);
-	fprintf(f, "struct %sop { enum %svmOp op; unsigned char c; enum %sactionOp action; int32_t arg; };\n\n",
+	if (opt->ambig != AMBIG_NONE) {
+		fprintf(f, "struct %sret { const unsigned *ids; size_t count; };\n\n", prefix);
+	}
+	fprintf(f, "struct %sop { enum %svmOp op; unsigned char c; enum %sactionOp action; int32_t arg; int32_t ret; };\n\n",
 		prefix, prefix, prefix);
+	if (opt->ambig != AMBIG_NONE) {
+		fprintf(f, "extern struct %sret %sRet[];\n", prefix, prefix);
+		fprintf(f, "extern const size_t %sRet_count;\n", prefix);
+	}
 	fprintf(f, "#endif /* %sLIBFSM_VMOPS_H */\n", prefix);
 
 	return 0;
@@ -329,6 +363,11 @@ fsm_print_vmops_main(FILE *f,
 	(void) retlist;
 	(void) ops;
 
+	if (opt->fragment) {
+		errno = ENOTSUP;
+		return -1;
+	}
+
 	if (opt->prefix != NULL) {
 		prefix = opt->prefix;
 	} else {
@@ -342,21 +381,32 @@ fsm_print_vmops_main(FILE *f,
 	fprintf(f, "#include \"%svmops.h\"\n", prefix);
 	fprintf(f, "#endif /* %sLIBFSM_VMOPS_H */\n", prefix);
 	fprintf(f, "extern struct %sop %sOps[];\n", prefix, prefix);
+	if (opt->ambig != AMBIG_NONE) {
+		fprintf(f, "extern struct %sret %sRet[];\n", prefix, prefix);
+		fprintf(f, "extern const size_t %sRet_count;\n", prefix);
+	}
 	fprintf(f, "\n");
 
+	fprintf(f, "int %smatch(", prefix);
 	switch (opt->io) {
 	case FSM_IO_PAIR:
-		fprintf(f, "int %smatch(const char *b, const char *e)\n", prefix);
+		fprintf(f, "const char *b, const char *e");
 		break;
 
 	case FSM_IO_STR:
-		fprintf(f, "int %smatch(const char *s)\n", prefix);
+		fprintf(f, "const char *s");
 		break;
 
 	case FSM_IO_GETC:
 		errno = ENOTSUP;
 		return -1;
 	}
+	if (opt->ambig != AMBIG_NONE) {
+		fprintf(f, ",\n");
+		fprintf(f, "\tconst unsigned **ids, size_t *count");
+	}
+	fprintf(f, ")\n");
+
 	fprintf(f, "{\n");
 	fprintf(f, "\tunsigned int i = 0;\n");
 	fprintf(f, "\t/* The compiler doesn't know the op stream will have fetch before the first comparison. */\n");
@@ -421,6 +471,12 @@ fsm_print_vmops_main(FILE *f,
 	fprintf(f, "\t\t}\n");
 	fprintf(f, "\t\tif (ok) {\n");
 	fprintf(f, "\t\t\tif (ops[i].action == %sactionRET) {\n", prefix);
+	if (opt->ambig != AMBIG_NONE) {
+		fprintf(f, "\t\t\t\tif (ops[i].arg) {\n");
+		fprintf(f, "\t\t\t\t\t*ids   = %sRet[ops[i].ret].ids;\n", prefix);
+		fprintf(f, "\t\t\t\t\t*count = %sRet[ops[i].ret].count;\n", prefix);
+		fprintf(f, "\t\t\t\t}\n");
+	}
 	fprintf(f, "\t\t\t\treturn (int) (ops[i].arg);\n");
 	fprintf(f, "\t\t\t}\n");
 	fprintf(f, "\t\t\ti = ops[i].arg;\n");
@@ -435,6 +491,10 @@ fsm_print_vmops_main(FILE *f,
 	fprintf(f, "int main(void)\n");
 	fprintf(f, "{\n");
 	fprintf(f, "\tchar *buf, *p;\n");
+	if (opt->ambig != AMBIG_NONE) {
+		fprintf(f, "\tconst unsigned *ids;\n");
+		fprintf(f, "\tsize_t count, i;\n");
+	}
 	fprintf(f, "\tint r;\n");
 	fprintf(f, "\n");
 	fprintf(f, "\tbuf = malloc(%sBUFFER_SIZE);\n", prefix);
@@ -448,18 +508,34 @@ fsm_print_vmops_main(FILE *f,
 	fprintf(f, "\t\t\tbreak;\n");
 	fprintf(f, "\t\t}\n");
 
+	fprintf(f, "\t\tr = %smatch(", prefix);
 	switch (opt->io) {
 	case FSM_IO_PAIR:
-		fprintf(f, "\t\tr = %smatch(p, p + strlen(p));\n", prefix);
+		fprintf(f, "p, p + strlen(p)");
 		break;
 	case FSM_IO_STR:
-		fprintf(f, "\t\tr = %smatch(p);\n", prefix);
+		fprintf(f, "p");
 		break;
 	case FSM_IO_GETC:
+		// TODO: getc from string buffer
 		errno = ENOTSUP;
 		return -1;
 	}
+	if (opt->ambig != AMBIG_NONE) {
+		fprintf(f, ", &ids, &count");
+	}
+	fprintf(f, ");\n");
+
 	fprintf(f, "\t\tprintf(\"%%smatch\\n\", r == 0 ? \"no \" : \"\");\n");
+	if (opt->ambig != AMBIG_NONE) {
+		fprintf(f, "\t\tif (r) {\n");
+		fprintf(f, "\t\t\tprintf(\"ids:\");\n");
+		fprintf(f, "\t\t\tfor (i = 0; i < count; i++) {\n");
+		fprintf(f, "\t\t\t\tprintf(\" %%u\", ids[i]);\n");
+		fprintf(f, "\t\t\t}\n");
+		fprintf(f, "\t\t\tprintf(\"\\n\");\n");
+		fprintf(f, "\t\t}\n");
+	}
 	fprintf(f, "\t}\n");
 	fprintf(f, "\treturn 0;\n");
 	fprintf(f, "}\n");

--- a/src/libfsm/print/vmops.c
+++ b/src/libfsm/print/vmops.c
@@ -459,7 +459,7 @@ fsm_print_vmops_main(FILE *f,
 		errno = ENOTSUP;
 		return -1;
 	}
-	fprintf(f, "\t\tprintf(\"%%smatch\\n\", r ? \"no \" : \"\");\n");
+	fprintf(f, "\t\tprintf(\"%%smatch\\n\", r == 0 ? \"no \" : \"\");\n");
 	fprintf(f, "\t}\n");
 	fprintf(f, "\treturn 0;\n");
 	fprintf(f, "}\n");

--- a/src/libfsm/print/vmops.c
+++ b/src/libfsm/print/vmops.c
@@ -303,7 +303,17 @@ fsm_print_vmops_c(FILE *f,
 			break;
 		}
 
-		fprintf(f, "},\n");
+		fprintf(f, "},");
+
+		if (op->instr == VM_OP_STOP && op->u.stop.end_bits == VM_END_SUCC) {
+			if (-1 == print_hook_comment(f, opt, hooks,
+				op->ret->ids, op->ret->count))
+			{
+				return -1;
+			}
+		}
+
+		fprintf(f, "\n");
 	}
 
 	fprintf(f, "\t};\n");

--- a/src/libfsm/print/vmops.c
+++ b/src/libfsm/print/vmops.c
@@ -25,6 +25,7 @@
 #include "libfsm/internal.h"
 #include "libfsm/print.h"
 
+#include "libfsm/vm/retlist.h"
 #include "libfsm/vm/vm.h"
 
 enum vmops_dialect {
@@ -140,7 +141,7 @@ print_end(FILE *f, const struct dfavm_op_ir *op,
 
 	case VM_END_SUCC:
 		if (-1 == print_hook_accept(f, opt, hooks,
-			op->endids.ids, op->endids.count,
+			op->ret->ids, op->ret->count,
 			default_accept,
 			(void *) prefix))
 		{
@@ -187,6 +188,7 @@ static int
 fsm_print_vmopsfrag(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
+	const struct ret_list *retlist,
 	struct dfavm_op_ir *ops,
 	const char *prefix)
 {
@@ -194,6 +196,8 @@ fsm_print_vmopsfrag(FILE *f,
 
 	assert(f != NULL);
 	assert(opt != NULL);
+
+	(void) retlist;
 
 	for (op = ops; op != NULL; op = op->next) {
 		if (op->num_incoming > 0) {
@@ -242,6 +246,7 @@ int
 fsm_print_vmops(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
+	const struct ret_list *retlist,
 	struct dfavm_op_ir *ops,
 	enum vmops_dialect dialect)
 {
@@ -259,7 +264,7 @@ fsm_print_vmops(FILE *f,
 
 	if (opt->fragment) {
 		if (dialect == VMOPS_C) {
-			if (-1 == fsm_print_vmopsfrag(f, opt, hooks, ops, prefix)) {
+			if (-1 == fsm_print_vmopsfrag(f, opt, hooks, retlist, ops, prefix)) {
 				return -1;
 			}
 		}
@@ -271,7 +276,7 @@ fsm_print_vmops(FILE *f,
 			fprintf(f, "#include \"%svmops.h\"\n", prefix);
 			fprintf(f, "#endif /* %sLIBFSM_VMOPS_H */\n", prefix);
 			fprintf(f, "struct %sop %sOps[] = {\n", prefix, prefix);
-			if (-1 == fsm_print_vmopsfrag(f, opt, hooks, ops, prefix)) {
+			if (-1 == fsm_print_vmopsfrag(f, opt, hooks, retlist, ops, prefix)) {
 				return -1;
 			}
 			fprintf(f, "\t};\n");
@@ -429,26 +434,29 @@ int
 fsm_print_vmops_c(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
+	const struct ret_list *retlist,
 	struct dfavm_op_ir *ops)
 {
-	return fsm_print_vmops(f, opt, hooks, ops, VMOPS_C);
+	return fsm_print_vmops(f, opt, hooks, retlist, ops, VMOPS_C);
 }
 
 int
 fsm_print_vmops_h(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
+	const struct ret_list *retlist,
 	struct dfavm_op_ir *ops)
 {
-	return fsm_print_vmops(f, opt, hooks, ops, VMOPS_H);
+	return fsm_print_vmops(f, opt, hooks, retlist, ops, VMOPS_H);
 }
 
 int
 fsm_print_vmops_main(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
+	const struct ret_list *retlist,
 	struct dfavm_op_ir *ops)
 {
-	return fsm_print_vmops(f, opt, hooks, ops, VMOPS_MAIN);
+	return fsm_print_vmops(f, opt, hooks, retlist, ops, VMOPS_MAIN);
 }
 

--- a/src/libfsm/vm.c
+++ b/src/libfsm/vm.c
@@ -18,6 +18,7 @@
 #include "internal.h"
 
 #include "vm/vm.h"
+#include "vm/retlist.h"
 #include "print/ir.h"
 
 // VM state:
@@ -92,6 +93,7 @@ fsm_vm_compile_with_options(const struct fsm *fsm,
 	static const struct dfavm_assembler_ir zero;
 	struct dfavm_assembler_ir a;
 	struct ir *ir;
+	struct ret_list retlist;
 	struct fsm_dfavm *vm;
 
 	assert(fsm != NULL);
@@ -102,9 +104,15 @@ fsm_vm_compile_with_options(const struct fsm *fsm,
 		return NULL;
 	}
 
+	if (!build_retlist(&retlist, ir)) {
+		free_ir(fsm, ir);
+		return NULL;
+	}
+
 	a = zero;
 
-	if (!dfavm_compile_ir(&a, ir, vmopts)) {
+	if (!dfavm_compile_ir(&a, ir, &retlist, vmopts)) {
+		free_retlist(&retlist);
 		free_ir(fsm, ir);
 		return NULL;
 	}
@@ -116,6 +124,7 @@ fsm_vm_compile_with_options(const struct fsm *fsm,
 		return NULL;
 	}
 
+	free_retlist(&retlist);
 	dfavm_opasm_finalize_op(&a);
 
 	return vm;

--- a/src/libfsm/vm/Makefile
+++ b/src/libfsm/vm/Makefile
@@ -4,6 +4,7 @@ SRC += src/libfsm/vm/ir.c
 SRC += src/libfsm/vm/vm.c
 SRC += src/libfsm/vm/v1.c
 SRC += src/libfsm/vm/v2.c
+SRC += src/libfsm/vm/retlist.c
 
 .for src in ${SRC:Msrc/libfsm/vm/*.c}
 CFLAGS.${src} += -I src # XXX: for internal.h

--- a/src/libfsm/vm/retlist.c
+++ b/src/libfsm/vm/retlist.c
@@ -68,6 +68,13 @@ cmp_ret(const void *pa, const void *pb)
 	if (a->count < b->count) { return -1; }
 	if (a->count > b->count) { return +1; }
 
+	if (a->count == 0) {
+		return 0;
+	}
+
+	assert(a->ids != NULL);
+	assert(b->ids != NULL);
+
 	return memcmp(a->ids, b->ids, a->count * sizeof *a->ids);
 }
 

--- a/src/libfsm/vm/retlist.h
+++ b/src/libfsm/vm/retlist.h
@@ -7,6 +7,8 @@
 #ifndef FSM_INTERNAL_RETLIST_H
 #define FSM_INTERNAL_RETLIST_H
 
+struct ir;
+
 struct ret {
 	size_t count;
 	const fsm_end_id_t *ids;
@@ -17,15 +19,11 @@ struct ret_list {
 	struct ret *a;
 };
 
-int
-cmp_ret_by_endid(const void *pa, const void *pb);
-
 struct ret *
-find_ret(const struct ret_list *list, const struct dfavm_op_ir *op,
-	int (*cmp)(const void *pa, const void *pb));
+find_ret(const struct ret_list *list, const fsm_end_id_t *ids, size_t count);
 
 bool
-build_retlist(struct ret_list *list, const struct dfavm_op_ir *a);
+build_retlist(struct ret_list *list, const struct ir *ir);
 
 void
 free_retlist(struct ret_list *list);

--- a/src/libfsm/vm/retlist.h
+++ b/src/libfsm/vm/retlist.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 Katherine Flavel
+ *
+ * See LICENCE for the full copyright terms.
+ */
+
+#ifndef FSM_INTERNAL_RETLIST_H
+#define FSM_INTERNAL_RETLIST_H
+
+struct ret {
+	size_t count;
+	const fsm_end_id_t *ids;
+};
+
+struct ret_list {
+	size_t count;
+	struct ret *a;
+};
+
+int
+cmp_ret_by_endid(const void *pa, const void *pb);
+
+struct ret *
+find_ret(const struct ret_list *list, const struct dfavm_op_ir *op,
+	int (*cmp)(const void *pa, const void *pb));
+
+bool
+build_retlist(struct ret_list *list, const struct dfavm_op_ir *a);
+
+void
+free_retlist(struct ret_list *list);
+
+#endif
+

--- a/src/libfsm/vm/vm.h
+++ b/src/libfsm/vm/vm.h
@@ -20,6 +20,8 @@
 #define DFAVM_MAGIC "DFAVM$"
 
 struct ir;
+struct ret;
+struct ret_list;
 struct fsm_vm_compile_opts;
 struct dfavm_op_ir_pool;
 
@@ -74,15 +76,8 @@ struct dfavm_op_ir {
 	 */
 	uint32_t index;
 
-
-
-const char *example;
-
-struct {
-	fsm_end_id_t *ids; /* NULL -> 0 */
-	size_t count;
-} endids;
-
+	const char *example;
+	const struct ret *ret;
 
 	uint32_t num_incoming; // number of branches to this instruction
 	int in_trace;
@@ -198,7 +193,7 @@ const char *
 cmp_name(int cmp);
 
 int
-dfavm_compile_ir(struct dfavm_assembler_ir *a, const struct ir *ir, struct fsm_vm_compile_opts opts);
+dfavm_compile_ir(struct dfavm_assembler_ir *a, const struct ir *ir, const struct ret_list *retlist, struct fsm_vm_compile_opts opts);
 
 struct fsm_dfavm *
 dfavm_compile_vm(const struct dfavm_assembler_ir *a, struct fsm_vm_compile_opts opts);

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -336,16 +336,14 @@ conflict(FILE *f, const struct fsm_options *opt,
 static int
 comment_c(FILE *f, const struct fsm_options *opt,
 	const fsm_end_id_t *ids, size_t count,
-	void *lang_opaque, void *hook_opaque)
+	void *hook_opaque)
 {
 	size_t i;
 
 	assert(opt != NULL);
-	assert(lang_opaque == NULL);
 	assert(hook_opaque == NULL);
 
 	(void) opt;
-	(void) lang_opaque;
 	(void) hook_opaque;
 
 	fprintf(f, "/* ");
@@ -368,19 +366,17 @@ comment_c(FILE *f, const struct fsm_options *opt,
 static int
 comment_rust(FILE *f, const struct fsm_options *opt,
 	const fsm_end_id_t *ids, size_t count,
-	void *lang_opaque, void *hook_opaque)
+	void *hook_opaque)
 {
 	size_t i;
 
 	assert(opt != NULL);
-	assert(lang_opaque != NULL);
 	assert(hook_opaque == NULL);
 
 	(void) opt;
-	(void) lang_opaque;
 	(void) hook_opaque;
 
-	fprintf(f, "/* ");
+	fprintf(f, "// ");
 
 	for (i = 0; i < count; i++) {
 		assert(ids[i] < matchc);
@@ -392,24 +388,20 @@ comment_rust(FILE *f, const struct fsm_options *opt,
 		}
 	}
 
-	fprintf(f, " */");
-
 	return 0;
 }
 
 static int
 comment_llvm(FILE *f, const struct fsm_options *opt,
 	const fsm_end_id_t *ids, size_t count,
-	void *lang_opaque, void *hook_opaque)
+	void *hook_opaque)
 {
 	size_t i;
 
 	assert(opt != NULL);
-	assert(lang_opaque == NULL);
 	assert(hook_opaque == NULL);
 
 	(void) opt;
-	(void) lang_opaque;
 	(void) hook_opaque;
 
 	fprintf(f, "; ");
@@ -430,12 +422,11 @@ comment_llvm(FILE *f, const struct fsm_options *opt,
 static int
 comment_dot(FILE *f, const struct fsm_options *opt,
 	const fsm_end_id_t *ids, size_t count,
-	void *lang_opaque, void *hook_opaque)
+	void *hook_opaque)
 {
 	size_t i;
 
 	assert(opt != NULL);
-	assert(lang_opaque != NULL);
 	assert(hook_opaque == NULL);
 
 	(void) opt;
@@ -1066,6 +1057,7 @@ main(int argc, char *argv[])
 			break;
 
 		case FSM_PRINT_RUST:
+		case FSM_PRINT_GO: /* close enough */
 			hooks.comment = comment_rust;
 			break;
 

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -373,7 +373,7 @@ comment_rust(FILE *f, const struct fsm_options *opt,
 	size_t i;
 
 	assert(opt != NULL);
-	assert(lang_opaque == NULL);
+	assert(lang_opaque != NULL);
 	assert(hook_opaque == NULL);
 
 	(void) opt;

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -420,25 +420,40 @@ accept_llvm(FILE *f, const struct fsm_options *opt,
 	const fsm_end_id_t *ids, size_t count,
 	void *lang_opaque, void *hook_opaque)
 {
-	unsigned n;
+	const char *prefix;
 	size_t i;
 
 	assert(opt != NULL);
 	assert(lang_opaque != NULL);
 	assert(hook_opaque == NULL);
 
+	if (opt->prefix != NULL) {
+		prefix = opt->prefix;
+	} else {
+		prefix = "fsm.";
+	}
+
 	(void) opt;
 	(void) hook_opaque;
 
-	n = 0;
-
-	for (i = 0; i < count; i++) {
-		n |= 1U << ids[i];
-	}
-
 	i = * (const size_t *) lang_opaque;
 
-	fprintf(f, "[u%#x, %%ret%zu],", (unsigned) n, i);
+	if (opt->ambig == AMBIG_MULTIPLE) {
+// XXX
+#define ptr_i8 "ptr"
+		fprintf(f, "[{ i1 true, %s @%sr%zu, i32 %zu }, %%ret%zu],", ptr_i8, prefix, i, count, i);
+#undef ptr_i8
+	} else {
+		unsigned n;
+
+		n = 0;
+
+		for (i = 0; i < count; i++) {
+			n |= 1U << ids[i];
+		}
+
+		fprintf(f, "[u%#x, %%ret%zu],", (unsigned) n, i);
+	}
 
 	fprintf(f, " ; ");
 

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -334,60 +334,6 @@ conflict(FILE *f, const struct fsm_options *opt,
 }
 
 static int
-accept_c(FILE *f, const struct fsm_options *opt,
-	const fsm_end_id_t *ids, size_t count,
-	void *lang_opaque, void *hook_opaque)
-{
-	unsigned n;
-	size_t i;
-
-	assert(opt != NULL);
-	assert(lang_opaque == NULL);
-	assert(hook_opaque == NULL);
-
-	(void) opt;
-	(void) lang_opaque;
-	(void) hook_opaque;
-
-	n = 0;
-
-	for (i = 0; i < count; i++) {
-		n |= 1U << ids[i];
-	}
-
-	fprintf(f, "return %#x;", (unsigned) n);
-
-	return 0;
-}
-
-static int
-accept_rust(FILE *f, const struct fsm_options *opt,
-	const fsm_end_id_t *ids, size_t count,
-	void *lang_opaque, void *hook_opaque)
-{
-	unsigned n;
-	size_t i;
-
-	assert(opt != NULL);
-	assert(lang_opaque == NULL);
-	assert(hook_opaque == NULL);
-
-	(void) opt;
-	(void) lang_opaque;
-	(void) hook_opaque;
-
-	n = 0;
-
-	for (i = 0; i < count; i++) {
-		n |= 1U << ids[i];
-	}
-
-	fprintf(f, "return Some(%#x)", (unsigned) n);
-
-	return 0;
-}
-
-static int
 comment_c(FILE *f, const struct fsm_options *opt,
 	const fsm_end_id_t *ids, size_t count,
 	void *lang_opaque, void *hook_opaque)
@@ -1116,12 +1062,10 @@ main(int argc, char *argv[])
 
 		case FSM_PRINT_C:
 		case FSM_PRINT_VMC:
-			hooks.accept  = accept_c;
 			hooks.comment = comment_c;
 			break;
 
 		case FSM_PRINT_RUST:
-			hooks.accept  = accept_rust;
 			hooks.comment = comment_rust;
 			break;
 

--- a/src/retest/runner.c
+++ b/src/retest/runner.c
@@ -379,7 +379,7 @@ runner_init_compiled(struct fsm *fsm,
 
 	case IMPL_LLVM:
 		r->u.impl_llvm.h = h;
-		r->u.impl_llvm.func = (bool (*)(const char *, const char *)) (uintptr_t) dlsym(h, "fsm_main");
+		r->u.impl_llvm.func = (bool (*)(const char *, const char *)) (uintptr_t) dlsym(h, "fsm.main");
 		break;
 
 	case IMPL_GO:


### PR DESCRIPTION
This PR:

* Implements `AMBIG_MULTIPLE` for various languages (go, rust, llvm especially)
* Adds `(struct fsm_hooks).comment()`
* Strips all comments from generated code in the absence of `(struct fsm_options).comments`
* Quietly fixes a couple of unremarkable bugs
* Does a bit more refactoring around the output routines

Here's how the generated `AMBIG_MULTIPLE` code looks for the following example:
```
aria; ./build/bin/re -k str -zabupl $lang 'x' 'x?'
```
for go:
```go
package fsm_fsm

var ret0 []uint = []uint{1}
var ret1 []uint = []uint{0, 1}

func fsm_Match(data string) (bool, []uint) {
	var idx = ^uint(0)

	if idx++; idx >= uint(len(data)) {
		return true, ret0
	}

	if data[idx] != 'x' {
		return false, nil
	}

	if idx++; idx >= uint(len(data)) {
		return true, ret1
	}

	{
		return false, nil
	}

}
```

Rust:
```rust
aria; ./build/bin/re -k str -zabupl rust 'x' 'x?'

pub fn fsm_main(input: &str) -> Option<&'static [u32]> {
    use Label::*;
    static RET0: [u32; 1] = [1];
    static RET1: [u32; 2] = [0, 1];

    let mut bytes = input.bytes();

    pub enum Label {
        Ls,
    }

    let l = Ls;

    loop {
        match l {
            Ls => { // e.g. ""
                let c = match bytes.next() {
                    None => return Some(&RET0) /* "x?" */,
                    Some(c) => c,
                };
                if c != b'x' { return None }
                let _c = match bytes.next() {
                    None => return Some(&RET1) /* "x", "x?" */,
                    Some(_c) => _c,
                };
                return None
            }
        }
    }
}
```

and (my current favourite) for llvm, with many thanks to @mcy for the guidance:
```llvm
; generated
%rt = type { ptr, i64 }
@fsm.r0 = internal unnamed_addr constant [1 x i32] [i32 1] ; "x?"
@fsm.r1 = internal unnamed_addr constant [2 x i32] [i32 0, i32 1] ; "x", "x?"
@fsm.r = internal unnamed_addr constant [3 x %rt] [
	 %rt { ptr bitcast ([1 x i32]* @fsm.r0 to ptr), i64 1 },
	 %rt { ptr bitcast ([2 x i32]* @fsm.r1 to ptr), i64 2 },
	 %rt { ptr poison, i64 -1 } ; fail
	]
define dso_local %rt @fsm.main(ptr nocapture noundef readonly %s) local_unnamed_addr hot nosync nounwind norecurse willreturn #0 {
	%n = alloca i32
	store i32 0, ptr %n
	br label %l0
stop:
	%i = phi i64
	 [0, %ret0],
	 [1, %ret1],
	 [2, %fail]
	%p = getelementptr inbounds [3 x %rt], [3 x %rt]* @fsm.r, i64 0, i64 %i
	%ret = load %rt, ptr %p
	ret %rt %ret
fail:
	br label %stop
ret0:
	br label %stop
ret1:
	br label %stop
l0:
	; e.g. ""
	%n0 = load i32, ptr %n
	%p0 = getelementptr inbounds i8, ptr %s, i32 %n0
	%c0 = load i8, ptr %p0
	%r0 = icmp eq i8 %c0, 0 ; EOT
	br i1 %r0, label %t0, label %f0
f0:
	%n.new0 = add i32 1, %n0
	store i32 %n.new0, ptr %n
	br label %l1
t0:
	br label %ret0
l1:
	; e.g. ""
	%r1 = icmp ne i8 %c0, 120 ; 'x'
	br i1 %r1, label %fail, label %l2
l2:
	; e.g. "x"
	%n1 = load i32, ptr %n
	%p1 = getelementptr inbounds i8, ptr %s, i32 %n1
	%c1 = load i8, ptr %p1
	%r2 = icmp eq i8 %c1, 0 ; EOT
	br i1 %r2, label %t2, label %f2
f2:
	%n.new1 = add i32 1, %n1
	store i32 %n.new1, ptr %n
	br label %fail
t2:
	br label %ret1
}
```

And the vmops structures also now carry the endids for all ambig modes except for `AMBIG_NONE`:
```
aria; ./build/bin/re -k str -zabupl vmops_c x 'x?'
#include <stdint.h>

#ifndef fsm_LIBFSM_VMOPS_H
#include "fsm_vmops.h"
#endif /* fsm_LIBFSM_VMOPS_H */

struct fsm_ret fsm_Ret[] = {
	{ (const unsigned []) { 1 }, 1 },
	{ (const unsigned []) { 0, 1 }, 2 },
};
const size_t fsm_Ret_count = sizeof fsm_Ret / sizeof *fsm_Ret;

struct fsm_op fsm_Ops[] = {
	{fsm_opEOF, 0, fsm_actionRET, 1, 0},
	{fsm_opNE, 'x', fsm_actionRET, 0, 0},
	{fsm_opEOF, 0, fsm_actionRET, 1, 1},
	{fsm_opALWAYS, '\x00', fsm_actionRET, 0, 0},
```