### PR TITLE
Makefile: grep for 'FAIL' should use -I to ignore binary files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,6 @@ STAGE_BUILD := ${STAGE_BUILD:Nbin/cvtpcre}
 
 .if make(test)
 .END::
-	grep FAIL ${BUILD}/tests/*/*res*; [ $$? -ne 0 ]
+	grep -I FAIL ${BUILD}/tests/*/*res*; [ $$? -ne 0 ]
 .endif
 


### PR DESCRIPTION
I ran into a test failure:

    grep FAIL build/tests/*/*res*; [ $? -ne 0 ]
    grep: build/tests/eager_output/run_mixed_start_anchor_regression: binary file matches
    *** Error code 1

because tests/eager_output/eager_output_mixed_start_anchor_regression.c contains the substring "res" in "regression", and the binary file contains "FAIL:

    $ strings build/tests/eager_output/run_mixed_start_anchor_regression | grep FAIL
    VM_END_FAIL
    VM_FAIL

This shouldn't matter for testing purposes, the 'test' target only cares about the test result files containing "PASS" or "FAIL". The change in cb42d58 to allow prefixed result files (e.g. "dyn-fdgetc-getc-res0") made this check ANY files with "res" in the name, but grep should ignore binary files.