### PR TITLE
Temporary interface: Add fsm_determinise_with_config.

### DIFF
--- a/include/fsm/fsm.h
+++ b/include/fsm/fsm.h
@@ -385,6 +385,21 @@ fsm_remove_epsilons(struct fsm *fsm);
 int
 fsm_determinise(struct fsm *fsm);
 
+/* Determinise, with a passed in configuration
+ * and a distinct return value for reaching
+ * the state limit. */
+struct fsm_determinise_config {
+	size_t state_limit;	/* 0: no limit */
+};
+enum fsm_determinise_with_config_res {
+	FSM_DETERMINISE_WITH_CONFIG_OK,
+	FSM_DETERMINISE_WITH_CONFIG_STATE_LIMIT_REACHED,
+	FSM_DETERMINISE_WITH_CONFIG_ERRNO,
+};
+enum fsm_determinise_with_config_res
+fsm_determinise_with_config(struct fsm *fsm,
+	const struct fsm_determinise_config *config);
+
 /*
  * Make a DFA complete, as per fsm_iscomplete.
  */

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -336,6 +336,7 @@ fsm_determinise(struct fsm *nfa)
 		/* unreachable */
 		return 0;
 	case FSM_DETERMINISE_WITH_CONFIG_ERRNO:
+	default:
 		return 0;
 	}
 }

--- a/src/libfsm/libfsm.syms
+++ b/src/libfsm/libfsm.syms
@@ -101,6 +101,7 @@ fsm_countstates
 fsm_trim
 fsm_reverse
 fsm_determinise
+fsm_determinise_with_config
 fsm_remove_epsilons
 fsm_complete
 fsm_minimise


### PR DESCRIPTION
This works, but we may want to make some naming changes. I'd prefer to use a struct rather than a single parameter here -- as long as other fields have a sensible default when zeroed, the callers will only need to make the interface change once.

I think it's worth having some kind of limit here, since determinisation is most likely to have wide variation in resource usage.

- The names (particularly the enum) are cumbersome here, but I would really rather have a distinct return value for exceeding the passed-in limit, rather than using something that nominally fits something from `errno`, like `E2BIG`.
- It seems a bit silly to pass in a struct with just the one field, but as long as they have a reasonable default when zeroed, we could add other fields to the struct later without needing interface changes. We could just give fsm_determinise an extra step_limit argument, but if we're potentially going to add any other options at any point (logging flags?) then a struct would be less hassle.
- I'm adding a separate function fsm_determinise_with_config to avoid an interface change with fsm_determinise directly (which is called all over the place). We could either change fsm_determinise (once) and take a struct, come up with a naming convention for `<function>_with_an_extra_configuration_struct` (`fsm_determinise_with_config`? `fsm_determinise_cfg`?) and keep both (and possibly add similar variants for other functions later), or just add a `state_limit` param, but that would be my last choice.