### PR TITLE
Happier cache lines

### DIFF
--- a/include/adt/path.h
+++ b/include/adt/path.h
@@ -12,8 +12,9 @@ struct fsm_state;
 
 struct path {
 	fsm_state_t state;
-	struct path *next;
 	char c;
+
+	struct path *next;
 };
 
 struct path *

--- a/include/fsm/options.h
+++ b/include/fsm/options.h
@@ -81,17 +81,17 @@ struct fsm_options {
 	 */
 	unsigned int group_edges:1;
 
-	/* for generated code, what kind of I/O API to generate */
-	enum fsm_io io;
-
-	/* for generated code, how to handle multiple endids on an accepting state */
-	enum fsm_ambig ambig;
-
 	/* a prefix for namespacing generated identifiers. NULL if not required. */
 	const char *prefix;
 
 	/* the name of the enclosing package; NULL to use `prefix` (default). */
 	const char *package_prefix;
+
+	/* for generated code, what kind of I/O API to generate */
+	enum fsm_io io;
+
+	/* for generated code, how to handle multiple endids on an accepting state */
+	enum fsm_ambig ambig;
 };
 
 #endif

--- a/src/adt/edgeset.c
+++ b/src/adt/edgeset.c
@@ -121,7 +121,7 @@ dump_edge_set(const struct edge_set *set)
 static struct edge_set *
 init_empty(const struct fsm_alloc *alloc)
 {
-	struct edge_set *set = f_calloc(alloc, 1, sizeof(*set));
+	struct edge_set *set = f_malloc(alloc, sizeof(*set));
 	if (set == NULL) {
 		return NULL;
 	}
@@ -719,7 +719,7 @@ edge_set_copy(struct edge_set **dst, const struct fsm_alloc *alloc,
 		return 1;
 	}
 
-	set = f_calloc(alloc, 1, sizeof(*set));
+	set = f_malloc(alloc, sizeof(*set));
 	if (set == NULL) {
 		return 0;
 	}

--- a/src/adt/edgeset.c
+++ b/src/adt/edgeset.c
@@ -35,8 +35,8 @@ struct edge_set {
 	size_t ceil;		/* nonzero */
 	size_t count;		/* <= ceil */
 	struct edge_group {
-		fsm_state_t to;	/* distinct */
 		uint64_t symbols[256/64];
+		fsm_state_t to;	/* distinct */
 	} *groups;		/* sorted by .to */
 };
 

--- a/src/adt/idmap.c
+++ b/src/adt/idmap.c
@@ -119,6 +119,7 @@ grow_bucket_values(struct idmap *m, unsigned old_words, unsigned new_words)
 			return 0;
 		}
 
+		// TODO: memcpy
 		for (size_t w_i = 0; w_i < old_words; w_i++) {
 			nv[w_i] = b->values[w_i];
 		}

--- a/src/adt/internedstateset.c
+++ b/src/adt/internedstateset.c
@@ -77,7 +77,7 @@ interned_state_set_pool_alloc(const struct fsm_alloc *a)
 	fsm_state_t *buf = NULL;
 	uint32_t *buckets = NULL;
 
-	res = f_calloc(a, 1, sizeof(*res));
+	res = f_malloc(a, sizeof(*res));
 	if (res == NULL) { goto cleanup; }
 
 	sets = f_malloc(a, DEF_SETS * sizeof(sets[0]));
@@ -93,7 +93,7 @@ interned_state_set_pool_alloc(const struct fsm_alloc *a)
 		buckets[i] = NO_ID;
 	}
 
-	struct interned_state_set_pool p = {
+	*res = (struct interned_state_set_pool) {
 		.alloc = a,
 		.sets = {
 			.ceil = DEF_SETS,
@@ -108,7 +108,7 @@ interned_state_set_pool_alloc(const struct fsm_alloc *a)
 			.buckets = buckets,
 		},
 	};
-	memcpy(res, &p, sizeof(p));
+
 	return res;
 
 cleanup:

--- a/src/adt/queue.c
+++ b/src/adt/queue.c
@@ -30,11 +30,13 @@ queue_new(const struct fsm_alloc *a, size_t max_capacity)
 	if (max_capacity == 0) { return NULL; }
 	alloc_size = sizeof(*q) + (max_capacity - 1) * sizeof(q->q[0]);
 
-	q = f_calloc(a, 1, alloc_size);
+	q = f_malloc(a, alloc_size);
 	if (q == NULL) { return NULL; }
 
 	q->alloc = a;
 	q->capacity = max_capacity;
+	q->rd = 0;
+	q->wr = 0;
 
 	return q;
 }

--- a/src/libfsm/capture.c
+++ b/src/libfsm/capture.c
@@ -14,11 +14,16 @@ fsm_capture_init(struct fsm *fsm)
 	struct fsm_capture_info *ci = NULL;
 	size_t i;
 
-	ci = f_calloc(fsm->alloc,
-	    1, sizeof(*ci));
+	ci = f_malloc(fsm->alloc, sizeof(*ci));
 	if (ci == NULL) {
 		goto cleanup;
 	}
+
+	ci->max_capture_id = 0;
+	ci->bucket_count   = 0;
+	ci->buckets_used   = 0;
+	ci->buckets        = NULL;
+
 	fsm->capture_info = ci;
 
 	for (i = 0; i < fsm->statealloc; i++) {

--- a/src/libfsm/clone.c
+++ b/src/libfsm/clone.c
@@ -118,7 +118,9 @@ copy_capture_actions(struct fsm *dst, const struct fsm *src)
 }
 
 struct copy_end_ids_env {
+#ifndef NDEBUG
 	char tag;
+#endif
 	struct fsm *dst;
 	const struct fsm *src;
 	bool ok;
@@ -146,7 +148,9 @@ static int
 copy_end_ids(struct fsm *dst, const struct fsm *src)
 {
 	struct copy_end_ids_env env;
+#ifndef NDEBUG
 	env.tag = 'c';		/* for clone */
+#endif
 	env.dst = dst;
 	env.src = src;
 	env.ok = true;

--- a/src/libfsm/clone.c
+++ b/src/libfsm/clone.c
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdbool.h>
 
 #include <fsm/fsm.h>
 #include <fsm/pred.h>
@@ -86,7 +87,7 @@ fsm_clone(const struct fsm *fsm)
 
 struct copy_capture_actions_env {
 	struct fsm *dst;
-	int ok;
+	bool ok;
 };
 
 static int
@@ -99,7 +100,7 @@ copy_capture_actions_cb(fsm_state_t state,
 
 	if (!fsm_capture_add_action(env->dst,
 		state, type, capture_id, to)) {
-		env->ok = 0;
+		env->ok = false;
 	}
 
 	return env->ok;
@@ -108,7 +109,7 @@ copy_capture_actions_cb(fsm_state_t state,
 static int
 copy_capture_actions(struct fsm *dst, const struct fsm *src)
 {
-	struct copy_capture_actions_env env = { NULL, 1 };
+	struct copy_capture_actions_env env = { NULL, true };
 	env.dst = dst;
 
 	fsm_capture_action_iter(src,
@@ -120,7 +121,7 @@ struct copy_end_ids_env {
 	char tag;
 	struct fsm *dst;
 	const struct fsm *src;
-	int ok;
+	bool ok;
 };
 
 static int
@@ -134,7 +135,7 @@ copy_end_ids_cb(fsm_state_t state, const fsm_end_id_t id, void *opaque)
 #endif
 
 	if (!fsm_endid_set(env->dst, state, id)) {
-		env->ok = 0;
+		env->ok = false;
 		return 0;
 	}
 
@@ -148,7 +149,7 @@ copy_end_ids(struct fsm *dst, const struct fsm *src)
 	env.tag = 'c';		/* for clone */
 	env.dst = dst;
 	env.src = src;
-	env.ok = 1;
+	env.ok = true;
 
 	fsm_endid_iter(src, copy_end_ids_cb, &env);
 

--- a/src/libfsm/consolidate.c
+++ b/src/libfsm/consolidate.c
@@ -36,7 +36,9 @@ struct mapping_closure {
 };
 
 struct consolidate_copy_capture_actions_env {
+#ifndef NDEBUG
 	char tag;
+#endif
 	struct fsm *dst;
 	size_t mapping_count;
 	const fsm_state_t *mapping;
@@ -201,7 +203,9 @@ consolidate_copy_capture_actions(struct fsm *dst, const struct fsm *src,
 	size_t i;
 
 	struct consolidate_copy_capture_actions_env env;
+#ifndef NDEBUG
 	env.tag = 'C';
+#endif
 	env.dst = dst;
 	env.mapping_count = mapping_count;
 	env.mapping = mapping;
@@ -249,7 +253,9 @@ consolidate_end_ids(struct fsm *dst, const struct fsm *src,
 	struct consolidate_end_ids_env env;
 	int ret;
 
+#ifndef NDEBUG
 	env.tag = 'C';		/* for Consolidate */
+#endif
 	env.dst = dst;
 	env.src = src;
 	env.mapping = mapping;

--- a/src/libfsm/consolidate.c
+++ b/src/libfsm/consolidate.c
@@ -9,6 +9,7 @@
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <stdio.h>
 
 #include <fsm/fsm.h>
@@ -39,7 +40,7 @@ struct consolidate_copy_capture_actions_env {
 	struct fsm *dst;
 	size_t mapping_count;
 	const fsm_state_t *mapping;
-	int ok;
+	bool ok;
 };
 
 static int
@@ -186,7 +187,7 @@ consolidate_copy_capture_actions_cb(fsm_state_t state,
 
 	if (!fsm_capture_add_action(env->dst,
 		s, type, capture_id, t)) {
-		env->ok = 0;
+		env->ok = false;
 		return 0;
 	}
 
@@ -204,7 +205,7 @@ consolidate_copy_capture_actions(struct fsm *dst, const struct fsm *src,
 	env.dst = dst;
 	env.mapping_count = mapping_count;
 	env.mapping = mapping;
-	env.ok = 1;
+	env.ok = true;
 
 #if LOG_MAPPING
 	for (i = 0; i < mapping_count; i++) {

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -382,7 +382,12 @@ static int
 det_copy_capture_actions(struct reverse_mapping *reverse_mappings,
     struct fsm *dst, struct fsm *src)
 {
-	struct det_copy_capture_actions_env env = { 'D', NULL, NULL, 1 };
+	struct det_copy_capture_actions_env env = {
+#ifndef NDEBUG
+		'D',
+#endif
+		NULL, NULL, 1
+	};
 	env.dst = dst;
 	env.reverse_mappings = reverse_mappings;
 

--- a/src/libfsm/determinise_internal.h
+++ b/src/libfsm/determinise_internal.h
@@ -83,7 +83,9 @@ struct reverse_mapping {
 };
 
 struct det_copy_capture_actions_env {
+#ifndef NDEBUG
 	char tag;
+#endif
 	struct fsm *dst;
 	struct reverse_mapping *reverse_mappings;
 	bool ok;

--- a/src/libfsm/determinise_internal.h
+++ b/src/libfsm/determinise_internal.h
@@ -3,6 +3,7 @@
 
 #include <assert.h>
 #include <stddef.h>
+#include <stdbool.h>
 #include <string.h>
 #include <errno.h>
 
@@ -85,7 +86,7 @@ struct det_copy_capture_actions_env {
 	char tag;
 	struct fsm *dst;
 	struct reverse_mapping *reverse_mappings;
-	int ok;
+	bool ok;
 };
 
 #define MAPPINGSTACK_DEF_CEIL 16

--- a/src/libfsm/endids.c
+++ b/src/libfsm/endids.c
@@ -89,7 +89,7 @@ fsm_endid_init(struct fsm *fsm)
 {
 	struct endid_info_bucket *buckets = NULL;
 	size_t i;
-	struct endid_info *res = f_calloc(fsm->alloc, 1, sizeof(*res));
+	struct endid_info *res = f_malloc(fsm->alloc, sizeof(*res));
 	if (res == NULL) {
 		return 0;
 	}

--- a/src/libfsm/endids.c
+++ b/src/libfsm/endids.c
@@ -5,6 +5,7 @@
  */
 
 #include <stddef.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <inttypes.h>
 
@@ -755,7 +756,7 @@ struct carry_env {
 	char tag;
 	struct fsm *dst;
 	fsm_state_t dst_state;
-	int ok;
+	bool ok;
 };
 
 static int
@@ -767,7 +768,7 @@ carry_iter_cb(fsm_state_t state, fsm_end_id_t id, void *opaque)
 	(void)state;
 
 	if (!fsm_endid_set(env->dst, env->dst_state, id)) {
-		env->ok = 0;
+		env->ok = false;
 		return 0;
 	}
 	return 1;
@@ -798,7 +799,7 @@ fsm_endid_carry(const struct fsm *src_fsm, const struct state_set *src_set,
 		env.tag = 'C';
 		env.dst = dst_fsm;
 		env.dst_state = dst_state;
-		env.ok = 1;
+		env.ok = true;
 
 		if (!fsm_isend(src_fsm, s)) {
 			continue;

--- a/src/libfsm/endids.c
+++ b/src/libfsm/endids.c
@@ -753,7 +753,9 @@ fsm_endid_get(const struct fsm *fsm, fsm_state_t end_state,
 }
 
 struct carry_env {
+#ifndef NDEBUG
 	char tag;
+#endif
 	struct fsm *dst;
 	fsm_state_t dst_state;
 	bool ok;
@@ -796,7 +798,9 @@ fsm_endid_carry(const struct fsm *src_fsm, const struct state_set *src_set,
 
 	for (state_set_reset(src_set, &it); state_set_next(&it, &s); ) {
 		struct carry_env env;
+#ifndef NDEBUG
 		env.tag = 'C';
+#endif
 		env.dst = dst_fsm;
 		env.dst_state = dst_state;
 		env.ok = true;

--- a/src/libfsm/epsilons.c
+++ b/src/libfsm/epsilons.c
@@ -28,7 +28,9 @@
 #define DEF_CARRY_ENDIDS_COUNT 2
 
 struct remap_env {
+#ifndef NDEBUG
 	char tag;
+#endif
 	bool ok;
 	const struct fsm_alloc *alloc;
 	struct state_set **rmap;
@@ -183,7 +185,12 @@ remap_capture_actions(struct fsm *nfa, struct state_set **eclosures)
 	struct state_set **rmap;
 	struct state_iter si;
 	fsm_state_t si_s;
-	struct remap_env env = { 'R', true, NULL, NULL, 0, 0, NULL };
+	struct remap_env env = {
+#ifndef NDEBUG
+		'R',
+#endif
+		true, NULL, NULL, 0, 0, NULL
+	};
 	env.alloc = nfa->alloc;
 
 	/* build a reverse mapping */

--- a/src/libfsm/gen.c
+++ b/src/libfsm/gen.c
@@ -74,21 +74,23 @@ struct gen_ctx {
 	const struct fsm *fsm;
 	size_t max_length;
 	fsm_generate_matches_cb *cb;
-	void *opaque;
+
+	bool done;
 
 	size_t buf_ceil;
 	size_t buf_used;
 	char *buf;
+
+	void *opaque;
+
+	unsigned depth;
+	unsigned steps;
 
 	/* This is used to avoid useless cycles -- if a state
 	 * was reached since the same match_count, then don't
 	 * explore it again. */
 	unsigned match_count;
 	unsigned *state_counts;
-
-	unsigned depth;
-	unsigned steps;
-	bool done;
 
 	/* Shortest end distance for a state: sed[s_id] */
 	unsigned *sed;

--- a/src/libfsm/internal.h
+++ b/src/libfsm/internal.h
@@ -44,11 +44,14 @@ struct state_array;
 #define FSM_CAPTURE_MAX INT_MAX
 
 struct fsm_edge {
-	fsm_state_t state; /* destination */
+	fsm_state_t state:24; /* destination. :24 for packing */
 	unsigned char symbol;
 };
 
 struct fsm_state {
+	struct edge_set *edges;
+	struct state_set *epsilons;
+
 	unsigned int end:1;
 
 	/* If 0, then this state has no need for checking
@@ -57,9 +60,6 @@ struct fsm_state {
 
 	/* meaningful within one particular transformation only */
 	unsigned int visited:1;
-
-	struct edge_set *edges;
-	struct state_set *epsilons;
 };
 
 struct fsm {
@@ -68,10 +68,10 @@ struct fsm {
 
 	size_t statealloc; /* number of elements allocated */
 	size_t statecount; /* number of elements populated */
-	size_t endcount;
+	size_t endcount:31; /* :31 for packing */
 
-	fsm_state_t start;
 	unsigned int hasstart:1;
+	fsm_state_t start;
 
 	struct fsm_capture_info *capture_info;
 	struct endid_info *endid_info;

--- a/src/libfsm/merge.c
+++ b/src/libfsm/merge.c
@@ -27,8 +27,8 @@
 
 struct copy_capture_env {
 	char tag;
+	bool ok;
 	struct fsm *dst;
-	int ok;
 };
 
 static int
@@ -134,7 +134,7 @@ copy_capture_cb(fsm_state_t state,
 
 	if (!fsm_capture_add_action(env->dst, state, type,
 		capture_id, to)) {
-		env->ok = 0;
+		env->ok = false;
 		return 0;
 	}
 
@@ -147,7 +147,7 @@ copy_capture_actions(struct fsm *dst, struct fsm *src)
 	struct copy_capture_env env;
 	env.tag = 'C';
 	env.dst = dst;
-	env.ok = 1;
+	env.ok = true;
 
 	fsm_capture_action_iter(src, copy_capture_cb, &env);
 

--- a/src/libfsm/merge.c
+++ b/src/libfsm/merge.c
@@ -26,7 +26,9 @@
 #define LOG_MERGE_ENDIDS 0
 
 struct copy_capture_env {
+#ifndef NDEBUG
 	char tag;
+#endif
 	bool ok;
 	struct fsm *dst;
 };
@@ -145,7 +147,9 @@ static int
 copy_capture_actions(struct fsm *dst, struct fsm *src)
 {
 	struct copy_capture_env env;
+#ifndef NDEBUG
 	env.tag = 'C';
+#endif
 	env.dst = dst;
 	env.ok = true;
 
@@ -180,7 +184,9 @@ static int
 copy_end_ids(struct fsm *dst, struct fsm *src, fsm_state_t base_src)
 {
 	struct copy_end_ids_env env;
+#ifndef NDEBUG
 	env.tag = 'M';		/* for Merge */
+#endif
 	env.dst = dst;
 	env.src = src;
 	env.base_src = base_src;

--- a/src/libfsm/print.c
+++ b/src/libfsm/print.c
@@ -354,7 +354,7 @@ fsm_print(FILE *f, const struct fsm *fsm,
 				continue;
 			}
 
-			assert(ir->states[i].endids.count <= 1);
+			assert(ir->states[i].count <= 1);
 		}
 	}
 

--- a/src/libfsm/print/c.c
+++ b/src/libfsm/print/c.c
@@ -375,7 +375,7 @@ print_endstates(FILE *f,
 		fprintf(f, "\tcase S%u: ", i);
 
 		if (-1 == print_hook_accept(f, opt, hooks,
-			ir->states[i].endids.ids, ir->states[i].endids.count,
+			ir->states[i].ids, ir->states[i].count,
 			default_accept,
 			NULL))
 		{
@@ -383,7 +383,7 @@ print_endstates(FILE *f,
 		}
 
 		if (-1 == print_hook_comment(f, opt, hooks,
-			ir->states[i].endids.ids, ir->states[i].endids.count))
+			ir->states[i].ids, ir->states[i].count))
 		{
 			return -1;
 		}

--- a/src/libfsm/print/ir.c
+++ b/src/libfsm/print/ir.c
@@ -541,8 +541,8 @@ make_ir(const struct fsm *fsm, const struct fsm_options *opt)
 		assert(i < ir->n);
 
 		ir->states[i].isend  = fsm_isend(fsm, i);
-		ir->states[i].endids.ids = NULL;
-		ir->states[i].endids.count = 0;
+		ir->states[i].ids = NULL;
+		ir->states[i].count = 0;
 
 		if (fsm_isend(fsm, i)) {
 			fsm_end_id_t *ids;
@@ -563,8 +563,8 @@ make_ir(const struct fsm *fsm, const struct fsm_options *opt)
 				assert(res == 1);
 			}
 
-			ir->states[i].endids.ids = ids;
-			ir->states[i].endids.count = count;
+			ir->states[i].ids = ids;
+			ir->states[i].count = count;
 		}
 
 		if (make_state(fsm, i, &ir->states[i]) == -1) {
@@ -629,7 +629,7 @@ free_ir(const struct fsm *fsm, struct ir *ir)
 
 	for (i = 0; i < ir->n; i++) {
 		f_free(fsm->alloc, (void *) ir->states[i].example);
-		f_free(fsm->alloc, (void *) ir->states[i].endids.ids);
+		f_free(fsm->alloc, (void *) ir->states[i].ids);
 
 		switch (ir->states[i].strategy) {
 		case IR_TABLE:

--- a/src/libfsm/print/ir.h
+++ b/src/libfsm/print/ir.h
@@ -53,12 +53,11 @@ struct ir_error {
 
 struct ir_state {
 	const char *example;
-	unsigned int isend:1;
 
-	struct {
-		fsm_end_id_t *ids; /* NULL -> 0 */
-		size_t count;
-	} endids;
+	fsm_end_id_t *ids; /* NULL -> 0 */
+	size_t count:31; // :31 for packing
+
+	unsigned int isend:1;
 
 	enum ir_strategy strategy;
 	union {

--- a/src/libfsm/print/irdot.c
+++ b/src/libfsm/print/irdot.c
@@ -195,13 +195,13 @@ print_state(FILE *f,
 	fprintf(f, "\t\t  <TR><TD COLSPAN='2' ALIGN='LEFT'>S%u</TD><TD ALIGN='LEFT'>%s</TD></TR>\n",
 		ir_indexof(ir, cs), strategy_name(cs->strategy));
 
-	if (cs->isend && cs->endids.count > 0) {
+	if (cs->isend && cs->count > 0) {
 		fprintf(f, "\t\t  <TR><TD COLSPAN='2' ALIGN='LEFT'>end id</TD><TD ALIGN='LEFT'>");
 
-		for (size_t i = 0; i < cs->endids.count; i++) {
-			fprintf(f, "#%u", cs->endids.ids[i]);
+		for (size_t i = 0; i < cs->count; i++) {
+			fprintf(f, "#%u", cs->ids[i]);
 
-			if (i < cs->endids.count - 1) {
+			if (i < (size_t) cs->count - 1) {
 				fprintf(f, " ");
 			}
 		}
@@ -220,7 +220,7 @@ print_state(FILE *f,
 		fprintf(f, "\t\t  <TR><TD COLSPAN='3' ALIGN='LEFT'>");
 
 		if (-1 == print_hook_accept(f, opt, hooks,
-			cs->endids.ids, cs->endids.count,
+			cs->ids, cs->count,
 			NULL,
 			NULL))
 		{

--- a/src/libfsm/print/irjson.c
+++ b/src/libfsm/print/irjson.c
@@ -127,12 +127,12 @@ print_state(FILE *f,
 	fprintf(f, "\t\t{\n");
 
 	fprintf(f, "\t\t\t\"end\": %s,\n", cs->isend ? "true" : "false");
-	if (cs->isend && cs->endids.count > 0) {
+	if (cs->isend && cs->count > 0) {
 		fprintf(f, "\t\t\t\"end_id\": [");
-		for (size_t i = 0; i < cs->endids.count; i++) {
-			fprintf(f, "%u", cs->endids.ids[i]);
+		for (size_t i = 0; i < cs->count; i++) {
+			fprintf(f, "%u", cs->ids[i]);
 
-			if (i < cs->endids.count - 1) {
+			if (i < (size_t) cs->count - 1) {
 				fprintf(f, ", ");
 			}
 		}
@@ -144,7 +144,7 @@ print_state(FILE *f,
 		fprintf(f, "\t\t\t\"endleaf\": ");
 
 		if (-1 == print_hook_accept(f, opt, hooks,
-			cs->endids.ids, cs->endids.count,
+			cs->ids, cs->count,
 			NULL, NULL))
 		{
 			return -1;

--- a/src/libfsm/vm/ir.c
+++ b/src/libfsm/vm/ir.c
@@ -309,7 +309,7 @@ opasm_new(struct dfavm_assembler_ir *a, const struct ret_list *retlist,
 	if (ir_state != NULL) {
 		op->example = ir_state->example;
 		op->ret = ir_state->isend
-			? find_ret(retlist, ir_state->endids.ids, ir_state->endids.count)
+			? find_ret(retlist, ir_state->ids, ir_state->count)
 			: NULL;
 	}
 
@@ -968,7 +968,7 @@ order_basic_blocks(struct dfavm_assembler_ir *a)
 
 	/* mark all states as !in_trace */
 	for (i=0; i < n; i++) {
-		a->ops[i]->in_trace = 0;
+		a->ops[i]->in_trace = false;
 	}
 
 	opp = &a->linked;
@@ -987,7 +987,7 @@ order_basic_blocks(struct dfavm_assembler_ir *a)
 		assert(opp != NULL);
 		assert(*opp == NULL);
 
-		st->in_trace = 1;
+		st->in_trace = true;
 
 		/* look for branches to states not in the trace.
 		 * Start at the last branch and work toward the first.

--- a/src/libfsm/vm/retlist.c
+++ b/src/libfsm/vm/retlist.c
@@ -105,7 +105,7 @@ build_retlist(struct ret_list *list, const struct ir *ir)
 			continue;
 		}
 
-		if (!append_ret(list, ir->states[i].endids.ids, ir->states[i].endids.count)) {
+		if (!append_ret(list, ir->states[i].ids, ir->states[i].count)) {
 			return false;
 		}
 	}

--- a/src/libfsm/vm/vm.h
+++ b/src/libfsm/vm/vm.h
@@ -79,8 +79,9 @@ struct dfavm_op_ir {
 	const char *example;
 	const struct ret *ret;
 
-	uint32_t num_incoming; // number of branches to this instruction
-	int in_trace;
+	uint32_t num_incoming:31; // number of branches to this instruction, :31 for packing
+	unsigned int in_trace:1;
+
 	int cmp_arg;
 
 	enum dfavm_op_cmp cmp;

--- a/src/libre/ast_analysis.c
+++ b/src/libre/ast_analysis.c
@@ -2014,10 +2014,10 @@ analysis_iter_repetition(struct ast_expr *n, struct ast_expr *outermost_repeat_p
 }
 
 struct pincer_anchors_env {
-	int always_consumes_or_anchored_start;
-	int always_consumes_or_anchored_end;
+	unsigned int always_consumes_or_anchored_start:1;
+	unsigned int always_consumes_or_anchored_end:1;
 
-	int alloc_fail;
+	unsigned int alloc_fail:1;
 	size_t used;
 	size_t ceil;
 	struct ast_expr **nodes;


### PR DESCRIPTION
Here I rearranged some structs for slightly denser layout, and (in the case of `struct ir_state`) to now fit in a single cache line instead of two.

compared to the parent branch this makes basically no difference for testing real-world data. but it does make both me and my cache lines a little bit happier