### PR TITLE
Stray const in generated code

### DIFF
--- a/man/fsm.1/fsm.1.xml
+++ b/man/fsm.1/fsm.1.xml
@@ -22,6 +22,7 @@
 	<!ENTITY io.arg "<replaceable>io</replaceable>">
 	<!ENTITY iterations.arg "<replaceable>iterations</replaceable>">
 	<!ENTITY length.arg "<replaceable>length</replaceable>">
+	<!ENTITY limit.arg "<replaceable>limit</replaceable>">
 	<!ENTITY charset.arg "<replaceable>charset</replaceable>">
 
 	<!ENTITY a.opt "<option>-a</option>">
@@ -33,7 +34,7 @@
 	<!ENTITY G.opt "<option>-G</option>&nbsp;&length.arg;">
 	<!ENTITY k.opt "<option>-k</option>&nbsp;&io.arg;">
 	<!ENTITY i.opt "<option>-i</option>&nbsp;&iterations.arg;">
-	<!ENTITY G.opt "<option>-S</option>&nbsp;&limit.arg;">
+	<!ENTITY S.opt "<option>-S</option>&nbsp;&limit.arg;">
 	<!ENTITY U.opt "<option>-U</option>&nbsp;&charset.arg;">
 	<!ENTITY X.opt "<option>-X</option>">
 

--- a/src/libfsm/print/c.c
+++ b/src/libfsm/print/c.c
@@ -581,7 +581,7 @@ fsm_print_c(FILE *f,
 		case AMBIG_ERROR:
 		case AMBIG_EARLIEST:
 			fprintf(f, ",\n");
-			fprintf(f, "\tconst unsigned *id");
+			fprintf(f, "\tunsigned *id");
 			break;
 
 		case AMBIG_MULTIPLE:

--- a/src/libfsm/print/vmc.c
+++ b/src/libfsm/print/vmc.c
@@ -588,7 +588,7 @@ fsm_print_vmc(FILE *f,
 		case AMBIG_ERROR:
 		case AMBIG_EARLIEST:
 			fprintf(f, ",\n");
-			fprintf(f, "\tconst unsigned *id");
+			fprintf(f, "\tunsigned *id");
 			break;
 
 		case AMBIG_MULTIPLE:


### PR DESCRIPTION
For AMBIG_ERROR we generate `const unsigned *id` and write out through `*id`, which is no good. Someone reported this earlier, and I thought I'd fix it, but evidently I didn't.