### PR TITLE
print API: Box end_ids and end_id_count in a struct for callbacks.

### DIFF
--- a/include/fsm/print.h
+++ b/include/fsm/print.h
@@ -42,6 +42,11 @@ enum fsm_print_lang {
 	FSM_PRINT_VMOPS_MAIN
 };
 
+struct fsm_state_metadata {
+	const fsm_end_id_t *end_ids;
+	size_t end_id_count;
+};
+
 /*
  * Hooks to override generated code. These give an oportunity to
  * emit application-specific constructs, especially based on ids
@@ -66,19 +71,19 @@ struct fsm_hooks {
 		void *lang_opaque, void *hook_opaque);
 
 	int (*accept)(FILE *, const struct fsm_options *opt,
-		const fsm_end_id_t *ids, size_t count,
+		const struct fsm_state_metadata *state_metadata,
 		void *lang_opaque, void *hook_opaque);
 
 	int (*reject)(FILE *, const struct fsm_options *opt,
 		void *lang_opaque, void *hook_opaque);
 
 	int (*comment)(FILE *, const struct fsm_options *opt,
-		const fsm_end_id_t *ids, size_t count,
+		const struct fsm_state_metadata *state_metadata,
 		void *hook_opaque);
 
 	/* only called for AMBIG_ERROR; see opt.ambig */
 	int (*conflict)(FILE *, const struct fsm_options *opt,
-		const fsm_end_id_t *ids, size_t count,
+		const struct fsm_state_metadata *state_metadata,
 		const char *example,
 		void *hook_opaque);
 

--- a/src/libfsm/print.c
+++ b/src/libfsm/print.c
@@ -358,7 +358,7 @@ fsm_print(FILE *f, const struct fsm *fsm,
 				continue;
 			}
 
-			assert(ir->states[i].count <= 1);
+			assert(ir->states[i].endids.count <= 1);
 		}
 	}
 

--- a/src/libfsm/print.c
+++ b/src/libfsm/print.c
@@ -53,9 +53,9 @@ int
 print_hook_accept(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
-	const fsm_end_id_t *ids, size_t count,
+	const struct fsm_state_metadata *state_metadata,
 	int (*default_accept)(FILE *f, const struct fsm_options *opt,
-		const fsm_end_id_t *ids, size_t count,
+		const struct fsm_state_metadata *state_metadata,
 		void *lang_opaque, void *hook_opaque),
 	void *lang_opaque)
 {
@@ -64,7 +64,7 @@ print_hook_accept(FILE *f,
 	assert(hooks != NULL);
 
 	if (opt->ambig == AMBIG_ERROR) {
-		assert(count <= 1);
+		assert(state_metadata->end_id_count <= 1);
 	}
 
 	if (default_accept == NULL) {
@@ -72,10 +72,10 @@ print_hook_accept(FILE *f,
 	}
 
 	if (hooks->accept != NULL) {
-		return hooks->accept(f, opt, ids, count,
+		return hooks->accept(f, opt, state_metadata,
 			lang_opaque, hooks->hook_opaque);
 	} else if (default_accept != NULL) {
-		return default_accept(f, opt, ids, count,
+		return default_accept(f, opt, state_metadata,
 			lang_opaque, hooks->hook_opaque);
 	}
 
@@ -86,21 +86,21 @@ int
 print_hook_comment(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
-	const fsm_end_id_t *ids, size_t count)
+	const struct fsm_state_metadata *state_metadata)
 {
 	assert(f != NULL);
 	assert(opt != NULL);
 	assert(hooks != NULL);
 
 	if (opt->ambig == AMBIG_ERROR) {
-		assert(count <= 1);
+		assert(state_metadata->end_id_count <= 1);
 	}
 
 	if (opt->comments && hooks->comment != NULL) {
 		/* this space is a polyglot */
 		fprintf(f, " ");
 
-		return hooks->comment(f, opt, ids, count,
+		return hooks->comment(f, opt, state_metadata,
 			hooks->hook_opaque);
 	}
 
@@ -138,7 +138,7 @@ int
 print_hook_conflict(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
-	const fsm_end_id_t *ids, size_t count,
+	const struct fsm_state_metadata *state_metadata,
 	const char *example)
 {
 	assert(opt != NULL);
@@ -147,7 +147,7 @@ print_hook_conflict(FILE *f,
 	/* f may be NULL for FSM_PRINT_NONE */
 
 	if (hooks->conflict != NULL) {
-		return hooks->conflict(f, opt, ids, count,
+		return hooks->conflict(f, opt, state_metadata,
 			example,
 			hooks->hook_opaque);
 	}
@@ -211,8 +211,12 @@ print_conflicts(FILE *f, const struct fsm *fsm,
 		 * The conflict hook is called here (rather in the caller),
 		 * because it can be called multiple times, for different states.
 		 */
+		struct fsm_state_metadata state_metadata = {
+			.end_ids = ids,
+			.end_id_count = count,
+		};
 		if (-1 == print_hook_conflict(f, opt, hooks,
-			ids, count,
+			&state_metadata,
 			example))
 		{
 			goto error;

--- a/src/libfsm/print.h
+++ b/src/libfsm/print.h
@@ -14,6 +14,8 @@ struct ir;
 struct dfavm_op_ir;
 struct ret_list;
 
+#include <fsm/print.h>
+
 int
 print_hook_args(FILE *f,
 	const struct fsm_options *opt,
@@ -26,9 +28,9 @@ int
 print_hook_accept(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
-	const fsm_end_id_t *ids, size_t count,
+	const struct fsm_state_metadata *state_metadata,
 	int (*default_accept)(FILE *f, const struct fsm_options *opt,
-		const fsm_end_id_t *ids, size_t count,
+		const struct fsm_state_metadata *state_metadata,
 		void *lang_opaque, void *hook_opaque),
 	void *lang_opaque);
 
@@ -36,7 +38,7 @@ int
 print_hook_comment(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
-	const fsm_end_id_t *ids, size_t count);
+	const struct fsm_state_metadata *state_metadata);
 
 int
 print_hook_reject(FILE *f,
@@ -50,7 +52,7 @@ int
 print_hook_conflict(FILE *f,
 	const struct fsm_options *opt,
 	const struct fsm_hooks *hooks,
-	const fsm_end_id_t *ids, size_t count,
+	const struct fsm_state_metadata *state_metadata,
 	const char *example);
 
 typedef int fsm_print_f(FILE *f,

--- a/src/libfsm/print/c.c
+++ b/src/libfsm/print/c.c
@@ -375,8 +375,8 @@ print_endstates(FILE *f,
 		fprintf(f, "\tcase S%u: ", i);
 
 		const struct fsm_state_metadata state_metadata = {
-			.end_ids = ir->states[i].ids,
-			.end_id_count = ir->states[i].count,
+			.end_ids = ir->states[i].endids.ids,
+			.end_id_count = ir->states[i].endids.count,
 		};
 
 		if (-1 == print_hook_accept(f, opt, hooks,

--- a/src/libfsm/print/c.c
+++ b/src/libfsm/print/c.c
@@ -56,17 +56,17 @@ ir_hasend(const struct ir *ir)
 // TODO: centralise vmc/c
 static int
 print_ids(FILE *f,
-	enum fsm_ambig ambig, const fsm_end_id_t *ids, size_t count)
+	enum fsm_ambig ambig, const struct fsm_state_metadata *state_metadata)
 {
 	switch (ambig) {
 	case AMBIG_NONE:
 		// TODO: for C99 we'd return bool
-		fprintf(f, "return 1;");   
+		fprintf(f, "return 1;");
 		break;
 
 	case AMBIG_ERROR:
 // TODO: decide if we deal with this ahead of the call to print or not
-		if (count > 1) {
+		if (state_metadata->end_id_count > 1) {
 			errno = EINVAL;
 			return -1;
 		}
@@ -79,7 +79,7 @@ print_ids(FILE *f,
 		 * and only appear once each, and are sorted.
 		 */
 		fprintf(f, "{\n");
-		fprintf(f, "\t\t*id = %u;\n", ids[0]);
+		fprintf(f, "\t\t*id = %u;\n", state_metadata->end_ids[0]);
 		fprintf(f, "\t\treturn 1;\n");
 		fprintf(f, "\t}");
 		break;
@@ -94,15 +94,15 @@ print_ids(FILE *f,
 
 		fprintf(f, "{\n");
 		fprintf(f, "\t\tstatic const unsigned a[] = { ");
-		for (fsm_end_id_t i = 0; i < count; i++) {
-			fprintf(f, "%u", ids[i]);
-			if (i + 1 < count) {
+		for (fsm_end_id_t i = 0; i < state_metadata->end_id_count; i++) {
+			fprintf(f, "%u", state_metadata->end_ids[i]);
+			if (i + 1 < state_metadata->end_id_count) {
 				fprintf(f, ", ");
 			}
 		}
 		fprintf(f, " };\n");
 		fprintf(f, "\t\t*ids = a;\n");
-		fprintf(f, "\t\t*count = %zu;\n", count);
+		fprintf(f, "\t\t*count = %zu;\n", state_metadata->end_id_count);
 		fprintf(f, "\t\treturn 1;\n");
 		fprintf(f, "\t}");
 		break;
@@ -117,7 +117,7 @@ print_ids(FILE *f,
 
 static int
 default_accept(FILE *f, const struct fsm_options *opt,
-	const fsm_end_id_t *ids, size_t count,
+	const struct fsm_state_metadata *state_metadata,
 	void *lang_opaque, void *hook_opaque)
 {
 	assert(f != NULL);
@@ -127,7 +127,7 @@ default_accept(FILE *f, const struct fsm_options *opt,
 	(void) lang_opaque;
 	(void) hook_opaque;
 
-	if (-1 == print_ids(f, opt->ambig, ids, count)) {
+	if (-1 == print_ids(f, opt->ambig, state_metadata)) {
 		return -1;
 	}
 
@@ -374,8 +374,13 @@ print_endstates(FILE *f,
 
 		fprintf(f, "\tcase S%u: ", i);
 
+		const struct fsm_state_metadata state_metadata = {
+			.end_ids = ir->states[i].ids,
+			.end_id_count = ir->states[i].count,
+		};
+
 		if (-1 == print_hook_accept(f, opt, hooks,
-			ir->states[i].ids, ir->states[i].count,
+			&state_metadata,
 			default_accept,
 			NULL))
 		{
@@ -383,7 +388,7 @@ print_endstates(FILE *f,
 		}
 
 		if (-1 == print_hook_comment(f, opt, hooks,
-			ir->states[i].ids, ir->states[i].count))
+			&state_metadata))
 		{
 			return -1;
 		}

--- a/src/libfsm/print/dot.c
+++ b/src/libfsm/print/dot.c
@@ -27,7 +27,7 @@
 
 static int
 default_accept(FILE *f, const struct fsm_options *opt,
-	const fsm_end_id_t *ids, size_t count,
+	const struct fsm_state_metadata *state_metadata,
 	void *lang_opaque, void *hook_opaque)
 {
 	fsm_state_t s;
@@ -45,15 +45,15 @@ default_accept(FILE *f, const struct fsm_options *opt,
 	if (!opt->anonymous_states) {
 		fprintf(f, "%u", s);
 
-		if (count > 0) {
+		if (state_metadata->end_id_count > 0) {
 			fprintf(f, "<BR/>");
 		}
 	}
 
-	for (size_t i = 0; i < count; i++) {
-		fprintf(f, "#%u", ids[i]);
+	for (size_t i = 0; i < state_metadata->end_id_count; i++) {
+		fprintf(f, "#%u", state_metadata->end_ids[i]);
 
-		if (i < count - 1) {
+		if (i < state_metadata->end_id_count - 1) {
 			fprintf(f, ",");
 		}
 	}
@@ -66,7 +66,7 @@ default_accept(FILE *f, const struct fsm_options *opt,
 static int
 default_reject(FILE *f, const struct fsm_options *opt,
 	void *lang_opaque, void *hook_opaque)
-{   
+{
 	fsm_state_t s;
 
 	assert(f != NULL);
@@ -258,8 +258,13 @@ print_dotfrag(FILE *f,
 
 			fprintf(f, ", ");
 
+			const struct fsm_state_metadata state_metadata = {
+				.end_ids = ids,
+				.end_id_count = count,
+			};
+
 			if (-1 == print_hook_accept(f, opt, hooks,
-				ids, count,
+				&state_metadata,
 				default_accept, &s))
 			{
 				return -1;
@@ -269,7 +274,7 @@ print_dotfrag(FILE *f,
 				fprintf(f, ",");
 
 				if (-1 == print_hook_comment(f, opt, hooks,
-					ids, count))
+					&state_metadata))
 				{
 					return -1;
 				}

--- a/src/libfsm/print/fsm.c
+++ b/src/libfsm/print/fsm.c
@@ -27,7 +27,7 @@
 
 static int
 default_accept(FILE *f, const struct fsm_options *opt,
-	const fsm_end_id_t *ids, size_t count,
+	const struct fsm_state_metadata *state_metadata,
 	void *lang_opaque, void *hook_opaque)
 {
 	assert(f != NULL);
@@ -36,16 +36,16 @@ default_accept(FILE *f, const struct fsm_options *opt,
 
 	(void) hook_opaque;
 
-	if (count == 0) {
+	if (state_metadata->end_id_count == 0) {
 		return 0;
 	}
 
 	fprintf(f, " = [");
 
-	for (size_t i = 0; i < count; i++) {
-		fprintf(f, "%u", ids[i]);
+	for (size_t i = 0; i < state_metadata->end_id_count; i++) {
+		fprintf(f, "%u", state_metadata->end_ids[i]);
 
-		if (i + 1 < count) {
+		if (i + 1 < state_metadata->end_id_count) {
 			fprintf(f, ", ");
 		}
 	}
@@ -361,8 +361,13 @@ fsm_print_fsm(FILE *f,
 
 		fprintf(f, "%u", s);
 
+		const struct fsm_state_metadata state_metadata = {
+			.end_ids = ids,
+			.end_id_count = count,
+		};
+
 		if (-1 == print_hook_accept(f, opt, hooks,
-			ids, count,    
+			&state_metadata,
 			default_accept,
 			NULL))
 		{
@@ -370,7 +375,7 @@ fsm_print_fsm(FILE *f,
 		}
 
 		if (-1 == print_hook_comment(f, opt, hooks,
-			ids, count))
+			&state_metadata))
 		{
 			return -1;
 		}

--- a/src/libfsm/print/ir.c
+++ b/src/libfsm/print/ir.c
@@ -541,8 +541,8 @@ make_ir(const struct fsm *fsm, const struct fsm_options *opt)
 		assert(i < ir->n);
 
 		ir->states[i].isend  = fsm_isend(fsm, i);
-		ir->states[i].ids = NULL;
-		ir->states[i].count = 0;
+		ir->states[i].endids.ids = NULL;
+		ir->states[i].endids.count = 0;
 
 		if (fsm_isend(fsm, i)) {
 			fsm_end_id_t *ids;
@@ -563,8 +563,8 @@ make_ir(const struct fsm *fsm, const struct fsm_options *opt)
 				assert(res == 1);
 			}
 
-			ir->states[i].ids = ids;
-			ir->states[i].count = count;
+			ir->states[i].endids.ids = ids;
+			ir->states[i].endids.count = count;
 		}
 
 		if (make_state(fsm, i, &ir->states[i]) == -1) {
@@ -629,7 +629,7 @@ free_ir(const struct fsm *fsm, struct ir *ir)
 
 	for (i = 0; i < ir->n; i++) {
 		f_free(fsm->alloc, (void *) ir->states[i].example);
-		f_free(fsm->alloc, (void *) ir->states[i].ids);
+		f_free(fsm->alloc, (void *) ir->states[i].endids.ids);
 
 		switch (ir->states[i].strategy) {
 		case IR_TABLE:

--- a/src/libfsm/print/ir.h
+++ b/src/libfsm/print/ir.h
@@ -54,8 +54,10 @@ struct ir_error {
 struct ir_state {
 	const char *example;
 
-	fsm_end_id_t *ids; /* NULL -> 0 */
-	size_t count:31; // :31 for packing
+	struct ir_state_endids {
+		fsm_end_id_t *ids; /* NULL -> 0 */
+		size_t count;
+	} endids;
 
 	unsigned int isend:1;
 

--- a/src/libfsm/print/irdot.c
+++ b/src/libfsm/print/irdot.c
@@ -195,13 +195,13 @@ print_state(FILE *f,
 	fprintf(f, "\t\t  <TR><TD COLSPAN='2' ALIGN='LEFT'>S%u</TD><TD ALIGN='LEFT'>%s</TD></TR>\n",
 		ir_indexof(ir, cs), strategy_name(cs->strategy));
 
-	if (cs->isend && cs->count > 0) {
+	if (cs->isend && cs->endids.count > 0) {
 		fprintf(f, "\t\t  <TR><TD COLSPAN='2' ALIGN='LEFT'>end id</TD><TD ALIGN='LEFT'>");
 
-		for (size_t i = 0; i < cs->count; i++) {
-			fprintf(f, "#%u", cs->ids[i]);
+		for (size_t i = 0; i < cs->endids.count; i++) {
+			fprintf(f, "#%u", cs->endids.ids[i]);
 
-			if (i < (size_t) cs->count - 1) {
+			if (i < (size_t) cs->endids.count - 1) {
 				fprintf(f, " ");
 			}
 		}
@@ -220,8 +220,8 @@ print_state(FILE *f,
 		fprintf(f, "\t\t  <TR><TD COLSPAN='3' ALIGN='LEFT'>");
 
 		const struct fsm_state_metadata state_metadata = {
-			.end_ids = cs->ids,
-			.end_id_count = cs->count,
+			.end_ids = cs->endids.ids,
+			.end_id_count = cs->endids.count,
 		};
 
 		if (-1 == print_hook_accept(f, opt, hooks,

--- a/src/libfsm/print/irdot.c
+++ b/src/libfsm/print/irdot.c
@@ -219,8 +219,13 @@ print_state(FILE *f,
 	if (cs->isend && hooks->accept != NULL) {
 		fprintf(f, "\t\t  <TR><TD COLSPAN='3' ALIGN='LEFT'>");
 
+		const struct fsm_state_metadata state_metadata = {
+			.end_ids = cs->ids,
+			.end_id_count = cs->count,
+		};
+
 		if (-1 == print_hook_accept(f, opt, hooks,
-			cs->ids, cs->count,
+			&state_metadata,
 			NULL,
 			NULL))
 		{

--- a/src/libfsm/print/irjson.c
+++ b/src/libfsm/print/irjson.c
@@ -127,12 +127,12 @@ print_state(FILE *f,
 	fprintf(f, "\t\t{\n");
 
 	fprintf(f, "\t\t\t\"end\": %s,\n", cs->isend ? "true" : "false");
-	if (cs->isend && cs->count > 0) {
+	if (cs->isend && cs->endids.count > 0) {
 		fprintf(f, "\t\t\t\"end_id\": [");
-		for (size_t i = 0; i < cs->count; i++) {
-			fprintf(f, "%u", cs->ids[i]);
+		for (size_t i = 0; i < cs->endids.count; i++) {
+			fprintf(f, "%u", cs->endids.ids[i]);
 
-			if (i < (size_t) cs->count - 1) {
+			if (i < (size_t) cs->endids.count - 1) {
 				fprintf(f, ", ");
 			}
 		}
@@ -140,8 +140,8 @@ print_state(FILE *f,
 	}
 
 	const struct fsm_state_metadata state_metadata = {
-		.end_ids = cs->ids,
-		.end_id_count = cs->count,
+		.end_ids = cs->endids.ids,
+		.end_id_count = cs->endids.count,
 	};
 
 	/* showing hook in addition to existing content */

--- a/src/libfsm/print/irjson.c
+++ b/src/libfsm/print/irjson.c
@@ -139,12 +139,17 @@ print_state(FILE *f,
 		fprintf(f, "],\n");
 	}
 
+	const struct fsm_state_metadata state_metadata = {
+		.end_ids = cs->ids,
+		.end_id_count = cs->count,
+	};
+
 	/* showing hook in addition to existing content */
 	if (cs->isend && hooks->accept != NULL) {
 		fprintf(f, "\t\t\t\"endleaf\": ");
 
 		if (-1 == print_hook_accept(f, opt, hooks,
-			cs->ids, cs->count,
+			&state_metadata,
 			NULL, NULL))
 		{
 			return -1;

--- a/src/libfsm/print/json.c
+++ b/src/libfsm/print/json.c
@@ -280,8 +280,13 @@ fsm_print_json(FILE *f,
 
 			fprintf(f, "{ %u, ", i);
 
+			const struct fsm_state_metadata state_metadata = {
+				.end_ids = ids,
+				.end_id_count = count,
+			};
+
 			if (-1 == print_hook_accept(f, opt, hooks,
-				ids, count,
+				&state_metadata,
 				NULL, NULL))
 			{
 				return -1;

--- a/src/libfsm/print/sh.c
+++ b/src/libfsm/print/sh.c
@@ -107,7 +107,7 @@ print_ids(FILE *f,
 
 static int
 default_accept(FILE *f, const struct fsm_options *opt,
-	const fsm_end_id_t *ids, size_t count,
+	const struct fsm_state_metadata *state_metadata,
 	void *lang_opaque, void *hook_opaque)
 {
 	assert(f != NULL);
@@ -119,7 +119,7 @@ default_accept(FILE *f, const struct fsm_options *opt,
 
 	fprintf(f, "matched");
 
-	if (-1 == print_ids(f, opt->ambig, ids, count)) {
+	if (-1 == print_ids(f, opt->ambig, state_metadata->end_ids, state_metadata->end_id_count)) {
 		return -1;
 	}
 
@@ -204,9 +204,13 @@ print_end(FILE *f, const struct dfavm_op_ir *op,
 	case VM_END_FAIL:
 		return print_hook_reject(f, opt, hooks, default_reject, NULL);
 
-	case VM_END_SUCC:
+	case VM_END_SUCC:;
+		const struct fsm_state_metadata state_metadata = {
+			.end_ids = op->ret->ids,
+			.end_id_count = op->ret->count,
+		};
 		if (-1 == print_hook_accept(f, opt, hooks,
-			op->ret->ids, op->ret->count,
+			&state_metadata,
 			default_accept,
 			NULL))
 		{
@@ -214,7 +218,7 @@ print_end(FILE *f, const struct dfavm_op_ir *op,
 		}
 
 		if (-1 == print_hook_comment(f, opt, hooks,
-			op->ret->ids, op->ret->count))
+			&state_metadata))
 		{
 			return -1;
 		}

--- a/src/libfsm/print/vmasm.c
+++ b/src/libfsm/print/vmasm.c
@@ -49,15 +49,19 @@ print_end(FILE *f, const struct dfavm_op_ir *op,
 		}
 		break;
 
-	case VM_END_SUCC:
+	case VM_END_SUCC:;
+		const struct fsm_state_metadata state_metadata = {
+			.end_ids = op->ret->ids,
+			.end_id_count = op->ret->count,
+		};
 		if (-1 == print_hook_accept(f, opt, hooks,
-			op->ret->ids, op->ret->count,
+			&state_metadata,
 			NULL, NULL))
 		{
 			return -1;
 		}
 		if (-1 == print_hook_comment(f, opt, hooks,
-			op->ret->ids, op->ret->count))
+			&state_metadata))
 		{
 			return -1;
 		}

--- a/src/libfsm/print/vmdot.c
+++ b/src/libfsm/print/vmdot.c
@@ -48,7 +48,7 @@ cmp_operator(int cmp)
 
 static int
 default_accept(FILE *f, const struct fsm_options *opt,
-	const fsm_end_id_t *ids, size_t count,
+	const struct fsm_state_metadata *state_metadata,
 	void *lang_opaque, void *hook_opaque)
 {
 	assert(f != NULL);
@@ -60,13 +60,13 @@ default_accept(FILE *f, const struct fsm_options *opt,
  
 	fprintf(f, "match");
 
-	if (count > 0) {
+	if (state_metadata->end_id_count > 0) {
 		fprintf(f, " / ");
 
-		for (size_t i = 0; i < count; i++) {
-			fprintf(f, "#%u", ids[i]);
+		for (size_t i = 0; i < state_metadata->end_id_count; i++) {
+			fprintf(f, "#%u", state_metadata->end_ids[i]);
 
-			if (i < count - 1) {
+			if (i < state_metadata->end_id_count - 1) {
 				fprintf(f, " ");
 			}
 		}
@@ -128,9 +128,13 @@ print_end(FILE *f,
 	case VM_END_FAIL:
 		return print_hook_reject(f, opt, hooks, default_reject, NULL);
 
-	case VM_END_SUCC:
+	case VM_END_SUCC:;
+		struct fsm_state_metadata state_metadata = {
+			.end_ids = op->ret->ids,
+			.end_id_count = op->ret->count,
+		};
 		if (-1 == print_hook_accept(f, opt, hooks,
-			op->ret->ids, op->ret->count,
+			&state_metadata,
 			default_accept,
 			NULL))
 		{

--- a/src/libfsm/vm/ir.c
+++ b/src/libfsm/vm/ir.c
@@ -309,7 +309,7 @@ opasm_new(struct dfavm_assembler_ir *a, const struct ret_list *retlist,
 	if (ir_state != NULL) {
 		op->example = ir_state->example;
 		op->ret = ir_state->isend
-			? find_ret(retlist, ir_state->ids, ir_state->count)
+			? find_ret(retlist, ir_state->endids.ids, ir_state->endids.count)
 			: NULL;
 	}
 

--- a/src/libfsm/vm/retlist.c
+++ b/src/libfsm/vm/retlist.c
@@ -105,7 +105,7 @@ build_retlist(struct ret_list *list, const struct ir *ir)
 			continue;
 		}
 
-		if (!append_ret(list, ir->states[i].ids, ir->states[i].count)) {
+		if (!append_ret(list, ir->states[i].endids.ids, ir->states[i].endids.count)) {
 			return false;
 		}
 	}

--- a/src/lx/main.c
+++ b/src/lx/main.c
@@ -523,7 +523,7 @@ run_threads(int concurrency, void *(*fn)(void *))
 
 static int
 conflict(FILE *f, const struct fsm_options *opt,
-	const fsm_end_id_t *ids, size_t count, const char *example,
+	const struct fsm_state_metadata *state_metadata, const char *example,
 	void *hook_opaque)
 {
 	const struct ast *ast;
@@ -531,7 +531,7 @@ conflict(FILE *f, const struct fsm_options *opt,
 
 	assert(opt != NULL);
 	assert(opt->ambig == AMBIG_ERROR);
-	assert(count > 1);
+	assert(state_metadata->end_id_count > 1);
 
 	(void) f;
 	(void) opt;
@@ -544,7 +544,7 @@ conflict(FILE *f, const struct fsm_options *opt,
 
 	fprintf(stderr, "ambiguous mappings to ");
 
-	for (i = 0; i < count; i++) {
+	for (i = 0; i < state_metadata->end_id_count; i++) {
 		const struct ast_mapping *m;
 
 		/*
@@ -557,7 +557,7 @@ conflict(FILE *f, const struct fsm_options *opt,
 			continue;
 		}
 
-		m = ast_getendmappingbyendid(ids[i]);
+		m = ast_getendmappingbyendid(state_metadata->end_ids[i]);
 
 		if (m->token != NULL) {
 			fprintf(stderr, "$%s", m->token->s);
@@ -573,7 +573,7 @@ conflict(FILE *f, const struct fsm_options *opt,
 			fprintf(stderr, "z%p", (void *) m->to); /* TODO: zindexof(n->to) */
 		}
 
-		if (i + 1 < count) {
+		if (i + 1 < state_metadata->end_id_count) {
 			fprintf(stderr, ", ");
 		}
 	}

--- a/src/lx/print/c.c
+++ b/src/lx/print/c.c
@@ -139,7 +139,7 @@ shortest_example(const struct fsm *fsm, const struct ast_token *token,
 
 static int
 accept_c(FILE *f, const struct fsm_options *opt,
-	const fsm_end_id_t *ids, size_t count,
+	const struct fsm_state_metadata *state_metadata,
 	void *lang_opaque, void *hook_opaque)
 {
 	const struct ast *ast;
@@ -147,13 +147,13 @@ accept_c(FILE *f, const struct fsm_options *opt,
 
 	assert(f != NULL);
 	assert(opt != NULL);
-	assert(ids != NULL);
-	assert(count > 0);
+	assert(state_metadata->end_ids != NULL);
+	assert(state_metadata->end_id_count > 0);
 	assert(lang_opaque == NULL);
 	assert(hook_opaque != NULL);
 
 	ast = hook_opaque;
-	m = ast_getendmappingbyendid(ids[0]);
+	m = ast_getendmappingbyendid(state_metadata->end_ids[0]);
 
 	/* XXX: don't need this if complete */
 	fprintf(f, "%sungetc(lx, c); ", prefix.api);

--- a/src/lx/print/dot.c
+++ b/src/lx/print/dot.c
@@ -66,7 +66,7 @@ mapping(FILE *f, const struct ast_mapping *m, const struct ast *ast)
 
 static int
 accept_dot(FILE *f, const struct fsm_options *opt,
-	const fsm_end_id_t *ids, size_t count,
+	const struct fsm_state_metadata *state_metadata,
 	void *lang_opaque, void *hook_opaque)
 {
 	const struct ast_mapping *m;
@@ -75,8 +75,8 @@ accept_dot(FILE *f, const struct fsm_options *opt,
 
 	assert(f != NULL);
 	assert(opt != NULL);
-	assert(ids != NULL);
-	assert(count > 0);
+	assert(state_metadata->end_ids != NULL);
+	assert(state_metadata->end_id_count > 0);
 	assert(lang_opaque != NULL);
 	assert(hook_opaque != NULL);
 
@@ -89,19 +89,19 @@ accept_dot(FILE *f, const struct fsm_options *opt,
 		fprintf(f, "%u<br/>", s);
 	}
 
-	if (count == 1) {
-		m = ast_getendmappingbyendid(ids[0]);
+	if (state_metadata->end_id_count == 1) {
+		m = ast_getendmappingbyendid(state_metadata->end_ids[0]);
 		mapping(f, m, ast);
 	} else {
 		size_t i;
 
 		fprintf(f, "<font color=\"red\">");
 
-		for (i = 0; i < count; i++) {
-			m = ast_getendmappingbyendid(ids[i]);
+		for (i = 0; i < state_metadata->end_id_count; i++) {
+			m = ast_getendmappingbyendid(state_metadata->end_ids[i]);
 			mapping(f, m, ast);
 
-			if (i + 1 < count) {
+			if (i + 1 < state_metadata->end_id_count) {
 				fprintf(f, "<br/>");
 			}
 		}

--- a/src/re/main.c
+++ b/src/re/main.c
@@ -294,14 +294,14 @@ printexample(FILE *f, const struct fsm *fsm, fsm_state_t state)
 
 static int
 conflict(FILE *f, const struct fsm_options *opt,
-	const fsm_end_id_t *ids, size_t count, const char *example,
+	const struct fsm_state_metadata *state_metadata, const char *example,
 	void *hook_opaque)
 {
 	size_t i;
 
 	assert(opt != NULL);
 	assert(opt->ambig == AMBIG_ERROR);
-	assert(count > 1);
+	assert(state_metadata->end_id_count > 1);
 
 	(void) f;
 	(void) opt;
@@ -312,13 +312,13 @@ conflict(FILE *f, const struct fsm_options *opt,
 
 	fprintf(stderr, "ambiguous matches for ");
 
-	for (i = 0; i < count; i++) {
-		assert(ids[i] < matchc);
+	for (i = 0; i < state_metadata->end_id_count; i++) {
+		assert(state_metadata->end_ids[i] < matchc);
 
 		/* TODO: print nicely */
-		fprintf(stderr, "/%s/", matchv[ids[i]]);
+		fprintf(stderr, "/%s/", matchv[state_metadata->end_ids[i]]);
 
-		if (i + 1 < count) {
+		if (i + 1 < state_metadata->end_id_count) {
 			fprintf(stderr, ", ");
 		}
 	}
@@ -335,7 +335,7 @@ conflict(FILE *f, const struct fsm_options *opt,
 
 static int
 comment_c(FILE *f, const struct fsm_options *opt,
-	const fsm_end_id_t *ids, size_t count,
+	const struct fsm_state_metadata *state_metadata,
 	void *hook_opaque)
 {
 	size_t i;
@@ -348,12 +348,12 @@ comment_c(FILE *f, const struct fsm_options *opt,
 
 	fprintf(f, "/* ");
 
-	for (i = 0; i < count; i++) {
-		assert(ids[i] < matchc);
+	for (i = 0; i < state_metadata->end_id_count; i++) {
+		assert(state_metadata->end_ids[i] < matchc);
 
-		fprintf(f, "\"%s\"", matchv[ids[i]]); /* XXX: escape string (and comment) */
+		fprintf(f, "\"%s\"", matchv[state_metadata->end_ids[i]]); /* XXX: escape string (and comment) */
 
-		if (i + 1 < count) {
+		if (i + 1 < state_metadata->end_id_count) {
 			fprintf(f, ", ");
 		}
 	}
@@ -365,7 +365,7 @@ comment_c(FILE *f, const struct fsm_options *opt,
 
 static int
 comment_rust(FILE *f, const struct fsm_options *opt,
-	const fsm_end_id_t *ids, size_t count,
+	const struct fsm_state_metadata *state_metadata,
 	void *hook_opaque)
 {
 	size_t i;
@@ -378,12 +378,12 @@ comment_rust(FILE *f, const struct fsm_options *opt,
 
 	fprintf(f, "// ");
 
-	for (i = 0; i < count; i++) {
-		assert(ids[i] < matchc);
+	for (i = 0; i < state_metadata->end_id_count; i++) {
+		assert(state_metadata->end_ids[i] < matchc);
 
-		fprintf(f, "\"%s\"", matchv[ids[i]]); /* XXX: escape string (and comment) */
+		fprintf(f, "\"%s\"", matchv[state_metadata->end_ids[i]]); /* XXX: escape string (and comment) */
 
-		if (i + 1 < count) {
+		if (i + 1 < state_metadata->end_id_count) {
 			fprintf(f, ", ");
 		}
 	}
@@ -393,7 +393,7 @@ comment_rust(FILE *f, const struct fsm_options *opt,
 
 static int
 comment_llvm(FILE *f, const struct fsm_options *opt,
-	const fsm_end_id_t *ids, size_t count,
+	const struct fsm_state_metadata *state_metadata,
 	void *hook_opaque)
 {
 	size_t i;
@@ -406,12 +406,12 @@ comment_llvm(FILE *f, const struct fsm_options *opt,
 
 	fprintf(f, "; ");
 
-	for (i = 0; i < count; i++) {
-		assert(ids[i] < matchc);
+	for (i = 0; i < state_metadata->end_id_count; i++) {
+		assert(state_metadata->end_ids[i] < matchc);
 
-		fprintf(f, "\"%s\"", matchv[ids[i]]); /* XXX: escape string (and comment) */
+		fprintf(f, "\"%s\"", matchv[state_metadata->end_ids[i]]); /* XXX: escape string (and comment) */
 
-		if (i + 1 < count) {
+		if (i + 1 < state_metadata->end_id_count) {
 			fprintf(f, ", ");
 		}
 	}
@@ -421,7 +421,7 @@ comment_llvm(FILE *f, const struct fsm_options *opt,
 
 static int
 comment_dot(FILE *f, const struct fsm_options *opt,
-	const fsm_end_id_t *ids, size_t count,
+	const struct fsm_state_metadata *state_metadata,
 	void *hook_opaque)
 {
 	size_t i;
@@ -434,12 +434,12 @@ comment_dot(FILE *f, const struct fsm_options *opt,
 
 	fprintf(f, "/* ");
 
-	for (i = 0; i < count; i++) {
-		assert(ids[i] < matchc);
+	for (i = 0; i < state_metadata->end_id_count; i++) {
+		assert(state_metadata->end_ids[i] < matchc);
 
-		fprintf(f, "\"%s\"", matchv[ids[i]]); /* XXX: escape string (and comment) */
+		fprintf(f, "\"%s\"", matchv[state_metadata->end_ids[i]]); /* XXX: escape string (and comment) */
 
-		if (i + 1 < count) {
+		if (i + 1 < state_metadata->end_id_count) {
 			fprintf(f, ", ");
 		}
 	}

--- a/src/rx/main.c
+++ b/src/rx/main.c
@@ -567,7 +567,7 @@ build_pattern_fsm(bool show_stats,
 
 static int
 conflict(FILE *f, const struct fsm_options *opt,
-	const fsm_end_id_t *ids, size_t count,
+	const struct fsm_state_metadata *state_metadata,
 	const char *example,
 	void *hook_opaque)
 {
@@ -578,10 +578,10 @@ conflict(FILE *f, const struct fsm_options *opt,
 	assert(env->general != NULL);
 
 	/* in rx all end states have an end id */
-	assert(count > 0);
+	assert(state_metadata->end_id_count > 0);
 
 	/* ...and we only conflict when there's more than one */
-	assert(count > 1);
+	assert(state_metadata->end_id_count > 1);
 
 	(void) f;
 	(void) opt;
@@ -592,14 +592,14 @@ conflict(FILE *f, const struct fsm_options *opt,
 	}
 	fprintf(stderr, "\n");
 
-	for (fsm_end_id_t i = 0; i < count; i++) {
+	for (fsm_end_id_t i = 0; i < state_metadata->end_id_count; i++) {
 		for (size_t k = 0; k < sizeof *env->literals / sizeof **env->literals; k++) {
 			const struct literal_set *literals = &(*env->literals)[k];
 			for (size_t j = 0; j < literals->count; j++) {
-				if (literals->a[j].id == ids[i]) {
+				if (literals->a[j].id == state_metadata->end_ids[i]) {
 					// TODO: escape, centralise with libre's re_perror()
 					fprintf(stderr, "#%u: /%s%.*s%s/\n",
-						ids[i],
+						state_metadata->end_ids[i],
 						(k & RE_STRINGS_ANCHOR_LEFT) ? "^" : "",
 						(int) literals->a[j].n, (const char *) literals->a[j].p,
 						(k & RE_STRINGS_ANCHOR_RIGHT) ? "$" : "");
@@ -610,9 +610,9 @@ conflict(FILE *f, const struct fsm_options *opt,
 
 		for (size_t j = 0; j < env->general->count; j++) {
 			// TODO: delimiters per dialect, centralise with libre's re_perror()
-			if (env->general->a[i].id == ids[i]) {
+			if (env->general->a[i].id == state_metadata->end_ids[i]) {
 				fprintf(stderr, "#%u: /%s/\n",
-					ids[i],
+					state_metadata->end_ids[i],
 					env->general->a[i].s);
 				goto next;
 			}


### PR DESCRIPTION
Move the end_id array and its count into a struct for state metadata, and rename access throughout to end_ids and end_id_count.

Upcoming changes for eager output IDs will soon be passing more info to all of these callbacks, but only callers making use of those fields need to care. Instead of making callers add more `(void) param;` declarations all over the place to avoid warnings, just pass in a metadata struct pointer. Also, "count" is a pretty generic name and what it refers to will soon be ambiguous.

This should not be a functional change on its own, it's just clearing the way for new features.