### PR TITLE
Fix a memory leak during `fsm_determinise_with_config`'s early exit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,7 @@ SUBDIR += tests/pcre-repeat
 SUBDIR += tests/pred
 SUBDIR += tests/re_literal
 SUBDIR += tests/re_strings
+SUBDIR += tests/regressions
 SUBDIR += tests/reverse
 SUBDIR += tests/trim
 SUBDIR += tests/union

--- a/src/libfsm/determinise.c
+++ b/src/libfsm/determinise.c
@@ -237,6 +237,7 @@ fsm_determinise_with_config(struct fsm *nfa,
 			assert(dfa->states[m->dfastate].edges == NULL);
 
 			dfa->states[m->dfastate].edges = m->edges;
+			m->edges = NULL; /* transfer ownership */
 
 			/*
 			 * The current DFA state is an end state if any of its associated NFA
@@ -593,6 +594,8 @@ map_free(struct map *map)
 		if (b == NULL) {
 			continue;
 		}
+		/* free any edge sets that didn't get transferred */
+		edge_set_free(map->alloc, b->edges);
 		f_free(map->alloc, b);
 	}
 

--- a/tests/regressions/Makefile
+++ b/tests/regressions/Makefile
@@ -1,0 +1,20 @@
+.include "../../share/mk/top.mk"
+
+TEST.tests/regressions != ls -1 tests/regressions/regressions*.c
+TEST_SRCDIR.tests/regressions = tests/regressions
+TEST_OUTDIR.tests/regressions = ${BUILD}/tests/regressions
+
+.for n in ${TEST.tests/regressions:T:R:C/^regressions//}
+INCDIR.${TEST_SRCDIR.tests/regressions}/regressions${n}.c += src/adt
+.endfor
+
+.for n in ${TEST.tests/regressions:T:R:C/^regressions//}
+test:: ${TEST_OUTDIR.tests/regressions}/res${n}
+SRC += ${TEST_SRCDIR.tests/regressions}/regressions${n}.c
+CFLAGS.${TEST_SRCDIR.tests/regressions}/regressions${n}.c += -UNDEBUG
+
+${TEST_OUTDIR.tests/regressions}/run${n}: ${TEST_OUTDIR.tests/regressions}/regressions${n}.o ${BUILD}/lib/libfsm.a ${BUILD}/lib/libre.a
+	${CC} ${CFLAGS} ${CFLAGS.${TEST_SRCDIR.tests/regressions}/regressions${n}.c} -o ${TEST_OUTDIR.tests/regressions}/run${n} ${TEST_OUTDIR.tests/regressions}/regressions${n}.o ${BUILD}/lib/libfsm.a ${BUILD}/lib/libre.a
+${TEST_OUTDIR.tests/regressions}/res${n}: ${TEST_OUTDIR.tests/regressions}/run${n}
+	( ${TEST_OUTDIR.tests/regressions}/run${n} 1>&2 && echo PASS || echo FAIL ) > ${TEST_OUTDIR.tests/regressions}/res${n}
+.endfor

--- a/tests/regressions/regressions_determinise_state_limit_leak.c
+++ b/tests/regressions/regressions_determinise_state_limit_leak.c
@@ -1,0 +1,69 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include <assert.h>
+
+#include <re/re.h>
+#include <fsm/fsm.h>
+#include <fsm/bool.h>
+
+static const char *strings[] = {
+	[0] = "apple",
+	[1] = "banana",
+	[2] = "carrot",
+	[3] = "durian",
+	[4] = "eggplant",
+};
+#define STRING_COUNT sizeof(strings)/sizeof(strings[0])
+
+int main(void)
+{
+	struct fsm *fsms[STRING_COUNT] = {0};
+
+	for (size_t i = 0; i < STRING_COUNT; i++) {
+		fsms[i] = re_comp(RE_PCRE, fsm_sgetc, &strings[i], NULL, 0, NULL);
+		assert(fsms[i] != NULL);
+	}
+
+	struct fsm *combined_fsm = fsm_union_array(STRING_COUNT, fsms, NULL);
+	assert(combined_fsm != NULL);
+
+	size_t state_limit_base = fsm_countstates(combined_fsm);
+	size_t max_state_limit = state_limit_base + 100;
+
+	bool hit_state_limit = false;
+
+	for (size_t state_limit = state_limit_base; state_limit < max_state_limit; state_limit += 10) {
+		struct fsm *cp = fsm_clone(combined_fsm);
+
+		const struct fsm_determinise_config det_config = {
+			.state_limit = state_limit,
+		};
+
+		/* Previously this would leak memory when hitting the STATE_LIMIT_REACHED
+		 * early exit, because the edge sets for the DFA being constructed were
+		 * not freed properly.
+		 *
+		 * The first time this should fail immediately because the state limit IS the starting size,
+		 * but later on it should halt in the middle of construction. */
+		switch (fsm_determinise_with_config(cp, &det_config)) {
+		case FSM_DETERMINISE_WITH_CONFIG_OK:
+			fsm_free(cp);
+			break;
+		case FSM_DETERMINISE_WITH_CONFIG_STATE_LIMIT_REACHED:
+			hit_state_limit = true;
+			fsm_free(cp);
+			break;
+		case FSM_DETERMINISE_WITH_CONFIG_ERRNO:
+			assert(!"internal error");
+			return EXIT_FAILURE;
+		}
+	}
+
+	assert(hit_state_limit);
+
+	fsm_free(combined_fsm);
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
- Add a `tests/regressions` directory for test cases that need a standalone C file, because they aren't easily reproducible via fsm, re, etc. input files.
- Add a test case that exercises `fsm_determinise_with_config`'s early exit due to the state limit. When run with LeakSanitizer or Valgrind and with the previous commit reverted, it will show that the edge sets for the DFA being constructed weren't freed properly.
- Explicitly set m->edges to NULL when transferring ownership from the stack/map to the DFA, and free any edge sets in the cleanup handler that are still in the map.