### PR TITLE
In `closure_free()`, use the FSM allocator instead of `free()`.

### DIFF
--- a/src/fsm/main.c
+++ b/src/fsm/main.c
@@ -666,7 +666,7 @@ main(int argc, char *argv[])
 				printf("\n");
 			}
 
-			closure_free(closures, fsm->statecount);
+			closure_free(fsm, closures, fsm->statecount);
 
 			return 0;
 		} else {

--- a/src/libfsm/closure.c
+++ b/src/libfsm/closure.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <fsm/alloc.h>
 #include <fsm/fsm.h>
 #include <fsm/pred.h>
 #include <fsm/walk.h>
@@ -189,7 +190,7 @@ error:
 }
 
 void
-closure_free(struct state_set **closures, size_t n)
+closure_free(struct fsm *fsm, struct state_set **closures, size_t n)
 {
 	fsm_state_t s;
 
@@ -197,6 +198,6 @@ closure_free(struct state_set **closures, size_t n)
 		state_set_free(closures[s]);
 	}
 
-	free(closures);
+	f_free(fsm->alloc, closures);
 }
 

--- a/src/libfsm/epsilons.c
+++ b/src/libfsm/epsilons.c
@@ -168,7 +168,7 @@ fsm_remove_epsilons(struct fsm *nfa)
 	res = 1;
 cleanup:
 	if (eclosures != NULL) {
-		closure_free(eclosures, state_count);
+		closure_free(nfa, eclosures, state_count);
 	}
 
 	return res;

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -92,7 +92,7 @@ struct state_set **
 epsilon_closure(struct fsm *fsm);
 
 void
-closure_free(struct state_set **closures, size_t n);
+closure_free(struct fsm *fsm, struct state_set **closures, size_t n);
 
 /*
  * Internal free function that invokes free(3) by default, or a user-provided


### PR DESCRIPTION
`closure_free()` should use the free implementation provided by the FSM's allocator.

While attempting to make bindings to the libfsm API for a Rust project, I came across a case where my allocator was giving me the same pointer twice. I added instrumentation that places guard regions on either side of the allocation, and with this, I was able to observe `closure_free()` attempting to free the internal pointer between the guards rather than the pointer to the start of the allocation.

With this change in place, I was able to run my test program to completion.
