### PR TITLE
retest: Remove `isatty` check and extra logging output.

### DIFF
--- a/src/retest/main.c
+++ b/src/retest/main.c
@@ -56,7 +56,6 @@ struct match {
 	struct match *next;
 };
 
-static int tty_output = 0;
 static int do_timing  = 0;
 
 static int do_watchdog   = 0;
@@ -969,14 +968,6 @@ process_test_file(const char *filename,
 
 			flagstring(flags, &flagdesc[0]);
 
-			if (tty_output) {
-				char *re  = dup_str_esc(regexp, NULL);
-				printf("[      ] line %d: working on %s regexp /%s/%s ...\r",
-					linenum, dialect_name, re, flagdesc);
-				fflush(stdout);
-				free(re);
-			}
-
 			re_str = regexp;
 			fsm = re_comp(dialect, fsm_sgetc, &re_str, alloc, flags, &err);
 			if (fsm == NULL) {
@@ -1229,9 +1220,6 @@ main(int argc, char *argv[])
 	int max_test_errors;
 
 	int optlevel = 1;
-
-	/* is output to a tty or not? */
-	tty_output = isatty(fileno(stdout));
 
 	/* note these defaults are the opposite than for fsm(1) */
 	opt.anonymous_states  = 1;


### PR DESCRIPTION
While discussing other issues, kate said she'd rather not have this have different behavior when stdout is / isn't a tty.