### PR TITLE
A few small bugfixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Cache checkout
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-checkout
       with:
         path: ${{ env.wc }}
@@ -27,7 +27,7 @@ jobs:
 
     - name: Checkout
       if: steps.cache-checkout.outputs.cache-hit != 'true'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: recursive
         path: ${{ env.wc }}
@@ -49,7 +49,7 @@ jobs:
 
     steps:
     - name: Cache PCRE suite
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-pcre
       with:
         path: pcre-suite/${{ env.pcre2 }}
@@ -67,7 +67,7 @@ jobs:
         chmod -R ug-w pcre-suite
 
     - name: Cache converted PCRE tests
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-cvtpcre
       with:
         path: ${{ env.cvtpcre }}
@@ -75,7 +75,7 @@ jobs:
 
     - name: Fetch build
       if: steps.cache-cvtpcre.outputs.cache-hit != 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-build
       with:
         path: ${{ env.build }}
@@ -155,14 +155,14 @@ jobs:
 
     steps:
     - name: Fetch checkout
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-checkout
       with:
         path: ${{ env.wc }}
         key: checkout-${{ github.sha }}
 
     - name: Cache build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-build
       with:
         path: ${{ env.build }}
@@ -185,7 +185,7 @@ jobs:
 
     - name: Get number of CPU cores
       if: steps.cache-build.outputs.cache-hit != 'true'
-      uses: SimenB/github-actions-cpu-cores@v1
+      uses: SimenB/github-actions-cpu-cores@v2
       id: cpu-cores
 
     - name: Make
@@ -233,7 +233,7 @@ jobs:
 
     steps:
     - name: Fetch checkout
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-checkout
       with:
         path: ${{ env.wc }}
@@ -241,7 +241,7 @@ jobs:
 
     # An arbitary build.
     - name: Fetch build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-build
       with:
         path: ${{ env.build }}
@@ -273,7 +273,7 @@ jobs:
         ${{ matrix.cc }} --version
 
     - name: Get number of CPU cores
-      uses: SimenB/github-actions-cpu-cores@v1
+      uses: SimenB/github-actions-cpu-cores@v2
       id: cpu-cores
 
     - name: Make
@@ -292,7 +292,7 @@ jobs:
     # kmkf duplicate install targets, it's not interesting for libfsm's CI,
     # so I'm retrying on error here. # github.com/katef/kmkf/issues/14
     - name: Install
-      uses: nick-fields/retry@v2.8.3
+      uses: nick-fields/retry@v3
       with:
         timeout_seconds: 10 # required, but not a problem for the kmkf bug
         max_attempts: 3
@@ -322,7 +322,7 @@ jobs:
 
     steps:
     - name: Fetch checkout
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-checkout
       with:
         path: ${{ env.wc }}
@@ -344,14 +344,14 @@ jobs:
         ${{ matrix.cc }} --version
 
     - name: Fetch build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-build
       with:
         path: ${{ env.build }}
         key: build-${{ matrix.make }}-${{ matrix.os }}-${{ matrix.cc }}-${{ matrix.debug }}-${{ matrix.san }}-${{ github.sha }}
 
     - name: Get number of CPU cores
-      uses: SimenB/github-actions-cpu-cores@v1
+      uses: SimenB/github-actions-cpu-cores@v2
       id: cpu-cores
 
     - name: Test
@@ -381,7 +381,7 @@ jobs:
 
     steps:
     - name: Fetch checkout
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-checkout
       with:
         path: ${{ env.wc }}
@@ -403,7 +403,7 @@ jobs:
         ${{ matrix.cc }} --version
 
     - name: Fetch build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-build
       with:
         path: ${{ env.build }}
@@ -418,7 +418,7 @@ jobs:
     # still run fuzzing, just from empty, and do not save their seeds.
     - name: Restore seeds (mode ${{ matrix.mode }})
       if: github.repository == 'katef/libfsm'
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@v4
       id: cache-seeds
       with:
         path: ${{ env.seeds }}-${{ matrix.mode }}
@@ -429,7 +429,7 @@ jobs:
       run: mkdir -p ${{ env.seeds }}-${{ matrix.mode }}
 
     - name: Get number of CPU cores
-      uses: SimenB/github-actions-cpu-cores@v1
+      uses: SimenB/github-actions-cpu-cores@v2
       id: cpu-cores
 
     - name: Fuzz
@@ -455,7 +455,7 @@ jobs:
     # the same seeds for a given bug.
     # The explicit cache/restore and cache/save actions are just for that.
     - name: Save seeds (mode ${{ matrix.mode }}-${{ matrix.debug }})
-      uses: actions/cache/save@v3
+      uses: actions/cache/save@v4
       if: always()
       with:
         path: ${{ env.seeds }}-${{ matrix.mode }}
@@ -463,7 +463,7 @@ jobs:
 
     # nothing to do with the caching, I'm uploading the seeds so a developer can grab them to fuzz locally
     - name: Upload seeds (mode ${{ matrix.mode }}-${{ matrix.debug }})
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: seeds-${{ matrix.mode }}-${{ matrix.debug }}
         path: ${{ env.seeds }}-${{ matrix.mode }}
@@ -513,14 +513,14 @@ jobs:
         go version
 
     - name: Fetch build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-build
       with:
         path: ${{ env.build }}
         key: build-${{ matrix.make }}-${{ matrix.os }}-${{ matrix.cc }}-${{ matrix.debug }}-${{ matrix.san }}-${{ github.sha }}
 
     - name: Fetch converted PCRE tests
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-cvtpcre
       with:
         path: ${{ env.cvtpcre }}
@@ -539,7 +539,7 @@ jobs:
 
     steps:
     - name: Cache docs
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-docs
       with:
         path: ${{ env.build }}
@@ -554,7 +554,7 @@ jobs:
 
     - name: Fetch checkout
       if: steps.cache-docs.outputs.cache-hit != 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-checkout
       with:
         path: ${{ env.wc }}
@@ -562,7 +562,7 @@ jobs:
 
     - name: Get number of CPU cores
       if: steps.cache-docs.outputs.cache-hit != 'true'
-      uses: SimenB/github-actions-cpu-cores@v1
+      uses: SimenB/github-actions-cpu-cores@v2
       id: cpu-cores
 
     - name: Test docs
@@ -594,7 +594,7 @@ jobs:
 
     steps:
     - name: Cache prefix
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-prefix
       with:
         path: ${{ env.prefix }}
@@ -608,7 +608,7 @@ jobs:
 
     - name: Fetch checkout
       if: steps.cache-prefix.outputs.cache-hit != 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-checkout
       with:
         path: ${{ env.wc }}
@@ -616,7 +616,7 @@ jobs:
 
     - name: Fetch build
       if: steps.cache-prefix.outputs.cache-hit != 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-build
       with:
         path: ${{ env.build }}
@@ -624,7 +624,7 @@ jobs:
 
     - name: Fetch docs
       if: steps.cache-prefix.outputs.cache-hit != 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-docs
       with:
         path: ${{ env.build }}
@@ -632,7 +632,7 @@ jobs:
 
     - name: Get number of CPU cores
       if: steps.cache-prefix.outputs.cache-hit != 'true'
-      uses: SimenB/github-actions-cpu-cores@v1
+      uses: SimenB/github-actions-cpu-cores@v2
       id: cpu-cores
 
     - name: Install
@@ -668,7 +668,7 @@ jobs:
         fpm -v
 
     - name: Fetch prefix
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-prefix
       with:
         path: ${{ env.prefix }}
@@ -691,7 +691,7 @@ jobs:
         printf "package_file=%s\n" $(basename pkg/*) >> $GITHUB_ENV
 
     - name: Upload
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.package_file }}
         path: pkg/${{ env.package_file }}

--- a/examples/bm/libfsm.c
+++ b/examples/bm/libfsm.c
@@ -61,7 +61,7 @@ main(int argc, char *argv[])
 	opt.io = FSM_IO_STR;
 
 	p = argv[0];
-	fsm = re_comp(RE_PCRE, fsm_sgetc, &p, &opt, flags, &e);
+	fsm = re_comp(RE_PCRE, fsm_sgetc, &p, NULL, flags, &e);
 	if (fsm == NULL) {
 		re_perror(RE_LITERAL, &e, NULL, s);
 		return 1;
@@ -80,7 +80,7 @@ main(int argc, char *argv[])
 	printf("#include <time.h>\n");
 	printf("\n");
 
-	fsm_print(stdout, fsm, FSM_PRINT_C);
+	fsm_print(stdout, fsm, &opt, NULL, FSM_PRINT_C);
 
 	printf("int\n");
 	printf("main(void)\n");

--- a/examples/glob/main.c
+++ b/examples/glob/main.c
@@ -196,7 +196,7 @@ main(int argc, char *argv[])
 	}
 
 	if (!quiet) {
-		fsm_print(stdout, fsm, FSM_PRINT_FSM);
+		fsm_print(stdout, fsm, NULL, NULL, FSM_PRINT_FSM);
 	}
 
 	matched = match(fsm, argv[1]);

--- a/examples/utf8dfa/main.c
+++ b/examples/utf8dfa/main.c
@@ -164,7 +164,7 @@ main(int argc, char *argv[])
 		return EXIT_FAILURE;
 	}
 
-	fsm = fsm_new(&opt);
+	fsm = fsm_new(NULL);
 	if (fsm == NULL) {
 		perror("fsm_new");
 		exit(1);
@@ -215,12 +215,17 @@ main(int argc, char *argv[])
 		}
 	}
 
+	if (!fsm_determinise(fsm)) {
+		perror("fsm_determinise");
+		exit(1);
+	}
+
 	if (!fsm_minimise(fsm)) {
 		perror("fsm_minimise");
 		exit(1);
 	}
 
-	fsm_print(stdout, fsm, lang);
+	fsm_print(stdout, fsm, NULL, NULL, lang);
 
 	fsm_free(fsm);
 

--- a/examples/words/main.c
+++ b/examples/words/main.c
@@ -86,7 +86,7 @@ int main(int argc, char *argv[]) {
 			exit(EXIT_FAILURE);
 		}
 	} else {
-		fsm = fsm_new(&opt);
+		fsm = fsm_new(NULL);
 		if (fsm == NULL) {
 			perror("fsm_new");
 			return 1;
@@ -127,7 +127,7 @@ int main(int argc, char *argv[]) {
 			struct fsm *r;
 			struct fsm_combine_info ci;
 
-			r = re_comp(native ? RE_NATIVE : RE_LITERAL, fsm_sgetc, &p, &opt, 0, &e);
+			r = re_comp(native ? RE_NATIVE : RE_LITERAL, fsm_sgetc, &p, NULL, 0, &e);
 			if (r == NULL) {
 				re_perror(native ? RE_NATIVE : RE_LITERAL, &e, NULL, s);
 				return 1;
@@ -168,7 +168,7 @@ int main(int argc, char *argv[]) {
 		}
 
 		fsm = re_strings_build(g,
-			&opt, unanchored ? 0 : (RE_STRINGS_ANCHOR_LEFT | RE_STRINGS_ANCHOR_RIGHT));
+			NULL, unanchored ? 0 : (RE_STRINGS_ANCHOR_LEFT | RE_STRINGS_ANCHOR_RIGHT));
 		if (fsm == NULL) {
 			perror("re_strings_builder_build");
 			exit(EXIT_FAILURE);
@@ -211,7 +211,7 @@ int main(int argc, char *argv[]) {
 		           + ((long) post.tv_nsec - (long) pre.tv_nsec) / 1000000;
 	}
 
-	fsm_print(stdout, fsm, lang);
+	fsm_print(stdout, fsm, &opt, NULL, lang);
 
 	if (timing) {
 		printf("construction, reduction, total: %lu, %lu, %lu\n", ms, mt, ms + mt);

--- a/src/libfsm/gen.c
+++ b/src/libfsm/gen.c
@@ -193,7 +193,7 @@ gen_init_outer(struct fsm *fsm, size_t max_length,
     fsm_generate_matches_cb *cb, void *opaque,
     bool randomized, unsigned seed)
 {
-	int res = 0;
+	int res = false;
 	if (fsm == NULL || cb == NULL || max_length == 0) {
 		return false;
 	}
@@ -222,11 +222,11 @@ gen_init_outer(struct fsm *fsm, size_t max_length,
 		goto cleanup;
 	}
 
-	res = 1;
+	res = true;
 
 	while (!ctx.done) {
 		if (!gen_iter(&ctx)) {
-			res = 0;
+			res = false;
 			break;
 		}
 	}

--- a/src/libfsm/gen.c
+++ b/src/libfsm/gen.c
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <string.h>
+#include <errno.h>
 
 #include <fsm/fsm.h>
 #include <fsm/pred.h>
@@ -139,6 +140,11 @@ int
 fsm_generate_matches(struct fsm *fsm, size_t max_length,
     fsm_generate_matches_cb *cb, void *opaque)
 {
+	if (max_length == 0) {
+		errno = EINVAL;
+		return 0;
+	}
+
 	INIT_TIMERS();
 	TIME(&pre);
 	int res = gen_init_outer(fsm, max_length, cb, opaque, false, 0);
@@ -562,8 +568,8 @@ sfs_step_edges(struct gen_ctx *ctx, struct gen_stack_frame *sf)
 		sf->u.step_edges.initialized = true;
 	}
 
-	if (ctx->buf_used + ctx->sed[sf->s_id] >= ctx->max_length) {
-		LOG(2, "PRUNING due to max length: used:%zu + sed[%d]:%u >= max_length:%zu\n",
+	if (ctx->buf_used + ctx->sed[sf->s_id] > ctx->max_length) {
+		LOG(2, "PRUNING due to max length: used:%zu + sed[%d]:%u > max_length:%zu\n",
 		    ctx->buf_used, sf->s_id, ctx->sed[sf->s_id], ctx->max_length);
 		sf->t = GEN_SFS_LEAVING_STATE;
 		return true;

--- a/src/libfsm/print/rust.c
+++ b/src/libfsm/print/rust.c
@@ -520,14 +520,18 @@ fsm_print_rust(FILE *f,
 
 	switch (opt->ambig) {
 	case AMBIG_NONE:
+		fprintf(f, "Option<()>");
+		break;
+
 	case AMBIG_ERROR:
 	case AMBIG_EARLIEST:
-		fprintf(f, "Option<()>");
+		fprintf(f, "Option<u32>");
 		break;
 
 	case AMBIG_MULTIPLE:
 		fprintf(f, "Option<&'static [u32]>");
 		break;
+
 	default:
 		fprintf(stderr, "unsupported ambig mode\n");
 		exit(EXIT_FAILURE);

--- a/src/libre/print/abnf.c
+++ b/src/libre/print/abnf.c
@@ -212,7 +212,6 @@ pp_iter(FILE *f, const struct fsm_options *opt, enum re_flags *re_flags, struct 
 		break;
 
 	case AST_EXPR_SUBTRACT:
-		assert(!"unimplemented");
 		pp_atomic(f, opt, re_flags, n->u.subtract.a, n);
 		fprintf(f, " - ");
 		pp_atomic(f, opt, re_flags, n->u.subtract.b, n);

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -1047,7 +1047,11 @@ main(int argc, char *argv[])
 	}
 
 	if (generate_bounds > 0) {
-		return fsm_generate_matches(fsm, generate_bounds, fsm_generate_cb_printf_escaped, &opt);
+		if (!fsm_generate_matches(fsm, generate_bounds, fsm_generate_cb_printf_escaped, &opt)) {
+			exit(EXIT_FAILURE);
+		}
+
+		return 0;
 	}
 
 	if (fsm_lang != FSM_PRINT_NONE) {

--- a/src/retest/main.c
+++ b/src/retest/main.c
@@ -1270,16 +1270,10 @@ main(int argc, char *argv[])
 				break;
 
 			case 'l':
-				if (strcmp(optarg, "vm") == 0) {
-					impl = IMPL_INTERPRET;
+				if (strcmp(optarg, "asm") == 0) {
+					impl = IMPL_VMASM;
 				} else if (strcmp(optarg, "c") == 0) {
 					impl = IMPL_C;
-				} else if (strcmp(optarg, "asm") == 0) {
-					impl = IMPL_VMASM;
-				} else if (strcmp(optarg, "vmc") == 0) {
-					impl = IMPL_VMC;
-				} else if (strcmp(optarg, "vmops") == 0) {
-					impl = IMPL_VMOPS;
 				} else if (strcmp(optarg, "go") == 0) {
 					impl = IMPL_GO;
 				} else if (strcmp(optarg, "goasm") == 0) {
@@ -1288,6 +1282,12 @@ main(int argc, char *argv[])
 					impl = IMPL_LLVM;
 				} else if (strcmp(optarg, "rust") == 0) {
 					impl = IMPL_RUST;
+				} else if (strcmp(optarg, "vm") == 0) {
+					impl = IMPL_INTERPRET;
+				} else if (strcmp(optarg, "vmc") == 0) {
+					impl = IMPL_VMC;
+				} else if (strcmp(optarg, "vmops") == 0) {
+					impl = IMPL_VMOPS;
 				} else {
 					fprintf(stderr, "unknown argument to -l: %s\n", optarg);
 					usage();

--- a/src/retest/reperf.c
+++ b/src/retest/reperf.c
@@ -1154,18 +1154,24 @@ main(int argc, char *argv[])
 				break;
 
 			case 'l':
-				if (strcmp(optarg, "vm") == 0) {
-					impl = IMPL_INTERPRET;
+				if (strcmp(optarg, "asm") == 0) {
+					impl = IMPL_VMASM;
 				} else if (strcmp(optarg, "c") == 0) {
 					impl = IMPL_C;
+				} else if (strcmp(optarg, "go") == 0) {
+					impl = IMPL_GO;
+				} else if (strcmp(optarg, "goasm") == 0) {
+					impl = IMPL_GOASM;
 				} else if (strcmp(optarg, "llvm") == 0) {
 					impl = IMPL_LLVM;
 				} else if (strcmp(optarg, "rust") == 0) {
 					impl = IMPL_RUST;
-				} else if (strcmp(optarg, "asm") == 0) {
-					impl = IMPL_VMASM;
+				} else if (strcmp(optarg, "vm") == 0) {
+					impl = IMPL_INTERPRET;
 				} else if (strcmp(optarg, "vmc") == 0) {
 					impl = IMPL_VMC;
+				} else if (strcmp(optarg, "vmops") == 0) {
+					impl = IMPL_VMOPS;
 				} else {
 					fprintf(stderr, "unknown argument to -l: %s\n", optarg);
 					usage();

--- a/src/retest/runner.c
+++ b/src/retest/runner.c
@@ -158,7 +158,7 @@ compile(enum implementation impl,
 		break;
 
 	case IMPL_RUST:
-		if (0 != systemf("%s %s --crate-type dylib %s -o %s",
+		if (0 != systemf("%s %s -C opt-level=3 --crate-type dylib %s -o %s",
 				"rustc", "--edition 2021",
 				tmp_src, tmp_so))
 		{

--- a/src/retest/runner.h
+++ b/src/retest/runner.h
@@ -27,13 +27,13 @@ enum error_type {
 
 enum implementation {
 	IMPL_C,
-	IMPL_RUST,
-	IMPL_LLVM,
 	IMPL_GO,
 	IMPL_GOASM,
-	IMPL_VMC,
-	IMPL_VMASM,
 	IMPL_INTERPRET,
+	IMPL_LLVM,
+	IMPL_RUST,
+	IMPL_VMASM,
+	IMPL_VMC,
 	IMPL_VMOPS,
 };
 


### PR DESCRIPTION
- Reported by @pierreganty: #478, off-by-one for `re -G <max-length>` and also in the same ticket, wrong exit status for `re -G` 
- Suggested by @sw17ch: `-C opt-level=3` does help for performance of rust generated code, and I'd also hoped it'd improve time in CI. But sadly no, that's still dominated by the rustc compile time.
- Spotted by @sw17ch: wrong return type for AMBIG_ERROR/AMBIG_EARLIEST for rust generated code